### PR TITLE
Docker: Handle switching reference repo

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -494,7 +494,7 @@ sub init_repos {
     $tracker_path = "$target_repo_checkout/$tracker_path";
     eval {
         $target_repo->update_from_remote();
-        say " - Checking out: target_repo";
+        printf(" - %20s: Checking out\n", 'target_repo');
         $target_repo->checkout_to($target_repo_checkout);
         1;
     } or do {


### PR DESCRIPTION
If you run `build_docs.pl --all --reference ....` then the cloned repos
retain a reference to the path on your filesystem. If you run
`build_docs --all --reference ....` then the cloned repos retain a
reference to the path that docker mounts the reference directory which
isn't the same as your filesystem. If you switch back and forth between
`build_docs` and `build_docs.pl` then the git operations will fail
because those paths don't exist. This change fixes that problem by
blowing away the clone if the reference repository doesn't exist.

We don't just mount the reference repository into the docker container
in the same spot as it is on your filesystem because it could be
*anywhere* on your filesystem. If it happened to be some place *weird*
then if likely wouldn't mount into the docker container. Or it'd mount
and cause strange failures. That just isn't worth the trouble.

This also changes the logging that we produce when updating
repositories to something consistent. This is important because we fork
this cloning process so lines don't really have any relationship to one
another. This consistent formatting makes sure that every line has all
of the context that we need. It also makes every line align vertically
which makes my heart happy. All of this is needed with or without this
change but the inconsistent logging made debugging this change locally
difficult. So I added it.
