### PR TITLE
Build Java agent 1.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -927,8 +927,8 @@ contents:
               -
                 title:      APM Java Agent
                 prefix:     java
-                current:    0.7
-                branches:   [ master, 0.6, 0.7 ]
+                current:    1.x
+                branches:   [ master, 0.6, 0.7, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Java Agent/Reference
                 subject:    APM


### PR DESCRIPTION
Even though the agent is not released just yet, this is safe to merge as I have already created a `1.x` branch. After the release, I'll move the branch to point to the `v1.0.0` tag.