### PR TITLE
Remove `//` from included callouts

### DIFF
--- a/resources/extract-tagged.py
+++ b/resources/extract-tagged.py
@@ -6,6 +6,7 @@ def extract_tagged(target, tag):
     import re
     start = re.compile('^(\s+).+tag::' + tag)
     end = re.compile('end::' + tag)
+    callout = re.compile(r'// (<[^>]+>)')
     foundTag = False
 
     result = ''
@@ -14,7 +15,9 @@ def extract_tagged(target, tag):
             if end.search(line):
                 return result
             if foundTag:
-                result = result + line.replace(indentation, '', 1)
+                line = line.replace(indentation, '', 1)
+                line = callout.sub(r'\1', line)
+                result = result + line
             else:
                 m = start.search(line)
                 if m:

--- a/resources/extract-tagged.py
+++ b/resources/extract-tagged.py
@@ -6,7 +6,7 @@ def extract_tagged(target, tag):
     import re
     start = re.compile('^(\s+).+tag::' + tag)
     end = re.compile('end::' + tag)
-    callout = re.compile(r'// (<[^>]+>)')
+    callout = re.compile(r'// (<[^>]+>)\s*?\n')
     foundTag = False
 
     result = ''
@@ -16,7 +16,7 @@ def extract_tagged(target, tag):
                 return result
             if foundTag:
                 line = line.replace(indentation, '', 1)
-                line = callout.sub(r'\1', line)
+                line = callout.sub(r'\1\n', line)
                 result = result + line
             else:
                 m = start.search(line)


### PR DESCRIPTION
Java files that are references by `include-tagged` have to
comment out the callouts so the java files compile:
```java
        // tag::bool
        boolQuery()
                .must(termQuery("content", "test1"))    // <1>
                .must(termQuery("content", "test4"))    // <1>
                .mustNot(termQuery("content", "test2")) // <2>
                .should(termQuery("content", "test3"))  // <3>
                .filter(termQuery("content", "test5")); // <4>
        // end::bool
```

This removes the `// ` part from the docs because it is distracting.
