### PR TITLE
Update Cloud milestone release builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -437,8 +437,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-13
-            branches:   [ release-ms-14, release-ms-13, saas-release, saas-release-heroku ]
+            current:    release-ms-14
+            branches:   [ release-ms-14, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
This PR changes `current` for the Elasticsearch Service to point to `release-ms-14` and removes the previous `release-ms-13` build. 

Relates to https://github.com/elastic/cloud/issues/23611 and https://github.com/elastic/cloud/issues/22665.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->