### PR TITLE
[DOCS] Updates docbldesold alias and adds docbldesoldx

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -18,7 +18,9 @@ alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesoldx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+
+alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --chunk 1'
 
 # Kibana
 alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR updates the doc_build_aliases.sh file such that the docbldesold alias creates the OSS-only Elasticsearch Reference for old versions. It adds the docbldesoldx to build the X-Pack-inclusive Elasticsearch Reference for old versions. 