### PR TITLE
Remove pre-1.0.0 ECE docs except beta2

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -447,7 +447,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0.0
-            branches:   [ 1.0.0 ]
+            branches:   [ 1.0.0, 1.0.0-beta2 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -447,7 +447,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0.0
-            branches:   [ 1.0.0, 1.0.0-beta2, 1.0.0-beta1, 1.0.0-alpha4, 1.0.0-alpha3 ]
+            branches:   [ 1.0.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
ECE has GA'ed and we no longer offer the install scripts for versions before GA. Time to remove the old docs?
