### PR TITLE
Beats: add path x-pack/filebeat/docs to 6.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -613,7 +613,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/filebeat/docs
-                exclude_branches:   [ 6.x, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc


### PR DESCRIPTION
This updates the docs build to look for docs in `x-pack/filebeat/docs` in the 6.x branch too.