### PR TITLE
Revert .NET API's branch to 6.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -315,8 +315,10 @@ contents:
               -
                 title:      .NET API
                 prefix:     net-api
-                current:    6.7
-                branches:   [ master, 6.7, 5.x, 2.x, 1.x ]
+                # The elasticsearch-net repo only keeps .x branches. Do not
+                # bump these with the rest of the stack.
+                current:    6.x
+                branches:   [ master, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients


### PR DESCRIPTION
The .NET API doesn't branch the same way as the stack. It looks like
most of the clients don't actually. We bumped its branch to 6.7 as part
of bumping the stack. This was incorrect because they have no plans to
create a 6.7 branch.
