### PR TITLE
Asciidoctor: Log absolute path when copying images

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -23,7 +23,7 @@ class CopyImages < TreeProcessorScaffold
     return unless @copied.add? uri      # Skip images we've copied before
     source = find_source block, uri
     return unless source                # Skip images we can't find
-    logger.info message_with_context "copying #{uri}", :source_location => block.source_location
+    logger.info message_with_context "copying #{source}", :source_location => block.source_location
     copy_image_proc = block.document.attr 'copy_image'
     if copy_image_proc
       # Delegate to a proc for copying if one is defined. Used for testing.

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -33,7 +33,8 @@ RSpec.describe CopyImages do
       == Example
       image::resources/copy_images/example1.png[]
     ASCIIDOC
-    convert input, attributes, match(/INFO: <stdin>: line 2: copying resources\/copy_images\/example1.png/)
+    convert input, attributes,
+        eq("INFO: <stdin>: line 2: copying #{spec_dir}\/resources\/copy_images\/example1.png")
     expect(copied).to eq([
         ["resources/copy_images/example1.png", "#{spec_dir}/resources/copy_images/example1.png"]
     ])
@@ -46,7 +47,8 @@ RSpec.describe CopyImages do
       == Example
       image::example1.png[]
     ASCIIDOC
-    convert input, attributes, match(/INFO: <stdin>: line 2: copying example1.png/)
+    convert input, attributes,
+        eq("INFO: <stdin>: line 2: copying #{spec_dir}/resources/copy_images/example1.png")
     expect(copied).to eq([
         ["example1.png", "#{spec_dir}/resources/copy_images/example1.png"]
     ])
@@ -59,7 +61,8 @@ RSpec.describe CopyImages do
       == Example
       image::copy_images/example1.png[]
     ASCIIDOC
-    convert input, attributes, match(/INFO: <stdin>: line 2: copying copy_images\/example1.png/)
+    convert input, attributes,
+        eq("INFO: <stdin>: line 2: copying #{spec_dir}/resources/copy_images/example1.png")
     expect(copied).to eq([
         ["copy_images/example1.png", "#{spec_dir}/resources/copy_images/example1.png"]
     ])
@@ -93,9 +96,12 @@ RSpec.describe CopyImages do
       image::resources/copy_images/example2.png[]
       image::resources/copy_images/example1.png[]
       image::resources/copy_images/example2.png[]
-      ASCIIDOC
-    convert input, attributes, match(/INFO: <stdin>: line 2: copying resources\/copy_images\/example1.png/).and(
-        match(/INFO: <stdin>: line 4: copying resources\/copy_images\/example2.png/))
+    ASCIIDOC
+    expected_warnings = <<~LOG
+      INFO: <stdin>: line 2: copying #{spec_dir}/resources/copy_images/example1.png
+      INFO: <stdin>: line 4: copying #{spec_dir}/resources/copy_images/example2.png
+    LOG
+    convert input, attributes, eq(expected_warnings.strip)
     expect(copied).to eq([
         ["resources/copy_images/example1.png", "#{spec_dir}/resources/copy_images/example1.png"],
         ["resources/copy_images/example2.png", "#{spec_dir}/resources/copy_images/example2.png"],
@@ -127,8 +133,8 @@ RSpec.describe CopyImages do
         == Example
         image::tmp_example1.png[]
       ASCIIDOC
-      # NOCOMMIT full paths in logs too, I think
-      convert input, attributes, match(/INFO: <stdin>: line 2: copying tmp_example1.png/)
+      convert input, attributes,
+          eq("INFO: <stdin>: line 2: copying #{tmp}/tmp_example1.png")
       expect(copied).to eq([
           ["tmp_example1.png", "#{tmp}/tmp_example1.png"]
       ])
@@ -149,7 +155,8 @@ RSpec.describe CopyImages do
         == Example
         image::tmp_example1.png[]
       ASCIIDOC
-      convert input, attributes, match(/INFO: <stdin>: line 2: copying tmp_example1.png/)
+      convert input, attributes,
+          eq("INFO: <stdin>: line 2: copying #{tmp}/tmp_example1.png")
       expect(copied).to eq([
           ["tmp_example1.png", "#{tmp}/tmp_example1.png"]
       ])

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -33,7 +33,7 @@ def convert input, extra_attributes = {}, warnings_matcher = eq('')
     }
   warnings_string = logger.messages
         .map { |l| "#{l[:severity]}: #{l[:message].inspect}" }
-        .join('\n')
+        .join("\n")
   expect(warnings_string).to warnings_matcher
   result
 end


### PR DESCRIPTION
Switch the `copy_images` Asciidoctor plugin to log the absolute path
when copying images and clean up some rough spots in the tests around
`copy_images` that I bumped into when making this change.
