### PR TITLE
[DOCS] Adds qa/sql to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -130,7 +130,10 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/docs
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
+              -
+                repo:   elasticsearch
+                path:   x-pack/qa/sql
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           -
             title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide


### PR DESCRIPTION
This PR adds the x-pack/qa/sql resource for building the Elasticsearch Reference in 6.x and master branches.  That directory contains files that are used for code snippet testing. 