### PR TITLE
[DOCS] Updates shared versions for 5.6.11

### DIFF
--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,7 +1,7 @@
-:version:                5.6.10
-:logstash_version:       5.6.10
-:elasticsearch_version:  5.6.10
-:kibana_version:         5.6.10
+:version:                5.6.11
+:logstash_version:       5.6.11
+:elasticsearch_version:  5.6.11
+:kibana_version:         5.6.11
 :branch:                 5.6
 :major-version:          5.x
 


### PR DESCRIPTION
This PR updates the shared version information that is used by a subset of the 5.6.11 documentation. 