### PR TITLE
Added Reporting docs & bumped versions for 2.4.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -6,7 +6,7 @@ paths:
 repos:
     elasticsearch:
         url:        https://github.com/elastic/elasticsearch.git
-        current:    2.3
+        current:    2.4
         branches:
             - master: 5.0.0-alpha5
             - 2.4
@@ -66,7 +66,7 @@ repos:
 
     logstash:
         url:        https://github.com/elastic/logstash-docs.git
-        current:    2.3
+        current:    2.4
         branches:
             - master
             - 5.0: 5.0.0-alpha5
@@ -98,7 +98,7 @@ repos:
 
     kibana:
         url:        https://github.com/elastic/kibana.git
-        current:    4.5
+        current:    4.x
         branches:
             - master
             - 5.0: 5.0.0-alpha5
@@ -129,9 +129,10 @@ repos:
     x-plugins:
         url:        https://github.com/elastic/x-plugins.git
         private:    1
-        current:    2.3
+        current:    2.4
         branches:
             - v5.0.0-alpha5-docs
+            - 2.4
             - 2.3
             - 2.2
             - 2.1
@@ -312,8 +313,9 @@ contents:
             abbr:       marvel
             chunk:      1
             tags:       Marvel/Reference
-            current:    2.3
+            current:    2.4
             branches:
+                - 2.4
                 - 2.3
                 - 2.2
                 - 2.1
@@ -330,8 +332,9 @@ contents:
             abbr:       shield
             chunk:      1
             tags:       Shield/Reference
-            current:    2.3
+            current:    2.4
             branches:
+                - 2.4            
                 - 2.3
                 - 2.2
                 - 2.1
@@ -352,13 +355,28 @@ contents:
             abbr:       watcher
             chunk:      1
             tags:       Watcher/Reference
-            current:    2.3
+            current:    2.4
             branches:
+                - 2.4
                 - 2.3
                 - 2.2
                 - 2.1
                 - 2.0
                 - watcher-1.0: 1.0
+    -
+        title:      "Reporting: Reporting for Elasticsearch"
+        sections:
+         -
+            title:      Reporting Reference
+            prefix:     en/reporting
+            repo:       x-plugins
+            index:      docs/public/reporting/index.asciidoc
+            abbr:       reporting
+            chunk:      1
+            tags:       Reporting/Reference
+            current:    2.4
+            branches:
+                - 2.4               
     -
         title:      "Graph: Graph for Elasticsearch"
         sections:
@@ -370,8 +388,9 @@ contents:
             abbr:       graph
             chunk:      1
             tags:       Graph/Reference
-            current:    2.3
+            current:    2.4
             branches:
+                - 2.4
                 - 2.3
 
     -
@@ -446,7 +465,7 @@ contents:
             index:      topbeat/docs/index.asciidoc
             chunk:      1
             tags:       Topbeat/Reference
-            current:    1.2
+            current:    1.3
             branches:
               - 1.3
               - 1.2

--- a/conf.yaml
+++ b/conf.yaml
@@ -98,11 +98,11 @@ repos:
 
     kibana:
         url:        https://github.com/elastic/kibana.git
-        current:    4.x
+        current:    4.6
         branches:
             - master
             - 5.0: 5.0.0-alpha5
-            - 4.x
+            - 4.6
             - 4.5
             - 4.4
             - 4.3


### PR DESCRIPTION
Staging docs to https://stag-www.elastic.co/guide. A couple things to note:

- Kibana docs need to be bumped to 4.6 branch, but it hasn't been created yet. 
- There are a couple of outstanding Reporting PRs that Joe needs to merge.


