### PR TITLE
Asciidoctor: Support added inline macro

### DIFF
--- a/resources/asciidoctor/lib/added/extension.rb
+++ b/resources/asciidoctor/lib/added/extension.rb
@@ -2,6 +2,13 @@ require 'asciidoctor/extensions'
 
 include Asciidoctor
 
+class Added < Extensions::Group
+  def activate registry
+    registry.block_macro AddedBlock
+    registry.inline_macro AddedInline
+  end
+end
+
 # Extension for marking when something was added.
 #
 # Usage
@@ -21,5 +28,32 @@ class AddedBlock < Extensions::BlockMacroProcessor
     DOCBOOK
     
     create_pass_block parent, docbook, {}, subs: nil
+  end
+end
+
+# Extension for marking when something was added.
+#
+# Usage
+#
+#   Foo added:[6.0.0-beta1]
+#
+class AddedInline < Extensions::InlineMacroProcessor
+  use_dsl
+  named :added
+  name_positional_attributes :version, :text
+  with_format :short
+
+  def process parent, target, attrs
+    if attrs[:text]
+      <<~DOCBOOK
+        <phrase revisionflag="added" revision="#{attrs[:version]}">
+          #{attrs[:text]}
+        </phrase>
+      DOCBOOK
+    else
+      <<~DOCBOOK
+        <phrase revisionflag="added" revision="#{attrs[:version]}"/>
+      DOCBOOK
+    end
   end
 end

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -132,7 +132,8 @@ class ElasticCompatPreprocessor < Extensions::Preprocessor
             @code_block_start = line
           end
         end
-        line&.gsub!(/(added)\[([^\]]*)\]/, '\1::[\2]')
+        line&.gsub!(/^(added)\[([^\]]*)\]/, '\1::[\2]')
+        line&.gsub!(/(added)\[([^\]]*)\]/, '\1:[\2]')
       end
     end
     reader

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -132,7 +132,11 @@ class ElasticCompatPreprocessor < Extensions::Preprocessor
             @code_block_start = line
           end
         end
+        # First convert the "block" version of these macros. We convert them
+        # to block macros because they are at the start of the line....
         line&.gsub!(/^(added)\[([^\]]*)\]/, '\1::[\2]')
+        # Then convert the "inline" version of these macros. We convert them
+        # to inline macros because they are *not* at the start of the line....
         line&.gsub!(/(added)\[([^\]]*)\]/, '\1:[\2]')
       end
     end

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -5,6 +5,7 @@ require_relative 'elastic_compat_tree_processor/extension'
 require_relative 'elastic_compat_preprocessor/extension'
 require_relative 'elastic_include_tagged/extension'
 
+Extensions.register Added
 Extensions.register do
   # Enable storing the source locations so we can look at them. This is required
   # for EditMe to get a nice location.
@@ -14,5 +15,4 @@ Extensions.register do
   treeprocessor EditMe
   treeprocessor ElasticCompatTreeProcessor
   include_processor ElasticIncludeTagged
-  block_macro AddedBlock
 end

--- a/resources/asciidoctor/spec/added_spec.rb
+++ b/resources/asciidoctor/spec/added_spec.rb
@@ -1,17 +1,15 @@
 require 'added/extension'
 
-RSpec.describe AddedBlock do
+RSpec.describe Added do
   before(:each) do
-    Extensions.register do
-      block_macro AddedBlock
-    end
+    Extensions.register Added
   end
 
   after(:each) do
     Extensions.unregister_all
   end
 
-  it "creates a note" do
+  it "block version creates a note" do
     actual = convert <<~ASCIIDOC
       == Example
       added::[some_version]
@@ -27,7 +25,7 @@ RSpec.describe AddedBlock do
     expect(actual).to eq(expected.strip)
   end
 
-  it "is not invoked without the ::" do
+  it "block version is not invoked without the ::" do
     actual = convert <<~ASCIIDOC
       == Example
       added[some_version]
@@ -36,6 +34,52 @@ RSpec.describe AddedBlock do
       <chapter id="_example">
       <title>Example</title>
       <simpara>added[some_version]</simpara>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "inline version creates a phrase" do
+    actual = convert <<~ASCIIDOC
+      == Example
+      words added:[some_version]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_example">
+      <title>Example</title>
+      <simpara>words <phrase revisionflag="added" revision="some_version"/>
+      </simpara>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "inline version creates a phrase with extra text if provided" do
+    actual = convert <<~ASCIIDOC
+      == Example
+      words added:[some_version, more words]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_example">
+      <title>Example</title>
+      <simpara>words <phrase revisionflag="added" revision="some_version">
+        more words
+      </phrase>
+      </simpara>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "inline version is not invoked without the ::" do
+    actual = convert <<~ASCIIDOC
+      == Example
+      words added[some_version]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_example">
+      <title>Example</title>
+      <simpara>words added[some_version]</simpara>
       </chapter>
     DOCBOOK
     expect(actual).to eq(expected.strip)

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -5,10 +5,10 @@ require 'shared_examples/does_not_break_line_numbers'
 
 RSpec.describe ElasticCompatPreprocessor do
   before(:each) do
+    Extensions.register Added
     Extensions.register do
       preprocessor ElasticCompatPreprocessor
       include_processor ElasticIncludeTagged
-      block_macro AddedBlock
     end
   end
 
@@ -18,7 +18,7 @@ RSpec.describe ElasticCompatPreprocessor do
 
   include_examples "doesn't break line numbers"
 
-  it "invokes added[version]" do
+  it "invokes the added block macro when added[version] starts a line" do
     actual = convert <<~ASCIIDOC
       == Example
       added[some_version]
@@ -29,6 +29,21 @@ RSpec.describe ElasticCompatPreprocessor do
       <note revisionflag="added" revision="some_version">
         <simpara></simpara>
       </note>
+      </chapter>
+    DOCBOOK
+    expect(actual).to eq(expected.strip)
+  end
+
+  it "invokes the added inline macro when added[version] is otherwise on the line" do
+    actual = convert <<~ASCIIDOC
+      == Example
+      words added[some_version]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_example">
+      <title>Example</title>
+      <simpara>words <phrase revisionflag="added" revision="some_version"/>
+      </simpara>
       </chapter>
     DOCBOOK
     expect(actual).to eq(expected.strip)


### PR DESCRIPTION
Adds support for the added inline macro which would normally be
specified like this:

```
words added:[version]
```

But for compatibility with Elastic's asciidoc customizations we support
specifying it like this as well:

```
words added[version]
```

Note that we'll want to build on this to add support for `coming` and
`deprecated` as well.
