### PR TITLE
[DOCS] Added --nolinkcheck parameter

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -51,7 +51,7 @@ GetOptions(
     $Opts,    #
     'all', 'push', 'update!',    #
     'single',  'pdf',     'doc=s',           'out=s',  'toc', 'chunk=i',
-    'open',    'nolinkcheck', 'staging', 'procs=i',         'user=s', 'lang=s',
+    'open',    'skiplinkcheck', 'staging', 'procs=i',         'user=s', 'lang=s',
     'lenient', 'verbose', 'reload_template', 'resource=s@'
 ) || exit usage();
 
@@ -191,7 +191,7 @@ sub build_all {
         write_html_redirect( $build_dir->subdir( $_->{prefix} ),
             $_->{redirect} );
     }
-    if ( $Opts->{nolinkcheck} ) {
+    if ( $Opts->{skiplinkcheck} ) {
       say "Skipped Checking links";
       }
      else {
@@ -199,7 +199,7 @@ sub build_all {
        check_links($build_dir);
          }
      push_changes($build_dir)
-     if $Opts->{push};
+       if $Opts->{push};
 }
 
 #===================================
@@ -628,7 +628,7 @@ sub usage {
           --lenient         Ignore linking errors
           --lang            Defaults to 'en'
           --resource        Path to image dir - may be repeated
-          --nolinkcheck     Omit the step that checks for broken links
+          --skiplinkcheck     Omit the step that checks for broken links
 
         WARNING: Anything in the `out` dir will be deleted!
 

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -193,17 +193,13 @@ sub build_all {
     }
     if ( $Opts->{nolinkcheck} ) {
       say "Skipped Checking links";
-
-      push_changes($build_dir)
-      if $Opts->{push};
       }
      else {
        say "Checking links";
        check_links($build_dir);
-
-       push_changes($build_dir)
-           if $Opts->{push};
          }
+     push_changes($build_dir)
+     if $Opts->{push};
 }
 
 #===================================

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -51,7 +51,7 @@ GetOptions(
     $Opts,    #
     'all', 'push', 'update!',    #
     'single',  'pdf',     'doc=s',           'out=s',  'toc', 'chunk=i',
-    'open',    'staging', 'procs=i',         'user=s', 'lang=s',
+    'open',    'nolinkcheck', 'staging', 'procs=i',         'user=s', 'lang=s',
     'lenient', 'verbose', 'reload_template', 'resource=s@'
 ) || exit usage();
 
@@ -191,12 +191,19 @@ sub build_all {
         write_html_redirect( $build_dir->subdir( $_->{prefix} ),
             $_->{redirect} );
     }
+    if ( $Opts->{nolinkcheck} ) {
+      say "Skipped Checking links";
 
-    say "Checking links";
-    check_links($build_dir);
+      push_changes($build_dir)
+      if $Opts->{push};
+      }
+     else {
+       say "Checking links";
+       check_links($build_dir);
 
-    push_changes($build_dir)
-        if $Opts->{push};
+       push_changes($build_dir)
+           if $Opts->{push};
+         }
 }
 
 #===================================
@@ -625,6 +632,7 @@ sub usage {
           --lenient         Ignore linking errors
           --lang            Defaults to 'en'
           --resource        Path to image dir - may be repeated
+          --nolinkcheck     Omit the step that checks for broken links
 
         WARNING: Anything in the `out` dir will be deleted!
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/249

This PR adds the --nolinkcheck parameter, which skips the step that checks links at the end of a --all build.  For example, you can use it as follows:

> ./build_docs.pl —all —nolinkcheck
...
Writing main TOC
Writing extra HTML redirects
Skipped Checking links

This is required for when a broken link is preventing us from successfully publishing the documentation in a time-critical situation.  

The expectation is that any broken links would be fixed as soon as possible and link checking would be resumed immediately thereafter. 
