### PR TITLE
Fix entry for APM frontend docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -795,6 +795,8 @@ contents:
                 sources:
                   -
                     repo:   apm-agent-ruby
+                    path:   docs
+              -
                 title:      APM Frontend JavaScript Agent
                 prefix:     js-base
                 current:    master


### PR DESCRIPTION
The entry was missing the leading dash and the docs path had been removed.