### PR TITLE
Docker: Fix default destionation directory

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -176,8 +176,7 @@ def run_build_docs(args):
     if not saw_out:
         # If you don't specify --out then we dump the output into
         # $cwd/html_docsto keep backwards compatibility with build_docs.pl.
-        docker_args.extend(['-v',
-                            '%s:/out:delegated' % dirname(realpath('.'))])
+        docker_args.extend(['-v', '%s:/out:delegated' % realpath('.')])
         build_docs_args.extend(['--out', "/out/html_docs"])
 
     def handle_line(line):


### PR DESCRIPTION
When I first made `build_docs` I picked the wrong default output
directory when you specify `--doc`. It should be `./html_docs`. I made
it `../html_docs`. See the subtle difference? I didn't notice for a
while at first. Then I was really confused. Then I tracked down the
extra `dirname`. Then I fixed it. This is the fix.
