### PR TITLE
[DOCS] Add elastic/docs repo to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -26,6 +26,7 @@ repos:
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
+    docs:                 https://github.com/elastic/docs.git
 
 contents_title:     Elastic Stack and Product Documentation
 
@@ -66,6 +67,8 @@ contents:
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
               -
                 repo:   elasticsearch
                 path:   docs/src/test/cluster/config
@@ -334,6 +337,8 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 exclude_branches: [ 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   docs
 
 
           -
@@ -474,6 +479,8 @@ contents:
               -
                 repo:   x-pack-kibana
                 path:   docs/en
+              -
+                repo:   docs
 
           -
             title:      "Legacy: Sense Editor for 4.x"
@@ -510,6 +517,8 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
+              -
+                repo:   docs
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
This pull request adds the elastic/docs repository to the conflict.yaml and associates it with several books that are seeking a shared attributes file in that repository.