### PR TITLE
[DOCS] Update location of Installation and Upgrade guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -49,14 +49,14 @@ contents:
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
             current:    6.6
-            index:      docs/index.asciidoc
+            index:      docs/en/install-grade/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
             sources:
               -
                 repo:   stack-docs
-                path:   docs/
+                path:   docs/en
               -
                 repo:   elasticsearch
                 path:   docs/

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -39,7 +39,7 @@ alias docbldls=docbldlsx
 alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Stack
-alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/index.asciidoc'
+alias docbldstk='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/'
 
 alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 


### PR DESCRIPTION
Replaces https://github.com/elastic/docs/pull/571

This PR adds the missing --resource parameter to the docbldstk build alias and updates the path information for the Installation and Upgrade Guide.