### PR TITLE
Add ECE 1.0.0-beta2 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -416,8 +416,8 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0.0-beta1
-            branches:   [ 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
+            current:    1.0.0-beta2
+            branches:   [ 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
We're releasing a 1.0.0-beta2 branch next week, which requires an accompanying doc branch.