### PR TITLE
[DOCS] Adds xpack-basic and xpack-pro roles

### DIFF
--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -44,6 +44,38 @@
   font-weight: inherit;
 }
 
+/* Format floating role=xpack-basic titles */
+#guide h1 > span[class~="xpack-basic"],
+#guide h2 > span[class~="xpack-basic"],
+#guide h3 > span[class~="xpack-basic"],
+#guide h4 > span[class~="xpack-basic"],
+#guide h5 > span[class~="xpack-basic"],
+#guide h6 > span[class~="xpack-basic"] {
+  display: inherit;
+  font-size: inherit;
+  margin-top: inherit;
+  margin-bottom: inherit;
+  margin-left: inherit;
+  margin-right: inherit;
+  font-weight: inherit;
+}
+
+/* Format floating role=xpack-pro titles */
+#guide h1 > span[class~="xpack-pro"],
+#guide h2 > span[class~="xpack-pro"],
+#guide h3 > span[class~="xpack-pro"],
+#guide h4 > span[class~="xpack-pro"],
+#guide h5 > span[class~="xpack-pro"],
+#guide h6 > span[class~="xpack-pro"] {
+  display: inherit;
+  font-size: inherit;
+  margin-top: inherit;
+  margin-bottom: inherit;
+  margin-left: inherit;
+  margin-right: inherit;
+  font-weight: inherit;
+}
+
 /* Add xpack icon to role=xpack sidebar titles */
 #guide div[class~="xpack"] > div > div > div > p > strong:after,
 
@@ -65,6 +97,68 @@
 #guide div[class~="xpack"] > div > div > div > h4:after,
 #guide div[class~="xpack"] > div > div > div > h5:after,
 #guide div[class~="xpack"] > div > div > div> h6:after {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAUCAYAAADPym6aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAARTQAAEU0BwDlgYwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQfSURBVEiJ3VdbaBxlGD3fP5PtTqxBjYhYxCRqNAFtMZs3sQar0ezMThthEMFWVJBUUFpsY1NLg7RgHytSbAreQKQTarLzz24CiiNeXxKDWm2MD1KFtVIV4u6615nPh2YhLNmtiYW1HhiY+a7nzM+BGbJtW9E0bR8RPcnMbbi88Aszn8zn8yOqpmn7AOwC8CIR/dBoZqsBM99ARIc0TbtCBfAUgP26rr/WaGJrgeM454loQgC4CcB8owmtFb7vnwGwTjSayKWCWisRj8dvE0J0GoYhK7FkMrnO9/3Hcrnc25ZlFZfXT05O3qiq6kNLjwVmXjAM44t/Q05KmQ2FQtf19/dnL1Zb70RSAI46jtNbCQRBMAJgU7UIAFAU5Q5mHgZwNTPfDuCYlDLheV7Nl3UpUXOJaZrpRCKxMwiCMc/zehcXFzuZ+ZFcLtdTZ95Puq4fAQDbtg9qmjafTqfvAfAhADiO005EHcx8LhaLfbu8cXp6+ppyubzR9/1iS0vLbF9fX3553vM8NZvNbhRCnB4YGChUL67rkWg0Og3g60wms1tRlONE9IxlWZl6PRVYllVk5p+JqAUApJTPEdEJADEiekdKeaRS6zjOw6VSaS4IgieEEHuz2ezW5bNGR0dFOp1+g5kfXUkEUOdEKmhqatpVKpXmAUzruv7BPxHBzOS6rgngVkVRPgMAXddfIaKjwAU/KYoyC2DYtu31RHSMiO41DOPMSvN6enpeJaJsNBp9vtbOiwopl8vtAP4CcJdt2yHLsoq2bSvNzc2DSyW+ruvvLd3fLaX8w3XdPwF8A0AfGBg4DwDj4+NNruvez8y3ALhq6UI4HO4C8Kuu6yuKKJVKewF0zszMPKDrOq9JiOd5aiaTGRNCbA+CYEc4HH4BwEsdHR0ilUptAQAiKgGoCPnUMIy+6jlSymsBfMLME8z8uRAiy8z7AUAIsZ6Zc7U4MHM7gK5IJNIN4PSahGQymd1ENBeNRj+WUn5HRF9JKe1IJDIP4Ol6vVW4D8BZwzBGACAej98pxAV7+r7/vRCiMx6PX2maZrq6MRQKDRUKhQcBjNu23VvLozXNnkwmbwaws1gsDgOAYRi/ATgIYIyZaRUiEATBAoBNruvGpJTbhBCHAeQBwDTNFBGdFEKMSym3SSm3O46zeXl/LBY7xczva5p2vNaOmkJ8329j5h2Dg4O/V2Kzs7OvAzg1NTW1obqeiOaZeWylWaZpzgkhHg+CYAsRdSmKMsTMz1by0Wh0iIjeBLCZmbuZ+dxS6kBra2sRAFRV3UNEXyYSietX2kFSSgbQZxjGR7VE/ZcxMTHRpqrqj/+bby0B4CwRdTWayFqhqmo3gILKzCcAHHYch4QQC40mtkpsYOZDzPyWms/nX9Y0LRBC7LkMf3VTAN7N5/MH/gYB17/KZ7ITXwAAAABJRU5ErkJggg==');
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  display: inline-block;
+  width: 50px;
+  height: 1em;
+  margin-left: 10px;
+  content: " ";
+}
+
+/* Add xpack icon to role=xpack-basic sidebar titles */
+#guide div[class~="xpack-basic"] > div > div > div > p > strong:after,
+
+/* Add xpack icon to role=xpack-basic dt titles */
+#guide dt > span > span.xpack-basic:after,
+
+/* Add xpack icon to floating role=xpack-basic titles */
+#guide h1 > span[class~="xpack-basic"]::after,
+#guide h2 > span[class~="xpack-basic"]::after,
+#guide h3 > span[class~="xpack-basic"]::after,
+#guide h4 > span[class~="xpack-basic"]::after,
+#guide h5 > span[class~="xpack-basic"]::after,
+#guide h6 > span[class~="xpack-basic"]::after,
+
+/*Add xpack icon to non-floating role=xpack-basic titles*/
+#guide div[class~="xpack-basic"] > div > div > div > h1:after,
+#guide div[class~="xpack-basic"] > div > div > div > h2:after,
+#guide div[class~="xpack-basic"] > div > div > div > h3:after,
+#guide div[class~="xpack-basic"] > div > div > div > h4:after,
+#guide div[class~="xpack-basic"] > div > div > div > h5:after,
+#guide div[class~="xpack-basic"] > div > div > div> h6:after {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAUCAYAAADPym6aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAARTQAAEU0BwDlgYwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQfSURBVEiJ3VdbaBxlGD3fP5PtTqxBjYhYxCRqNAFtMZs3sQar0ezMThthEMFWVJBUUFpsY1NLg7RgHytSbAreQKQTarLzz24CiiNeXxKDWm2MD1KFtVIV4u6615nPh2YhLNmtiYW1HhiY+a7nzM+BGbJtW9E0bR8RPcnMbbi88Aszn8zn8yOqpmn7AOwC8CIR/dBoZqsBM99ARIc0TbtCBfAUgP26rr/WaGJrgeM454loQgC4CcB8owmtFb7vnwGwTjSayKWCWisRj8dvE0J0GoYhK7FkMrnO9/3Hcrnc25ZlFZfXT05O3qiq6kNLjwVmXjAM44t/Q05KmQ2FQtf19/dnL1Zb70RSAI46jtNbCQRBMAJgU7UIAFAU5Q5mHgZwNTPfDuCYlDLheV7Nl3UpUXOJaZrpRCKxMwiCMc/zehcXFzuZ+ZFcLtdTZ95Puq4fAQDbtg9qmjafTqfvAfAhADiO005EHcx8LhaLfbu8cXp6+ppyubzR9/1iS0vLbF9fX3553vM8NZvNbhRCnB4YGChUL67rkWg0Og3g60wms1tRlONE9IxlWZl6PRVYllVk5p+JqAUApJTPEdEJADEiekdKeaRS6zjOw6VSaS4IgieEEHuz2ezW5bNGR0dFOp1+g5kfXUkEUOdEKmhqatpVKpXmAUzruv7BPxHBzOS6rgngVkVRPgMAXddfIaKjwAU/KYoyC2DYtu31RHSMiO41DOPMSvN6enpeJaJsNBp9vtbOiwopl8vtAP4CcJdt2yHLsoq2bSvNzc2DSyW+ruvvLd3fLaX8w3XdPwF8A0AfGBg4DwDj4+NNruvez8y3ALhq6UI4HO4C8Kuu6yuKKJVKewF0zszMPKDrOq9JiOd5aiaTGRNCbA+CYEc4HH4BwEsdHR0ilUptAQAiKgGoCPnUMIy+6jlSymsBfMLME8z8uRAiy8z7AUAIsZ6Zc7U4MHM7gK5IJNIN4PSahGQymd1ENBeNRj+WUn5HRF9JKe1IJDIP4Ol6vVW4D8BZwzBGACAej98pxAV7+r7/vRCiMx6PX2maZrq6MRQKDRUKhQcBjNu23VvLozXNnkwmbwaws1gsDgOAYRi/ATgIYIyZaRUiEATBAoBNruvGpJTbhBCHAeQBwDTNFBGdFEKMSym3SSm3O46zeXl/LBY7xczva5p2vNaOmkJ8329j5h2Dg4O/V2Kzs7OvAzg1NTW1obqeiOaZeWylWaZpzgkhHg+CYAsRdSmKMsTMz1by0Wh0iIjeBLCZmbuZ+dxS6kBra2sRAFRV3UNEXyYSietX2kFSSgbQZxjGR7VE/ZcxMTHRpqrqj/+bby0B4CwRdTWayFqhqmo3gILKzCcAHHYch4QQC40mtkpsYOZDzPyWms/nX9Y0LRBC7LkMf3VTAN7N5/MH/gYB17/KZ7ITXwAAAABJRU5ErkJggg==');
+  background-repeat: no-repeat;
+  background-position: 0 0;
+  display: inline-block;
+  width: 50px;
+  height: 1em;
+  margin-left: 10px;
+  content: " ";
+}
+
+/* Add xpack icon to role=xpack-pro sidebar titles */
+#guide div[class~="xpack-pro"] > div > div > div > p > strong:after,
+
+/* Add xpack icon to role=xpack-pro dt titles */
+#guide dt > span > span.xpack-pro:after,
+
+/* Add xpack icon to floating role=xpack-pro titles */
+#guide h1 > span[class~="xpack-pro"]::after,
+#guide h2 > span[class~="xpack-pro"]::after,
+#guide h3 > span[class~="xpack-pro"]::after,
+#guide h4 > span[class~="xpack-pro"]::after,
+#guide h5 > span[class~="xpack-pro"]::after,
+#guide h6 > span[class~="xpack-pro"]::after,
+
+/*Add xpack icon to non-floating role=xpack-pro titles*/
+#guide div[class~="xpack-pro"] > div > div > div > h1:after,
+#guide div[class~="xpack-pro"] > div > div > div > h2:after,
+#guide div[class~="xpack-pro"] > div > div > div > h3:after,
+#guide div[class~="xpack-pro"] > div > div > div > h4:after,
+#guide div[class~="xpack-pro"] > div > div > div > h5:after,
+#guide div[class~="xpack-pro"] > div > div > div> h6:after {
   background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADIAAAAUCAYAAADPym6aAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAARTQAAEU0BwDlgYwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAQfSURBVEiJ3VdbaBxlGD3fP5PtTqxBjYhYxCRqNAFtMZs3sQar0ezMThthEMFWVJBUUFpsY1NLg7RgHytSbAreQKQTarLzz24CiiNeXxKDWm2MD1KFtVIV4u6615nPh2YhLNmtiYW1HhiY+a7nzM+BGbJtW9E0bR8RPcnMbbi88Aszn8zn8yOqpmn7AOwC8CIR/dBoZqsBM99ARIc0TbtCBfAUgP26rr/WaGJrgeM454loQgC4CcB8owmtFb7vnwGwTjSayKWCWisRj8dvE0J0GoYhK7FkMrnO9/3Hcrnc25ZlFZfXT05O3qiq6kNLjwVmXjAM44t/Q05KmQ2FQtf19/dnL1Zb70RSAI46jtNbCQRBMAJgU7UIAFAU5Q5mHgZwNTPfDuCYlDLheV7Nl3UpUXOJaZrpRCKxMwiCMc/zehcXFzuZ+ZFcLtdTZ95Puq4fAQDbtg9qmjafTqfvAfAhADiO005EHcx8LhaLfbu8cXp6+ppyubzR9/1iS0vLbF9fX3553vM8NZvNbhRCnB4YGChUL67rkWg0Og3g60wms1tRlONE9IxlWZl6PRVYllVk5p+JqAUApJTPEdEJADEiekdKeaRS6zjOw6VSaS4IgieEEHuz2ezW5bNGR0dFOp1+g5kfXUkEUOdEKmhqatpVKpXmAUzruv7BPxHBzOS6rgngVkVRPgMAXddfIaKjwAU/KYoyC2DYtu31RHSMiO41DOPMSvN6enpeJaJsNBp9vtbOiwopl8vtAP4CcJdt2yHLsoq2bSvNzc2DSyW+ruvvLd3fLaX8w3XdPwF8A0AfGBg4DwDj4+NNruvez8y3ALhq6UI4HO4C8Kuu6yuKKJVKewF0zszMPKDrOq9JiOd5aiaTGRNCbA+CYEc4HH4BwEsdHR0ilUptAQAiKgGoCPnUMIy+6jlSymsBfMLME8z8uRAiy8z7AUAIsZ6Zc7U4MHM7gK5IJNIN4PSahGQymd1ENBeNRj+WUn5HRF9JKe1IJDIP4Ol6vVW4D8BZwzBGACAej98pxAV7+r7/vRCiMx6PX2maZrq6MRQKDRUKhQcBjNu23VvLozXNnkwmbwaws1gsDgOAYRi/ATgIYIyZaRUiEATBAoBNruvGpJTbhBCHAeQBwDTNFBGdFEKMSym3SSm3O46zeXl/LBY7xczva5p2vNaOmkJ8329j5h2Dg4O/V2Kzs7OvAzg1NTW1obqeiOaZeWylWaZpzgkhHg+CYAsRdSmKMsTMz1by0Wh0iIjeBLCZmbuZ+dxS6kBra2sRAFRV3UNEXyYSietX2kFSSgbQZxjGR7VE/ZcxMTHRpqrqj/+bby0B4CwRdTWayFqhqmo3gILKzCcAHHYch4QQC40mtkpsYOZDzPyWms/nX9Y0LRBC7LkMf3VTAN7N5/MH/gYB17/KZ7ITXwAAAABJRU5ErkJggg==');
   background-repeat: no-repeat;
   background-position: 0 0;


### PR DESCRIPTION
Related: https://github.com/elastic/docs/pull/177/files

This PR adds "xpack-basic" and "xpack-pro" roles, so that we can tag pages differently depending on the high-level subscription types (https://www.elastic.co/subscriptions). 