### PR TITLE
apm: add ref for Elastic APM Node.js Agent v1.x

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -17,6 +17,7 @@
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
+:apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
 :apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/js-base/current
 :apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/current
 :apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current


### PR DESCRIPTION
This is needed to v6.5

When 6.5 is released we'll bump the version of the Node.js APM agent to v2.0.0 which will only support version 6.5 and above of the APM Server.

For users who are still on <6.5, I need to link them to the old version of the agent (v1.x) which still have support for older versions of the stack.

I'm not sure if I could make use of `{branch}` or something similar or if this is the way to do it?