### PR TITLE
[DOCS] Adds ilm attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -88,6 +88,9 @@
 :ml:                machine learning
 :ml-features:       machine learning features
 :ccr:               cross-cluster replication
+:ilm:               index lifecycle management
+:Ilm:               Index lifecycle management
+:ILM:               ILM
 
 :dfeed:           datafeed
 :dfeeds:          datafeeds


### PR DESCRIPTION
This PR adds the attributes related to index lifecycle management (which currently exist in
https://github.com/elastic/elasticsearch/blob/master/docs/reference/ilm/index.asciidoc) to the shared list of attributes, so that they can be used in the Stack Overview as well. 

Related to https://github.com/elastic/stack-docs/pull/172