### PR TITLE
transport.profiles.client.xpack.security.ssl.client_authentication: n…

### DIFF
--- a/html/en/x-pack/5.3/separating-node-client-traffic.html
+++ b/html/en/x-pack/5.3/separating-node-client-traffic.html
@@ -646,7 +646,7 @@ for the client traffic by adding the following to <code class="literal">elastics
 transport.profiles.client.xpack.security.ssl.keystore:
   path: /path/to/another/keystore
   password: changeme</pre></div><p>To change the default behavior that requires certificates for transport clients,
-set the following value in the <code class="literal">elasticsearch.yml</code> file:</p><div class="pre_wrapper"><pre class="programlisting prettyprint lang-yaml">transport.profiles.client.xpack.security.ssl.client_authentication: no</pre></div><p>This setting keeps certificate authentication active for node-to-node traffic,
+set the following value in the <code class="literal">elasticsearch.yml</code> file:</p><div class="pre_wrapper"><pre class="programlisting prettyprint lang-yaml">transport.profiles.client.xpack.security.ssl.client_authentication: none</pre></div><p>This setting keeps certificate authentication active for node-to-node traffic,
 but removes the requirement to distribute a signed certificate to transport
 clients. Please see the <a class="link" href="java-clients.html#transport-client" title="Configuring the Transport Client to work with a Secured Cluster">Transport Client</a> section.</p></div><div class="navfooter"><span class="prev"><a href="ciphers.html">
               « 


### PR DESCRIPTION
…o is not valid value

transport.profiles.client.xpack.security.ssl.client_authentication: no should actually be transport.profiles.client.xpack.security.ssl.client_authentication: none otherwise elasticsearch doesn't start.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
