### PR TITLE
Handle kibana-extra folder

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -333,6 +333,7 @@ contents:
                 path:   docs/en
               -
                 repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
                 exclude_branches:   [ 5.3, 5.2, 5.1, 5.0]
               -
@@ -468,7 +469,7 @@ contents:
             prefix:     en/kibana
             current:    6.0
             branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-            index:      ../x-pack-kibana/docs/en/index.asciidoc
+            index:      ../kibana-extra/x-pack-kibana/docs/en/index.asciidoc
             chunk:      1
             tags:       Kibana/Reference
             sources:
@@ -478,6 +479,7 @@ contents:
                 path:   docs/
               -
                 repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
               -
                 repo:   x-pack-elasticsearch
@@ -862,6 +864,7 @@ contents:
                 -
                   repo: x-pack-kibana
                   path: /docs/jp
+                  prefix: kibana-extra/x-pack-kibana
         -
           title:      한국어
           base_dir:   kr
@@ -929,6 +932,7 @@ contents:
                 -
                   repo: x-pack-kibana
                   path: /docs/kr
+                  prefix: kibana-extra/x-pack-kibana
 
 redirects:
     -


### PR DESCRIPTION
Preparing for x-pack-kibana moving into a `kibana-extra` folder, similarly to `x-pack-elasticsearch` and `x-pack-logstash`, see https://github.com/elastic/kibana/issues/15452.

This is not intended for merge just yet. I'm just going through and preparing all the necessary PRs for this move.