### PR TITLE
Change 1.0.0 to 1.0 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -447,7 +447,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0.0-beta2
-            branches:   [ 1.0.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
+            branches:   [ 1.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
The Cloud team has decided to release ECE GA as 1.0, not 1.0.0. This PR changes the branch we build from.