### PR TITLE
Branch 6.x to 6.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -50,7 +50,7 @@ contents:
             prefix:     en/elastic-stack
             current:    6.6
             index:      docs/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
             sources:
@@ -65,7 +65,7 @@ contents:
             prefix:     en/elastic-stack-get-started
             current:    6.6
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
@@ -90,7 +90,7 @@ contents:
             prefix:     en/elastic-stack-overview
             current:    6.6
             index:      docs/en/stack/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
@@ -127,7 +127,7 @@ contents:
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -140,12 +140,12 @@ contents:
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
-                exclude_branches:   [ master, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -170,7 +170,7 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/qa/sql
                 # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 6.x, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/plugin/sql/qa
@@ -193,7 +193,7 @@ contents:
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    6.6
-            branches:   [{ master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [{ master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -211,7 +211,7 @@ contents:
             repo:       elasticsearch
             current:    6.6
             index:      docs/plugins/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -235,7 +235,7 @@ contents:
                 title:      Java REST Client
                 prefix:     java-rest
                 current:    6.6
-                branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients
@@ -256,7 +256,7 @@ contents:
                 title:      Java API
                 prefix:     java-api
                 current:    6.6
-                branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients
@@ -315,8 +315,8 @@ contents:
               -
                 title:      .NET API
                 prefix:     net-api
-                current:    6.x
-                branches:   [ master, 6.x, 5.x, 2.x, 1.x ]
+                current:    6.7
+                branches:   [ master, 6.7, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -396,7 +396,7 @@ contents:
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -465,7 +465,7 @@ contents:
             title:      Kibana Reference
             prefix:     en/kibana
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -478,7 +478,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
     -
         title:      Logstash: Collect, Enrich, and Transport
@@ -487,7 +487,7 @@ contents:
             title:      Logstash Reference
             prefix:     en/logstash
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -500,7 +500,7 @@ contents:
                 repo:   x-pack-logstash
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -527,7 +527,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -543,7 +543,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats
@@ -565,7 +565,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
             subject:    Packetbeat
@@ -587,7 +587,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
             subject:    Filebeat
@@ -613,7 +613,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
             subject:    Winlogbeat
@@ -635,7 +635,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
             subject:    Metricbeat
@@ -652,7 +652,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/metricbeat/module
-                exclude_branches:   [ 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   beats
                 path:   metricbeat/scripts
@@ -667,7 +667,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    6.6
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
             subject:    Heartbeat
@@ -689,7 +689,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
             subject:    Auditbeat
@@ -721,7 +721,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    6.6
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5 ]
             chunk:      1
             tags:       Functionbeat/Reference
             subject:    Functionbeat
@@ -743,7 +743,7 @@ contents:
             prefix:     en/beats/journalbeat
             current:    6.6
             index:      journalbeat/docs/index.asciidoc
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5 ]
             chunk:      1
             tags:       Journalbeat/Reference
             subject:    Journalbeat
@@ -818,7 +818,7 @@ contents:
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
             current:    6.6
-            branches:   [ { master: 7.0.0-alpha2 }, 6.x, 6.6, 6.5 ]
+            branches:   [ { master: 7.0.0-alpha2 }, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
             tags:       Infrastructure/Guide
@@ -1177,12 +1177,12 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.x, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches:   [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches: [ master, 6.x, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches: [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
           -
             title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -2,7 +2,7 @@
 :logstash_version:       6.7.0
 :elasticsearch_version:  6.7.0
 :kibana_version:         6.7.0
-:branch:                 6.x
+:branch:                 6.7
 :major-version:          6.x
 
 //////////


### PR DESCRIPTION
We're removing the 6.x branch from all of the stack repos in favor of the
6.7 branch. I'm not sure what else needs to be updated here.