### PR TITLE
Add 6.4 branch to Azure ARM documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -111,7 +111,7 @@ contents:
             prefix:     en/elastic-stack-deploy
             current:    6.3
             index:      docs/index.asciidoc
-            branches:   [ master, 6.3 ]
+            branches:   [ master, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This commit adds a 6.4 branch to ARM template documentation in preparation for a new Marketplace release.