### PR TITLE
Add Curator 4.1 as a potential branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -115,6 +115,7 @@ repos:
         url:        https://github.com/elastic/curator.git
         current:    4.0
         branches:
+         - 4.1
          - 4.0
          - 3.5
          - 3.4


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

Curator 4.1 release can happen once this works.