### PR TITLE
Change Elastic Cloud current for UCv2

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -525,7 +525,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release
+            current:    saas-release-v2
             branches:   [ master, saas-release-v2, saas-release ]
             index:      docs/saas/index.asciidoc
             chunk:      1


### PR DESCRIPTION
With UCv2 out, we need to change `current`.
