### PR TITLE
Increase replica shards for Site/Docs Search

### DIFF
--- a/web/config_pages.json
+++ b/web/config_pages.json
@@ -1,6 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
+    "number_of_replicas": 2,
     "search": {
       "slowlog": {
         "threshold": {

--- a/web/config_site.json
+++ b/web/config_site.json
@@ -1,6 +1,7 @@
 {
   "settings": {
-    "number_of_shards": 1
+    "number_of_shards": 1,
+    "number_of_replicas": 2
   },
   "mappings": {
     "doc": {

--- a/web/config_titles.json
+++ b/web/config_titles.json
@@ -1,6 +1,7 @@
 {
   "settings": {
     "number_of_shards": 1,
+    "number_of_replicas": 2,
     "search": {
       "slowlog": {
         "threshold": {


### PR DESCRIPTION
The public search interface currently runs on a three node cluster. This
patch increases replica shards from 1 to 2, in order to distribute
search load more evenly across the production cluster.

Relates: elastic/infra#6636