### PR TITLE
Uncomment java REST client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -190,16 +190,16 @@ contents:
                 tags:       Clients/Java
                 chunk:      1
               
-#              -
-#                title:      Java REST Client
-#                prefix:     java-rest
-#                repo:       elasticsearch
-#                branches:   [master]
-#                current:    master
-#                index:      docs/java-rest/index.asciidoc
-#                tags:       Clients/JavaREST
-#                chunk:      1
-#
+              -
+                title:      Java REST Client
+                prefix:     java-rest
+                repo:       elasticsearch
+                branches:   [master]
+                current:    master
+                index:      docs/java-rest/index.asciidoc
+                tags:       Clients/JavaREST
+                chunk:      1
+
               -
                 title:      JavaScript API
                 prefix:     javascript-api


### PR DESCRIPTION
We disabled the java REST client docs temporarily till we get the next release out, otherwise it would be documentation about code that is not released yet.

We have to get this PR in once the next version is out.