### PR TITLE
Update Elastic Cloud builds to use milestones

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -420,8 +420,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release
-            branches:   [ saas-release, saas-release-heroku ]
+            current:    release-ms-13
+            branches:   [ release-ms-13, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -420,7 +420,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-13
+            current:    saas-release
             branches:   [ release-ms-13, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Our Elastic Cloud (Elasticsearch Service) releases are moving to a milestone-based release cycle. The docs are kept with the production code just as before (we follow the 'docs as code' principle), and so our docs need to follow suit. For the coming Cloud Service Release that goes to staging on November 1, this change means that we need to add `release-ms-13` and use it as `current`. 

(Looking ahead, milestone releases need to be removed and replaced at each milestone boundary. The next build change will remove `release-ms-13` and replace it with `release-ms-14`.)

EDIT: For testing purposes, we want to start building the milestone docs, but not yet change current. Current points to `saas-release` for now.