### PR TITLE
Add x-pack/metricbeat/module to build path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -663,6 +663,9 @@ contents:
                 path:   metricbeat/module
               -
                 repo:   beats
+                path:   x-pack/metricbeat/module
+              -
+                repo:   beats
                 path:   metricbeat/scripts
               -
                 repo:   beats


### PR DESCRIPTION
With the introduction of x-pack modules we started to add doc files in this directory.
