### PR TITLE
[DOCS] Adds CHANGELOG.asciidoc

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -117,6 +117,10 @@ contents:
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
+                path:   docs/CHANGELOG.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]  
+              -
+                repo:   elasticsearch
                 path:   docs/src/test/cluster/config
                 exclude_branches:   [ 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -


### PR DESCRIPTION
This PR adds a reference to the CHANGELOG.asciidoc in the conf.yaml, since it was otherwise not being found during the ./build_docs.pl --all build. 