### PR TITLE
Meta tags for Swiftype Search

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -46,6 +46,7 @@ contents:
             index:      docs/index.asciidoc
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
+            subject:    Elastic Stack
             sources:
               -
                 repo:   stack-docs
@@ -60,6 +61,7 @@ contents:
             index:      docs/en/glossary/index.asciidoc
             branches:   [ master ]
             tags:       Elastic Stack/Glossary
+            subject:    Elastic Stack
             sources:
               -
                 repo:   stack-docs
@@ -75,6 +77,7 @@ contents:
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
+            subject:    Elasticsearch
             sources:
               -
                 repo:   elasticsearch
@@ -113,6 +116,7 @@ contents:
             index:      book.asciidoc
             chunk:      1
             tags:       Elasticsearch/Definitive Guide
+            subject:    Elasticsearch
             sources:
               -
                 repo:   guide
@@ -126,6 +130,7 @@ contents:
             index:      docs/resiliency/index.asciidoc
             single:     1
             tags:       Elasticsearch/Resiliency Status
+            subject:    Elasticsearch
             sources:
               -
                 repo:   elasticsearch
@@ -138,6 +143,7 @@ contents:
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
+            subject:    Elasticsearch
             sources:
               -
                 repo:   elasticsearch
@@ -154,6 +160,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
+            subject:    Elasticsearch
             sources:
               -
                 repo:   elasticsearch
@@ -177,6 +184,7 @@ contents:
                 branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
+                subject:    Clients
                 chunk:      1
                 sources:
                   -
@@ -197,6 +205,7 @@ contents:
                 branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
+                subject:    Clients
                 chunk:      1
                 sources:
                   -
@@ -218,6 +227,7 @@ contents:
                 branches:   [ 14.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/JavaScript
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch-js
@@ -230,6 +240,7 @@ contents:
                 branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/groovy-api/index.asciidoc
                 tags:       Clients/Groovy
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch
@@ -246,6 +257,7 @@ contents:
                 branches:   [ master, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
+                subject:    Clients
                 chunk:      1
                 sources:
                   -
@@ -259,6 +271,7 @@ contents:
                 branches:   [ master, 6.0, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch-php
@@ -272,6 +285,7 @@ contents:
                 index:      docs/perl/index.asciidoc
                 single:     1
                 tags:       Clients/Perl
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch
@@ -285,6 +299,7 @@ contents:
                 index:      docs/python/index.asciidoc
                 single:     1
                 tags:       Clients/Python
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch
@@ -297,6 +312,7 @@ contents:
                 index:      docs/ruby/index.asciidoc
                 current:    master
                 tags:       Clients/Ruby
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch
@@ -310,6 +326,7 @@ contents:
                 index:      docs/community-clients/index.asciidoc
                 single:     1
                 tags:       Clients/Community
+                subject:    Clients
                 sources:
                   -
                     repo:   elasticsearch
@@ -321,6 +338,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
+            subject:    Elasticsearch
             sources:
               -
                 repo:   elasticsearch-hadoop
@@ -333,6 +351,7 @@ contents:
             branches:   [ 5.x, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
+            subject:    Clients
             sources:
               -
                 repo:   curator
@@ -347,6 +366,7 @@ contents:
             chunk:      1
             tags:       XPack/Reference
             current:    6.2
+            subject:    X-Pack
             index:      docs/en/index.asciidoc
             private:    1
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -370,6 +390,7 @@ contents:
             prefix:     en/marvel
             chunk:      1
             tags:       Marvel/Reference
+            subject:    Marvel
             current:    2.4
             index:      docs/public/marvel/index.asciidoc
             private:    1
@@ -389,6 +410,7 @@ contents:
             prefix:     en/shield
             chunk:      1
             tags:       Shield/Reference
+            subject:    Shield
             current:    2.4
             index:      docs/public/shield/index.asciidoc
             private:    1
@@ -412,6 +434,7 @@ contents:
             prefix:     en/watcher
             chunk:      1
             tags:       Watcher/Reference
+            subject:    Watcher
             current:    2.4
             index:      docs/public/watcher/index.asciidoc
             private:    1
@@ -431,6 +454,7 @@ contents:
             prefix:     en/reporting
             chunk:      1
             tags:       Reporting/Reference
+            subject:    Reporting
             current:    2.4
             index:      docs/public/reporting/index.asciidoc
             branches:   [ 2.4 ]
@@ -445,6 +469,7 @@ contents:
             repo:       x-pack
             chunk:      1
             tags:       Graph/Reference
+            subject:    Graph
             current:    2.4
             index:      docs/public/graph/index.asciidoc
             branches:   [ 2.4, 2.3 ]
@@ -461,6 +486,7 @@ contents:
             title:      Elastic Cloud - Hosted Elasticsearch and Kibana
             prefix:     en/cloud
             tags:       Cloud/Reference
+            subject:    Elastic Cloud
             current:    saas-release
             branches:   [ master, saas-release ]
             index:      docs/saas/index.asciidoc
@@ -474,6 +500,7 @@ contents:
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
+            subject:    ECE
             current:    1.1
             branches:   [ master, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
@@ -495,6 +522,7 @@ contents:
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
+            subject:    Kibana
             sources:
               -
                 repo:   kibana
@@ -512,6 +540,7 @@ contents:
             branches:   [ master ]
             index:      docs/index.asciidoc
             tags:       Elasticsearch/Sense-Editor
+            subject:    Sense
             sources:
               -
                 repo:   sense
@@ -528,6 +557,7 @@ contents:
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
+            subject:    Logstash
             sources:
               -
                 repo:   logstash
@@ -550,6 +580,7 @@ contents:
             chunk:      1
             noindex:    1
             tags:       Logstash/Plugin Reference
+            subject:    Logstash
             sources:
               -
                 repo:   logstash-docs
@@ -566,6 +597,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
+            subject:    libbeat
             sources:
               -
                 repo:   beats
@@ -581,6 +613,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
+            subject:    Beats
             sources:
               -
                 repo:   beats
@@ -602,6 +635,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
+            subject:    Packetbeat
             sources:
               -
                 repo:   beats
@@ -623,6 +657,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
+            subject:    Filebeat
             sources:
               -
                 repo:   beats
@@ -644,6 +679,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
+            subject:    Winlogbeat
             sources:
               -
                 repo:   beats
@@ -665,6 +701,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
+            subject:    Metricbeat
             sources:
               -
                 repo:   beats
@@ -692,6 +729,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
+            subject:    Heartbeat
             sources:
               -
                 repo:   beats
@@ -713,6 +751,7 @@ contents:
             branches:   [ master, 6.x, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
+            subject:    Auditbeat
             sources:
               -
                 repo:   beats
@@ -740,6 +779,7 @@ contents:
             branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
             chunk:      1
             tags:       Topbeat/Reference
+            subject:    Topbeat
             sources:
               -
                 repo:   beats
@@ -763,6 +803,7 @@ contents:
             branches:   [ master ]
             single:     1
             tags:       Site Search/Reference
+            subject:    Swiftype
             sources:
               -
                 repo:   swiftype
@@ -779,6 +820,7 @@ contents:
             branches:   [ master, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
+            subject:    APM
             sources:
               -
                 repo:   apm-server
@@ -794,6 +836,7 @@ contents:
             branches:   [ master, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
+            subject:    APM
             sources:
               -
                 repo:   apm-server
@@ -809,6 +852,7 @@ contents:
                 branches:   [ master, 0.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Node.js Agent/Reference
+                subject:    APM
                 chunk:      1
                 sources:
                   -
@@ -821,6 +865,7 @@ contents:
                 branches:   [ master, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Python Agent/Reference
+                subject:    APM
                 chunk:      1
                 sources:
                   -
@@ -833,6 +878,7 @@ contents:
                 branches:   [ master, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Ruby Agent/Reference
+                subject:    APM
                 chunk:      1
                 sources:
                   -
@@ -845,6 +891,7 @@ contents:
                 branches:   [ master, 0.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Frontend JavaScript Agent/Reference
+                subject:    APM
                 chunk:      1
                 sources:
                   -
@@ -869,6 +916,7 @@ contents:
               chunk:      1
               lang:       zh_cn
               tags:       Elasticsearch/Definitive Guide
+              subject:    Elasticsearch
               sources:
                 -
                   repo: guide-cn
@@ -887,6 +935,7 @@ contents:
               chunk:      1
               lang:       ja
               tags:       Elasticsearch/Reference
+              subject:    Elasticsearch
               sources:
                 -
                   repo: elasticsearch
@@ -903,6 +952,7 @@ contents:
               chunk:      1
               lang:       ja
               tags:       Logstash/Reference
+              subject:    Logstash
               sources:
                 -
                   repo: logstash
@@ -916,6 +966,7 @@ contents:
               chunk:      1
               lang:       ja
               tags:       Kibana/Reference
+              subject:    Kibana
               sources:
                 -
                   repo: kibana
@@ -929,6 +980,7 @@ contents:
               chunk:      1
               lang:       ja
               tags:       X-Pack/Reference
+              subject:    X-Pack
               sources:
                 -
                   repo: x-pack
@@ -955,6 +1007,7 @@ contents:
               chunk:      1
               lang:       ko
               tags:       Elasticsearch/Reference
+              subject:    Elasticsearch
               sources:
                 -
                   repo: elasticsearch
@@ -971,6 +1024,7 @@ contents:
               chunk:      1
               lang:       ko
               tags:       Logstash/Reference
+              subject:    Logstash
               sources:
                 -
                   repo: logstash
@@ -984,6 +1038,7 @@ contents:
               chunk:      1
               lang:       ko
               tags:       Kibana/Reference
+              subject:    Kibana
               sources:
                 -
                   repo: kibana
@@ -997,6 +1052,7 @@ contents:
               chunk:      1
               lang:       ko
               tags:       X-Pack/Reference
+              subject:    X-Pack
               sources:
                 -
                   repo: x-pack

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -109,6 +109,9 @@ sub new {
     my $tags = $args{tags}
         or die "No <tags> specified for book <$title>";
 
+    my $subject = $args{subject}
+        or die "No <subject> specified for book <$title>";
+
     my $lang = $args{lang} || 'en';
 
     bless {
@@ -125,6 +128,7 @@ sub new {
         branch_titles => \%branch_titles,
         current       => $current,
         tags          => $tags,
+        subject       => $subject,
         private       => $args{private} || '',
         noindex       => $args{noindex} || '',
         lang          => $lang
@@ -391,6 +395,7 @@ sub is_multi_version { @{ shift->branches } > 1 }
 sub private          { shift->{private} }
 sub noindex          { shift->{noindex} }
 sub tags             { shift->{tags} }
+sub subject          { shift->{subject} }
 sub source           { shift->{source} }
 sub lang             { shift->{lang} }
 #===================================

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -210,6 +210,7 @@ sub _build_book {
     my $template      = $self->template;
     my $index         = $self->index;
     my $section_title = $self->section_title($branch);
+    my $subject       = $self->subject;
     my $edit_url      = $self->source->edit_url($branch);
     my $lang          = $self->lang;
 
@@ -238,6 +239,7 @@ sub _build_book {
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
                 section_title => $section_title,
+                subject       => $subject,
                 toc           => $self->toc,
                 template      => $template,
                 resource      => [$checkout],
@@ -257,6 +259,7 @@ sub _build_book {
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
                 section_title => $section_title,
+                subject       => $subject,
                 template      => $template,
                 resource      => [$checkout],
             );

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -40,6 +40,7 @@ sub build_chunked {
     my $edit_url  = $opts{edit_url}      || '';
     my $root_dir  = $opts{root_dir}      || '';
     my $section   = $opts{section_title} || '';
+    my $subject   = $opts{subject}       || '';
     my $private   = $opts{private}       || '';
     my $resources = $opts{resource}      || [];
     my $noindex   = $opts{noindex}       || '';
@@ -73,6 +74,7 @@ sub build_chunked {
                 "local.book.multi_version" => $multi,
                 "local.page.header"        => $page_header,
                 "local.book.section.title" => "Learn/Docs/$section",
+                "local.book.subject"       => $subject,
                 "local.noindex"            => $noindex
             ),
             $index
@@ -107,6 +109,7 @@ sub build_single {
     my $edit_url  = $opts{edit_url}      || '';
     my $root_dir  = $opts{root_dir}      || '';
     my $section   = $opts{section_title} || '';
+    my $subject   = $opts{subject}       || '';    
     my $private   = $opts{private}       || '';
     my $noindex   = $opts{noindex}       || '';
     my $resources = $opts{resource}      || [];
@@ -137,6 +140,7 @@ sub build_single {
                 "local.book.multi_version" => $multi,
                 "local.page.header"        => $page_header,
                 "local.book.section.title" => "Learn/Docs/$section",
+                "local.book.subject"       => $subject,
                 "local.noindex"            => $noindex
             ),
             $index

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -1,3 +1,4 @@
+
 <xsl:stylesheet version="1.0"
                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
 
@@ -8,6 +9,9 @@
   <xsl:param name="local.book.multi_version" select="0"/>
   <xsl:param name="local.page.header"></xsl:param>
   <xsl:param name="local.book.section.title">Learn/Docs/</xsl:param>
+  <xsl:param name="local.book.subject"></xsl:param>
+  <xsl:param name="local.book.version"></xsl:param>
+
 
   <!-- header -->
   <xsl:param name="local.noindex" select="''"/>
@@ -42,6 +46,18 @@
     <meta name="DC.type">
       <xsl:attribute name="content">
         <xsl:value-of select="$local.book.section.title" />
+      </xsl:attribute>
+    </meta>
+    <meta name="description" content="{$meta-description}" />
+    <meta name="DC.subject">
+      <xsl:attribute name="content">
+        <xsl:value-of select="$local.book.subject" />
+      </xsl:attribute>
+    </meta>
+    <meta name="description" content="{$meta-description}" />
+    <meta name="DC.identifier">
+      <xsl:attribute name="content">
+        <xsl:value-of select="$local.book.version" />
       </xsl:attribute>
     </meta>
     <xsl:if test="$local.noindex!=''">


### PR DESCRIPTION
These  changes inject two new meta tags into the HTML files, DC.subject and DC.identifier. 

DC.subject is the subject set for each book in conf.yaml. This is the product facet that will be used for filtering in the Swiftype search results and aligns with the tags that the web team is applying to other types of content on the site.

DC.identifier is the version of the book. Explicitly setting the version in a separate meta tag makes it easier to extract.

These tags make it easier to extract and align the information needed for the Swiftype search, without affecting the values currently set in the tags attribute in conf.yaml.