### PR TITLE
Update for hosted Elasticsearch Service name change (do not merge, yet)

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -386,10 +386,10 @@ contents:
         title:      Cloud Provision, Manage and Monitor the Elastic Stack
         sections:
          -
-            title:      Elastic Cloud - Hosted Elasticsearch and Kibana
+            title:      Elasticsearch Service - Hosted Elasticsearch and Kibana
             prefix:     en/cloud
             tags:       Cloud/Reference
-            subject:    Elastic Cloud
+            subject:    Elasticsearch Service
             current:    saas-release-v2
             branches:   [ master, saas-release-v2, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc


### PR DESCRIPTION
**Do not merge, yet!**

With the rebranding of Elastic Cloud and the renaming of hosted Elasticsearch and Kibana to "Elasticsearch Service", we need to change the docs. Out with the old and in with the new!

Relates to https://github.com/elastic/cloud/pull/17486, https://github.com/elastic/cloud/pull/18359, and 
https://github.com/elastic/cloud/pull/18012 but requires additional discussion to make sure the timing is right before merging.
