### PR TITLE
Elastic Cloud: Switch current for DNT and remove saas-release-v2  (merge on Aug 1)

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -525,7 +525,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release-v2
+            current:    saas-release
             branches:   [ master, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -526,7 +526,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    saas-release-v2
-            branches:   [ master, saas-release-v2, saas-release, saas-release-heroku ]
+            branches:   [ master, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
With UCv2 out the door, one clean-up item is to remove our `saas-release-v2` builds, as UCv2 docs will build out of `saas-release`.

Depends on merging down `saas-release-v2` into `saas-release` via  https://github.com/elastic/cloud/pull/15813 
Depends on changing help links from UCv2 to `saas-release` via https://github.com/elastic/cloud/issues/15816
Relates to UCv2 clean-up https://github.com/elastic/cloud/issues/15752 
