### PR TITLE
Switch to 1.0 branch for ECE 1.0.x releases

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -444,8 +444,8 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0.1
-            branches:   [ 1.0.1, 1.0.0, 1.0.0-beta2 ]
+            current:    1.0
+            branches:   [ 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -445,7 +445,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0
-            branches:   [ 1.0 ]
+            branches:   [ 1.0, 1.0.1, 1.0.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
As discussed during a Cloud meeting, we plan to start building the docs for the ECE 1.0.x releases out of the `1.0` branch. We also want to remove the old 1.0.0-beta2 docs and, eventually, the  1.0.1 & 1.0.0 doc builds.

We probably want to do this in two stages, as we'll need to get the 1.0 docs building before putting redirects for 1.0.1 & 1.0.0 in place. So, add new current `1.0` branch first,  remove old 1.0.x branches later. 

Depends on:
- [ ] Redirects for links to 1.0.1/1.0.0 URLs to avoid broken links (and it seems we also have some older links to beta releases still)
- [ ] Update `1.0` branch in elastic/cloud with the combined docs from 1.0.1 & 1.0.0
- [ ] Cloud UI links that were updated for 1.0.2 need to be updated again to point to `1.0`
