### PR TITLE
Asciidoctor: Fix edit url for nested roots

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -85,7 +85,7 @@ sub build_chunked {
                 '-d' => 'book',
                 '-a' => 'showcomments=1',
                 '-a' => "lang=$lang",
-                '-a' => 'root_dir=' . $root_dir,
+                '-a' => 'repo_root=' . $root_dir,
                 # Use ` to delimit monospaced literals because our docs
                 # expect that
                 '-a' => 'compat-mode=legacy',
@@ -124,7 +124,7 @@ sub build_chunked {
                 '-a' => 'showcomments=1',
                 '-a' => "lang=$lang",
                 '-a' => 'base_edit_url=' . $edit_url,
-                '-a' => 'root_dir=' . $root_dir,
+                '-a' => 'repo_root=' . $root_dir,
                 # Use ` to delimit monospaced literals because our docs
                 # expect that
                 '-a' => 'compat-mode=legacy',

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require_relative '../scaffold.rb'
 
 include Asciidoctor
@@ -18,9 +19,16 @@ class EditMe < TreeProcessorScaffold
   def process_block block
     if [:preamble, :section, :floating_title].include? block.context
       def block.title
+        path = source_path
         url = @document.attributes['edit_url']
         url += '/' unless url.end_with?('/')
-        url += source_path
+        repo_root = @document.attributes['repo_root']
+        if repo_root
+          repo_root = Pathname.new repo_root
+          base_dir = Pathname.new @document.base_dir
+          url += "#{base_dir.relative_path_from(repo_root)}/"
+        end
+        url += path
         "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"
       end
       if :preamble == block.context

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -64,6 +64,29 @@ RSpec.describe EditMe do
     expect(convert input, attributes).to eq(expected.strip)
   end
 
+  it "respects the repo_root attribute" do
+    attributes = {
+      'edit_url' => 'www.example.com/docs/',
+      'repo_root' => File.dirname(File.dirname(__FILE__)),
+    }
+    input = <<~ASCIIDOC
+      include::resources/edit_me/chapter1.adoc[]
+
+      include::resources/edit_me/chapter2.adoc[]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_chapter_1">
+      <title>Chapter 1<ulink role="edit_me" url="www.example.com/docs/spec/resources/edit_me/chapter1.adoc">Edit me</ulink></title>
+      <simpara>Words.</simpara>
+      </chapter>
+      <chapter id="_chapter_2">
+      <title>Chapter 2<ulink role="edit_me" url="www.example.com/docs/spec/resources/edit_me/chapter2.adoc">Edit me</ulink></title>
+      <simpara>Words.</simpara>
+      </chapter>
+    DOCBOOK
+    expect(convert input, attributes).to eq(expected.strip)
+  end
+
   it "does not add a link to each chapter title if edit_link is not set" do
     input = <<~ASCIIDOC
       include::resources/edit_me/chapter1.adoc[]


### PR DESCRIPTION
Fixes the edit url when the "base" document directory isn't the base of
the repository.
