### PR TITLE
Update branch order for apm agents

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -875,7 +875,7 @@ contents:
                 title:      APM Node.js Agent
                 prefix:     nodejs
                 current:    2.x
-                branches:   [ master, 0.x, 1.x, 2.x ]
+                branches:   [ master, 2.x, 1.x, 0.x ]
                 index:      docs/index.asciidoc
                 tags:       APM Node.js Agent/Reference
                 subject:    APM
@@ -940,7 +940,7 @@ contents:
                 title:      APM Java Agent
                 prefix:     java
                 current:    1.x
-                branches:   [ master, 0.6, 0.7, 1.x ]
+                branches:   [ master, 1.x, 0.7, 0.6 ]
                 index:      docs/index.asciidoc
                 tags:       APM Java Agent/Reference
                 subject:    APM


### PR DESCRIPTION
The weird branch order for the node and java apm agents has annoyed me for quite some time, and I just figured out how to fix it:
<img width="363" alt="screen shot 2018-12-04 at 11 35 25 am" src="https://user-images.githubusercontent.com/5618806/49468205-19e13480-f7b9-11e8-8c18-72fa28e34458.png">

Updating the order of branches for the Node and Java agents to match the rest of the stack. 

@lcawl - is this a safe change to make?