### PR TITLE
Start building the 1.0.0 ECE docs for testing

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -428,7 +428,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0.0-beta2
-            branches:   [ 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
+            branches:   [ 1.0.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
We need to start building the 1.0.0 ECE docs, so that UI help links will work, both for manual and automated testing. Replaces https://github.com/elastic/docs/pull/181.
