### PR TITLE
[DOCS] Fixes Logstash path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -610,8 +610,7 @@ contents:
                 path:   docs/
               -
                 repo:   logstash
-                prefix: x-pack/docs
-                path:   docs/en
+                path:   x-pack/docs
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5]
 
           -


### PR DESCRIPTION
This PR corrects the path for the Logstash Reference in the conf.yaml to address documentation build errors. 