### PR TITLE
Rename entry point for APM getting started.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -723,7 +723,7 @@ contents:
           -
             title:      Getting Started with Elastic APM
             prefix:     en/apm/get-started
-            index:      docs/guide/apm-getting-started.asciidoc
+            index:      docs/guide/index.asciidoc
             current:    master
             branches:   [ master ]
             chunk:      1


### PR DESCRIPTION
Change file name to index.asciidoc to be more aligned with standard naming.

