### PR TITLE
Beats: add x-pack/filebeat/docs to contents

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -613,6 +613,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/filebeat/docs
+                exclude_branches:   [ 6.x, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -612,6 +612,9 @@ contents:
                 path:   filebeat/docs
               -
                 repo:   beats
+                path:   x-pack/filebeat/docs
+              -
+                repo:   beats
                 path:   CHANGELOG.asciidoc
               -
                 repo:   beats


### PR DESCRIPTION
This PR adds the `x-pack/filebeat/docs` to the list of directories to look for docs in Filebeat. This is needed so that we can include x-pack specific docs.
