### PR TITLE
[DOCS] Replaces OSS-only doc build command aliases

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -11,27 +11,27 @@
 
 
 # Elasticsearch
-alias docbldes='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --chunk 1'
-
 alias docbldesx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+
+alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
 alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
-alias docbldkb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
-
 alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs/ --chunk 1'
+
+alias docbldkb=docbldkbx
 
 # Kibana 6.2 and earlier
 
 alias docbldkbold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
-
 alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash/x-pack/docs/ --chunk 1'
+
+alias docbldls=docbldlsx
 
 # Logstash 6.2 and earlier
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -17,7 +17,7 @@ alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
 alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs/ --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -29,7 +29,7 @@ alias docbldkb=docbldkbx
 alias docbldkbold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash/x-pack/docs/ --chunk 1'
+alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash/x-pack/docs/ --chunk 1'
 
 alias docbldls=docbldlsx
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -20,7 +20,7 @@ alias docbldes=docbldesx
 alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
-alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs/ --chunk 1'
+alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs/ --chunk 1'
 
 alias docbldkb=docbldkbx
 


### PR DESCRIPTION
This PR updates the doc_build_aliases.sh file such that people who are using the aliases to build OSS-only documentation now build the full documentation instead. 

Related to https://github.com/elastic/logstash/issues/9596, https://github.com/elastic/kibana/issues/19156, and https://github.com/elastic/elasticsearch/issues/30665

The following PRs should be merged first:
https://github.com/elastic/kibana/pull/19192
https://github.com/elastic/logstash/pull/9607
https://github.com/elastic/elasticsearch/pull/30707