### PR TITLE
shared/attributes: add apm-forum

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -37,6 +37,7 @@
 :watcher-forum:        https://discuss.elastic.co/c/x-pack/watcher
 :monitoring-forum:     https://discuss.elastic.co/c/x-pack/marvel
 :graph-forum:          https://discuss.elastic.co/c/x-pack/graph
+:apm-forum:            https://discuss.elastic.co/c/apm
 
 :stack:           Elastic Stack
 :xpack:           X-Pack


### PR DESCRIPTION
Add a new attribute for APM docs to link to Discuss.