### PR TITLE
Asciidoctor: Fix crash on broken definition lists

### DIFF
--- a/resources/asciidoctor/lib/scaffold.rb
+++ b/resources/asciidoctor/lib/scaffold.rb
@@ -17,7 +17,10 @@ class TreeProcessorScaffold < Extensions::TreeProcessor
   def process_blocks block
     process_block block
     for subblock in block.context == :dlist ? block.blocks.flatten : block.blocks
-      process_blocks subblock
+      # subblock can be nil for definition lists without a definition.
+      # this is weird, but it is safe to skip nil here because subclasses
+      # can't change it anyway.
+      process_blocks subblock if subblock
     end
   end
 end

--- a/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
@@ -39,4 +39,34 @@ RSpec.describe ElasticCompatTreeProcessor do
     DOCBOOK
     expect(actual).to eq(expected.strip)
   end
+
+  it "doesn't mind missing definitions" do
+    actual = convert <<~ASCIIDOC
+      == Example
+      `thing1`::
+
+        def1
+
+      `thing2`::
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_example">
+      <title>Example</title>
+      <variablelist>
+      <varlistentry>
+      <term><literal>thing1</literal></term>
+      <listitem>
+      <simpara>def1</simpara>
+      </listitem>
+      </varlistentry>
+      <varlistentry>
+      <term><literal>thing2</literal></term>
+      <listitem>
+      </listitem>
+      </varlistentry>
+      </variablelist>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
 end


### PR DESCRIPTION
Our `TreeProcessorScaffold` would crash on definition lists where a term
wasn't matched with a definition. While these *are* broken definition
lists it is not ok for us to crash on them. This skips processing the
`nil` block that comes from such lists.

At this point the Elasticsearch reference builds, though it builds with
quite a few errors. The difference in performance is not as amazing
as the java-rest client but it is still substantial:

```
      Asciidoctor   Asciidoc
real  1m01.913s     3m09.738s
user  0m55.742s     3m02.545s
sys   0m02.910s     0m04.420s
```

So about 1/3 the time. For reference, this is the java rest client:

```
      Asciidoctor   Asciidoc
real  0m10.341s     1m05.432s
user  0m09.497s     0m55.270s
sys   0m00.616s     0m07.758s
```
Which, I suppose, is still just 1/6. It certainly *feels* faster though.
