### PR TITLE
[DOCS] Added 6.2 to documentation builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -43,7 +43,7 @@ contents:
             prefix:     en/elastic-stack
             current:    6.1
             index:      docs/index.asciidoc
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
             sources:
               -
@@ -70,7 +70,7 @@ contents:
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      ../elasticsearch-extra/x-pack-elasticsearch/docs/en/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -127,7 +127,7 @@ contents:
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    6.1
-            branches:   [master, 6.x, 6.1, 6.0, 5.6, 5.5]
+            branches:   [master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -144,7 +144,7 @@ contents:
             repo:       elasticsearch
             current:    6.1
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
             sources:
@@ -167,7 +167,7 @@ contents:
                 title:      Java REST Client
                 prefix:     java-rest
                 current:    6.1
-                branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 chunk:      1
@@ -187,7 +187,7 @@ contents:
                 title:      Java API
                 prefix:     java-api
                 current:    6.1
-                branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 chunk:      1
@@ -220,7 +220,7 @@ contents:
                 title:      Groovy API
                 prefix:     groovy-api
                 current:    6.1
-                branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/groovy-api/index.asciidoc
                 tags:       Clients/Groovy
                 sources:
@@ -311,7 +311,7 @@ contents:
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             sources:
@@ -342,7 +342,7 @@ contents:
             current:    6.1
             index:      docs/en/index.asciidoc
             private:    1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             sources:
               -
                 repo:   x-pack
@@ -484,7 +484,7 @@ contents:
             title:      Kibana Reference
             prefix:     en/kibana
             current:    6.1
-            branches:   [ master, 6.x, 6.2 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      ../kibana-extra/x-pack-kibana/docs/en/index.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -542,7 +542,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
             sources:
@@ -557,7 +557,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 6.x, 6.1, 6.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
             sources:
@@ -578,7 +578,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
             sources:
@@ -599,7 +599,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
             sources:
@@ -620,7 +620,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
             sources:
@@ -641,7 +641,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
             sources:
@@ -668,7 +668,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    6.1
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
             sources:
@@ -689,7 +689,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -484,7 +484,7 @@ contents:
             title:      Kibana Reference
             prefix:     en/kibana
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ master, 6.x, 6.2 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      ../kibana-extra/x-pack-kibana/docs/en/index.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -517,7 +517,7 @@ contents:
             title:      Logstash Reference
             prefix:     en/logstash
             current:    6.1
-            branches:   [ master, 6.x, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      ../logstash-extra/x-pack-logstash/docs/en/index.asciidoc
             chunk:      1
             tags:       Logstash/Reference


### PR DESCRIPTION
This PR adds the 6.2 branch to the documentation builds. 
At this time, only the Kibana and Logstash versioning is in place to go ahead with the documentation. 