### PR TITLE
[DOCS] Lowers X-Pack Reference on documentation site

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -395,129 +395,6 @@ contents:
               -
                 repo:   curator
                 path:   docs/asciidoc
-
-    -
-        title:      X-Pack Extension Pack for the Elastic Stack
-        sections:
-          -
-            title:      X-Pack Reference
-            prefix:     en/x-pack
-            chunk:      1
-            tags:       XPack/Reference
-            current:    6.2
-            subject:    X-Pack
-            index:      docs/en/index.asciidoc
-            private:    1
-            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/en
-              -
-                repo:   x-pack-kibana
-                prefix: kibana-extra/x-pack-kibana
-                path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
-              -
-                repo:   x-pack-elasticsearch
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-                path:   docs/en
-                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
-
-          -
-            title:      Legacy Marvel Reference for 2.x and 1.x
-            prefix:     en/marvel
-            chunk:      1
-            tags:       Marvel/Reference
-            subject:    Marvel
-            current:    2.4
-            index:      docs/public/marvel/index.asciidoc
-            private:    1
-            branches:
-              - 2.4
-              - 2.3
-              - 2.2
-              - 2.1
-              - 2.0
-              - marvel-1.3: 1.3
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/marvel
-          -
-            title:      Legacy Shield Reference for 2.x and 1.x
-            prefix:     en/shield
-            chunk:      1
-            tags:       Shield/Reference
-            subject:    Shield
-            current:    2.4
-            index:      docs/public/shield/index.asciidoc
-            private:    1
-            branches:
-                - 2.4
-                - 2.3
-                - 2.2
-                - 2.1
-                - 2.0
-                - shield-1.3: 1.3
-                - shield-1.2: 1.2
-                - shield-1.1: 1.1
-                - shield-1.0: 1.0
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/shield
-
-          -
-            title:      Legacy Watcher Reference for 2.x and 1.x
-            prefix:     en/watcher
-            chunk:      1
-            tags:       Watcher/Reference
-            subject:    Watcher
-            current:    2.4
-            index:      docs/public/watcher/index.asciidoc
-            private:    1
-            branches:
-                - 2.4
-                - 2.3
-                - 2.2
-                - 2.1
-                - 2.0
-                - watcher-1.0: 1.0
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/watcher
-          -
-            title:      Legacy Reporting Reference for 2.x
-            prefix:     en/reporting
-            chunk:      1
-            tags:       Reporting/Reference
-            subject:    Reporting
-            current:    2.4
-            index:      docs/public/reporting/index.asciidoc
-            branches:   [ 2.4 ]
-            private:    1
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/reporting
-          -
-            title:      Legacy Graph Reference for 2.x
-            prefix:     en/graph
-            repo:       x-pack
-            chunk:      1
-            tags:       Graph/Reference
-            subject:    Graph
-            current:    2.4
-            index:      docs/public/graph/index.asciidoc
-            branches:   [ 2.4, 2.3 ]
-            private:    1
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/graph
-
     -
         title:      Cloud Provision, Manage and Monitor the Elastic Stack
         sections:
@@ -983,9 +860,104 @@ contents:
                   -
                     repo:   apm-agent-java
                     path:   docs
-
-
-
+    -
+        title:      X-Pack Extension Pack for the Elastic Stack
+        sections:
+          -
+            title:      X-Pack Reference
+            prefix:     en/x-pack
+            chunk:      1
+            tags:       XPack/Reference
+            current:    6.2
+            subject:    X-Pack
+            index:      docs/en/index.asciidoc
+            private:    1
+            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/en
+              -
+                repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
+                path:   docs/en
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   docs/en
+                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+          -
+            title:      Legacy Marvel Reference for 2.x and 1.x
+            prefix:     en/marvel
+            chunk:      1
+            tags:       Marvel/Reference
+            subject:    Marvel
+            current:    2.4
+            index:      docs/public/marvel/index.asciidoc
+            private:    1
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/marvel
+          -
+            title:      Legacy Shield Reference for 2.x and 1.x
+            prefix:     en/shield
+            chunk:      1
+            tags:       Shield/Reference
+            subject:    Shield
+            current:    2.4
+            index:      docs/public/shield/index.asciidoc
+            private:    1
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/shield
+          -
+            title:      Legacy Watcher Reference for 2.x and 1.x
+            prefix:     en/watcher
+            chunk:      1
+            tags:       Watcher/Reference
+            subject:    Watcher
+            current:    2.4
+            index:      docs/public/watcher/index.asciidoc
+            private:    1
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/watcher
+          -
+            title:      Legacy Reporting Reference for 2.x
+            prefix:     en/reporting
+            chunk:      1
+            tags:       Reporting/Reference
+            subject:    Reporting
+            current:    2.4
+            index:      docs/public/reporting/index.asciidoc
+            branches:   [ 2.4 ]
+            private:    1
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/reporting
+          -
+            title:      Legacy Graph Reference for 2.x
+            prefix:     en/graph
+            repo:       x-pack
+            chunk:      1
+            tags:       Graph/Reference
+            subject:    Graph
+            current:    2.4
+            index:      docs/public/graph/index.asciidoc
+            branches:   [ 2.4, 2.3 ]
+            private:    1
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/graph
     -
       title:     Docs in Your Native Tongue
       sections:


### PR DESCRIPTION
This PR moves the X-Pack Reference to a lower position on the documentation site, since it won't be updated for 6.3 or later releases.