### PR TITLE
[DOCS] Adds 6.5 version information

### DIFF
--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -2,7 +2,7 @@
 :logstash_version:       6.4.0
 :elasticsearch_version:  6.4.0
 :kibana_version:         6.4.0
-:branch:                 6.x
+:branch:                 6.4
 :major-version:          6.x
 
 //////////

--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,0 +1,12 @@
+:version:                6.5.0
+:logstash_version:       6.5.0
+:elasticsearch_version:  6.5.0
+:kibana_version:         6.5.0
+:branch:                 6.x
+:major-version:          6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          unreleased


### PR DESCRIPTION
This PR creates the versions65.asciidoc file for use by the 6.x branches.