### PR TITLE
Point most recent topbeat build to 1.3 instead of master

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -413,7 +413,7 @@ contents:
             tags:       Topbeat/Reference
             current:    1.2
             branches:
-              - master
+              - 1.3
               - 1.2
               - 1.1
               - 1.0.1


### PR DESCRIPTION
Topbeat was removed in 5.0 release but still exists in the 1.x releases. As master is 5.x releases, the most recent docs have to be pointed to 1.3.