### PR TITLE
[DOCS] Updates stack overview location

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -73,7 +73,7 @@ contents:
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
             current:    6.3
-            index:      x-pack/docs/en/index.asciidoc
+            index:      docs/en/stack/index.asciidoc
             branches:   [ master, 6.x, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
@@ -81,7 +81,7 @@ contents:
             sources:
               -
                 repo:   stack-docs
-                path:   x-pack/docs/en
+                path:   docs/en/stack
               -
                 repo:   elasticsearch
                 path:   x-pack/docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -42,7 +42,7 @@ alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/in
 
 alias docbldgls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
-alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/49

This PR updates the conf.yaml and build commands to find the new location of the Stack Overview source files. 