### PR TITLE
Add option to skip fetching source repos

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -49,7 +49,7 @@ use ES::Template();
 
 GetOptions(
     $Opts,    #
-    'all', 'push', 'update!', 'target_repo=s', 'reference=s', 'rely_on_ssh_auth', 'rebuild', #
+    'all', 'push', 'update!', 'target_repo=s', 'reference=s', 'rely_on_ssh_auth', 'rebuild', 'no_fetch', #
     'single',  'pdf',     'doc=s',           'out=s',  'toc', 'chunk=i',
     'open',    'skiplinkcheck', 'linkcheckonly', 'staging', 'procs=i',         'user=s', 'lang=s',
     'lenient', 'verbose', 'reload_template', 'resource=s@', 'asciidoctor'
@@ -451,7 +451,7 @@ sub init_repos {
         else {
             $pm->start($name) and next;
             eval {
-                $repo->update_from_remote();
+                $repo->update_from_remote() unless $Opts->{no_fetch};
                 1;
             } or do {
                 # If creds are invalid, explicitly reject them to try to clear the cache
@@ -727,6 +727,7 @@ sub usage {
           --rely_on_ssh_auth
                             Skip the git auth check and translate configured repos into ssh
           --rebuild         Rebuild all branches of every book regardless of what has changed
+          --no_fetch        Skip fetching updates from source repos
 
     General Opts:
           --staging         Use the template from the staging website


### PR DESCRIPTION
Sometimes it is difficult to experiment with changes to the docs build
because we always fetch changes from the source repositories and those
changes can get mixed up in the changes from the experiment. This adds a
`--no_fetch` option to skip fetching changes from the source
repositories. We still fetch changes from the destination repo if there
is one, but the docs that we build are then based on whatever changes
we've pulled locally.

I suspect this'll never get used in CI, but I'll use it fairly
frequently when experimenting locally.
