### PR TITLE
Adds settings file for 6.2

### DIFF
--- a/shared/settings62.asciidoc
+++ b/shared/settings62.asciidoc
@@ -1,0 +1,23 @@
+You configure settings for {xpack} features in the `elasticsearch.yml`,
+`kibana.yml`, and `logstash.yml` configuration files.
+
+[options="header", cols="a,d,d,d"]
+|=======================
+|{xpack} Feature   |{es} Settings                         |{kib} Settings                                |Logstash Settings
+|APM UI            |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]        |No
+|Development Tools |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
+|Graph             |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
+|Machine learning  |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
+|Management        |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring        |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting         |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+.2+|Security
+
+* Auditing
+                   |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
+                   |{ref}/auditing-settings.html[Yes]     |No                                            |No
+|Watcher           |{ref}/notification-settings.html[Yes] |No                                            |No
+|=======================
+
+There are also {ref}/license-settings.html[{xpack} license settings] in the
+`elasticsearch.yml` file.


### PR DESCRIPTION
Since 6.2 currently points to settings61.asciidoc, contents here are a simple copy of the 6.1 file.