### PR TITLE
Add option to force rebuilding

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -49,7 +49,7 @@ use ES::Template();
 
 GetOptions(
     $Opts,    #
-    'all', 'push', 'update!', 'target_repo=s', 'reference=s', 'rely_on_ssh_auth',  #
+    'all', 'push', 'update!', 'target_repo=s', 'reference=s', 'rely_on_ssh_auth', 'rebuild', #
     'single',  'pdf',     'doc=s',           'out=s',  'toc', 'chunk=i',
     'open',    'skiplinkcheck', 'linkcheckonly', 'staging', 'procs=i',         'user=s', 'lang=s',
     'lenient', 'verbose', 'reload_template', 'resource=s@', 'asciidoctor'
@@ -309,7 +309,7 @@ sub build_entries {
             temp_dir => $temp_dir,
             %$entry
         );
-        $toc->add_entry( $book->build );
+        $toc->add_entry( $book->build($Opts->{rebuild}) );
     }
 
     return $toc;
@@ -726,6 +726,7 @@ sub usage {
           --reference       Directory of `--mirror` clones to use as a local cache
           --rely_on_ssh_auth
                             Skip the git auth check and translate configured repos into ssh
+          --rebuild         Rebuild all branches of every book regardless of what has changed
 
     General Opts:
           --staging         Use the template from the staging website

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -139,7 +139,7 @@ sub new {
 #===================================
 sub build {
 #===================================
-    my $self = shift;
+    my ( $self, $rebuild ) = @_;
 
     say "Book: " . $self->title;
 
@@ -158,7 +158,7 @@ sub build {
     );
 
     for my $branch ( @{ $self->branches } ) {
-        $self->_build_book( $branch, $pm );
+        $self->_build_book( $branch, $pm, $rebuild );
 
         my $branch_title = $self->branch_title($branch);
         if ( $branch eq $self->current ) {
@@ -204,7 +204,7 @@ sub build {
 #===================================
 sub _build_book {
 #===================================
-    my ( $self, $branch, $pm ) = @_;
+    my ( $self, $branch, $pm, $rebuild ) = @_;
 
     my $branch_dir    = $self->dir->subdir($branch);
     my $source        = $self->source;
@@ -217,6 +217,7 @@ sub _build_book {
 
     return
            if -e $branch_dir
+        && !$rebuild
         && !$template->md5_changed($branch_dir)
         && !$source->has_changed( $self->title, $branch );
 


### PR DESCRIPTION
Adds a `--rebuild` option to force rebuilding all branches of all books
regardless of whether or not the source of the books has changed. This
is useful when we need to rebuild the version drop downs after a
release.
