### PR TITLE
Remove logstash roadmap from the doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -382,16 +382,6 @@ contents:
             chunk:      1
             tags:       Logstash/Reference
 
-          -
-            title:      Logstash Roadmap
-            prefix:     en/logstash-roadmap
-            repo:       logstash
-            index:      docs/static/roadmap/index.asciidoc
-            toc:        1
-            branches:   [master]
-            current:    master
-            single:     1
-            tags:       Logstash/Roadmap
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
Removes the Logstash Roadmap from the doc build as requested by @acchen97 and @suyograo 