### PR TITLE
[DOCS] Update paths for Kibana Guide in conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -25,7 +25,7 @@ repos:
     x-pack:               https://github.com/elastic/x-pack.git
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
-#    x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
+    x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
 
 contents_title:     Elastic Stack and Product Documentation
 
@@ -463,19 +463,18 @@ contents:
             prefix:     en/kibana
             current:    5.4
             branches:   [ { master: 6.0.0-alpha2 }, 5.x, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-            index:      docs/index.asciidoc
+            index:      ../x-pack-kibana/docs/en/index.asciidoc
             chunk:      1
             tags:       Kibana/Reference
             sources:
+# Dummy repo checkout to set the right edit_url repo
               -
                 repo:   kibana
                 path:   docs/
-
               -
                 repo:   x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
-
+              
           -
             title:      "Legacy: Sense Editor for 4.x"
             prefix:     en/sense


### PR DESCRIPTION
This pull request is related to https://github.com/elastic/kibana/pull/12062

It updates the conf.yaml to match changes made in the section for the Elasticsearch Reference, so that the Kibana Guide is built from the appropriate directory and has appropriate edit_url paths. 