### PR TITLE
Bump Azure ARM template docs to 6.6

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -110,9 +110,9 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    6.5
+            current:    6.6
             index:      docs/index.asciidoc
-            branches:   [ master, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This PR bumps azure arm template docs to 6.6, now that 6.6.0 is released to the Marketplace
