### PR TITLE
Add 1.0.0 release for ECE

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -427,8 +427,8 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0.0-beta2
-            branches:   [ 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
+            current:    1.0.0
+            branches:   [ 1.0.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
The 1.0.0 ECE GA release is happening later this month. This PR adds the 1.0.0 release branch and changes current to 1.0.0.