### PR TITLE
Add attribute for APM RUM agent.

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -17,6 +17,7 @@
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
+:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/js-base/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}


### PR DESCRIPTION
We need an additional attribute pointing to the real user monitoring agent, so we can refer to it from the APM Server docs. 