### PR TITLE
Make Curator 4.2 the current branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -127,7 +127,7 @@ repos:
 
     curator:
         url:        https://github.com/elastic/curator.git
-        current:    4.1
+        current:    4.2
         branches:
          - 4.2
          - 4.1


### PR DESCRIPTION
Just a quick change of which is current

