### PR TITLE
Add shared folder for Cloud docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -535,6 +535,10 @@ contents:
               -
                 repo:   cloud
                 path:   docs/saas
+              -
+                repo:   cloud
+                path:   docs/shared
+              
          -
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
@@ -549,6 +553,9 @@ contents:
               -
                 repo:   cloud
                 path:   docs/cloud-enterprise
+              -
+                repo:   cloud
+                path:   docs/shared
 
     -
         title:      Kibana: Explore, Visualize, and Share


### PR DESCRIPTION
We started single-sourcing some content in a shared folder. Looks like we might need to add that folder for the builds to work.

