### PR TITLE
[DOCS] Adds elasticsearch/docs to Stack Overview resources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -100,6 +100,9 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/docs
               -
+                repo:   elasticsearch
+                path:   docs                
+              -
                 repo:   kibana
                 path:   docs
     -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -45,7 +45,7 @@ alias docbldgls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en
 
 alias docbldgs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
-alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Related to elastic/elasticsearch#30665, elastic/elasticsearch#33248, and https://github.com/elastic/stack-docs/pull/107.

As content moves from the x-pack/docs folder to the docs folder in the elasticsearch repo, the build commands for the Stack Overview (which pulls in some of those files) needs to be updated to find those files. 