### PR TITLE
Names of indexRouting and searchRouting infos are out of date.

### DIFF
--- a/html/en/elasticsearch/reference/current/cat-alias.html
+++ b/html/en/elasticsearch/reference/current/cat-alias.html
@@ -615,7 +615,7 @@
                »
             </a></span></div><div class="chapter"><div class="titlepage"><div><div><h2 class="title"><a id="cat-alias"></a>cat aliases<a href="https://github.com/elastic/elasticsearch/edit/1.7/docs/reference/cat/alias.asciidoc" class="edit_me" title="Edit this page on GitHub" rel="nofollow">edit</a></h2></div></div></div><p><code class="literal">aliases</code> shows information about currently configured aliases to indices
 including filter and routing infos.</p><div class="pre_wrapper"><pre class="programlisting prettyprint lang-shell">% curl '192.168.56.10:9200/_cat/aliases?v'
-alias  index filter indexRouting searchRouting
+alias  index filter routing.index routing.search
 alias2 test1 *      -            -
 alias4 test1 -      2            1,2
 alias1 test1 -      -            -


### PR DESCRIPTION
Hi,

I belive  `indexRouting` should be changed to `routing.index` and `searchRouting` to `routing.search`.
This is what my ES 2.0.0-rc1 instance returns when I hit cat alias api:

![image](https://cloud.githubusercontent.com/assets/2392583/10525415/f8c0db18-7384-11e5-995f-59bff72ec1ed.png)

Let me know if I should change other versions of documentation for this issue as well(Looks to me like it always was incorrect in docs).