### PR TITLE
Asciidoctor: Work around strange attribute rules

### DIFF
--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -7,20 +7,46 @@ include Asciidoctor
 #
 # Turns
 #   added[6.0.0-beta1]
-#   include-tagged::foo[tag]
-#
 # Into
 #   added::[6.0.0-beta1]
+# Because `::` is required by asciidoctor but isn't by asciidoc.
+#
+# Turns
+#   include-tagged::foo[tag]
+# Into
 #   include::elastic-include-tagged:foo[tag]
+# To chain into the ElasticIncludeTagged processor which is *slightly* different
+# than asciidoctor's built in tagging support.
+#
+# Turns
+#   --
+#   :api: bulk
+#   :request: BulkRequest
+#   :response: BulkResponse
+#   --
+# Into
+#   :api: bulk
+#   :request: BulkRequest
+#   :response: BulkResponse
+# Because asciidoctor clears attributes set in a block. See
+# https://github.com/asciidoctor/asciidoctor/issues/2993
 #
 class ElasticCompatPreprocessor < Extensions::Preprocessor
   IncludeTaggedDirectiveRx = /^include-tagged::([^\[][^\[]*)\[(#{CC_ANY}+)?\]$/
 
   def process document, reader
+    reader.instance_variable_set :@in_attribute_only_block, false
     def reader.process_line line
       return line unless @process_lines
 
-      if IncludeTaggedDirectiveRx =~ line then
+      if @in_attribute_only_block
+        if line == '--'
+          @in_attribute_only_block = false
+          line.clear
+        else
+          line
+        end
+      elsif IncludeTaggedDirectiveRx =~ line then
         if preprocess_include_directive "elastic-include-tagged:#{$1}", $2 then
           nil
         else
@@ -30,9 +56,20 @@ class ElasticCompatPreprocessor < Extensions::Preprocessor
           @look_ahead += 1
           line
         end
+      elsif line == '--'
+        lines = self.lines
+        lines.shift
+        while Asciidoctor::AttributeEntryRx =~ (check_line = lines.shift)
+        end
+        if check_line == '--' then
+          @in_attribute_only_block = true
+          line.clear
+        else
+          line
+        end
       else
         line = super
-        line&.gsub!(/(added)\[([^\]]*)\]/, '\1::[\2]')  
+        line&.gsub!(/(added)\[([^\]]*)\]/, '\1::[\2]')
       end
     end
     reader

--- a/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
@@ -24,22 +24,22 @@ include Asciidoctor
 #   <2> The categories retrieved
 #
 class ElasticCompatTreeProcessor < Extensions::TreeProcessor
-    def process document
-      process_blocks document
-      nil
+  def process document
+    process_blocks document
+    nil
+  end
+
+  def process_blocks block
+    if block.context == :listing && block.style == "source" &&
+          false == block.subs.include?(:specialcharacters)
+      # callouts have to come *after* special characters
+      had_callouts = block.subs.delete(:callouts)
+      block.subs << :specialcharacters
+      block.subs << :callouts if had_callouts
     end
-  
-    def process_blocks block
-      if block.context == :listing && block.style == "source" &&
-            false == block.subs.include?(:specialcharacters)
-        # callouts have to come *after* special characters
-        had_callouts = block.subs.delete(:callouts)
-        block.subs << :specialcharacters
-        block.subs << :callouts if had_callouts
-      end
-      for subblock in block.context == :dlist ? block.blocks.flatten : block.blocks
-        process_blocks subblock
-      end
+    for subblock in block.context == :dlist ? block.blocks.flatten : block.blocks
+      process_blocks subblock
     end
   end
+end
   

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -68,4 +68,73 @@ RSpec.describe ElasticCompatPreprocessor do
     expect { convert(input) }.to raise_error(
         ConvertError, /missing_callout.adoc: line 3: no callout found for <1>/)
   end
+
+  it "un-blocks blocks containing only attributes" do
+    actual = convert <<~ASCIIDOC
+      :inheader: foo
+
+      = Test
+
+      --
+      :outheader: bar
+      --
+
+      [id="{inheader}-{outheader}"]
+      == Header
+
+      <<{inheader}-{outheader}>>
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="foo-bar">
+      <title>Header</title>
+      <simpara><xref linkend="foo-bar"/></simpara>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "attribute only blocks don't break further processing" do
+    actual = convert <<~ASCIIDOC
+      :inheader: foo
+
+      = Test
+
+      --
+      :outheader: bar
+      --
+
+      == Header
+      added[some_version]
+
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_header">
+      <title>Header</title>
+      <note revisionflag="added" revision="some_version">
+        <simpara></simpara>
+      </note>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "attribute only only pick up attribute blocks" do
+    actual = convert <<~ASCIIDOC
+      == Header
+
+      --
+      added[some_version]
+      --
+
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_header">
+      <title>Header</title>
+      <note revisionflag="added" revision="some_version">
+        <simpara></simpara>
+      </note>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
 end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ElasticCompatPreprocessor do
     expect(actual).to eq(expected.strip)
   end
 
-  it "attribute only blocks don't pick up blocks with other stuff in it" do
+  it "attribute only blocks don't pick up blocks without attributes" do
     actual = convert <<~ASCIIDOC
       == Header
 
@@ -137,4 +137,32 @@ RSpec.describe ElasticCompatPreprocessor do
     DOCBOOK
     expect(actual).to eq(expected.strip)
   end
+
+  it "attribute only blocks don't pick up blocks with attributes and other stuff" do
+    actual = convert <<~ASCIIDOC
+      == Header
+
+      --
+      :attr: test
+      added[some_version]
+      --
+
+      [id="{attr}"]
+      == Header
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_header">
+      <title>Header</title>
+      <note revisionflag="added" revision="some_version">
+        <simpara></simpara>
+      </note>
+      </chapter>
+      <chapter id="test">
+      <title>Header</title>
+
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
 end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe ElasticCompatPreprocessor do
     expect(actual).to eq(expected.strip)
   end
 
-  it "attribute only only pick up attribute blocks" do
+  it "attribute only blocks don't pick up blocks with other stuff in it" do
     actual = convert <<~ASCIIDOC
       == Header
 

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -41,7 +41,6 @@ def convert input
       :backend    => :docbook45,
       :logger     => logger,
       :doctype    => :book,
-      :verbose    => true,
       :attributes => {
         'docdir' => File.dirname(__FILE__),
       },

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -28,16 +28,20 @@ class ConvertError < Exception
   end
 end
 
+# Put asciidoctor into verbose mode so it'll log reference errors
+$VERBOSE = true
+
 ##
 # Convert an asciidoc string into docbook. If the conversion results in any
 # errors or warnings then raises a ConvertError.
 def convert input
   logger = Asciidoctor::MemoryLogger.new
   result = Asciidoctor.convert input, {
-      :safe => :unsafe,  # Used to include "funny" files.
-      :backend => :docbook45,
-      :logger => logger,
-      :doctype => :book,
+      :safe       => :unsafe,  # Used to include "funny" files.
+      :backend    => :docbook45,
+      :logger     => logger,
+      :doctype    => :book,
+      :verbose    => true,
       :attributes => {
         'docdir' => File.dirname(__FILE__),
       },


### PR DESCRIPTION
Asciidoc requires that we fence attributes at the beginning of a section
like so:
```
--
:api: index
:request: IndexRequest
:response: IndexResponse
--
```

But asciidoctor drops the attribute values if they are in the block
which I've filed here:
https://github.com/asciidoctor/asciidoctor/issues/2993

That means that we have to *remove* the blocks for asciidoctor. This
does that.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
