### PR TITLE
Add pwd attribute to shared attributres

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -33,3 +33,5 @@
 :dfeeds:          datafeeds
 :dfeed-cap:       Datafeed
 :dfeeds-cap:      Datafeeds
+
+:pwd:             YOUR_PASSWORD


### PR DESCRIPTION
This centralizes the definition of the password that we show in examples.