### PR TITLE
Add note about --resources parameter

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -95,6 +95,14 @@ build_docs.pl --doc path/to/index.asciidoc
 To use simplified aliases for the build commands for each book, see
 `doc_build_aliases.sh`. 
 
+NOTE: Some documentation parts, e.g. the Elasticseach reference
+documentation, may need additional resources specified with the 
+`--resource` parameter. If you get errors with a particular book,
+you should consult the above mentioned alias file as well. For 
+example, to build the Elasticsearch reference documentation, you
+will need to run  
+`build_docs.pl --doc docs/reference/index.asciidoc --resource=x-pack/docs/` 
+
 === Specifying a different output dir
 
 By default, the HTML docs are generated in `./html_docs`. You can


### PR DESCRIPTION
After the x-pack merge, building the Elasticsearch reference documentation
requires specifying additional resources using the `--resource` parameter.
This change adds a note to check the doc_build_aliases.sh file if ommiting this
parameter leads to errors and adds an example for building the reference
documentation.