### PR TITLE
[DOCS] Add centralized pipeline configuration management

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -7,8 +7,8 @@ You configure settings for {xpack} features in the `elasticsearch.yml`,
 |Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
 |Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
 |Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Management        |No                             |No                                            |{logstash-ref}/settings-xpack.html#configuration-management-settings[Yes]
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/settings-xpack.html#monitoring-settings[Yes]
+|Management        |No                             |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
 |Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
 |Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
 |Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No


### PR DESCRIPTION
This PR adds links to the Centralized Pipeline Configuration Management settings in the Logstash Reference. 
