### PR TITLE
[DOCS] Updates Kibana Reference to use index.asciidoc

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -556,7 +556,7 @@ contents:
             prefix:     en/kibana
             current:    6.2
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-            index:      docs/index.x.asciidoc
+            index:      docs/index.asciidoc
             chunk:      1
             tags:       Kibana/Reference
             subject:    Kibana


### PR DESCRIPTION
Related to https://github.com/elastic/logstash/issues/9596, https://github.com/elastic/kibana/issues/19156, and https://github.com/elastic/elasticsearch/issues/30665

The following PRs should be merged first:
https://github.com/elastic/kibana/pull/19192
https://github.com/elastic/docs/pull/354
