### PR TITLE
[DOCS] Adding docs repos

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -26,7 +26,7 @@ repos:
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
-#    docs:                 https://github.com/elastic/docs.git
+    docs:                 https://github.com/elastic/docs.git
 
 contents_title:     Elastic Stack and Product Documentation
 
@@ -66,11 +66,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
               -
+                repo:   docs
+                path:   shared
+                exclude_branches:  [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-#              -
-#                repo:   docs
               -
                 repo:   elasticsearch
                 path:   docs/src/test/cluster/config
@@ -121,6 +123,9 @@ contents:
                 repo:   elasticsearch
                 path:   docs/painless
               -
+                repo:   docs
+                path:   shared
+              -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
           -
@@ -136,6 +141,10 @@ contents:
               -
                 repo:   elasticsearch
                 path:   docs/plugins
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -157,6 +166,10 @@ contents:
                     repo:   elasticsearch
                     path:   docs/java-api
                   -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
                     exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
@@ -177,6 +190,10 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest
+                  -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
@@ -209,6 +226,10 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/groovy-api
+                  -
+                    repo:   docs
+                    path:   shared
+                    exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc
@@ -338,9 +359,10 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 exclude_branches: [ 5.3, 5.2, 5.1, 5.0]
-#              -
-#                repo:   docs
-
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Legacy: Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
@@ -484,9 +506,10 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 exclude_branches: [5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
-#              -
-#                repo:   docs
-
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches: [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
           -
             title:      Legacy: Sense Editor for 4.x
             prefix:     en/sense
@@ -522,8 +545,11 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
-#              -
-#                repo:   docs
+              -
+                repo:   docs
+                path:   shared
+                exclude_branches:  [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+
 
     -
         title:      Beats: Collect, Parse, and Ship


### PR DESCRIPTION
As of documentation build #2380, the following error has occurred:

YAML Error: Couldn't parse single line value
   Code: YAML_PARSE_ERR_SINGLE_LINE
   Line: 74
   Document: 1
 at lib/YAML/Loader.pm line 148.

I tried reverting all of my commits today (https://github.com/elastic/docs/pull/207), but the YAML error persists.  

Notably, however, the build_docs.pl --all works consistently on my local machine.

This pull request contains the updated conf.yaml that contains all of today's updates.  It still does not work in the automatic builds at this time.   