### PR TITLE
Libbeat has now a normal reference guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -77,9 +77,10 @@ repos:
 
     libbeat:
         url:        https://github.com/elastic/libbeat.git
-        current:    master
+        current:    1.0.0-beta3
         branches:
             - master
+            - 1.0.0-beta3
 
     marvel:
         url:        https://github.com/elastic/elasticsearch-marvel.git
@@ -349,6 +350,12 @@ contents:
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:
           -
+            title:      Beats Platform Reference
+            prefix:     en/beats/libbeat
+            repo:       libbeat
+            index:      docs/index.asciidoc
+            tags:       Libbeat/Reference
+          -
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             repo:       packetbeat
@@ -360,13 +367,6 @@ contents:
             repo:       topbeat
             index:      docs/index.asciidoc
             tags:       Topbeat/Reference
-          -
-            title:      "Developer guide: creating a new Beat"
-            prefix:     en/beats/libbeat
-            repo:       libbeat
-            index:      docs/newbeat.asciidoc
-            single:     1
-            tags:       Libbeat/DevGuide
 
     -
         title:      "Elasticsearch for Apache Hadoop"


### PR DESCRIPTION
It used to be a single document, now it's a multi-page guide, similar
with the others.