### PR TITLE
[DOCS] Adds 6.7.0 version info

### DIFF
--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -2,7 +2,7 @@
 :logstash_version:       6.6.0
 :elasticsearch_version:  6.6.0
 :kibana_version:         6.6.0
-:branch:                 6.x
+:branch:                 6.6
 :major-version:          6.x
 
 //////////

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -1,0 +1,12 @@
+:version:                6.7.0
+:logstash_version:       6.7.0
+:elasticsearch_version:  6.7.0
+:kibana_version:         6.7.0
+:branch:                 6.x
+:major-version:          6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          unreleased


### PR DESCRIPTION
This PR adds the shared versions67.asciidoc, which will be used by 6.7 documentation
