### PR TITLE
Fix edit links for local books

### DIFF
--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -224,7 +224,13 @@ sub _tracker_branch {
 sub edit_url {
 #===================================
     my ( $self, $branch ) = @_;
-    my $url = $self->url;
+    return edit_url_for_url_and_branch($self->url, $branch);
+}
+
+#===================================
+sub edit_url_for_url_and_branch {
+#===================================
+    my ( $url, $branch ) = @_;
     # If the url is in ssh form, then convert it to https
     $url =~ s/git@([^:]+):/https:\/\/$1\//;
     # Strip trailing .git as it isn't in the edit link


### PR DESCRIPTION
The "Edit" links on each page have historically been broken when
building books with `./build_docs.pl --doc` because we don't have the
right urls. This is mostly fine, but I'd like to do some debugging of
how asciidoctor generates those links so it'd be nice if they worked
with `--doc`. This takes a reasonable stab at making them work by
looking for the git repository that contains the target of the `--doc`
parameter. It then looks for the clone that comes from the `elastic`
organization. It uses that clone as the basis for the edit url.
