### PR TITLE
Default Marketplace documentation to 6.4

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -109,7 +109,7 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    6.3
+            current:    6.4
             index:      docs/index.asciidoc
             branches:   [ master, 6.4, 6.3 ]
             chunk:      1


### PR DESCRIPTION
This commit updates the documentation for the Marketplace to 6.4, now that the 6.4
template version is live
