### PR TITLE
[DOCS] Added --resources for Stack Overview Guide in conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,13 +78,12 @@ contents:
               -
                 repo:   stack-docs
                 path:   x-pack/docs/en
-              -  
+              -
                 repo:   elasticsearch
                 path:   x-pack/docs
               - 
                 repo:   kibana
-                path:   x-pack/docs  
-                
+                path:   x-pack/docs
     -
         title:      Elasticsearch Store, Search, and Analyze
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -78,6 +78,13 @@ contents:
               -
                 repo:   stack-docs
                 path:   x-pack/docs/en
+              -  
+                repo:   elasticsearch
+                path:   x-pack/docs
+              - 
+                repo:   kibana
+                path:   x-pack/docs  
+                
     -
         title:      Elasticsearch Store, Search, and Analyze
         sections:


### PR DESCRIPTION
This PR fixes the Stack Overview Guide in the conf.yaml, so that it uses the same syntax as the successful command in the doc_build_aliases.sh.  That is to say:

'$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
