### PR TITLE
Add ECE 1.2 doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -410,7 +410,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    1.1
-            branches:   [ master, 1.1, 1.0 ]
+            branches:   [ master, 1.2, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
With the arrival of the ECE 1.2 dev branch, it's time to add ECE 1.2 to our roster of doc builds.