### PR TITLE
Fix the edit url with --rely_on_ssh_auth

### DIFF
--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -225,6 +225,9 @@ sub edit_url {
 #===================================
     my ( $self, $branch ) = @_;
     my $url = $self->url;
+    # If the url is in ssh form, then convert it to https
+    $url =~ s/git@([^:]+):/https:\/\/$1\//;
+    # Strip trailing .git as it isn't in the edit link
     $url =~ s/\.git$//;
     my $dir = Path::Class::dir( "edit", $branch )->cleanup->as_foreign('Unix');
     return "$url/$dir/";


### PR DESCRIPTION
The `--rely_on_ssh_auth` option designed for use with new-style CI
breaks that the "Edit Me" links by using ssh-style repos for the basis
of the links instead of https. These links obviously don't work in the
browser. This converts this ssh style links into https style links when
building the edit url.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->