### PR TITLE
[DOCS] Add X-Pack 5.4 doc version

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -294,7 +294,7 @@ contents:
             current:    5.3
             index:      docs/en/index.asciidoc
             private:    1
-            branches:   [ 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
This PR adds 5.4 to the list of version branches in the X-Pack Reference.
