### PR TITLE
[DOCS] Update 6.6.0 release-state

### DIFF
--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -9,4 +9,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released


### PR DESCRIPTION
This PR changes the release-state information that is used by the Stack Overview, Kibana Reference, etc.