### PR TITLE
Corrected aggregation name to match the example

### DIFF
--- a/html/en/elasticsearch/reference/6.2/search-aggregations-metrics-sum-aggregation.html
+++ b/html/en/elasticsearch/reference/6.2/search-aggregations-metrics-sum-aggregation.html
@@ -655,7 +655,7 @@ the sale price of all hats with:</p><div class="pre_wrapper"><pre class="program
            "value": 450.0
         }
     }
-}</pre></div><p>The name of the aggregation (<code class="literal">intraday_return</code> above) also serves as the key by which the aggregation result can be retrieved from the returned response.</p><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_script_9"></a>Script<a href="https://github.com/elastic/elasticsearch/edit/6.2/docs/reference/aggregations/metrics/sum-aggregation.asciidoc" class="edit_me" title="Edit this page on GitHub" rel="nofollow">edit</a></h3></div></div></div><p>We could also use a script to fetch the sales price:</p><div class="pre_wrapper"><pre class="programlisting prettyprint lang-js">POST /sales/_search?size=0
+}</pre></div><p>The name of the aggregation (<code class="literal">hat_prices</code> above) also serves as the key by which the aggregation result can be retrieved from the returned response.</p><div class="section"><div class="titlepage"><div><div><h3 class="title"><a id="_script_9"></a>Script<a href="https://github.com/elastic/elasticsearch/edit/6.2/docs/reference/aggregations/metrics/sum-aggregation.asciidoc" class="edit_me" title="Edit this page on GitHub" rel="nofollow">edit</a></h3></div></div></div><p>We could also use a script to fetch the sales price:</p><div class="pre_wrapper"><pre class="programlisting prettyprint lang-js">POST /sales/_search?size=0
 {
     "query" : {
         "constant_score" : {


### PR DESCRIPTION
Corrected aggregation name from intraday_return to hat_prices to match the aggregation name provided in the example

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
