### PR TITLE
shared/attributes: add apm-server-ref-62

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -13,6 +13,7 @@
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current


### PR DESCRIPTION
Add the apm-server-ref-62 attribute for referring
to version 6.2 specifically, when another branch
is used generally.

(In the Frontend JavaScript APM Agent docs
we use "current" generally, but make specific
reference to 6.2 in one case.)