### PR TITLE
Add Heroku doc builds for Cloud

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -526,7 +526,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    saas-release-v2
-            branches:   [ master, saas-release-v2, saas-release ]
+            branches:   [ master, saas-release-v2, saas-release saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud/issues/15752. We need to start building Heroku docs as part of the UCv2 clean-up work.


