### PR TITLE
Clean up argument handling

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -30,6 +30,7 @@ from __future__ import print_function
 import logging
 from os import environ, getgid, getuid
 from os.path import basename, dirname, exists, isdir, join, realpath
+import re
 import subprocess
 from sys import platform, version_info
 import time
@@ -205,10 +206,15 @@ def run_build_docs(args):
 
 class Args:
     def __init__(self, args):
-        # Replace equals delimited arguments with the space delimiated versions
-        # so it is simpler to iterate over them
+        # Normalize the args so it is simpler to iterate over them
         self.args = []
         for arg in args:
+            # Replace `-foo` style with `--foo` style
+            m = re.match('^-[^-]+$', arg)
+            if m:
+                arg = '-' + m.group(0)
+
+            # Replace `--foo=bar` style with `--foo bar` style
             split = arg.split('=')
             if len(split) > 2:
                 raise UserError('Invalid argument [%s]' % arg)

--- a/build_docs
+++ b/build_docs
@@ -209,15 +209,14 @@ class Args:
         # Normalize the args so it is simpler to iterate over them
         self.args = []
         for arg in args:
-            # Replace `-foo` style with `--foo` style
-            m = re.match('^-[^-]+$', arg)
-            if m:
-                arg = '-' + m.group(0)
+            # Fail `-foo` style arguments
+            if re.match('^-[^-]+$', arg):
+                raise ArgError('Use [-%s] instead of [%s]' % (arg, arg))
 
             # Replace `--foo=bar` style with `--foo bar` style
             split = arg.split('=')
             if len(split) > 2:
-                raise UserError('Invalid argument [%s]' % arg)
+                raise ArgError('Invalid argument [%s]' % arg)
             self.args.extend(split)
         self.current = 0
 

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -35,7 +35,7 @@ use ES::Util qw(
     write_html_redirect
 );
 
-use Getopt::Long;
+use Getopt::Long qw(:config no_auto_abbrev no_ignore_case no_getopt_compat);
 use YAML qw(LoadFile);
 use Path::Class qw(dir file);
 use Browser::Open qw(open_browser);


### PR DESCRIPTION
Drops support for single dashed long-opts from the docker build. Drops
support for "abbreviated" options, drops support for starting options
with a `+`, and drops support for specifying options in any case from the
perl build. I haven't see folks use any of the last three options and
they are incompatible with the docker build and would be very difficult
to *make* compatible with the docker build. I *have* seen folks use
single dashed long options. This will fail those single dashed arguments
on the docker build *only* and tell the user to use the double dashed
option.

I believe this might break some folks that are relying on undocumented
options, mostly the "automatic abbreviations" that the script supported.
For command line users I don't foresee an issue though - they'll get the
usage message and be fine. The bigger problem might be scripts that
build the docs. The [kibana] script looks ok. Elasticsearch uses
doc_build_aliases.sh. Cloud's script looks ok. I *suspect* we're ok
here.

[kibana]: https://github.com/elastic/kibana/blob/master/src/docs/docs_repo.js


Edit: The original version of this added support for the single dashed options to the docker build but I ended up dropping it after the conversation below.