### PR TITLE
Metricbeat can in alpha no more

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -504,7 +504,7 @@ contents:
              - 1.2
              - 1.1
           -
-            title:      Metricbeat Reference (alpha)
+            title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             repo:       beats
             index:      metricbeat/docs/index.asciidoc


### PR DESCRIPTION
Preparing for the beta release.
