### PR TITLE
[DOCS] Adds 6.6 shared version info

### DIFF
--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -2,7 +2,7 @@
 :logstash_version:       6.5.0
 :elasticsearch_version:  6.5.0
 :kibana_version:         6.5.0
-:branch:                 6.x
+:branch:                 6.5
 :major-version:          6.x
 
 //////////

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -1,0 +1,12 @@
+:version:                6.6.0
+:logstash_version:       6.6.0
+:elasticsearch_version:  6.6.0
+:kibana_version:         6.6.0
+:branch:                 6.x
+:major-version:          6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          unreleased


### PR DESCRIPTION
This PR updates the branch details for the 6.5 versions and adds a new set of information about version 6.6.0. 