### PR TITLE
Switch MS17 to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -427,8 +427,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-15
-            branches:   [ release-ms-17, release-ms-15, saas-release, saas-release-heroku ]
+            current:    release-ms-17
+            branches:   [ release-ms-17, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Changes the ESS current to MS17, removes MS15. To be merged when MS 17 releases.

