### PR TITLE
[DOCS] Updates version attributes for 5.6.12 and 6.4.1

### DIFF
--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,7 +1,7 @@
-:version:                5.6.11
-:logstash_version:       5.6.11
-:elasticsearch_version:  5.6.11
-:kibana_version:         5.6.11
+:version:                5.6.12
+:logstash_version:       5.6.12
+:elasticsearch_version:  5.6.12
+:kibana_version:         5.6.12
 :branch:                 5.6
 :major-version:          5.x
 

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -1,7 +1,7 @@
-:version:                6.4.0
-:logstash_version:       6.4.0
-:elasticsearch_version:  6.4.0
-:kibana_version:         6.4.0
+:version:                6.4.1
+:logstash_version:       6.4.1
+:elasticsearch_version:  6.4.1
+:kibana_version:         6.4.1
 :branch:                 6.4
 :major-version:          6.x
 


### PR DESCRIPTION
This PR updates the version information that is used by books such as the X-Pack Reference, Stack Overview, and Kibana Guide. 