### PR TITLE
Excludes branches from the x-pack metricbeat path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -664,6 +664,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/metricbeat/module
+                exclude_branches:   [ 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   beats
                 path:   metricbeat/scripts


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/556

This PR excludes branches where the x-pack/metricbeat/module path does not exist.