### PR TITLE
Asciidoctor: Better handling for resources attribute

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -46,8 +46,13 @@ class CopyImages < TreeProcessorScaffold
     checked = []
 
     resources = block.document.attr 'resources'
-    if resources
-      to_check += CSV.parse_line(resources)
+    if resources and not resources.empty?
+      begin
+        to_check += CSV.parse_line(resources)
+      rescue CSV::MalformedCSVError => error
+        logger.error message_with_context "Error loading [resources]: #{error}",
+            :source_location => block.source_location
+      end
     end
 
     while (dir = to_check.shift)

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -163,6 +163,39 @@ RSpec.describe CopyImages do
     }
   end
 
+  it "doesn't mind an empty resources attribute" do
+    copied = []
+    attributes = copy_attributes copied
+    attributes['resources'] = ''
+    input = <<~ASCIIDOC
+      == Example
+      image::example1.png[]
+    ASCIIDOC
+    convert input, attributes,
+        eq("INFO: <stdin>: line 2: copying #{spec_dir}/resources/copy_images/example1.png")
+    expect(copied).to eq([
+        ["example1.png", "#{spec_dir}/resources/copy_images/example1.png"]
+    ])
+  end
+
+  it "has a nice error message if resources is invalid CSV" do
+    copied = []
+    attributes = copy_attributes copied
+    attributes['resources'] = '"'
+    input = <<~ASCIIDOC
+      == Example
+      image::example1.png[]
+    ASCIIDOC
+    expected_warnings = <<~LOG
+      ERROR: <stdin>: line 2: Error loading [resources]: Unclosed quoted field on line 1.
+      INFO: <stdin>: line 2: copying #{spec_dir}/resources/copy_images/example1.png
+    LOG
+    convert input, attributes, eq(expected_warnings.strip)
+    expect(copied).to eq([
+        ["example1.png", "#{spec_dir}/resources/copy_images/example1.png"]
+    ])
+  end
+
   it "has a nice error message when it can't find a file with single valued resources attribute" do
     Dir.mktmpdir {|tmp|
       copied = []


### PR DESCRIPTION
Prevents the copy images asciidoctor extension from dying if the
`resources` attribute is an empty string and improves the error message
if it is invalid CSV.
