### PR TITLE
[DOCS] Add xpack-kibana repo to Kibana Reference

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -471,10 +471,12 @@ contents:
               -
                 repo:   kibana
                 path:   docs/
-#              -
-#                repo:   x-pack-kibana
-#                path:   docs/
-#                exclude_branches:   [ 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4. 1, 4.0, 3.0 ]
+
+              -
+                repo:   x-pack-kibana
+                path:   docs/en
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4. 1, 4.0, 3.0]
+        
           -
             title:      "Legacy: Sense Editor for 4.x"
             prefix:     en/sense


### PR DESCRIPTION
This PR adds the x-pack-kibana repo to the Kibana Reference in the conf.yaml so that it can start including content from that repo in the 5.x and master versions.