### PR TITLE
Build Alpha2 Logstash docs from new v5.0.0-alpha2-docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -66,7 +66,7 @@ repos:
         current:    2.3
         branches:
             - master
-            - 5.0: 5.0.0-alpha2
+            - v5.0.0-alpha2-docs
             - 2.3
             - 2.2
             - 2.1


### PR DESCRIPTION
I created the v5.0.0-alpha2-docs branch so we can continue to update the 5.0 branch without affecting the published alpha2 docs. We'll work in the 5.0 branch for Beta.

@clintongormley Does this look OK?  Oddly enough, this is the first time I've created a branch in a main repo. :-)

@suyograo FYI