### PR TITLE
Asciidoctor: Drop xml file after docbook

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -109,7 +109,7 @@ sub build_chunked {
                 "$dest/index.xml"
             );
             # TODO copy_resources?
-            # TODO clean the xml files
+            unlink "$dest/index.xml";
             1;
         } or do { $output = $@; $died = 1; };
     }
@@ -232,7 +232,7 @@ sub build_single {
                 "$dest/index.xml"
             );
             # TODO copy_resources?
-            # TODO clean the xml file
+            unlink "$dest/index.xml";
             1;
         } or do { $output = $@; $died = 1; };
     }


### PR DESCRIPTION
Drop the giant xml file produced by asciidoctor after docbook is all done.
We don't keep the xml file we make with asciidoc so we shouldn't keep
the xml file from asciidoctor either. It is useful for debugging, but we
can always get it if we need it.
