### PR TITLE
[DOCS] Add ECE 2.1 doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -457,7 +457,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    2.0
-            branches:   [ 2.0, 1.1, 1.0 ]
+            branches:   [ 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
In preparation for ECE 2.1.0, adding the 2.1.0 docs to our doc builds.

**Do not merge this PR before January 25th.**