### PR TITLE
Add 6.0 version for apm-server documentation.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -724,8 +724,8 @@ contents:
             title:      Getting Started with Elastic APM
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    master
-            branches:   [ master ]
+            current:    6.0
+            branches:   [ master,  { 6.0: 6.0.0-rc2  } ]
             chunk:      1
             tags:       APM Server/Reference
             sources:
@@ -736,8 +736,8 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    master
-            branches:   [ master ]
+            current:    6.0 
+            branches:   [ master,  { 6.0: 6.0.0-rc2  } ]
             chunk:      1
             tags:       APM Server/Reference
             sources:


### PR DESCRIPTION
This should only be merged shortly before rc2 is released.