### PR TITLE
Added ref for pre 4.x Python APM agent

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -16,6 +16,7 @@
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
+:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
 :apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/js-base/current


### PR DESCRIPTION
This should allow APM-Server <6.5 to link to the agent docs