### PR TITLE
Add required perl module installation for Fedora 25

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -26,6 +26,14 @@ First, you need to make sure that you have the following installed:
 
 TIP: Windows users are recommended to use http://www.cygwin.com/[Cygwin] (install `asciidoc` package and `libxslt`).
 
+=== Perl Modules
+
+You may need to install extra perl modules that do not come with your system's `perl` by default. For example, on Fedora 25, you will need to run:
+
+```
+sudo dnf install perl-Storable perl-Digest-MD5
+```
+
 [float]
 == Cloning the repository
 


### PR DESCRIPTION
Without this, the instructions are incomplete and I got errors such as `Can't locate Storable.pm'