### PR TITLE
Re-add 2.0 ECE doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -440,7 +440,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    1.1
-            branches:   [ 1.1, 1.0 ]
+            branches:   [ 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Re-adding the ECE 2.0 doc build in preparation for GA next week, as discussed with Brad.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
