### PR TITLE
Elastic Cloud docs: Switch to saas-release and retire external branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -437,8 +437,8 @@ contents:
             title:      Elastic Cloud - Hosted Elasticsearch and Kibana
             prefix:     en/cloud
             tags:       Cloud/Reference
-            current:    external
-            branches:   [ master, external ]
+            current:    saas-release
+            branches:   [ master, saas-release ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Elastic Cloud has switched to the `saas-release` branch for service releases. In an effort to keep the code and the docs together, I'd like to switch to the same branch for the current Elastic Cloud docs and to retire the arbitrarily chosen docs-only `external` branch.

Merging this PR should coincide with the release of the Cloud ID on Tuesday Oct 31 (see https://github.com/elastic/cloud/issues/7412), as `saas-external` already contains those docs.