### PR TITLE
Asciidoctor: Consistent sorting in warning message

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -124,6 +124,10 @@ class CopyImages < TreeProcessorScaffold
 
     # We'll skip images we can't find but we should log something about it so
     # we can fix them.
+    checked.sort! { |lhs, rhs|
+      by_depth = lhs.scan(/\//).count <=> rhs.scan(/\//).count
+      by_depth || lhs <=> rhs
+    }
     logger.warn message_with_context "can't read image at any of #{checked}", :source_location => block.source_location
     nil
   end

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -126,7 +126,11 @@ class CopyImages < TreeProcessorScaffold
     # we can fix them.
     checked.sort! { |lhs, rhs|
       by_depth = lhs.scan(/\//).count <=> rhs.scan(/\//).count
-      by_depth || lhs <=> rhs
+      if by_depth != 0
+        by_depth
+      else
+        lhs <=> rhs
+      end
     }
     logger.warn message_with_context "can't read image at any of #{checked}", :source_location => block.source_location
     nil

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -208,8 +208,8 @@ RSpec.describe CopyImages do
       ASCIIDOC
       convert input, attributes, match(/
           WARN:\ <stdin>:\ line\ 2:\ can't\ read\ image\ at\ any\ of\ \[
+            "#{tmp}\/not_found.png",\s
             "#{spec_dir}\/not_found.png",\s
-            "#{tmp}\/not_found.png"
             .+
           \]/x).and(not_match(/INFO: <stdin>/))
       expect(copied).to eq([])
@@ -227,9 +227,9 @@ RSpec.describe CopyImages do
       ASCIIDOC
       convert input, attributes, match(/
           WARN:\ <stdin>:\ line\ 2:\ can't\ read\ image\ at\ any\ of\ \[
-            "#{spec_dir}\/not_found.png",\s
+            "\/dummy2\/not_found.png",\s
             "#{tmp}\/not_found.png",\s
-            "\/dummy2\/not_found.png"
+            "#{spec_dir}\/not_found.png",\s
             .+
           \]/x).and(not_match(/INFO: <stdin>/))
       expect(copied).to eq([])


### PR DESCRIPTION
When our copy images extension can't find an image it outputs *all* of
the paths that it searched so you can be super sure it searched all the
places that you wanted it to search. This sorts the output so that the
error message is consistent. Which is mostly nice for tests. I mean, it
is nice for stuff like reproducibility of errors locally too, but it is
super nice for tests. And it is my tests that are failing.
