### PR TITLE
Fixes x-pack/auditbeat path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -710,7 +710,7 @@ contents:
                 path:   auditbeat/docs
               -
                 repo:   beats
-                path:   x-pack/auditbeat/docs
+                path:   x-pack/auditbeat
                 exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -73,7 +73,7 @@ alias docbldmb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/metricbeat/do
 alias docbldhb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
 
 alias docbldab='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
-alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat/docs/ --chunk 1'
+alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/512

The Auditbeat Reference was failing with the following errors:

> 13:44:15 asciidoc: WARNING: host.asciidoc: line 8: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/host/_meta/docs.asciidoc
13:44:15 asciidoc: WARNING: host.asciidoc: line 20: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/host/_meta/data.json
13:44:15 asciidoc: WARNING: process.asciidoc: line 8: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/process/_meta/docs.asciidoc
13:44:15 asciidoc: WARNING: process.asciidoc: line 20: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/process/_meta/data.json
13:44:15 asciidoc: WARNING: socket.asciidoc: line 8: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/socket/_meta/docs.asciidoc
13:44:15 asciidoc: WARNING: socket.asciidoc: line 20: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/socket/_meta/data.json
13:44:15 asciidoc: WARNING: user.asciidoc: line 8: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/user/_meta/docs.asciidoc
13:44:15 asciidoc: WARNING: user.asciidoc: line 20: include file not found: /home/docs/docs/.repos/.temp/nUU8NVjbpg/beats/x-pack/auditbeat/module/system/user/_meta/data.json

Those files exist under x-pack/auditbeat not x-pack/auditbeat/docs, so this PR updates the path in the conf.yaml and doc_build_aliases.sh appropriately.