### PR TITLE
Update Elastic Cloud and ECE doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -432,7 +432,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             current:    external
-            branches:   [ external ]
+            branches:   [ master, external ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -445,7 +445,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             current:    1.0
-            branches:   [ 1.0, 1.0.1, 1.0.0 ]
+            branches:   [ master, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Two changes here:
- Remove the 1.0.1 and 1.0.0 doc builds now that we are building from 1.0 as our preferred 1.0.x doc branch (depends on redirects to 1.0 being live via https://github.com/elastic/website-www.elastic.co/issues/1782)
- Add builds for master branches for both EC and ECE

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
