### PR TITLE
[DOCS] Creates a Legacy Documentation section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -458,19 +458,6 @@ contents:
                 path:   docs/en
                 exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
-          -
-            title:      Legacy Sense Editor for 4.x
-            prefix:     en/sense
-            current:    master
-            branches:   [ master ]
-            index:      docs/index.asciidoc
-            tags:       Elasticsearch/Sense-Editor
-            subject:    Sense
-            sources:
-              -
-                repo:   sense
-                path:   docs/
-
     -
         title:      Logstash: Collect, Enrich, and Transport
         sections:
@@ -1058,7 +1045,7 @@ contents:
         title:      Legacy Documentation
         sections:
           -
-            title:      X-Pack Reference
+            title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack
             chunk:      1
             tags:       XPack/Reference
@@ -1082,6 +1069,18 @@ contents:
                 path:   docs/en
                 exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
           -
+            title:      Sense Editor for 4.x
+            prefix:     en/sense
+            current:    master
+            branches:   [ master ]
+            index:      docs/index.asciidoc
+            tags:       Elasticsearch/Sense-Editor
+            subject:    Sense
+            sources:
+              -
+                repo:   sense
+                path:   docs/            
+          -  
             title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -861,104 +861,6 @@ contents:
                     repo:   apm-agent-java
                     path:   docs
     -
-        title:      X-Pack Extension Pack for the Elastic Stack
-        sections:
-          -
-            title:      X-Pack Reference
-            prefix:     en/x-pack
-            chunk:      1
-            tags:       XPack/Reference
-            current:    6.2
-            subject:    X-Pack
-            index:      docs/en/index.asciidoc
-            private:    1
-            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/en
-              -
-                repo:   x-pack-kibana
-                prefix: kibana-extra/x-pack-kibana
-                path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
-              -
-                repo:   x-pack-elasticsearch
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-                path:   docs/en
-                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
-          -
-            title:      Legacy Marvel Reference for 2.x and 1.x
-            prefix:     en/marvel
-            chunk:      1
-            tags:       Marvel/Reference
-            subject:    Marvel
-            current:    2.4
-            index:      docs/public/marvel/index.asciidoc
-            private:    1
-            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/marvel
-          -
-            title:      Legacy Shield Reference for 2.x and 1.x
-            prefix:     en/shield
-            chunk:      1
-            tags:       Shield/Reference
-            subject:    Shield
-            current:    2.4
-            index:      docs/public/shield/index.asciidoc
-            private:    1
-            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/shield
-          -
-            title:      Legacy Watcher Reference for 2.x and 1.x
-            prefix:     en/watcher
-            chunk:      1
-            tags:       Watcher/Reference
-            subject:    Watcher
-            current:    2.4
-            index:      docs/public/watcher/index.asciidoc
-            private:    1
-            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/watcher
-          -
-            title:      Legacy Reporting Reference for 2.x
-            prefix:     en/reporting
-            chunk:      1
-            tags:       Reporting/Reference
-            subject:    Reporting
-            current:    2.4
-            index:      docs/public/reporting/index.asciidoc
-            branches:   [ 2.4 ]
-            private:    1
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/reporting
-          -
-            title:      Legacy Graph Reference for 2.x
-            prefix:     en/graph
-            repo:       x-pack
-            chunk:      1
-            tags:       Graph/Reference
-            subject:    Graph
-            current:    2.4
-            index:      docs/public/graph/index.asciidoc
-            branches:   [ 2.4, 2.3 ]
-            private:    1
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/public/graph
-    -
       title:     Docs in Your Native Tongue
       sections:
         -
@@ -1151,6 +1053,105 @@ contents:
                   repo: x-pack-elasticsearch
                   path: /docs/kr
                   prefix: elasticsearch-extra/x-pack-elasticsearch
+
+    -
+        title:      Legacy Documentation
+        sections:
+          -
+            title:      X-Pack Reference
+            prefix:     en/x-pack
+            chunk:      1
+            tags:       XPack/Reference
+            current:    6.2
+            subject:    X-Pack
+            index:      docs/en/index.asciidoc
+            private:    1
+            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/en
+              -
+                repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
+                path:   docs/en
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   docs/en
+                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+          -
+            title:      Legacy Marvel Reference for 2.x and 1.x
+            prefix:     en/marvel
+            chunk:      1
+            tags:       Marvel/Reference
+            subject:    Marvel
+            current:    2.4
+            index:      docs/public/marvel/index.asciidoc
+            private:    1
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/marvel
+          -
+            title:      Legacy Shield Reference for 2.x and 1.x
+            prefix:     en/shield
+            chunk:      1
+            tags:       Shield/Reference
+            subject:    Shield
+            current:    2.4
+            index:      docs/public/shield/index.asciidoc
+            private:    1
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/shield
+          -
+            title:      Legacy Watcher Reference for 2.x and 1.x
+            prefix:     en/watcher
+            chunk:      1
+            tags:       Watcher/Reference
+            subject:    Watcher
+            current:    2.4
+            index:      docs/public/watcher/index.asciidoc
+            private:    1
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/watcher
+          -
+            title:      Legacy Reporting Reference for 2.x
+            prefix:     en/reporting
+            chunk:      1
+            tags:       Reporting/Reference
+            subject:    Reporting
+            current:    2.4
+            index:      docs/public/reporting/index.asciidoc
+            branches:   [ 2.4 ]
+            private:    1
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/reporting
+          -
+            title:      Legacy Graph Reference for 2.x
+            prefix:     en/graph
+            repo:       x-pack
+            chunk:      1
+            tags:       Graph/Reference
+            subject:    Graph
+            current:    2.4
+            index:      docs/public/graph/index.asciidoc
+            branches:   [ 2.4, 2.3 ]
+            private:    1
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/public/graph
 
 redirects:
     -

--- a/conf.yaml
+++ b/conf.yaml
@@ -1079,8 +1079,8 @@ contents:
             sources:
               -
                 repo:   sense
-                path:   docs/            
-          -  
+                path:   docs
+          -
             title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -1082,7 +1082,7 @@ contents:
                 path:   docs/en
                 exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
           -
-            title:      Legacy Marvel Reference for 2.x and 1.x
+            title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1
             tags:       Marvel/Reference
@@ -1096,7 +1096,7 @@ contents:
                 repo:   x-pack
                 path:   docs/public/marvel
           -
-            title:      Legacy Shield Reference for 2.x and 1.x
+            title:      Shield Reference for 2.x and 1.x
             prefix:     en/shield
             chunk:      1
             tags:       Shield/Reference
@@ -1110,7 +1110,7 @@ contents:
                 repo:   x-pack
                 path:   docs/public/shield
           -
-            title:      Legacy Watcher Reference for 2.x and 1.x
+            title:      Watcher Reference for 2.x and 1.x
             prefix:     en/watcher
             chunk:      1
             tags:       Watcher/Reference
@@ -1124,7 +1124,7 @@ contents:
                 repo:   x-pack
                 path:   docs/public/watcher
           -
-            title:      Legacy Reporting Reference for 2.x
+            title:      Reporting Reference for 2.x
             prefix:     en/reporting
             chunk:      1
             tags:       Reporting/Reference
@@ -1138,7 +1138,7 @@ contents:
                 repo:   x-pack
                 path:   docs/public/reporting
           -
-            title:      Legacy Graph Reference for 2.x
+            title:      Graph Reference for 2.x
             prefix:     en/graph
             repo:       x-pack
             chunk:      1


### PR DESCRIPTION
This PR creates a "Legacy Documentation" section, which contains the old X-Pack, Shield, Marvel, Watcher, and Reporting documentation.  Additional legacy content can be added to that section in subsequent PRs.