### PR TITLE
Don't add console widget to snippets marked // NOTCONSOLE

### DIFF
--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -262,7 +262,7 @@
         <xsl:when test="contains(text(),'AUTOSENSE')">
             <div class="sense_widget" data-snippet=":AUTOSENSE:"></div>
         </xsl:when>
-        <xsl:when test="contains(text(),'CONSOLE')">
+        <xsl:when test="contains(text(),'CONSOLE') and not(contains(text(),'NOTCONSOLE'))">
             <div class="console_widget" data-snippet=":CONSOLE:"></div>
         </xsl:when>
         <xsl:when test="contains(text(),'SENSE:')">
@@ -298,4 +298,3 @@
     </xsl:template>
 
 </xsl:stylesheet>
-


### PR DESCRIPTION
Those are just for explicitly tracking snippets that shouldn't be
converted to `// CONSOLE`. The console widget doesn't make sense
for them.