### PR TITLE
Asciidoctor: Fix raw xslt opts

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -420,7 +420,7 @@ sub rawxsltopts {
     while (@_) {
         my $key = shift;
         my $val = shift;
-        push @opts, '--stringparam', $key, "'$val'";
+        push @opts, '--stringparam', $key, "$val";
     }
     return @opts;
 }
@@ -451,7 +451,7 @@ sub run (@) {
     my ( $out, $err, $ok );
 
     if ( $Opts->{verbose} ) {
-        say "Running: @args";
+        say 'Running: ' . join(' ', map { "\"$_\"" } @args);
         ( $out, $err, $ok ) = tee { system(@args) == 0 };
     }
     else {


### PR DESCRIPTION
My previous work on raw xslt opts added extra `'`s around every
variable. This broke all kinds of stuff like chunking and headers and,
well, almost everything! This fixes that and makes that `--verbose`
printing of commands a little more clear.
