### PR TITLE
Add 5.0 branch for Beats

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,8 @@ repos:
         url: https://github.com/elastic/beats.git
         current:    1.2
         branches:
-            - master: 5.0.0-alpha4
+            - master
+            - 5.0: 5.0.0-alpha4
             - 1.2
             - 1.1
             - 1.0.1
@@ -456,7 +457,8 @@ contents:
             tags:       Winlogbeat/Reference
             current:    1.2
             branches:
-             - master: 5.0.0-alpha4
+             - master
+             - 5.0: 5.0.0-alpha4
              - 1.2
              - 1.1
           -
@@ -466,9 +468,10 @@ contents:
             index:      metricbeat/docs/index.asciidoc
             chunk:      1
             tags:       Metricbeat/Reference
-            current:    master
+            current:    5.0
             branches:
-             - master: 5.0.0-alpha4
+             - master
+             - 5.0: 5.0.0-alpha4
 
     -
         title:      "Elasticsearch for Apache Hadoop"


### PR DESCRIPTION
Still referring to alpha4 for now, will change it to alpha5 on the release day. But this gets us the 5.0 online so we know it works.