### PR TITLE
Add infra and logs UI to overview topic

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -7,6 +7,8 @@ You configure settings for {xpack} features in the `elasticsearch.yml`,
 |APM UI             |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]        |No
 |Development Tools  |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
 |Graph              |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Infrastructure UI  |No                                    |{kibana-ref}/infrastructure-ui-settings-kb.html[Yes]  |No
+|Logs UI            |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]            |No
 |Machine learning   |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
 |Management         |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
 |Monitoring         |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]


### PR DESCRIPTION
The overview topic was missing links for the infra and logs UIs added in 6.5. 

@lcawl FYI. For backporting, I guess we need a new version of the settings file, no? Let me know if there is anything I'm overlooking. 
