### PR TITLE
[DOCS] Updated Elasticsearch and Cloud titles

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -46,9 +46,9 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    6.3
+            current:    6.4
             index:      docs/index.asciidoc
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
             sources:
@@ -73,9 +73,9 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    6.3
+            current:    6.4
             index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 6.x, 6.3 ]
+            branches:   [ master, 6.x, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
@@ -95,8 +95,8 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -109,12 +109,12 @@ contents:
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
-                exclude_branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -156,8 +156,8 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    6.3
-            branches:   [master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            current:    6.4
+            branches:   [master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -173,9 +173,9 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    6.3
+            current:    6.4
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -198,8 +198,8 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    6.3
-                branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                current:    6.4
+                branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients
@@ -219,8 +219,8 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    6.3
-                branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                current:    6.4
+                branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients
@@ -360,8 +360,8 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -390,8 +390,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release-v2
-            branches:   [ master, saas-release-v2, saas-release, saas-release-heroku ]
+            current:    saas-release
+            branches:   [ saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -410,7 +410,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    1.1
-            branches:   [ master, 1.1, 1.0 ]
+            branches:   [ 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1
@@ -429,8 +429,8 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -443,7 +443,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
     -
         title:      Logstash: Collect, Enrich, and Transport
@@ -451,8 +451,8 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -465,7 +465,7 @@ contents:
                 repo:   x-pack-logstash
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -491,8 +491,8 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -508,7 +508,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats
@@ -529,8 +529,8 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
             subject:    Packetbeat
@@ -551,8 +551,8 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
             subject:    Filebeat
@@ -573,8 +573,8 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
             subject:    Winlogbeat
@@ -595,8 +595,8 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
             subject:    Metricbeat
@@ -622,9 +622,9 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    6.3
+            current:    6.4
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
             subject:    Heartbeat
@@ -645,8 +645,8 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.4
+            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
             subject:    Auditbeat
@@ -727,8 +727,8 @@ contents:
             title:      Getting Started with Elastic APM
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.4
+            branches:   [ master, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
@@ -743,8 +743,8 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    6.3
-            branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.4
+            branches:   [ master, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
@@ -788,7 +788,7 @@ contents:
               -
                 title:      APM Ruby Agent
                 prefix:     ruby
-                current:    master
+                current:    1.x
                 branches:   [ master, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Ruby Agent/Reference
@@ -799,12 +799,12 @@ contents:
                     repo:   apm-agent-ruby
                     path:   docs
               -
-                title:      APM Frontend JavaScript Agent
+                title:      APM Real User Monitoring JavaScript Agent
                 prefix:     js-base
-                current:    0.x
-                branches:   [ master, 0.x ]
+                current:    1.x
+                branches:   [ master, 1.x, 0.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Frontend JavaScript Agent/Reference
+                tags:       APM Real User Monitoring JavaScript Agent/Reference
                 subject:    APM
                 chunk:      1
                 sources:
@@ -814,8 +814,8 @@ contents:
               -
                 title:      APM Go Agent
                 prefix:     go
-                current:    master
-                branches:   [ master ]
+                current:    0.5
+                branches:   [ master, 0.5 ]
                 index:      docs/index.asciidoc
                 tags:       APM Go Agent/Reference
                 subject:    APM
@@ -827,8 +827,8 @@ contents:
               -
                 title:      APM Java Agent
                 prefix:     java
-                current:    master
-                branches:   [ master ]
+                current:    0.6
+                branches:   [ master, 0.6 ]
                 index:      docs/index.asciidoc
                 tags:       APM Java Agent/Reference
                 subject:    APM
@@ -1052,12 +1052,12 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches: [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
           -
             title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -46,9 +46,9 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    6.4
+            current:    6.3
             index:      docs/index.asciidoc
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
             sources:
@@ -73,9 +73,9 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    6.4
+            current:    6.3
             index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 6.x, 6.4, 6.3 ]
+            branches:   [ master, 6.x, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
@@ -90,13 +90,13 @@ contents:
                 repo:   kibana
                 path:   docs
     -
-        title:      Elasticsearch Store, Search, and Analyze
+        title:      Elasticsearch: Store, Search, and Analyze
         sections:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -109,12 +109,12 @@ contents:
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
-                exclude_branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -156,8 +156,8 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    6.4
-            branches:   [master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            current:    6.3
+            branches:   [master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -173,9 +173,9 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    6.4
+            current:    6.3
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -198,8 +198,8 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    6.4
-                branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                current:    6.3
+                branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients
@@ -219,8 +219,8 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    6.4
-                branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                current:    6.3
+                branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients
@@ -360,8 +360,8 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -383,15 +383,15 @@ contents:
                 repo:   curator
                 path:   docs/asciidoc
     -
-        title:      Cloud Provision, Manage and Monitor the Elastic Stack
+        title:      Cloud: Provision, Manage and Monitor the Elastic Stack
         sections:
          -
             title:      Elastic Cloud - Hosted Elasticsearch and Kibana
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release
-            branches:   [ saas-release, saas-release-heroku ]
+            current:    saas-release-v2
+            branches:   [ master, saas-release-v2, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -410,7 +410,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    1.1
-            branches:   [ 1.1, 1.0 ]
+            branches:   [ master, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1
@@ -429,8 +429,8 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -443,7 +443,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
     -
         title:      Logstash: Collect, Enrich, and Transport
@@ -451,8 +451,8 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -465,7 +465,7 @@ contents:
                 repo:   x-pack-logstash
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -491,8 +491,8 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -508,7 +508,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats
@@ -529,8 +529,8 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
             subject:    Packetbeat
@@ -551,8 +551,8 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
             subject:    Filebeat
@@ -573,8 +573,8 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
             subject:    Winlogbeat
@@ -595,8 +595,8 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
             subject:    Metricbeat
@@ -622,9 +622,9 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    6.4
+            current:    6.3
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
             subject:    Heartbeat
@@ -645,8 +645,8 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.x, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.3
+            branches:   [ master, 6.x, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
             subject:    Auditbeat
@@ -727,8 +727,8 @@ contents:
             title:      Getting Started with Elastic APM
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.3
+            branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
@@ -743,8 +743,8 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    6.4
-            branches:   [ master, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            current:    6.3
+            branches:   [ master, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
@@ -788,7 +788,7 @@ contents:
               -
                 title:      APM Ruby Agent
                 prefix:     ruby
-                current:    1.x
+                current:    master
                 branches:   [ master, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Ruby Agent/Reference
@@ -799,12 +799,12 @@ contents:
                     repo:   apm-agent-ruby
                     path:   docs
               -
-                title:      APM Real User Monitoring JavaScript Agent
+                title:      APM Frontend JavaScript Agent
                 prefix:     js-base
-                current:    1.x
-                branches:   [ master, 1.x, 0.x ]
+                current:    0.x
+                branches:   [ master, 0.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Real User Monitoring JavaScript Agent/Reference
+                tags:       APM Frontend JavaScript Agent/Reference
                 subject:    APM
                 chunk:      1
                 sources:
@@ -814,8 +814,8 @@ contents:
               -
                 title:      APM Go Agent
                 prefix:     go
-                current:    0.5
-                branches:   [ master, 0.5 ]
+                current:    master
+                branches:   [ master ]
                 index:      docs/index.asciidoc
                 tags:       APM Go Agent/Reference
                 subject:    APM
@@ -827,8 +827,8 @@ contents:
               -
                 title:      APM Java Agent
                 prefix:     java
-                current:    0.6
-                branches:   [ master, 0.6 ]
+                current:    master
+                branches:   [ master ]
                 index:      docs/index.asciidoc
                 tags:       APM Java Agent/Reference
                 subject:    APM
@@ -1052,12 +1052,12 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches:   [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches: [ master, 6.x, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches: [ master, 6.x, 6.3, 5.3, 5.2, 5.1, 5.0]
           -
             title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide


### PR DESCRIPTION
On https://www.elastic.co/guide/index.html, added a `:` between `Elasticsearch` and `Store`, and between `Cloud` and `Provision`. 