### PR TITLE
[DOCS] Updates current and release-state for 6.6

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -48,7 +48,7 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    6.5
+            current:    6.6
             index:      docs/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
@@ -63,7 +63,7 @@ contents:
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
-            current:    6.5
+            current:    6.6
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
@@ -88,7 +88,7 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    6.5
+            current:    6.6
             index:      docs/en/stack/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
@@ -126,7 +126,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -192,7 +192,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    6.5
+            current:    6.6
             branches:   [{ master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -209,7 +209,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    6.5
+            current:    6.6
             index:      docs/plugins/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
@@ -234,7 +234,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    6.5
+                current:    6.6
                 branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
@@ -255,7 +255,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    6.5
+                current:    6.6
                 branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -397,7 +397,7 @@ contents:
             prefix:     en/elasticsearch/sql-odbc
             branches:   [{ master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5]
             index:      docs/odbc.asciidoc
-            current:    6.5
+            current:    6.6
             tags:       Elasticsearch/SQL
             subject:    Elasticsearch SQL
             sources:
@@ -407,7 +407,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -476,7 +476,7 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -498,7 +498,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -538,7 +538,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
@@ -576,7 +576,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
@@ -598,7 +598,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
@@ -624,7 +624,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -646,7 +646,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
@@ -677,7 +677,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    6.5
+            current:    6.6
             index:      heartbeat/docs/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
@@ -700,7 +700,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
@@ -731,7 +731,7 @@ contents:
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    6.5
+            current:    6.6
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
             chunk:      1
@@ -753,7 +753,7 @@ contents:
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    6.5
+            current:    6.6
             index:      journalbeat/docs/index.asciidoc
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
             chunk:      1
@@ -829,7 +829,7 @@ contents:
           -
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
@@ -847,7 +847,7 @@ contents:
             title:      APM Overview
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
@@ -863,7 +863,7 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    6.5
+            current:    6.6
             branches:   [ { master: 7.0.0-alpha2 }, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -9,4 +9,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/550 and https://github.com/elastic/docs/pull/549

This PR re-implements the reverted changes. 
