### PR TITLE
Remove ECE 1.2 and all Cloud master doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -391,7 +391,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    saas-release
-            branches:   [ master, saas-release, saas-release-heroku ]
+            branches:   [saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -410,7 +410,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    1.1
-            branches:   [ master, 1.2, 1.1, 1.0 ]
+            branches:   [1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Based on the email thread "When should Cloud docs go live?", we decided to pull the doc build for upcoming releases, such as ECE 1.2 and master. This PR removes these branches from our builds. 