### PR TITLE
Updates URL for ref-70 adds ref-80

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,5 +1,6 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
-:ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
 :xpack-ref:            https://www.elastic.co/guide/en/elastic-stack-overview/{branch}


### PR DESCRIPTION
This PR updates the "ref-70" attribute and adds the "ref-80" attribute, since the former is no longer associated with the master branch. 
