### PR TITLE
Use python2.7 rather than system default python version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin
 !html/sitemap.xml
 metastore_db
 html_docs/
+.idea

--- a/resources/asciidoc-8.6.8/a2x
+++ b/resources/asciidoc-8.6.8/a2x
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 '''
 a2x - A toolchain manager for AsciiDoc (converts Asciidoc text files to other
       file formats)

--- a/resources/asciidoc-8.6.8/asciidoc
+++ b/resources/asciidoc-8.6.8/asciidoc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 """
 asciidoc - converts an AsciiDoc text file to HTML or DocBook
 

--- a/resources/asciidoc-8.6.8/asciidocapi.py
+++ b/resources/asciidoc-8.6.8/asciidocapi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 """
 asciidocapi - AsciiDoc API wrapper class.
 

--- a/resources/asciidoc-8.6.8/filters/code/code-filter.py
+++ b/resources/asciidoc-8.6.8/filters/code/code-filter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 '''
 NAME
     code-filter - AsciiDoc filter to highlight language keywords

--- a/resources/asciidoc-8.6.8/filters/graphviz/graphviz2png.py
+++ b/resources/asciidoc-8.6.8/filters/graphviz/graphviz2png.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 import os, sys, subprocess
 from optparse import *

--- a/resources/asciidoc-8.6.8/filters/latex/latex2png.py
+++ b/resources/asciidoc-8.6.8/filters/latex/latex2png.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 '''
 NAME
     latex2png - Converts LaTeX source to PNG file

--- a/resources/asciidoc-8.6.8/filters/music/music2png.py
+++ b/resources/asciidoc-8.6.8/filters/music/music2png.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 '''
 NAME
     music2png - Converts textual music notation to classically notated PNG file

--- a/resources/asciidoc-8.6.8/tests/testasciidoc.py
+++ b/resources/asciidoc-8.6.8/tests/testasciidoc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 USAGE = '''Usage: testasciidoc.py [OPTIONS] COMMAND
 

--- a/resources/docbook-xsl-1.78.1/extensions/xslt.py
+++ b/resources/docbook-xsl-1.78.1/extensions/xslt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/python2.7 -u
 # $Id: xslt.py 8353 2009-03-17 16:57:50Z mzjn $
 
 import sys

--- a/resources/extract-tagged.py
+++ b/resources/extract-tagged.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 
 # Extract a tagged portion of a file.
 

--- a/resources/http.py
+++ b/resources/http.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2.7
 import SimpleHTTPServer
 
 class MyHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):


### PR DESCRIPTION
My OS defaults to python 3
```
/usr/bin/env python --version
Python 3.6.0
```
so doc generation fails.  

I propose changing the hash bang lines to be explicit about using python2.7 the changes should work cross platform but I've only tested locally.