### PR TITLE
Point Azure ARM documentation to 6.3 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -109,9 +109,9 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    master
+            current:    6.3
             index:      docs/index.asciidoc
-            branches:   [ master ]
+            branches:   [ master, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This PR points the Azure documentation to the 6.3 branch in preparation for an update in https://github.com/elastic/azure-marketplace/pull/223 that adds Logstash to the template, including documentation