### PR TITLE
Update current for Elastic Cloud to release-ms-13

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -425,7 +425,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    saas-release
+            current:    release-ms-13
             branches:   [ release-ms-13, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1


### PR DESCRIPTION
When the release-ms-13 goes to production, we need to change `current`.

