### PR TITLE
[DOCS] Add docs repo to books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -64,11 +64,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
               -
+                repo:   docs
+                path:   shared
+                exclude_branches:  [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-#              -
-#                repo:   docs
               -
                 repo:   elasticsearch
                 path:   docs/src/test/cluster/config
@@ -119,6 +121,9 @@ contents:
                 repo:   elasticsearch
                 path:   docs/painless
               -
+                repo:   docs
+                path:   shared
+              -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
           -
@@ -134,6 +139,10 @@ contents:
               -
                 repo:   elasticsearch
                 path:   docs/plugins
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -155,6 +164,10 @@ contents:
                     repo:   elasticsearch
                     path:   docs/java-api
                   -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
                     exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
@@ -175,6 +188,10 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest
+                  -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
@@ -207,6 +224,10 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/groovy-api
+                  -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
@@ -486,9 +507,10 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 exclude_branches: [5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
-#              -
-#                repo:   docs
-
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
           -
             title:      "Legacy: Sense Editor for 4.x"
             prefix:     en/sense
@@ -527,8 +549,7 @@ contents:
               -
                 repo:   docs
                 path:   shared
-                exclude_branches:  [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
This pull request is related to efforts to re-use a set of shared attributes across multiple books.  
It adds the docs repo to multiple books, in particular the docs/shared folder.

For example, see https://github.com/elastic/elasticsearch/pull/25479

