### PR TITLE
Add apm related asciidoc attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -4,6 +4,9 @@
 :logstash-ref:    http://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:      https://www.elastic.co/guide/en/kibana/{branch}
 :beats-ref:      https://www.elastic.co/guide/en/beats/libbeat/{branch}
+:apm-server-ref:  https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-py-ref:      https://www.elastic.co/guide/en/apm/agent/python/current
+:apm-node-ref:    https://www.elastic.co/guide/en/apm/agent/nodejs/current
 :hadoop-ref:      https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:       http://www.elastic.co/guide/en/elastic-stack/{branch}
 :javaclient:      https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}


### PR DESCRIPTION
I'm not sure if this is the normal procedure for adding new references, so please let me know if I should do this in another way.

We're going to be making a lot of cross reference links in the docs between the different APM components. So having these references will help keep everything nice and clean.