### PR TITLE
Update ARM template docs to 6.5

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -110,9 +110,9 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    6.4
+            current:    6.5
             index:      docs/index.asciidoc
-            branches:   [ master, 6.4, 6.3 ]
+            branches:   [ master, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This PR updates the ARM template docs to point at the 6.5 branch, to align with the release of 6.5.0 of the ARM template.