### PR TITLE
[DOCS] Set current documentation to 6.3

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -46,7 +46,7 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    6.2
+            current:    6.3
             index:      docs/index.asciidoc
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
@@ -95,7 +95,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -169,7 +169,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    6.2
+            current:    6.3
             branches:   [master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -186,7 +186,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    6.2
+            current:    6.3
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
@@ -211,7 +211,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    6.2
+                current:    6.3
                 branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
@@ -232,7 +232,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    6.2
+                current:    6.3
                 branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -373,7 +373,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -565,7 +565,7 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -600,7 +600,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -640,7 +640,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
@@ -678,7 +678,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
@@ -700,7 +700,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
@@ -722,7 +722,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -744,7 +744,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
@@ -771,7 +771,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    6.2
+            current:    6.3
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
@@ -794,7 +794,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
@@ -876,7 +876,7 @@ contents:
             title:      Getting Started with Elastic APM
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
@@ -892,7 +892,7 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    6.2
+            current:    6.3
             branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference

--- a/shared/versions63.asciidoc
+++ b/shared/versions63.asciidoc
@@ -9,4 +9,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released


### PR DESCRIPTION
This PR sets the state of the Stack Overview and Kibana Reference to "released" and changes the "current" documentation version to 6.3 in the conf.yaml.

This PR should not be merged until the day of the release.