### PR TITLE
[DOCS] Update Elasticsearch doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -72,7 +72,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    6.1
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            index:      ../elasticsearch-extra/x-pack-elasticsearch/docs/en/index.asciidoc
+            index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
             sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -13,7 +13,7 @@
 # Elasticsearch
 alias docbldes='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --chunk 1'
 
-alias docbldesx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/en/index.asciidoc --resource=elasticsearch/docs --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
 alias docbldkb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR is related to https://github.com/elastic/elasticsearch/pull/28469
It updates the conf.yaml and doc_build_aliases.sh to reflect the changed location of the index for the Elasticsearch Reference.