### PR TITLE
[DOCS] Updated version attributes for 5.6.13 and 6.4.3

### DIFF
--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,7 +1,7 @@
-:version:                5.6.12
-:logstash_version:       5.6.12
-:elasticsearch_version:  5.6.12
-:kibana_version:         5.6.12
+:version:                5.6.13
+:logstash_version:       5.6.13
+:elasticsearch_version:  5.6.13
+:kibana_version:         5.6.13
 :branch:                 5.6
 :major-version:          5.x
 

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -1,7 +1,7 @@
-:version:                6.4.2
-:logstash_version:       6.4.2
-:elasticsearch_version:  6.4.2
-:kibana_version:         6.4.2
+:version:                6.4.3
+:logstash_version:       6.4.3
+:elasticsearch_version:  6.4.3
+:kibana_version:         6.4.3
 :branch:                 6.4
 :major-version:          6.x
 


### PR DESCRIPTION
Updated the version information that the doc books use, such as the X-Pack Reference, Stack Overview, and Kibana Guide.
