### PR TITLE
Add Azure Marketplace and ARM template docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -14,6 +14,7 @@ repos:
     apm-agent-js-base:    https://github.com/elastic/apm-agent-js-base.git
     apm-agent-go:         https://github.com/elastic/apm-agent-go.git
     apm-agent-java:       https://github.com/elastic/apm-agent-java.git
+    azure-marketplace:    https://github.com/elastic/azure-marketplace.git
     beats:                https://github.com/elastic/beats.git
     cloud:                https://github.com/elastic/cloud.git
     curator:              https://github.com/elastic/curator.git
@@ -104,6 +105,19 @@ contents:
                 path:   docs                
               -
                 repo:   kibana
+                path:   docs
+          -
+            title:      Azure Marketplace and Resource Manager (ARM) template
+            prefix:     azure-resource-manager
+            current:    master
+            index:      docs/index.asciidoc
+            branches:   [ master ]
+            chunk:      1
+            tags:       Elastic Stack/Azure
+            subject:    Azure Marketplace and Resource Manager (ARM) template
+            sources:
+              -
+                repo:   azure-marketplace
                 path:   docs
     -
         title:      Elasticsearch Store, Search, and Analyze

--- a/conf.yaml
+++ b/conf.yaml
@@ -107,8 +107,8 @@ contents:
                 repo:   kibana
                 path:   docs
           -
-            title:      Azure Marketplace and Resource Manager (ARM) template
-            prefix:     azure-resource-manager
+            title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
+            prefix:     en/elastic-stack-deploy
             current:    master
             index:      docs/index.asciidoc
             branches:   [ master ]


### PR DESCRIPTION
This commit adds the Azure Marketplace and
Azure Resource Manager (ARM) template documentation
to the elastic.co documentation.

Closes https://github.com/elastic/azure-marketplace/issues/97
