### PR TITLE
Update conf.yaml for ECE beta1 and add chunk=1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -396,9 +396,10 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0.0-alpha4
-            branches:   [ 1.0.0-alpha4, 1.0.0-alpha3 ]
+            current:    1.0.0-beta1
+            branches:   [ 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
+            chunk:      1
             private:    1
             sources:
               -


### PR DESCRIPTION
Two changes in this PR:

- ECE beta1 goes live in two days and we need to be able to build from the 1.0.0-beta1 branch  
- On Clint's recommendation, switching to chunk=1 so that we can build the Swagger API docs as hoped (I'm going through the output separately to add any missing [float] tags)

