### PR TITLE
ECE - Fixed incorrect product names.

### DIFF
--- a/html/en/cloud-enterprise/2.0/ece-glossary.html
+++ b/html/en/cloud-enterprise/2.0/ece-glossary.html
@@ -694,11 +694,11 @@
 </span></dt><dd>
   A deployable, reusable template that supports a specific use case for the Elastic Stack, such as a logging cluster or a cluster with a hot-warm architecture.
 </dd><dt><span class="term">
-<a id="ec"></a>Elastic Cloud Enterprise, EC
+<a id="ec"></a>Elastic Cloud, EC
 </span></dt><dd>
   The official hosted Elastic Stack offering, from the makers of Elasticsearch. Available as a software-as-a-service (SaaS) offering on different cloud platforms, such as AWS and GCP.
 </dd><dt><span class="term">
-<a id="ece"></a>Elastic Cloud Enterprise Enterprise, ECE
+<a id="ece"></a>Elastic Cloud Enterprise, ECE
 </span></dt><dd>
   The official enterprise offering host and manage the Elastic Stack yourself at scale. Can be installed on a public cloud platform, such as AWS or GCP, on your own private cloud, or on bare metal.
 </dd><dt><span class="term">

--- a/html/en/cloud-enterprise/current/ece-glossary.html
+++ b/html/en/cloud-enterprise/current/ece-glossary.html
@@ -694,11 +694,11 @@
 </span></dt><dd>
   A deployable, reusable template that supports a specific use case for the Elastic Stack, such as a logging cluster or a cluster with a hot-warm architecture.
 </dd><dt><span class="term">
-<a id="ec"></a>Elastic Cloud Enterprise, EC
+<a id="ec"></a>Elastic Cloud, EC
 </span></dt><dd>
   The official hosted Elastic Stack offering, from the makers of Elasticsearch. Available as a software-as-a-service (SaaS) offering on different cloud platforms, such as AWS and GCP.
 </dd><dt><span class="term">
-<a id="ece"></a>Elastic Cloud Enterprise Enterprise, ECE
+<a id="ece"></a>Elastic Cloud Enterprise, ECE
 </span></dt><dd>
   The official enterprise offering host and manage the Elastic Stack yourself at scale. Can be installed on a public cloud platform, such as AWS or GCP, on your own private cloud, or on bare metal.
 </dd><dt><span class="term">


### PR DESCRIPTION
Since Elastic Cloud Enterprise is not a public repository I figured the best way of sharing this issue with fix was to create this pull request. 

The labels in the glossary appear to be incorrect. "Elastic Cloud Enterprise" being applied to what should have been simply "Elastic Cloud" and "Elastic Cloud Enterprise Enterprise" to what should be simply Elastic Cloud Enterprise.