### PR TITLE
Fix broken doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -219,6 +219,10 @@ contents:
                     repo:   elasticsearch
                     path:   client/rest-high-level/src/test/java/org/elasticsearch/client/documentation
                     exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   server/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
               -
                 title:      JavaScript API


### PR DESCRIPTION
Fixes issue in the broken doc build. I had to exclude all branches because this file was added to master only. Someone will need to update the exclude_branches setting when https://github.com/elastic/elasticsearch/pull/28814 gets ported to other branches.

@debadair 