### PR TITLE
Update conf.yaml for Cloud Enterprise to pull from 1.0.0-alpha3 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -8,7 +8,7 @@ repos:
         url:        https://github.com/elastic/elasticsearch.git
         current:    2.3
         branches:
-            - master: 5.0.0-alpha4
+            - master: 5.0.0-alpha5
             - 2.3
             - 2.2
             - 2.1
@@ -32,7 +32,7 @@ repos:
         url:        https://github.com/elastic/elasticsearch-hadoop.git
         current:    2.3
         branches:
-            - master: 5.0.0-alpha4
+            - master: 5.0.0-alpha5
             - 2.3
             - 2.2
             - 2.1
@@ -58,7 +58,7 @@ repos:
         url:        https://github.com/elastic/elasticsearch-net.git
         current:    2.x
         branches:
-            - master: 5.0.0-alpha4
+            - master: 5.0.0-alpha5
             - 2.x
             - 1.x
 
@@ -67,7 +67,7 @@ repos:
         current:    2.3
         branches:
             - master
-            - 5.0: 5.0.0-alpha4
+            - 5.0: 5.0.0-alpha5
             - 2.3
             - 2.2
             - 2.1
@@ -80,7 +80,7 @@ repos:
         current:    1.2
         branches:
             - master
-            - 5.0: 5.0.0-alpha4
+            - 5.0: 5.0.0-alpha5
             - 1.2
             - 1.1
             - 1.0.1
@@ -97,7 +97,7 @@ repos:
         current:    4.5
         branches:
             - master
-            - 5.0: 5.0.0-alpha4
+            - 5.0: 5.0.0-alpha5
             - 4.5
             - 4.4
             - 4.3
@@ -126,7 +126,7 @@ repos:
         private:    1
         current:    2.3
         branches:
-            - v5.0.0-alpha4-docs
+            - v5.0.0-alpha5-docs
             - 2.3
             - 2.2
             - 2.1
@@ -171,7 +171,7 @@ contents:
             abbr:       plugins
             current:    2.3
             branches:
-              - master: 5.0.0-alpha4
+              - master: 5.0.0-alpha5
               - 2.3
               - 2.2
               - 2.1
@@ -191,16 +191,17 @@ contents:
                 tags:       Clients/Java
                 chunk:      1
 
-#              -
-#                title:      Java REST Client
-#                prefix:     java-rest
-#                repo:       elasticsearch
-#                branches:   [master]
-#                current:    master
-#                index:      docs/java-rest/index.asciidoc
-#                tags:       Clients/JavaREST
-#                chunk:      1
-#
+              -
+                title:      Java REST Client
+                prefix:     java-rest
+                repo:       elasticsearch
+                branches:
+                 - master: 5.0.0-alpha5
+                current:    master
+                index:      docs/java-rest/index.asciidoc
+                tags:       Clients/JavaREST
+                chunk:      1
+
               -
                 title:      JavaScript API
                 prefix:     javascript-api
@@ -291,9 +292,9 @@ contents:
             abbr:       xpack
             chunk:      1
             tags:       XPack/Reference
-            current:    v5.0.0-alpha4-docs
+            current:    v5.0.0-alpha5-docs
             branches:
-                - v5.0.0-alpha4-docs
+                - v5.0.0-alpha5-docs
     -
         title:      "Marvel: Monitoring for Elasticsearch"
         sections:
@@ -389,9 +390,9 @@ contents:
             repo:       cloud
             index:      docs/cloud-enterprise/index.asciidoc
             tags:       CloudEnterprise/Reference
-            current:    master
+            current:    1.0.0-alpha3
             branches:
-                - master: 1.0.0-alpha2
+                - 1.0.0-alpha3
 
     -
         title:      "Kibana: Explore, Visualize, and Share"
@@ -461,7 +462,7 @@ contents:
             current:    1.2
             branches:
              - master
-             - 5.0: 5.0.0-alpha4
+             - 5.0: 5.0.0-alpha5
              - 1.2
              - 1.1
           -
@@ -474,7 +475,7 @@ contents:
             current:    5.0
             branches:
              - master
-             - 5.0: 5.0.0-alpha4
+             - 5.0: 5.0.0-alpha5
 
     -
         title:      "Elasticsearch for Apache Hadoop"


### PR DESCRIPTION
Changed lines 393-395, and tested with `build_docs.pl --all`

```
            current:    1.0.0-alpha3
            branches:
                - 1.0.0-alpha3
```