### PR TITLE
set current branch of apm-agent-python to "1.x"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -773,8 +773,8 @@ contents:
               -
                 title:      APM Python Agent
                 prefix:     python
-                current:    master
-                branches:   [ master ]
+                current:    1.x
+                branches:   [ master, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Python Agent/Reference
                 chunk:      1


### PR DESCRIPTION
The master branch will see some incompatibilities landed between
now and 6.2 (when APM goes GA). This should avoid that those
incompatibilities land on
https://www.elastic.co/guide/en/apm/agent/python/current/index.html
before GA.


