### PR TITLE
elastic-apm-nodejs: add 2.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -862,8 +862,8 @@ contents:
               -
                 title:      APM Node.js Agent
                 prefix:     nodejs
-                current:    1.x
-                branches:   [ master, 0.x, 1.x ]
+                current:    2.x
+                branches:   [ master, 0.x, 1.x, 2.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Node.js Agent/Reference
                 subject:    APM


### PR DESCRIPTION
This is needed for 6.5.

While the `2.x` branch already exists, version 2.0.0 of the agent hasn't been released yet. It will be at the same time as the 6.5 release, but as the docs build is currently halted until the 6.5 release, this PR should be safe to merge already now.