### PR TITLE
[DOCS] Adds Getting Started book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -59,6 +59,19 @@ contents:
                 repo:   elasticsearch
                 path:   docs/
           -
+            title:      Getting Started
+            prefix:     en/elastic-stack-get-started
+            current:    master
+            index:      docs/en/getting-started/index.asciidoc
+            branches:   [ master ]
+            chunk:      1
+            tags:       Elastic Stack/Getting started
+            subject:    Elastic Stack
+            sources: 
+              -
+                repo:   stack-docs
+                path:   docs/en 
+          -
             title:      Glossary
             prefix:     en/elastic-stack-glossary
             current:    master

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -43,6 +43,8 @@ alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/in
 
 alias docbldgls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
+alias docbldgs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
+
 alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --chunk 1'
 
 # Curator

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -22,6 +22,7 @@
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
+:stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/master


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/423

This PR adds the "Getting Started" book under the "Elastic Stack" section of the documentation landing page. 