### PR TITLE
Add saas-release-v2 branch for UCv2 docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -523,7 +523,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    saas-release
-            branches:   [ master, saas-release ]
+            branches:   [ master, saas-release-v2, saas-release ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Two purposes for this branch:

1. Build UCv2 docs for testing
2. Have a Plan B in case we don't have a hard cut-over from UCv1 to UCv2

