### PR TITLE
Change Elastic Cloud docs build to use --chunk=1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -408,6 +408,7 @@ contents:
             current:    external
             branches:   [ external ]
             index:      docs/saas/index.asciidoc
+            chunk:      1
             private:    1
             sources:
               -


### PR DESCRIPTION
The Elastic Cloud Enterprise docs already used chunk=1. I did some reshuffling of Elastic Cloud content and I would prefer that content to also use --chunk=1. By and large, we have the right [float] tags in place to make this work.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
