### PR TITLE
Add version attributes for 7.0 and 7.x

### DIFF
--- a/shared/versions.asciidoc
+++ b/shared/versions.asciidoc
@@ -1,9 +1,9 @@
-:version:        7.0.0-alpha2
-:logstash_version:       7.0.0-alpha2
-:elasticsearch_version:  7.0.0-alpha2
-:kibana_version:         7.0.0-alpha2
-:branch:         master
-:major-version:  7.x
+:version:                8.0.0-alpha1
+:logstash_version:       8.0.0-alpha1
+:elasticsearch_version:  8.0.0-alpha1
+:kibana_version:         8.0.0-alpha1
+:branch:                 master
+:major-version:          8.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions70.asciidoc
+++ b/shared/versions70.asciidoc
@@ -1,0 +1,12 @@
+:version:                7.0.0-alpha2
+:logstash_version:       7.0.0-alpha2
+:elasticsearch_version:  7.0.0-alpha2
+:kibana_version:         7.0.0-alpha2
+:branch:                 7.0
+:major-version:          7.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   prerelease

--- a/shared/versions71.asciidoc
+++ b/shared/versions71.asciidoc
@@ -1,0 +1,12 @@
+:version:                7.1.0
+:logstash_version:       7.1.0
+:elasticsearch_version:  7.1.0
+:kibana_version:         7.1.0
+:branch:                 7.x
+:major-version:          7.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   prerelease


### PR DESCRIPTION
This PR adds the versions70.asciidoc for use by 7.0 branches and the versions71.asciidoc file for use by 7.x branches. It also updates the details in the versions.asciidoc file, which is used by master branches. 