### PR TITLE
Fix URL for versioned plugin reference

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -538,7 +538,7 @@ contents:
 
           -
             title:      Logstash Versioned Plugin Reference
-            prefix:     en/logstash/versioned-plugins
+            prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
             branches:   [ versioned_plugin_docs ]
             index:      docs/versioned-plugins/index.asciidoc


### PR DESCRIPTION
Fixes the doc build so the versioned plugin reference doesn't get build every time you run the doc build with the --all option.
