### PR TITLE
Switch ECE current branch to 1.0.0

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -446,7 +446,7 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0.0-beta2
+            current:    1.0.0
             branches:   [ 1.0.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1


### PR DESCRIPTION
We GA on May 31. I need to switch the current branch for the ECE doc builds to 1.0.0 for that event.