### PR TITLE
[DOCS] Updates searchprofiler attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -83,7 +83,7 @@
 :report-features:   reporting features
 :graph:             X-Pack graph
 :graph-features:    graph analytics features
-:searchprofiler:    X-Pack search profiler
+:searchprofiler:    Query Profiler
 :xpackml:           X-Pack machine learning
 :ml:                machine learning
 :ml-features:       machine learning features

--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -61,7 +61,7 @@
 :report-features:   reporting features
 :graph:             X-Pack graph
 :graph-features:    graph analytics features
-:searchprofiler:    X-Pack search profiler
+:searchprofiler:    Query Profiler
 :xpackml:           X-Pack machine learning
 :ml:                machine learning
 :ml-features:       machine learning features


### PR DESCRIPTION
This PR updates the {searchprofiler} attribute to match the "Query Profiler" terminology on https://www.elastic.co/subscriptions