### PR TITLE
Add new branch for Elastic Cloud to externalize doc changes from

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -190,7 +190,7 @@ contents:
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 chunk:      1
-              
+
 #              -
 #                title:      Java REST Client
 #                prefix:     java-rest
@@ -376,6 +376,9 @@ contents:
             repo:       cloud
             index:      docs/saas/index.asciidoc
             tags:       Cloud/Reference
+            current:    external
+            branches:
+                - external
 
     -
         title:      "Cloud Enterprise: Provision, Manage and Monitor the Elastic Stack"


### PR DESCRIPTION
@clintongormley or @debadair Could you review and let me know if these changes are LGTM?

I updated conf.yaml to change where Elastic Cloud docs get built (and externalized) from. See #1820 for the background why this change is being made.  

(Not sure what the change at l193 is. I'm guessing there were some stray spaces that got removed. )