### PR TITLE
[DOCS] Add Java API URL to shared attributes

### DIFF
--- a/sharedattributes.asciidoc
+++ b/sharedattributes.asciidoc
@@ -3,6 +3,7 @@
 :logstash-ref:    http://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
 :stack-ref:       http://www.elastic.co/guide/en/elastic-stack/{branch}
+:javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 
 :xpack:           X-Pack
 :es:              Elasticsearch


### PR DESCRIPTION
This PR adds the "javaclient" attribute to the list of shared attributes.
