### PR TITLE
Added 4.x and 3.x branches for APM Python agent

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -875,8 +875,8 @@ contents:
               -
                 title:      APM Python Agent
                 prefix:     python
-                current:    2.x
-                branches:   [ master, 2.x, 1.x ]
+                current:    4.x
+                branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Python Agent/Reference
                 subject:    APM


### PR DESCRIPTION
The 4.x branch coincides with the 6.5 release. Unfortunately I forgot to add the 3.x branch earlier, since it is virtually identical with the 2.x branch when it comes to docs.
