### PR TITLE
Remove docker detection

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -94,6 +94,8 @@ def run_build_docs(args):
     # it needs to die.
     docker_args.append('-i')
 
+    build_docs_args.append('--in_standard_docker')
+
     open_browser = False
     args = Args(args)
     saw_out = False


### PR DESCRIPTION
When I first allowed running the docs build in docker I made the
incorrect assumption that any time the build is running in docker it is
running in the docker container that we manage. Lots of folks were using
docker to manage the pl dependencies of the build. This drops that
assumption and adds an explicit parameter to engage `build_docs.pl`'s
customizations that work for our docker image. The folks who were building
the docs in their own docker image have their own customizations and
won't need ours.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
