### PR TITLE
Exclude 5.x, 5.3 branch for metricset path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -559,7 +559,7 @@ contents:
               -
                 repo:   beats
                 path:   generate/metricbeat/metricset
-                exclude_branches: [master]
+                exclude_branches: [master, 5.x, 5.3]
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
@@ -645,4 +645,3 @@ template:
         FINAL: |
             <script type="text/javascript" src="docs.js"></script>
             <script type='text/javascript' src='https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?lang=yaml'></script>
-


### PR DESCRIPTION
This path does not exist anymore in 5.x and 5.3.