### PR TITLE
[DOCS] Updates for 6.5.2 version attributes

### DIFF
--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,7 +1,7 @@
-:version:                6.5.1
-:logstash_version:       6.5.1
-:elasticsearch_version:  6.5.1
-:kibana_version:         6.5.1
+:version:                6.5.2
+:logstash_version:       6.5.2
+:elasticsearch_version:  6.5.2
+:kibana_version:         6.5.2
 :branch:                 6.5
 :major-version:          6.x
 


### PR DESCRIPTION
Updates the version information that is used by the Logstash, Elasticsearch, and Kibana books.