### PR TITLE
Add APM Server and Agents to doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2,11 +2,14 @@ paths:
     build:          html/
     repos:          .repos/
     branch_tracker: html/branches.yaml
- 
+
 docs_repo:
     url:            https://github.com/elastic/html-docs.git
 
 repos:
+    apm-server:           https://github.com/elastic/apm-server.git
+    apm-agent-nodejs:     https://github.com/elastic/apm-agent-nodejs.git
+    apm-agent-python:     https://github.com/elastic/apm-agent-python.git
     beats:                https://github.com/elastic/beats.git
     cloud:                https://github.com/elastic/cloud.git
     curator:              https://github.com/elastic/curator.git
@@ -562,7 +565,7 @@ contents:
             branches:   [ master, 6.x, { 6.0: 6.0.0-beta1 }, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
-            sources:            
+            sources:
               -
                 repo:   beats
                 path:   packetbeat
@@ -710,6 +713,51 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+
+    -
+        title:      APM
+        sections:
+          -
+            title:      APM Server
+            prefix:     en/apm/server
+            index:      docs/index.asciidoc
+            current:    master
+            branches:   [ master ]
+            chunk:      1
+            tags:       APM Server/Reference
+            sources:
+              -
+                repo:   apm-server
+                path:   docs
+          -
+            title:      APM Agents
+            base_dir:   en/apm/agent
+            sections:
+              -
+                title:      APM Node.js Agent
+                prefix:     nodejs
+                current:    master
+                branches:   [ master ]
+                index:      docs/index.asciidoc
+                tags:       APM Node.js Agent/Reference
+                chunk:      1
+                sources:
+                  -
+                    repo:   apm-agent-nodejs
+                    path:   docs
+              -
+                title:      APM Python Agent
+                prefix:     python
+                current:    master
+                branches:   [ master ]
+                index:      docs/index.asciidoc
+                tags:       APM Python Agent/Reference
+                chunk:      1
+                sources:
+                  -
+                    repo:   apm-agent-python
+                    path:   docs
+
 
     -
       title:     Docs in Your Native Tongue


### PR DESCRIPTION
This adds the apm server and apm agents to the doc build. On the top level there will be a link to the `APM Server` docs and a link to the `Agents`. The Agents are nested the same way as the Elasticsearch Clients. Under `Agents` there is a list with the Node.js and Python agent at the moment. The docs for now are only shown from `master` as there are no release branches yet.

Server and Agents already have the `docs/index.asciidoc` file in their master branch.

* @roncohen @makwarth Does this structure work for you? Later on we should probably come up with a longer title.
* @debadair I saw that some projects now have `docs/en/index.asciidoc` in the repo itself. Could it make sense to introduce this structure or will this only apply to a subset of repos?
* @dedemorton I was not sure what to put under tags