### PR TITLE
Removes references to Swiftype

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -779,38 +779,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
-
-    -
-        title:      Swiftype: Site, App, and Enterprise Search
-        sections:
-          -
-            title:      Site Search Reference
-            prefix:     en/swiftype/sitesearch
-            index:      docs/sitesearch/index.asciidoc
-            private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
-            tags:       Site Search/Reference
-            subject:    Swiftype
-            sources:
-              -
-                repo:   swiftype
-                path:   docs
-          -
-            title:      App Search Reference
-            prefix:     en/swiftype/appsearch
-            index:      docs/appsearch/index.asciidoc
-            private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
-            tags:       App Search/Reference
-            subject:    Swiftype
-            sources:
-              -
-                repo:   swiftype
-                path:   docs
+                
     -
         title:      Infrastructure and Logs
         sections:


### PR DESCRIPTION
Remove until this content can be curated as part of “Swiftype" knowledge infrastructure.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
