### PR TITLE
[DOCS] Build Logstash Reference from x-pack-logstash

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -495,17 +495,18 @@ contents:
             prefix:     en/logstash
             current:    5.4
             branches:   [ { master: 6.0.0-alpha2 }, 5.x, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            index:      docs/en/index.asciidoc
+            index:      ../logstash-extra/x-pack-logstash/docs/en/index.asciidoc
             chunk:      1
             tags:       Logstash/Reference
             sources:
-              -
-                repo:   x-pack-kibana
-                path:   docs/en
 # Dummy repo checkout to set the right edit_url repo
               -
                 repo:   logstash
-                path:   README.md
+                path:   docs/
+              -
+                repo:   xpack-logstash
+                prefix: logstash-extra/x-pack-logstash
+                path:   docs/en
               -
                 repo:   logstash-docs
                 path:   docs/

--- a/conf.yaml
+++ b/conf.yaml
@@ -495,10 +495,13 @@ contents:
             prefix:     en/logstash
             current:    5.4
             branches:   [ { master: 6.0.0-alpha2 }, 5.x, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            index:      ../logstash-docs/docs/index.asciidoc
+            index:      docs/en/index.asciidoc
             chunk:      1
             tags:       Logstash/Reference
             sources:
+              -
+                repo:   x-pack-kibana
+                path:   docs/en
 # Dummy repo checkout to set the right edit_url repo
               -
                 repo:   logstash
@@ -506,11 +509,6 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
-#              -
-#                repo:   xpack-logstash
-#                path:   docs/
-#                exclude_branches:   [ 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
This pull request updates the conf.yaml to build the Logstash Reference from the x-pack-logstash repository instead of the logstash or logstash-docs repos.

I have run successful local documentation build tests against all of the Logstash releases.

Note that it also integrates and duplicates a recent commit @clintongormley made to address problems with the edit_url links.