### PR TITLE
Drop files used to deploy this repo

### DIFF
--- a/appspec.yml
+++ b/appspec.yml
@@ -1,6 +1,0 @@
-version: 0.0
-os: linux
-hooks:
-  ApplicationStart:
-  - location: docs-push.sh
-    runas: rawengwww

--- a/docs-push.sh
+++ b/docs-push.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# Get latest code 
-cd /opt/node_apps/docs && CURRENT="$(git symbolic-ref --short HEAD)" && git fetch && git reset --hard origin/$CURRENT


### PR DESCRIPTION
Drops two files that were used to deploy this repo to the web servers.
They have been moved to the `built-docs` repo.
