### PR TITLE
apm-agent-nodejs: add 0.x and 1.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -764,8 +764,8 @@ contents:
               -
                 title:      APM Node.js Agent
                 prefix:     nodejs
-                current:    master
-                branches:   [ master ]
+                current:    0.x
+                branches:   [ master, 0.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Node.js Agent/Reference
                 chunk:      1


### PR DESCRIPTION
In anticipation of the upcoming release of version 1.0.0 of the Node.js APM Agent we have made a `1.x` branch. In the upcoming Kibana 6.2 we have embedded links to the `1.x` version of the Node agent docs, so it's important that this is merged in before the 6.2 release.

Once version 1.0.0 is released I'll make a PR to switch `current` to point to `1.x` instead.