### PR TITLE
[DOCS] Added x-pack-kibana to jp and kr

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -893,6 +893,10 @@ contents:
                   repo: x-pack
                   path: /docs/jp
                 -
+                  repo:   x-pack-kibana
+                  path:   docs/jp
+                  prefix: kibana-extra/x-pack-kibana
+                -
                   repo: x-pack-elasticsearch
                   path: /docs/jp
                   prefix: elasticsearch-extra/x-pack-elasticsearch
@@ -956,6 +960,10 @@ contents:
                 -
                   repo: x-pack
                   path: /docs/kr
+                -
+                  repo: x-pack-kibana
+                  path: /docs/kr
+                  prefix: kibana-extra/x-pack-kibana
                 -
                   repo: x-pack-elasticsearch
                   path: /docs/kr


### PR DESCRIPTION
The Japanese and Korean versions of the X-Pack Reference have dependencies on the x-pack-kibana repository, so this PR adds those dependencies to the conf.yaml.