### PR TITLE
[DOCS] Remove x-pack/docs from Logstash, Kibana, and Stack Overview doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -573,10 +573,6 @@ contents:
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
                 exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   kibana
-                path:   x-pack/docs
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
           -
             title:      Legacy Sense Editor for 4.x

--- a/conf.yaml
+++ b/conf.yaml
@@ -615,11 +615,6 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
-              -
-                repo:   logstash
-                path:   x-pack/docs
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5]
-
           -
             title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins

--- a/conf.yaml
+++ b/conf.yaml
@@ -81,7 +81,7 @@ contents:
             sources:
               -
                 repo:   stack-docs
-                path:   docs/en/stack
+                path:   x-pack/docs/en
               -
                 repo:   elasticsearch
                 path:   x-pack/docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -73,7 +73,7 @@ contents:
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
             current:    6.3
-            index:      docs/en/stack/index.asciidoc
+            index:      x-pack/docs/en/index.asciidoc
             branches:   [ master, 6.x, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview

--- a/conf.yaml
+++ b/conf.yaml
@@ -73,7 +73,7 @@ contents:
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
             current:    6.3
-            index:      x-pack/docs/en/index.asciidoc
+            index:      docs/en/stack/index.asciidoc
             branches:   [ master, 6.x, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
@@ -81,12 +81,9 @@ contents:
             sources:
               -
                 repo:   stack-docs
-                path:   x-pack/docs/en
+                path:   docs/en/stack
               -
                 repo:   elasticsearch
-                path:   x-pack/docs
-              -
-                repo:   kibana
                 path:   x-pack/docs
               -
                 repo:   kibana

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -20,7 +20,7 @@ alias docbldes=docbldesx
 alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
-alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs/ --chunk 1'
+alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
 
 alias docbldkb=docbldkbx
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -42,7 +42,7 @@ alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/in
 
 alias docbldgls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
-alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana/x-pack/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -29,7 +29,7 @@ alias docbldkb=docbldkbx
 alias docbldkbold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash/x-pack/docs/ --chunk 1'
+alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
 
 alias docbldls=docbldlsx
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -42,7 +42,7 @@ alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/in
 
 alias docbldgls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
-alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Related to https://github.com/elastic/logstash/issues/9596 and https://github.com/elastic/kibana/issues/19156

This PR removes references to the x-pack/docs directories in the elastic/logstash and elastic/kibana repos, since that directory doesn't exist anymore in 6.3+
