### PR TITLE
[DOCS] Updated glossary URL

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -54,7 +54,7 @@ contents:
                 path:   docs/
           -
             title:      Glossary
-            prefix:     en/elastic-stack/glossary
+            prefix:     en/elastic-stack-glossary
             current:    master
             index:      docs/en/glossary/index.asciidoc
             branches:   [ master ]

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -23,7 +23,7 @@
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
-:glossary:             http://www.elastic.co/guide/en/elastic-stack/glossary/current
+:glossary:             http://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 
 :xpack:           X-Pack


### PR DESCRIPTION
This PR updates the URL for the Elastic Stack Glossary. This change was necessary to address documentation build issues. 