### PR TITLE
Removed version 1.0.0 for Beats

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,7 +70,6 @@ repos:
         branches:
             - master
             - 1.0.1
-            - 1.0.0
 
     found:
         url:        https://github.com/elastic/found.git


### PR DESCRIPTION
It's practically identical with 1.0.1, so we don't need to keep it around.