### PR TITLE
[DOCS] Add links to X-Pack Security auditing settings

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -1,18 +1,22 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header,footer"]
+[options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
-|APM UI            |No                             |{kibana-ref}/apm-settings-kb.html[Yes]        |No
-|Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Management        |No                             |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
-|Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
-|Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
-|Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No
+|{xpack} Feature    |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|APM UI             |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]        |No
+|Development Tools  |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph              |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning   |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Management         |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring         |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting          |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                    |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                    |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher            |{ref}/notification-settings.html[Yes] |No                                            |No
 |=======================
 
 There are also {ref}/license-settings.html[{xpack} license settings] in the

--- a/shared/settings55.asciidoc
+++ b/shared/settings55.asciidoc
@@ -1,7 +1,7 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header,footer"]
+[options="header"]
 |=======================
 |{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
 |Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No

--- a/shared/settings55.asciidoc
+++ b/shared/settings55.asciidoc
@@ -1,14 +1,18 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header"]
+[options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
-|Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/settings-xpack.html#monitoring-settings[Yes]
-|Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
-|Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
-|Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No
+|{xpack} Feature   |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|Development Tools |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph             |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning  |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Monitoring        |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/settings-xpack.html#monitoring-settings[Yes]
+|Reporting         |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                   |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                   |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher           |{ref}/notification-settings.html[Yes] |No                                            |No
 |=======================

--- a/shared/settings56.asciidoc
+++ b/shared/settings56.asciidoc
@@ -1,7 +1,7 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header,footer"]
+[options="header"]
 |=======================
 |{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
 |Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No

--- a/shared/settings56.asciidoc
+++ b/shared/settings56.asciidoc
@@ -1,14 +1,18 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header"]
+[options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
-|Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/settings-xpack.html#monitoring-settings[Yes]
-|Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
-|Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
-|Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No
+|{xpack} Feature   |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|Development Tools |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph             |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning  |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Monitoring        |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/settings-xpack.html#monitoring-settings[Yes]
+|Reporting         |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                   |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                   |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher           |{ref}/notification-settings.html[Yes] |No                                            |No
 |=======================

--- a/shared/settings60.asciidoc
+++ b/shared/settings60.asciidoc
@@ -1,16 +1,19 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header"]
+[options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
-|Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Management        |No                             |No
-|{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
-|Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
-|Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
-|Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No
+|{xpack} Feature   |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|Development Tools |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph             |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning  |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Management        |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring        |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting         |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                   |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                   |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher           |{ref}/notification-settings.html[Yes] |No                                            |No
 |=======================

--- a/shared/settings60.asciidoc
+++ b/shared/settings60.asciidoc
@@ -1,7 +1,7 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header,footer"]
+[options="header"]
 |=======================
 |{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
 |Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No

--- a/shared/settings61.asciidoc
+++ b/shared/settings61.asciidoc
@@ -1,19 +1,22 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header"]
+[options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
-|APM UI            |No                             |{kibana-ref}/apm-settings-kb.html[Yes]        |No
-|Development Tools |No                             |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph             |No                             |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Machine learning  |{ref}/ml-settings.html[Yes]    |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Management        |No                             |No
-|{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
-|Monitoring        |{ref}/monitoring-settings.html[Yes]    |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
-|Reporting         |No                             |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
-|Security          |{ref}/security-settings.html[Yes]      |{kibana-ref}/security-settings-kb.html[Yes]   |No
-|Watcher           |{ref}/notification-settings.html[Yes]    |No                                  |No
+|{xpack} Feature   |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|APM UI            |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]        |No
+|Development Tools |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph             |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning  |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Management        |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring        |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting         |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                   |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                   |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher           |{ref}/notification-settings.html[Yes] |No                                            |No
 |=======================
 
 There are also {ref}/license-settings.html[{xpack} license settings] in the

--- a/shared/settings61.asciidoc
+++ b/shared/settings61.asciidoc
@@ -1,7 +1,7 @@
 You configure settings for {xpack} features in the `elasticsearch.yml`,
 `kibana.yml`, and `logstash.yml` configuration files.
 
-[options="header,footer"]
+[options="header"]
 |=======================
 |{xpack} Feature   |{es} Settings                  |{kib} Settings                                |Logstash Settings
 |APM UI            |No                             |{kibana-ref}/apm-settings-kb.html[Yes]        |No


### PR DESCRIPTION
This PR updates the X-Pack Settings tables to include a link to the new auditing settings page. 