### PR TITLE
Remove docs for Topbeat 1.3

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,6 +80,7 @@ repos:
         current:    1.2
         branches:
             - master: 5.0.0-alpha3
+            - 1.3
             - 1.2
             - 1.1
             - 1.0.1
@@ -413,7 +414,6 @@ contents:
             tags:       Topbeat/Reference
             current:    1.2
             branches:
-              - 1.3
               - 1.2
               - 1.1
               - 1.0.1


### PR DESCRIPTION
The 1.3 docs should be enabled when the 1.3.0 release is officially made.