### PR TITLE
Document analyzer options in the order they're executed.

### DIFF
--- a/html/en/elasticsearch/reference/master/analysis-custom-analyzer.html
+++ b/html/en/elasticsearch/reference/master/analysis-custom-analyzer.html
@@ -613,8 +613,8 @@
 zero or more <code class="literal">Token Filters</code>, and zero or more <code class="literal">Char Filters</code>. The
 custom analyzer accepts a logical/registered name of the tokenizer to
 use, and a list of logical/registered names of token filters.
-The name of the custom analyzer must not start with "_".</p><p>The following are settings that can be set for a <code class="literal">custom</code> analyzer type:</p><div class="informaltable"><table cellpadding="4px" border="1"><colgroup><col class="col_1" /><col class="col_2" /></colgroup><thead><tr><th align="left" valign="top">Setting </th><th align="left" valign="top">Description</th></tr></thead><tbody><tr><td align="left" valign="top"><p><code class="literal">tokenizer</code></p></td><td align="left" valign="top"><p>The logical / registered name of the tokenizer to use.</p></td></tr><tr><td align="left" valign="top"><p><code class="literal">filter</code></p></td><td align="left" valign="top"><p>An optional list of logical / registered name of token
-filters.</p></td></tr><tr><td align="left" valign="top"><p><code class="literal">char_filter</code></p></td><td align="left" valign="top"><p>An optional list of logical / registered name of char
+The name of the custom analyzer must not start with "_".</p><p>The following are settings that can be set for a <code class="literal">custom</code> analyzer type:</p><div class="informaltable"><table cellpadding="4px" border="1"><colgroup><col class="col_1" /><col class="col_2" /></colgroup><thead><tr><th align="left" valign="top">Setting </th><th align="left" valign="top">Description</th></tr></thead><tbody><tr><td align="left" valign="top"><p><code class="literal">char_filter</code></p></td><td align="left" valign="top"><p>An optional list of logical / registered name of char
+filters.</p></td></tr><tr><td align="left" valign="top"><p><code class="literal">tokenizer</code></p></td><td align="left" valign="top"><p>The logical / registered name of the tokenizer to use.</p></td></tr><tr><td align="left" valign="top"><p><code class="literal">filter</code></p></td><td align="left" valign="top"><p>An optional list of logical / registered name of token
 filters.</p></td></tr><tr><td align="left" valign="top"><p><code class="literal">position_increment_gap</code></p></td><td align="left" valign="top"><p>An optional number of positions to increment
 between each field value of a field using this analyzer. Defaults to 100.
 100 was chosen because it prevents phrase queries with reasonably large
@@ -623,10 +623,15 @@ slops (less than 100) from matching terms across field values.</p></td></tr></tb
         analyzer :
             myAnalyzer2 :
                 type : custom
+                char_filter : [my_html]
                 tokenizer : myTokenizer1
                 filter : [myTokenFilter1, myTokenFilter2]
-                char_filter : [my_html]
                 position_increment_gap: 256
+        char_filter :
+              my_html :
+                type : html_strip
+                escaped_tags : [xxx, yyy]
+                read_ahead : 1024
         tokenizer :
             myTokenizer1 :
                 type : standard
@@ -638,12 +643,7 @@ slops (less than 100) from matching terms across field values.</p></td></tr></tb
             myTokenFilter2 :
                 type : length
                 min : 0
-                max : 2000
-        char_filter :
-              my_html :
-                type : html_strip
-                escaped_tags : [xxx, yyy]
-                read_ahead : 1024</pre></div></div><div class="navfooter"><span class="prev"><a href="analysis-snowball-analyzer.html">
+                max : 2000</pre></div></div><div class="navfooter"><span class="prev"><a href="analysis-snowball-analyzer.html">
               « 
               Snowball Analyzer</a>
            


### PR DESCRIPTION
This updates `analysis-custom-analyzer.html` to be more clear. It places `char_filter` option before `tokenizer` and `filter`, since character filtering is done at the beginning of analysis.

Character filtering happens before tokenizing and token filtering, as mentioned [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-analyzers.html):

> Analyzers are composed of a single Tokenizer and zero or more TokenFilters. The tokenizer may be preceded by one or more CharFilters.

I think documenting these options in the order that they're executed could make ES docs clearer for newcomers.

(this probably applies elsewhere in the docs too -- I'd be happy to followup with another PR for those)