### PR TITLE
Correct statement on bulk failure with create

### DIFF
--- a/html/en/elasticsearch/reference/2.4/docs-bulk.html
+++ b/html/en/elasticsearch/reference/2.4/docs-bulk.html
@@ -629,7 +629,7 @@ optional_source\n</pre></div><p><span class="strong strong"><strong>NOTE</strong
 <code class="literal">index</code> and <code class="literal">create</code> expect a source on the next
 line, and have the same semantics as the <code class="literal">op_type</code> parameter to the
 standard index API (i.e. create will fail if a document with the same
-index and type exists already, whereas index will add or replace a
+<code class="literal">_id</code> and type exists already, whereas index will add or replace a
 document as necessary). <code class="literal">delete</code> does not expect a source on the
 following line, and has the same semantics as the standard delete API.
 <code class="literal">update</code> expects that the partial doc, upsert and script and its options


### PR DESCRIPTION
The current statement seems wrong, "create will fail if a document with the same *index* and type exists already, ...".  It seems like it should read, "create will fail if a document with the same `_id` and type exists already, ...".

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
