### PR TITLE
conf: add apm-agent-go repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -12,6 +12,7 @@ repos:
     apm-agent-python:     https://github.com/elastic/apm-agent-python.git
     apm-agent-ruby:       https://github.com/elastic/apm-agent-ruby.git
     apm-agent-js-base:    https://github.com/elastic/apm-agent-js-base.git
+    apm-agent-go:         https://github.com/elastic/apm-agent-go.git
     beats:                https://github.com/elastic/beats.git
     cloud:                https://github.com/elastic/cloud.git
     curator:              https://github.com/elastic/curator.git
@@ -961,6 +962,19 @@ contents:
                 sources:
                   -
                     repo:   apm-agent-js-base
+                    path:   docs
+              -
+                title:      APM Go Agent
+                prefix:     go
+                current:    master
+                branches:   [ master ]
+                index:      docs/index.asciidoc
+                tags:       APM Go Agent/Reference
+                subject:    APM
+                chunk:      1
+                sources:
+                  -
+                    repo:   apm-agent-go
                     path:   docs
 
 


### PR DESCRIPTION
I've just added asciidoc to the elastic/apm-agent-go repo, and would like to include it on elastic.co.