### PR TITLE
Add x-pack/auditbeat/docs to contents

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -710,6 +710,10 @@ contents:
                 path:   auditbeat/docs
               -
                 repo:   beats
+                path:   x-pack/auditbeat/docs
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
                 path:   auditbeat/module
               -
                 repo:   beats

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -73,6 +73,7 @@ alias docbldmb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/metricbeat/do
 alias docbldhb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
 
 alias docbldab='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
+alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat/docs/ --chunk 1'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'


### PR DESCRIPTION
Similar to https://github.com/elastic/docs/pull/507, this adds the [`x-pack/auditbeat/docs`](https://github.com/elastic/beats/tree/master/x-pack/auditbeat/docs/modules) folder to the contents.

This is being used by the new Auditbeat system module, and is already present in `master` and `6.x`.