### PR TITLE
[DOCS] Add legacy tags

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -767,7 +767,7 @@ contents:
             current:    1.3
             branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
             chunk:      1
-            tags:       Topbeat/Reference
+            tags:       Legacy/Topbeat/Reference
             subject:    Topbeat
             sources:
               -
@@ -1150,7 +1150,7 @@ contents:
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack
             chunk:      1
-            tags:       XPack/Reference
+            tags:       Legacy/XPack/Reference
             current:    6.2
             subject:    X-Pack
             index:      docs/en/index.asciidoc
@@ -1177,7 +1177,7 @@ contents:
             branches:   [ master, 2.x, 1.x ]
             index:      book.asciidoc
             chunk:      1
-            tags:       Elasticsearch/Definitive Guide
+            tags:       Legacy/Elasticsearch/Definitive Guide
             subject:    Elasticsearch
             sources:
               -
@@ -1190,7 +1190,7 @@ contents:
             current:    master
             branches:   [ master ]
             index:      docs/index.asciidoc
-            tags:       Elasticsearch/Sense-Editor
+            tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
             sources:
               -
@@ -1200,7 +1200,7 @@ contents:
             title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1
-            tags:       Marvel/Reference
+            tags:       Legacy/Marvel/Reference
             subject:    Marvel
             current:    2.4
             index:      docs/public/marvel/index.asciidoc
@@ -1214,7 +1214,7 @@ contents:
             title:      Shield Reference for 2.x and 1.x
             prefix:     en/shield
             chunk:      1
-            tags:       Shield/Reference
+            tags:       Legacy/Shield/Reference
             subject:    Shield
             current:    2.4
             index:      docs/public/shield/index.asciidoc
@@ -1228,7 +1228,7 @@ contents:
             title:      Watcher Reference for 2.x and 1.x
             prefix:     en/watcher
             chunk:      1
-            tags:       Watcher/Reference
+            tags:       Legacy/Watcher/Reference
             subject:    Watcher
             current:    2.4
             index:      docs/public/watcher/index.asciidoc
@@ -1242,7 +1242,7 @@ contents:
             title:      Reporting Reference for 2.x
             prefix:     en/reporting
             chunk:      1
-            tags:       Reporting/Reference
+            tags:       Legacy/Reporting/Reference
             subject:    Reporting
             current:    2.4
             index:      docs/public/reporting/index.asciidoc
@@ -1257,7 +1257,7 @@ contents:
             prefix:     en/graph
             repo:       x-pack
             chunk:      1
-            tags:       Graph/Reference
+            tags:       Legacy/Graph/Reference
             subject:    Graph
             current:    2.4
             index:      docs/public/graph/index.asciidoc


### PR DESCRIPTION
This PR adds a "Legacy" tag to the documentation Topbeat reference and to all the books in the "legacy" section of https://www.elastic.co/guide/index.html

For example, it adds the following to pages in the v6.2 X-Pack Reference:

`<meta name="DC.type" content="Learn/Docs/Legacy/XPack/Reference/6.2" />`