### PR TITLE
Added Swiftype placeholder book to the build.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -27,6 +27,7 @@ repos:
     logstash-docs:        https://github.com/elastic/logstash-docs.git
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
+    swiftype:             https://github.com/elastic/swiftype-doc-placeholder.git
     x-pack:               https://github.com/elastic/x-pack.git
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
@@ -743,6 +744,23 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+
+    -
+        title:      Swiftype: Site and Enterprise Search
+        sections:
+          -
+            title:      Site Search Reference
+            prefix:     en/swiftype
+            index:      docs/index.asciidoc
+            private:    1
+            current:    master
+            branches:   [ master ]
+            single:     1
+            tags:       Site Search/Reference
+            sources:
+              -
+                repo:   swiftype
+                path:   docs
 
     -
         title:      APM


### PR DESCRIPTION
The source files are in a new private repo: elastic/swiftype-doc-placeholder 

You can view the generated doc at: https://swiftype-doc.firebaseapp.com