### PR TITLE
Bumped versions for 5.6/beta2 and swapped order of ES Java client docs.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -39,7 +39,7 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    5.5
+            current:    5.6
             index:      docs/index.asciidoc
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
@@ -57,7 +57,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      ../elasticsearch-extra/x-pack-elasticsearch/docs/en/index.asciidoc
             chunk:      1
@@ -114,7 +114,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    5.5
+            current:    5.6
             branches:   [master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -130,7 +130,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    5.5
+            current:    5.6
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
@@ -148,9 +148,29 @@ contents:
             base_dir:   en/elasticsearch/client
             sections:
               -
+                title:      Java REST Client
+                prefix:     java-rest
+                current:    5.6
+                branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                index:      docs/java-rest/index.asciidoc
+                tags:       Clients/JavaREST
+                chunk:      1
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-rest
+                  -
+                    repo:   elasticsearch
+                    path:   docs/Versions.asciidoc
+                  -
+                    repo:   elasticsearch
+                    path:   client
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+
+              -
                 title:      Java API
                 prefix:     java-api
-                current:    5.5
+                current:    5.6
                 branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -169,26 +189,6 @@ contents:
                     exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
               -
-                title:      Java REST Client
-                prefix:     java-rest
-                current:    5.5
-                branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                index:      docs/java-rest/index.asciidoc
-                tags:       Clients/JavaREST
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-rest
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                  -
-                    repo:   elasticsearch
-                    path:   client
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-
-              -
                 title:      JavaScript API
                 prefix:     javascript-api
                 current:    13.x
@@ -203,7 +203,7 @@ contents:
               -
                 title:      Groovy API
                 prefix:     groovy-api
-                current:    5.5
+                current:    5.6
                 branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/groovy-api/index.asciidoc
                 tags:       Clients/Groovy
@@ -294,7 +294,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -323,7 +323,7 @@ contents:
             prefix:     en/x-pack
             chunk:      1
             tags:       XPack/Reference
-            current:    5.5
+            current:    5.6
             index:      docs/en/index.asciidoc
             private:    1
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -466,7 +466,7 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      ../x-pack-kibana/docs/en/index.asciidoc
             chunk:      1
@@ -503,7 +503,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      ../logstash-extra/x-pack-logstash/docs/en/index.asciidoc
             chunk:      1
@@ -528,7 +528,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
@@ -564,7 +564,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
@@ -585,7 +585,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
@@ -606,7 +606,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -627,7 +627,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    5.5
+            current:    5.6
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
@@ -653,7 +653,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    5.5
+            current:    5.6
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta2 }, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1

--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -9,4 +9,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:         unreleased
+:release-state:         released


### PR DESCRIPTION
Opening this now so we don't forget to change the order of the client docs to put the Java REST client before the Java API client.