### PR TITLE
Add 6.x to APM UI docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -728,7 +728,7 @@ contents:
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
             current:    6.4
-            branches:   [ master, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM


### PR DESCRIPTION
Add 6.x to APM UI docs:
https://www.elastic.co/guide/en/apm/get-started/current/index.html

Closes elastic/kibana#22318