### PR TITLE
Check out client documentation test for java api docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -203,6 +203,10 @@ contents:
                     repo:   elasticsearch
                     path:   client/rest-high-level/src/test/java/org/elasticsearch/client/documentation
                     exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   server/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
               -
                 title:      JavaScript API


### PR DESCRIPTION
This is required to include core snippets from core integration tests using the
transport client API in the documentation.

Opening this to get feedback about if this is the correct way of doing this (looks similar to what was previously done to include code snippets from client/rest-high-level/...). I would need this before merging elastic/elasticsearch#28260