### PR TITLE
Add versioned plugin docs to the build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -534,6 +534,19 @@ contents:
                 repo:   logstash-docs
                 path:   docs/
 
+          -
+            title:      Logstash Versioned Plugin Reference
+            prefix:     en/logstash/plugins
+            current:    versioned_plugin_docs
+            branches:   [ versioned_plugin_docs ]
+            index:      docs/versioned-plugins/index.asciidoc
+            chunk:      1
+            tags:       Logstash/Plugin Reference
+            sources:
+              -
+                repo:   logstash-docs
+                path:   docs/versioned-plugins
+
     -
         title:      Beats: Collect, Parse, and Ship
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -541,6 +541,7 @@ contents:
             branches:   [ versioned_plugin_docs ]
             index:      docs/versioned-plugins/index.asciidoc
             chunk:      1
+            noindex:    1
             tags:       Logstash/Plugin Reference
             sources:
               -

--- a/conf.yaml
+++ b/conf.yaml
@@ -536,7 +536,7 @@ contents:
 
           -
             title:      Logstash Versioned Plugin Reference
-            prefix:     en/logstash/plugins
+            prefix:     en/logstash/versioned-plugins
             current:    versioned_plugin_docs
             branches:   [ versioned_plugin_docs ]
             index:      docs/versioned-plugins/index.asciidoc


### PR DESCRIPTION
Don't merge this yet. Waiting for final approval from dev team.

Adds the versioned plugin reference to the documentation build. 