### PR TITLE
[DOCS] Add role=screenshot formatting for images

### DIFF
--- a/resources/fo.xsl
+++ b/resources/fo.xsl
@@ -82,5 +82,15 @@
   <!-- Don't display in ToC -->
   <xsl:template match="phrase" mode="no.anchor.mode" />
 
-</xsl:stylesheet>
+  <!--Images -->
+  <xsl:template match="mediaobject[@role = 'screenshot']" mode="class.value">
+    <xsl:value-of select="'screenshot'"/>
+  </xsl:template>
+  <xsl:template match="informalfigure[@role = 'screenshot']" mode="class.value">
+    <xsl:value-of select="'screenshot'"/>
+  </xsl:template>
+  <xsl:template match="inlinemediaobject[@role = 'screenshot']" mode="class.value">
+    <xsl:value-of select="'screenshot'"/>
+  </xsl:template>
 
+</xsl:stylesheet>

--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -522,23 +522,15 @@ p.remark {
 }
 
 /* Images */
+#guide .screenshot img {
+      max-width: 100%;
+      margin: 20px 0 20px 0;
+      box-shadow:  0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+  }
+
 #guide .inlinemediaobject img,
 #guide .mediaobject img {
     max-width: 100%;
-}
-#guide .inlinemediaobject.screenshot img {
-    max-width: 100%;
-    margin: 20px 0 20px 0;
-    box-shadow:
-0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
-;
-}
-#guide .mediaobject.screenshot img {
-    max-width: 100%;
-    margin: 20px 0 20px 0;
-    box-shadow:
-0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
-;
 }
 
 

--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -526,6 +526,21 @@ p.remark {
 #guide .mediaobject img {
     max-width: 100%;
 }
+#guide .inlinemediaobject.screenshot img {
+    max-width: 100%;
+    margin: 20px 0 20px 0;
+    box-shadow:
+0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
+;
+}
+#guide .mediaobject.screenshot img {
+    max-width: 100%;
+    margin: 20px 0 20px 0;
+    box-shadow:
+0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)
+;
+}
+
 
 /* Sense widget */
 #guide div.console_widget,

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -347,4 +347,15 @@
       </xsl:if>
     </xsl:template>
 
+<!--Images -->
+  <xsl:template match="mediaobject[@role = 'screenshot']" mode="class.value">
+      <xsl:value-of select="'screenshot'"/>
+    </xsl:template>
+  <xsl:template match="informalfigure[@role = 'screenshot']" mode="class.value">
+      <xsl:value-of select="'screenshot'"/>
+  </xsl:template>
+  <xsl:template match="inlinemediaobject[@role = 'screenshot']" mode="class.value">
+      <xsl:value-of select="'screenshot'"/>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
This PR implements shadow formatting for images that have "role"="screenshot".
It works in my local tests against the X-Pack Reference, in particular the Machine Learning Getting Started Tutorial.

It converts asciidoc content like this:
[role="screenshot"]
image::images/ml-kibana.jpg[Job Management]

To output HTML content like this:

----

<div class="screenshot"><div class="mediaobject"><img src="images/ml-kibana.jpg" alt="Job Management" /></div></div>

----

I'm not a XSLT guru, however, so if you have suggestions for a more elegant solution, please let me know.

