### PR TITLE
Change current ECE branch to 1.1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -450,7 +450,7 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
-            current:    1.0
+            current:    1.1
             branches:   [ master, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR sets the current branch for ECE to `1.1`, which is the correct branch when we GA tomorrow morning.

