### PR TITLE
Add 6.x and 6.5 branches for Functionbeat and Journalbeat

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -709,7 +709,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    master
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ master ]
+            branches:   [ master, 6.x, 6.5 ]
             chunk:      1
             tags:       Functionbeat/Reference
             subject:    Functionbeat
@@ -731,7 +731,7 @@ contents:
             prefix:     en/beats/journalbeat
             current:    master
             index:      journalbeat/docs/index.asciidoc
-            branches:   [ master ]
+            branches:   [ master, 6.x, 6.5 ]
             chunk:      1
             tags:       Journalbeat/Reference
             subject:    Journalbeat


### PR DESCRIPTION
Gets functionbeat and journalbeat docs building in 6.x and 6.5 branches.