### PR TITLE
Return "502 Bad Gateway" if Elasticsearch is down

### DIFF
--- a/web/search.psgi
+++ b/web/search.psgi
@@ -464,7 +464,7 @@ sub _run_request {
             # explain => 'true'
         );
     }
-        || do { warn $@; return _as_json( 200, {} ) };
+        || do { warn $@; return _as_text( 502, "502 Bad Gateway\n" ) };
 
     my $last_page = int( $result->{hits}{total} / $Page_Size ) + 1;
     $last_page = $Max_Page if $last_page > $Max_Page;


### PR DESCRIPTION
This patch makes the search app return an HTTP error (502) when it's unable
to interact with Elasticsearch. This is extremely useful in a load-balanced
configuration, since it allows the load-balancer to automatically drop a
node from rotation in the event of the localhost Elasticsearch process
stopping.

Without the patch, 200-OK is returned, the node stays in rotation, and null
results are returned all the way to the web client.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
