### PR TITLE
[DOCS] Updates version to 6.5.3

### DIFF
--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,7 +1,7 @@
-:version:                6.5.2
-:logstash_version:       6.5.2
-:elasticsearch_version:  6.5.2
-:kibana_version:         6.5.2
+:version:                6.5.3
+:logstash_version:       6.5.3
+:elasticsearch_version:  6.5.3
+:kibana_version:         6.5.3
 :branch:                 6.5
 :major-version:          6.x
 


### PR DESCRIPTION
This PR updates the version information that is used by documentation such as the Stack Overview, Kibana Guide, Getting Started Guide, etc. 

This PR should not be merged until that release is underway. 