### PR TITLE
[DOCS] Add xpack icon for sidebars

### DIFF
--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -44,6 +44,9 @@
   font-weight: inherit;
 }
 
+/* Add xpack icon to role=xpack sidebar titles */
+#guide div[class~="xpack"] > div > div > div > p > strong:after,
+
 /* Add xpack icon to role=xpack dt titles */
 #guide dt > span > span.xpack:after,
 


### PR DESCRIPTION
This pull request adds the x-pack icon for sidebars that are tagged as follows:

````
[role="xpack"]
.Block heading
*******************************************
Block text
*******************************************
````
