### PR TITLE
Add 6.2 branch to apm-server project

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -771,7 +771,7 @@ contents:
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.1, 6.0 ]
+            branches:   [ master, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             sources:
@@ -783,7 +783,7 @@ contents:
             prefix:     en/apm/server
             index:      docs/index.asciidoc
             current:    6.1
-            branches:   [ master, 6.1, 6.0 ]
+            branches:   [ master, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             sources:


### PR DESCRIPTION
There's [already a PR](https://github.com/elastic/docs/pull/307) that indirectly adds these, but it would be nice to get this in to `master` prior to that PR is merged so we know that the docs are building without any issues before the release.