### PR TITLE
[DOCS] Update conf.yaml with new X-Pack translation folders

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -288,20 +288,20 @@ contents:
             chunk:      1
             tags:       XPack/Reference
             current:    5.3
-            index:      docs/public/index.asciidoc
+            index:      docs/en/index.asciidoc
             private:    1
             branches:   [ 5.3, 5.2, 5.1, 5.0 ]
             sources:
               -
                 repo:   x-pack
-                path:   docs/public
+                path:   docs/en
               -
                 repo:   x-pack-kibana
-                path:   docs/public-kb
+                path:   docs/en
                 exclude_branches:   [ 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
               -
                 repo:   x-pack-elasticsearch
-                path:   docs/public
+                path:   docs/en
                 exclude_branches: [ 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
 
 


### PR DESCRIPTION
In preparation for translation, "docs/en" folders are being added to the x-pack-* repositories.
This PR updates the conf.yaml to use those new directories for the documentation builds.

