### PR TITLE
[DOCS] Use index-all.asciidoc for Elasticsearch Reference

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -74,10 +74,11 @@ contents:
                 repo:   elasticsearch
                 path:   docs/painless
                 exclude_branches:   [ 5.x, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-#              -
-#                repo:   x-pack-elasticsearch
-#                path:   docs/public
-#                exclude_branches: [ 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   docs/en
+                exclude_branches: [5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
           -
             title:      Elasticsearch - The Definitive Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -51,7 +51,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    5.4
             branches:   [ { master: 6.0.0-alpha2 }, 5.x, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            index:      docs/reference/index.asciidoc
+            index:      docs/reference/index-all.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
             sources:


### PR DESCRIPTION
This pull request updates the conf.yaml to use the index-all.asciidoc for building the Elasticsearch Reference. 

The index-all.asciidoc was created in https://github.com/elastic/elasticsearch/pull/25186 and https://github.com/elastic/elasticsearch/pull/25164

As a result of all these pull requests, the Elasticsearch Reference can integrate content from X-Pack-specific repositories. 