### PR TITLE
Revert "[DOCS] Update 6.6.0 release-state"

### DIFF
--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -9,4 +9,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          released
+:release-state:          unreleased


### PR DESCRIPTION
Reverts elastic/docs#550 because of delayed release date for 6.6.0