### PR TITLE
Add Infrastructure monitoring docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -756,6 +756,23 @@ contents:
                 repo:   swiftype
                 path:   docs
     -
+        title:      Infrastructure and Logs
+        sections:
+          -
+            title:      Infrastructure Monitoring Guide
+            prefix:     en/infrastructure/guide
+            current:    master
+            branches:   [ master, 6.x, 6.5 ]
+            index:      docs/en/infraops/index.asciidoc
+            chunk:      1
+            tags:       Infrastructure/Guide
+            subject:    Infrastructure
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+
+    -
         title:      APM
         sections:
           -


### PR DESCRIPTION
I'm open for recommendations about the prefix used to determine the URL. 