### PR TITLE
Add info about shared attributes

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -744,16 +744,38 @@ same as external links. However, for conciseness and
 maintainability, you should use an _attribute_ to
 represent the absolute URL of the docs.
 
-Attributes can be added to the beginning of the docs,
-under the book title:
+If possible, use attributes defined in the
+https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc[shared
+attributes file] to resolve links:
 
-.Using attributes for cross-document linking
+.Using shared attributes for cross-document linking
 ==================================
 
 [source,asciidoc]
 ----------------------------------
 = My Book Title
-:ref:  http://www.elastic.co/guide/elasticsearch/reference/current
+
+\include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+Here is a link to the {ref}/search.html[search page]
+----------------------------------
+
+Here is a link to the {ref}/search.html[search page]
+==================================
+
+
+For books that don't use the
+https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc[shared
+attributes file], the attributes appear at the beginning of the docs, under the
+book title:
+
+.Using book-scoped attributes for cross-document linking
+==================================
+
+[source,asciidoc]
+----------------------------------
+= My Book Title
+:ref:  https://www.elastic.co/guide/en/elasticsearch/reference/current
 
 Here is a link to the {ref}/search.html[search page]
 ----------------------------------


### PR DESCRIPTION
Devs and contributors are confused about how to do this now. I think we need to continue to mention that attributes can be defined in under the book title (until we get the whole library cleaned up), or people will be confused.