### PR TITLE
Add Beats devguide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -500,7 +500,28 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   CHANGELOG.asciidoc
+                path:   CHANGELOG.asciidoc                
+          -
+            title:      Beats Developer Guide
+            prefix:     en/beats/devguide
+            index:      docs/devguide/index.asciidoc
+            current:    master
+            branches:   [ master ]
+            chunk:      1
+            tags:       Devguide/Reference
+            sources:
+              -
+                repo:   beats
+                path:   docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   metricbeat/module
+              -
+                repo:   beats
+                path:   metricbeat/scripts
           -
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
@@ -573,16 +594,6 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
-              -
-                repo:   beats
-                path:   metricbeat/module
-              -
-                repo:   beats
-                path:   metricbeat/scripts
-              -
-                repo:   beats
-                path:   generate/metricbeat/metricset
-                exclude_branches: [master, 5.x, 5.3]
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat


### PR DESCRIPTION
Adds the Beats Developer Guide to the docs.

This PR needs to be merged at the same time as https://github.com/elastic/beats/pull/4030

Note that `generate/metricbeat/metricset` was removed from the Metricbeat section because the file at the path is no longer used in the docs.
