### PR TITLE
Exclude certain branches for shared folder

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -538,6 +538,7 @@ contents:
               -
                 repo:   cloud
                 path:   docs/shared
+                exclude_branches: [ saas-release-v2, saas-release-heroku ]
               
          -
             title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
@@ -556,6 +557,7 @@ contents:
               -
                 repo:   cloud
                 path:   docs/shared
+                exclude_branches: [ 1.0 ]
 
     -
         title:      Kibana: Explore, Visualize, and Share


### PR DESCRIPTION
Looks like the builds are failing because the `shared` folder isn't in all branches (and shouldn't be). This PR excludes the folder from the branches that don't need the folder.

