### PR TITLE
Changed current to 1.0.0.Beta1 for Packetbeat

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -59,6 +59,7 @@ repos:
         url:        https://github.com/elastic/packetbeat.git
         current:    1.0.0.Beta1
         branches:
+            - master
             - 1.0.0.Beta1
 
     marvel:

--- a/conf.yaml
+++ b/conf.yaml
@@ -57,9 +57,9 @@ repos:
 
     packetbeat:
         url:        https://github.com/elastic/packetbeat.git
-        current:    master
+        current:    1.0.0.Beta1
         branches:
-            - master
+            - 1.0.0.Beta1
 
     marvel:
         url:        https://github.com/elastic/elasticsearch-marvel.git


### PR DESCRIPTION
The docs in the master start to diverge from the ones in Beta1 (which is our current released version). So I'd like to change `current` to the `1.0.0.Beta1` branch in packetbeat. Let me know if this is not the right way to do it.