### PR TITLE
[DOCS] Updates ref-64 URLs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,6 +1,6 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
-:ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.x
+:ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
 :xpack-ref:            https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :logstash-ref:         http://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}

--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -1,6 +1,6 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
-:ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.x
+:ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
 :xpack-ref:            https://www.elastic.co/guide/en/x-pack/{branch}
 :logstash-ref:         http://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}


### PR DESCRIPTION
The "ref-64" attributes contain URLs that are pointing to the 6.x documentation.  This PR fixes the URLs. 
