### PR TITLE
Switch current to 2.0 for the ECE docs (do not merge before Sep 23)

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -68,10 +68,10 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
-            sources: 
+            sources:
               -
                 repo:   stack-docs
-                path:   docs/en 
+                path:   docs/en
           -
             title:      Glossary
             prefix:     en/elastic-stack-glossary
@@ -102,7 +102,7 @@ contents:
                 path:   x-pack/docs
               -
                 repo:   elasticsearch
-                path:   docs                
+                path:   docs
               -
                 repo:   kibana
                 path:   docs
@@ -439,7 +439,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    1.1
+            current:    2.0
             branches:   [ 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR switches `current` to ECE 2.0 in preparation for GA. It should not be merged until 48 hours before GA, i.e. September 23. 

There appear to be some stray spaces that got stripped out by Atom. I think these changes are OK. I will do a full local build before merging to confirm that the docs build cleanly.