### PR TITLE
[DOCS] Created shared attribute file

### DIFF
--- a/sharedattributes.asciidoc
+++ b/sharedattributes.asciidoc
@@ -1,0 +1,22 @@
+:ref:             https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
+:xpack-ref:       https://www.elastic.co/guide/en/x-pack/{branch}
+:logstash-ref:    http://www.elastic.co/guide/en/logstash/{branch}
+:kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
+:stack-ref:       http://www.elastic.co/guide/en/elastic-stack/{branch}
+
+:xpack:           X-Pack
+:es:              Elasticsearch
+:kib:             Kibana
+
+:security:        X-Pack security
+:monitoring:      X-Pack monitoring
+:watcher:         Watcher
+:reporting:       X-Pack reporting
+:graph:           X-Pack graph
+:searchprofiler:  X-Pack search profiler
+:xpackml:         X-Pack machine learning
+:ml:              machine learning
+:dfeed:           datafeed
+:dfeeds:          datafeeds
+:dfeed-cap:       Datafeed
+:dfeeds-cap:      Datafeeds


### PR DESCRIPTION
This pull request creates a list of attributes that can be used by all the documentation builds, so that attribute names are synchronized across the repositories.  This is particularly important since many of the builds now integrate content from multiple repositories.