### PR TITLE
Uses localhost:9200 for ES copy as curl

### DIFF
--- a/resources/web/docs.js
+++ b/resources/web/docs.js
@@ -230,9 +230,7 @@ jQuery(function() {
       function() {
         var div = jQuery(this);
         var snippet = div.attr('data-snippet');
-        div.html('<a class="sense_widget copy_as_curl" data-host="'
-          + sense_url
-          + '">'
+        div.html('<a class="sense_widget copy_as_curl" data-curl-host="localhost:9200">'
           + Strings['Copy as cURL']
           + '</a>'
           + '<a class="sense_widget" target="sense" '
@@ -262,9 +260,7 @@ jQuery(function() {
       function() {
         var div = jQuery(this);
         var snippet = div.attr('data-snippet');
-        div.html('<a class="sense_widget copy_as_curl" data-host="'
-          + console_url
-          + '">'
+        div.html('<a class="sense_widget copy_as_curl" data-curl-host="localhost:9200">'
           + Strings['Copy as cURL']
           + '</a>'
           + '<a class="console_widget" target="console" '
@@ -304,7 +300,7 @@ jQuery(function() {
       var regex = console_regex();
       var div = jQuery(this);
       var consoleText = div.parent().prev().text() + '\n';
-      var host = div.data('host');
+      var host = div.data('curl-host');
       var curlText = '';
       var match;
 
@@ -392,7 +388,7 @@ jQuery(function() {
       function() {
         var div = jQuery(this);
         var snippet = div.attr('data-snippet');
-        div.html('<a class="kibana_widget copy_as_curl" data-host="'
+        div.html('<a class="kibana_widget copy_as_curl" data-curl-host="'
           + kibana_url
           + '" data-kibana="true">'
           + Strings['Copy as cURL']


### PR DESCRIPTION
In #309 we began using the configured host for the "Copy as Curl" commands. However, the currently configured host is the Sense/Console host and not the ES host. Until we allow the ES host to be configurable in the way the Console/Sense host is, we will go back to using `localhost:9200`