### PR TITLE
Add Content-Type header to COPY AS CURL

### DIFF
--- a/resources/web/docs.js
+++ b/resources/web/docs.js
@@ -247,6 +247,7 @@ jQuery(function() {
           if (body) {
             body = body.replace(/\'/g, '\\u0027');
             body = body.replace(/\s*$/,"\n");
+            curlText += " -H 'Content-Type: application/json'";
             curlText += " -d'" + body + "'";
           }
           curlText += '\n';


### PR DESCRIPTION
Adds the `Content-Type: application/json` header to the curl
request generated by the `COPY AS CURL` links if the request
has a body.

Closes #143