### PR TITLE
Asciidoctor: Ruby style

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -54,31 +54,7 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Enabled: false
 
-Naming/ConstantName:
-  Enabled: false
-
-Style/BlockDelimiters:
-  Enabled: false
-
-Style/BracesAroundHashParameters:
-  Enabled: false
-
-Style/For:
-  Enabled: false
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/GuardClause:
-  Enabled: false
-
 Style/HashSyntax:
-  Enabled: false
-
-Style/IfUnlessModifier:
-  Enabled: false
-
-Style/MixinUsage:
   Enabled: false
 
 Style/MutableConstant:
@@ -94,7 +70,4 @@ Style/StringLiterals:
   Enabled: false
 
 Style/RedundantReturn:
-  Enabled: false
-
-Style/RegexpLiteral:
   Enabled: false

--- a/resources/asciidoctor/lib/change_admonishment/extension.rb
+++ b/resources/asciidoctor/lib/change_admonishment/extension.rb
@@ -1,6 +1,6 @@
-require 'asciidoctor/extensions'
+# frozen_string_literal: true
 
-include Asciidoctor
+require 'asciidoctor/extensions'
 
 ##
 # Extensions for marking when something was added, when it *will* be added, or
@@ -15,21 +15,21 @@ include Asciidoctor
 #   Foo coming:[6.0.0-beta1]
 #   Foo deprecated:[6.0.0-beta1]
 #
-class ChangeAdmonishment < Extensions::Group
+class ChangeAdmonishment < Asciidoctor::Extensions::Group
   def activate(registry)
     [
         [:added, 'added'],
         [:coming, 'changed'],
         [:deprecated, 'deleted'],
-    ].each { |(name, revisionflag)|
+    ].each do |(name, revisionflag)|
       registry.block_macro ChangeAdmonishmentBlock.new(revisionflag), name
       registry.inline_macro ChangeAdmonishmentInline.new(revisionflag), name
-    }
+    end
   end
 
   ##
   # Block change admonishment.
-  class ChangeAdmonishmentBlock < Extensions::BlockMacroProcessor
+  class ChangeAdmonishmentBlock < Asciidoctor::Extensions::BlockMacroProcessor
     use_dsl
     name_positional_attributes :version, :passtext
 
@@ -43,20 +43,20 @@ class ChangeAdmonishment < Extensions::Group
       # We can *almost* go through the standard :admonition conversion but
       # that won't render the revisionflag or the revision. So we have to
       # go with this funny compound pass thing.
-      note = Block.new(parent, :pass, :content_model => :compound)
-      note << Block.new(note, :pass,
+      note = Asciidoctor::Block.new(parent, :pass, :content_model => :compound)
+      note << Asciidoctor::Block.new(note, :pass,
           :source => "<note revisionflag=\"#{@revisionflag}\" revision=\"#{version}\">",
           :attributes => { 'revisionflag' => @revisionflag })
-      note << Block.new(note, :paragraph,
+      note << Asciidoctor::Block.new(note, :paragraph,
           :source => attrs[:passtext],
-          :subs => Substitutors::NORMAL_SUBS)
-      note << Block.new(note, :pass, :source => "</note>")
+          :subs => Asciidoctor::Substitutors::NORMAL_SUBS)
+      note << Asciidoctor::Block.new(note, :pass, :source => "</note>")
     end
   end
 
   ##
   # Inline change admonishment.
-  class ChangeAdmonishmentInline < Extensions::InlineMacroProcessor
+  class ChangeAdmonishmentInline < Asciidoctor::Extensions::InlineMacroProcessor
     use_dsl
     name_positional_attributes :version, :text
     with_format :short

--- a/resources/asciidoctor/lib/copy_images/copier.rb
+++ b/resources/asciidoctor/lib/copy_images/copier.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'csv'
+require 'fileutils'
+require 'set'
+
+module CopyImages
+  ##
+  # Handles finding images, copying them, and *not* copying them if they have
+  # already been copied.
+  class Copier
+    include Asciidoctor::Logging
+
+    def initialize
+      @copied = Set[]
+    end
+
+    def copy_image(block, uri)
+      return unless @copied.add? uri      # Skip images we've copied before
+
+      source = find_source block, uri
+      return unless source                # Skip images we can't find
+
+      logger.info message_with_context "copying #{source}", :source_location => block.source_location
+      copy_image_proc = block.document.attr 'copy_image'
+      if copy_image_proc
+        # Delegate to a proc for copying if one is defined. Used for testing.
+        copy_image_proc.call(uri, source)
+      else
+        destination = ::File.join block.document.options[:to_dir], uri
+        destination_dir = ::File.dirname destination
+        FileUtils.mkdir_p destination_dir
+        FileUtils.cp source, destination
+      end
+    end
+
+    ##
+    # Does a breadth first search starting at the base_dir of the document and
+    # any referenced resources. This isn't super efficient but it is how a2x works
+    # and we strive for compatibility.
+    #
+    def find_source(block, uri)
+      to_check = [block.document.base_dir]
+      checked = []
+
+      resources = block.document.attr 'resources'
+      if resources && !resources.empty?
+        begin
+          to_check += CSV.parse_line(resources)
+        rescue CSV::MalformedCSVError => error
+          logger.error message_with_context "Error loading [resources]: #{error}",
+              :source_location => block.source_location
+        end
+      end
+
+      while (dir = to_check.shift)
+        checked << block.normalize_system_path(uri, dir)
+        return checked.last if File.readable? checked.last
+        next unless Dir.exist?(dir)
+
+        Dir.new(dir).each do |f|
+          next if ['.', '..'].include? f
+
+          f = File.join(dir, f)
+          to_check << f if File.directory?(f)
+        end
+      end
+
+      # We'll skip images we can't find but we should log something about it so
+      # we can fix them.
+      checked.sort! do |lhs, rhs|
+        by_depth = lhs.scan(%r{/}).count <=> rhs.scan(%r{/}).count
+        if by_depth != 0
+          by_depth
+        else
+          lhs <=> rhs
+        end
+      end
+      logger.warn message_with_context "can't read image at any of #{checked}", :source_location => block.source_location
+      nil
+    end
+  end
+end

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -1,138 +1,92 @@
-require 'csv'
-require 'fileutils'
-require 'set'
+# frozen_string_literal: true
+
 require_relative '../scaffold.rb'
+require_relative 'copier.rb'
 
-include Asciidoctor
-
-##
-# Copies images that are referenced into the same directory as the output files.
-#
-# It finds the images by looking in a comma separated list of directories
-# defined by the `resources` attribute.
-#
-# It can also be configured to copy the images that number callout lists by
-# setting `copy-callout-images` to the file extension of the images to copy.
-#
-class CopyImages < TreeProcessorScaffold
-  include Logging
-  ADMONITION_IMAGE_FOR_REVISION_FLAG = {
-    'added' => 'note',
-    'changed' => 'note',
-    'deleted' => 'warning',
-  }
-
-  def initialize(name)
-    super
-    @copied = Set[]
-  end
-
-  def process_block(block)
-    if block.context == :image
-      uri = block.image_uri(block.attr 'target')
-      return if Helpers.uriish? uri # Skip external images
-
-      copy_image block, uri
-      return
-    end
-    callout_extension = block.document.attr 'copy-callout-images'
-    if callout_extension
-      if block.parent && block.parent.context == :colist
-        coids = block.attr('coids')
-        return unless coids
-
-        coids.scan(/CO(?:\d+)-(\d+)/) {
-          copy_image block, "images/icons/callouts/#{$1}.#{callout_extension}"
-        }
-        return
-      end
-    end
-    admonition_extension = block.document.attr 'copy-admonition-images'
-    if admonition_extension
-      if block.context == :admonition
-        # The image for a standard admonition comes from the style
-        style = block.attr 'style'
-        return unless style
-
-        copy_image block, "images/icons/#{style.downcase}.#{admonition_extension}"
-        return
-      end
-      # The image for a change admonition comes from the revisionflag
-      revisionflag = block.attr 'revisionflag'
-      if revisionflag
-        admonition_image = ADMONITION_IMAGE_FOR_REVISION_FLAG[revisionflag]
-        if admonition_image
-          copy_image block, "images/icons/#{admonition_image}.#{admonition_extension}"
-        else
-          logger.warn message_with_context "unknow revisionflag #{revisionflag}", :source_location => block.source_location
-        end
-        return
-      end
-    end
-  end
-
-  def copy_image(block, uri)
-    return unless @copied.add? uri      # Skip images we've copied before
-
-    source = find_source block, uri
-    return unless source                # Skip images we can't find
-
-    logger.info message_with_context "copying #{source}", :source_location => block.source_location
-    copy_image_proc = block.document.attr 'copy_image'
-    if copy_image_proc
-      # Delegate to a proc for copying if one is defined. Used for testing.
-      copy_image_proc.call(uri, source)
-    else
-      destination = ::File.join block.document.options[:to_dir], uri
-      destination_dir = ::File.dirname destination
-      FileUtils.mkdir_p destination_dir
-      FileUtils.cp source, destination
-    end
-  end
-
+module CopyImages
   ##
-  # Does a breadth first search starting at the base_dir of the document and
-  # any referenced resources. This isn't super efficient but it is how a2x works
-  # and we strive for compatibility.
+  # Copies images that are referenced into the same directory as the output files.
   #
-  def find_source(block, uri)
-    to_check = [block.document.base_dir]
-    checked = []
+  # It finds the images by looking in a comma separated list of directories
+  # defined by the `resources` attribute.
+  #
+  # It can also be configured to copy the images that number callout lists by
+  # setting `copy-callout-images` to the file extension of the images to copy.
+  #
+  # It can also be configured to copy the that decoration admonitions by
+  # setting `copy-admonition-images` to the file extension of the images
+  # to copy.
+  #
+  class CopyImages < TreeProcessorScaffold
+    include Asciidoctor::Logging
 
-    resources = block.document.attr 'resources'
-    if resources && !resources.empty?
-      begin
-        to_check += CSV.parse_line(resources)
-      rescue CSV::MalformedCSVError => error
-        logger.error message_with_context "Error loading [resources]: #{error}",
-            :source_location => block.source_location
-      end
-    end
-
-    while (dir = to_check.shift)
-      checked << block.normalize_system_path(uri, dir)
-      return checked.last if File.readable? checked.last
-      next unless Dir.exist?(dir)
-
-      Dir.new(dir).each { |f|
-        next if ['.', '..'].include? f
-
-        f = File.join(dir, f)
-        to_check << f if File.directory?(f)
-      }
-    end
-
-    # We'll skip images we can't find but we should log something about it so
-    # we can fix them.
-    checked.sort! { |lhs, rhs|
-      by_depth = lhs.scan(/\//).count <=> rhs.scan(/\//).count
-      if by_depth != 0
-        by_depth
-      else
-        lhs <=> rhs
-      end
+    ADMONITION_IMAGE_FOR_REVISION_FLAG = {
+      'added' => 'note',
+      'changed' => 'note',
+      'deleted' => 'warning',
     }
-    logger.warn message_with_context "can't read image at any of #{checked}", :source_location => block.source_location
-    nil
+
+    def initialize(name)
+      super
+      @copier = Copier.new
+    end
+
+    def process_block(block)
+      process_image block
+      process_callout block
+      process_admonition block
+    end
+
+    def process_image(block)
+      return unless block.context == :image
+
+      uri = block.image_uri(block.attr 'target')
+      return if Asciidoctor::Helpers.uriish? uri # Skip external images
+
+      @copier.copy_image block, uri
+    end
+
+    def process_callout(block)
+      callout_extension = block.document.attr 'copy-callout-images'
+      return unless callout_extension
+      return unless block.parent && block.parent.context == :colist
+
+      coids = block.attr('coids')
+      return unless coids
+
+      coids.scan(/CO(?:\d+)-(\d+)/) do
+        @copier.copy_image block, "images/icons/callouts/#{$1}.#{callout_extension}"
+      end
+    end
+
+    def process_admonition(block)
+      admonition_extension = block.document.attr 'copy-admonition-images'
+      return unless admonition_extension
+
+      process_standard_admonition admonition_extension, block
+      process_change_admonition admonition_extension, block
+    end
+
+    def process_standard_admonition(admonition_extension, block)
+      return unless block.context == :admonition
+
+      # The image for a standard admonition comes from the style
+      style = block.attr 'style'
+      return unless style
+
+      @copier.copy_image block, "images/icons/#{style.downcase}.#{admonition_extension}"
+    end
+
+    def process_change_admonition(admonition_extension, block)
+      revisionflag = block.attr 'revisionflag'
+      return unless revisionflag
+
+      admonition_image = ADMONITION_IMAGE_FOR_REVISION_FLAG[revisionflag]
+      if admonition_image
+        @copier.copy_image block, "images/icons/#{admonition_image}.#{admonition_extension}"
+      else
+        logger.warn message_with_context "unknow revisionflag #{revisionflag}", :source_location => block.source_location
+      end
+    end
   end
 end

--- a/resources/asciidoctor/lib/cramped_include/extension.rb
+++ b/resources/asciidoctor/lib/cramped_include/extension.rb
@@ -1,7 +1,8 @@
+# frozen_string_literal: true
+
 require 'asciidoctor/extensions'
 
-include Asciidoctor
-
+##
 # Preprocessor to support more "cramped" include statements. Usually something
 # like
 #   include::resources/1.adoc[]
@@ -13,7 +14,8 @@ include Asciidoctor
 # this problem by adding an extra new line after every sequence of lines we
 # include. In theory this *shouldn't* bother us because we don't include things
 # that are sensitive to the extra line.
-class CrampedInclude < Extensions::Preprocessor
+#
+class CrampedInclude < Asciidoctor::Extensions::Preprocessor
   def process(_document, reader)
     def reader.prepare_lines(data, opts = {})
       super << ''

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -1,44 +1,43 @@
+# frozen_string_literal: true
+
 require 'pathname'
 require_relative '../scaffold.rb'
-
-include Asciidoctor
 
 ##
 # TreeProcessor extension to automatically add "Edit Me" links to appropriate
 # spots in the documentation.
+#
 class EditMe < TreeProcessorScaffold
-  include Logging
+  include Asciidoctor::Logging
 
   def process(document)
     logger.error("sourcemap is required") unless document.sourcemap
-    if document.attributes['edit_url']
-      super
-    end
+    super if document.attributes['edit_url']
   end
 
   def process_block(block)
-    if %i[preamble section floating_title].include? block.context
-      def block.title
-        path = source_path
-        url = @document.attributes['edit_url']
-        url += '/' unless url.end_with?('/')
-        repo_root = @document.attributes['repo_root']
-        if repo_root
-          repo_root = Pathname.new repo_root
-          base_dir = Pathname.new @document.base_dir
-          url += "#{base_dir.relative_path_from(repo_root)}/"
-        end
-        url += path
-        "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"
+    return unless %i[preamble section floating_title].include? block.context
+
+    def block.title
+      path = source_path
+      url = @document.attributes['edit_url']
+      url += '/' unless url.end_with?('/')
+      repo_root = @document.attributes['repo_root']
+      if repo_root
+        repo_root = Pathname.new repo_root
+        base_dir = Pathname.new @document.base_dir
+        url += "#{base_dir.relative_path_from(repo_root)}/"
       end
-      if block.context == :preamble
-        def block.source_path
-          document.source_location.path
-        end
-      else
-        def block.source_path
-          source_location.path
-        end
+      url += path
+      "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"
+    end
+    if block.context == :preamble
+      def block.source_path
+        document.source_location.path
+      end
+    else
+      def block.source_path
+        source_location.path
       end
     end
   end

--- a/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
@@ -1,6 +1,6 @@
-require_relative '../scaffold.rb'
+# frozen_string_literal: true
 
-include Asciidoctor
+require_relative '../scaffold.rb'
 
 # TreeProcessor extension to automatically escape special characters in code
 # listings and always shift "callouts" after "specialcharacters".

--- a/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
+++ b/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
@@ -1,6 +1,6 @@
-require 'asciidoctor/extensions'
+# frozen_string_literal: true
 
-include Asciidoctor
+require 'asciidoctor/extensions'
 
 # Extension to emulate Elastic's asciidoc customization to include tagged
 # portions of a file. While it was originally modeled after asciidoctor's
@@ -10,14 +10,15 @@ include Asciidoctor
 #
 #   include:elastic-include-tagged:{doc-tests}/RestClientDocumentation.java[rest-client-init]
 #
-class ElasticIncludeTagged < Extensions::IncludeProcessor
-  include Logging
+class ElasticIncludeTagged < Asciidoctor::Extensions::IncludeProcessor
+  include Asciidoctor::Logging
 
   def handles?(target)
-    target.sub!(/^elastic-include-tagged:/, '')
+    /^elastic-include-tagged:/.match target
   end
 
   def process(_doc, reader, target, attrs)
+    target = target.sub(/^elastic-include-tagged:/, '')
     if attrs.size != 1
       # NOCOMMIT test this
       logger.warn message_with_context %(elastic-include-tagged expects only a tag but got: #{attrs}), :source_location => reader.cursor
@@ -68,7 +69,7 @@ class ElasticIncludeTagged < Extensions::IncludeProcessor
       return path
     end
     if found_end == false
-      warn Reader::Cursor.new(path, relpath, relpath, start_of_include),
+      warn Asciidoctor::Reader::Cursor.new(path, relpath, relpath, start_of_include),
           "missing end tag [#{tag}]"
     end
     reader.push_include included_lines, path, relpath, start_of_include, attrs

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'change_admonishment/extension'
 require_relative 'copy_images/extension'
 require_relative 'cramped_include/extension'

--- a/resources/asciidoctor/lib/scaffold.rb
+++ b/resources/asciidoctor/lib/scaffold.rb
@@ -1,10 +1,11 @@
-require 'asciidoctor/extensions'
+# frozen_string_literal: true
 
-include Asciidoctor
+require 'asciidoctor/extensions'
 
 ##
 # Scaffolding for TreeProcessor extensions to automatically iterate.
-class TreeProcessorScaffold < Extensions::TreeProcessor
+#
+class TreeProcessorScaffold < Asciidoctor::Extensions::TreeProcessor
   def process_block(_document)
     raise ::NotImplementedError, %(TreeProcessorScaffold subclass must implement ##{__method__} method)
   end
@@ -16,7 +17,7 @@ class TreeProcessorScaffold < Extensions::TreeProcessor
 
   def process_blocks(block)
     process_block block
-    for subblock in block.context == :dlist ? block.blocks.flatten : block.blocks
+    (block.context == :dlist ? block.blocks.flatten : block.blocks).each do |subblock|
       # subblock can be nil for definition lists without a definition.
       # this is weird, but it is safe to skip nil here because subclasses
       # can't change it anyway.

--- a/resources/asciidoctor/spec/change_admonishment_spec.rb
+++ b/resources/asciidoctor/spec/change_admonishment_spec.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 require 'change_admonishment/extension'
 
 RSpec.describe ChangeAdmonishment do
   before(:each) do
-    Extensions.register ChangeAdmonishment
+    Asciidoctor::Extensions.register ChangeAdmonishment
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   [
       %w[added added],
       %w[coming changed],
       %w[deprecated deleted],
-  ].each { |(name, revisionflag)|
+  ].each do |(name, revisionflag)|
     it "#{name}'s block version creates a note" do
       actual = convert <<~ASCIIDOC
         == Example
@@ -111,5 +113,5 @@ RSpec.describe ChangeAdmonishment do
       DOCBOOK
       expect(actual).to eq(expected.strip)
     end
-  }
+  end
 end

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -1,20 +1,22 @@
+# frozen_string_literal: true
+
 require 'change_admonishment/extension'
 require 'copy_images/extension'
 require 'fileutils'
 require 'tmpdir'
 
-RSpec.describe CopyImages do
+RSpec.describe CopyImages::CopyImages do
   RSpec::Matchers.define_negated_matcher :not_match, :match
 
   before(:each) do
-    Extensions.register ChangeAdmonishment
-    Extensions.register do
-      tree_processor CopyImages
+    Asciidoctor::Extensions.register ChangeAdmonishment
+    Asciidoctor::Extensions.register do
+      tree_processor CopyImages::CopyImages
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   def copy_attributes(copied)
@@ -76,14 +78,14 @@ RSpec.describe CopyImages do
       == Example
       image::not_found.jpg[]
     ASCIIDOC
-    convert input, attributes, match(/
+    convert input, attributes, match(%r{
         WARN:\ <stdin>:\ line\ 2:\ can't\ read\ image\ at\ any\ of\ \[
-          "#{spec_dir}\/not_found.jpg",\s
-          "#{spec_dir}\/resources\/not_found.jpg",\s
+          "#{spec_dir}/not_found.jpg",\s
+          "#{spec_dir}/resources/not_found.jpg",\s
           .+
-          "#{spec_dir}\/resources\/copy_images\/not_found.jpg"
+          "#{spec_dir}/resources/copy_images/not_found.jpg"
           .+
-        \]/x).and(not_match(/INFO: <stdin>/))
+        \]}x).and(not_match(/INFO: <stdin>/))
     expect(copied).to eq([])
   end
 
@@ -121,7 +123,7 @@ RSpec.describe CopyImages do
   end
 
   it "can find files using a single valued resources attribute" do
-    Dir.mktmpdir { |tmp|
+    Dir.mktmpdir do |tmp|
       FileUtils.cp(
         ::File.join(spec_dir, 'resources', 'copy_images', 'example1.png'),
         ::File.join(tmp, 'tmp_example1.png')
@@ -139,11 +141,11 @@ RSpec.describe CopyImages do
       expect(copied).to eq([
           ["tmp_example1.png", "#{tmp}/tmp_example1.png"],
       ])
-    }
+    end
   end
 
   it "can find files using a multi valued resources attribute" do
-    Dir.mktmpdir { |tmp|
+    Dir.mktmpdir do |tmp|
       FileUtils.cp(
         ::File.join(spec_dir, 'resources', 'copy_images', 'example1.png'),
         ::File.join(tmp, 'tmp_example1.png')
@@ -161,7 +163,7 @@ RSpec.describe CopyImages do
       expect(copied).to eq([
           ["tmp_example1.png", "#{tmp}/tmp_example1.png"],
       ])
-    }
+    end
   end
 
   it "doesn't mind an empty resources attribute" do
@@ -198,7 +200,7 @@ RSpec.describe CopyImages do
   end
 
   it "has a nice error message when it can't find a file with single valued resources attribute" do
-    Dir.mktmpdir { |tmp|
+    Dir.mktmpdir do |tmp|
       copied = []
       attributes = copy_attributes copied
       attributes['resources'] = tmp
@@ -206,18 +208,18 @@ RSpec.describe CopyImages do
         == Example
         image::not_found.png[]
       ASCIIDOC
-      convert input, attributes, match(/
+      convert input, attributes, match(%r{
           WARN:\ <stdin>:\ line\ 2:\ can't\ read\ image\ at\ any\ of\ \[
-            "#{tmp}\/not_found.png",\s
-            "#{spec_dir}\/not_found.png",\s
+            "#{tmp}/not_found.png",\s
+            "#{spec_dir}/not_found.png",\s
             .+
-          \]/x).and(not_match(/INFO: <stdin>/))
+          \]}x).and(not_match(/INFO: <stdin>/))
       expect(copied).to eq([])
-    }
+    end
   end
 
   it "has a nice error message when it can't find a file with multi valued resources attribute" do
-    Dir.mktmpdir { |tmp|
+    Dir.mktmpdir do |tmp|
       copied = []
       attributes = copy_attributes copied
       attributes['resources'] = "#{tmp},/dummy2"
@@ -225,15 +227,15 @@ RSpec.describe CopyImages do
         == Example
         image::not_found.png[]
       ASCIIDOC
-      convert input, attributes, match(/
+      convert input, attributes, match(%r{
           WARN:\ <stdin>:\ line\ 2:\ can't\ read\ image\ at\ any\ of\ \[
-            "\/dummy2\/not_found.png",\s
-            "#{tmp}\/not_found.png",\s
-            "#{spec_dir}\/not_found.png",\s
+            "/dummy2/not_found.png",\s
+            "#{tmp}/not_found.png",\s
+            "#{spec_dir}/not_found.png",\s
             .+
-          \]/x).and(not_match(/INFO: <stdin>/))
+          \]}x).and(not_match(/INFO: <stdin>/))
       expect(copied).to eq([])
-    }
+    end
   end
 
   it "copies images for callouts when requested (png)" do
@@ -291,14 +293,14 @@ RSpec.describe CopyImages do
       <1> words
       <2> words
     ASCIIDOC
-    convert input, attributes, match(/
+    convert input, attributes, match(%r{
     WARN:\ <stdin>:\ line\ 6:\ can't\ read\ image\ at\ any\ of\ \[
-      "#{spec_dir}\/images\/icons\/callouts\/2.gif",\s
-      "#{spec_dir}\/resources\/images\/icons\/callouts\/2.gif",\s
+      "#{spec_dir}/images/icons/callouts/2.gif",\s
+      "#{spec_dir}/resources/images/icons/callouts/2.gif",\s
       .+
-      "#{spec_dir}\/resources\/copy_images\/images\/icons\/callouts\/2.gif"
+      "#{spec_dir}/resources/copy_images/images/icons/callouts/2.gif"
       .+
-    \]/x).and(match(/INFO: <stdin>: line 5: copying #{spec_dir}\/resources\/copy_images\/images\/icons\/callouts\/1.gif/))
+    \]}x).and(match(%r{INFO: <stdin>: line 5: copying #{spec_dir}/resources/copy_images/images/icons/callouts/1.gif}))
     expect(copied).to eq([
         ["images/icons/callouts/1.gif", "#{spec_dir}/resources/copy_images/images/icons/callouts/1.gif"],
     ])
@@ -399,7 +401,7 @@ RSpec.describe CopyImages do
     expect(copied).to eq([])
   end
 
-  %w[note tip important caution warning].each { |(name)|
+  %w[note tip important caution warning].each do |(name)|
     it "copies images for the #{name} admonition when requested" do
       copied = []
       attributes = copy_attributes copied
@@ -415,13 +417,13 @@ RSpec.describe CopyImages do
           ["images/icons/#{name}.png", "#{spec_dir}/resources/copy_images/images/icons/#{name}.png"],
       ])
     end
-  }
+  end
 
   [
       %w[added note],
       %w[coming note],
       %w[deprecated warning],
-  ].each { |(name, admonition)|
+  ].each do |(name, admonition)|
     it "copies images for the block formatted #{name} change admonition when requested" do
       copied = []
       attributes = copy_attributes copied
@@ -439,7 +441,7 @@ RSpec.describe CopyImages do
           ["images/icons/#{admonition}.png", "#{spec_dir}/resources/copy_images/images/icons/#{admonition}.png"],
       ])
     end
-  }
+  end
 
   it "copies images for admonitions when requested with a different file extension" do
     copied = []

--- a/resources/asciidoctor/spec/cramped_include_spec.rb
+++ b/resources/asciidoctor/spec/cramped_include_spec.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 require 'cramped_include/extension'
 require 'shared_examples/does_not_break_line_numbers'
 
 RSpec.describe CrampedInclude do
   before(:each) do
-    Extensions.register do
+    Asciidoctor::Extensions.register do
       preprocessor CrampedInclude
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   include_examples "doesn't break line numbers"

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require 'edit_me/extension'
 
 RSpec.describe EditMe do
   before(:each) do
-    Extensions.register do
+    Asciidoctor::Extensions.register do
       tree_processor EditMe
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   it "adds a link to the preface" do

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'change_admonishment/extension'
 require 'elastic_compat_preprocessor/extension'
 require 'elastic_include_tagged/extension'
@@ -5,15 +7,15 @@ require 'shared_examples/does_not_break_line_numbers'
 
 RSpec.describe ElasticCompatPreprocessor do
   before(:each) do
-    Extensions.register ChangeAdmonishment
-    Extensions.register do
+    Asciidoctor::Extensions.register ChangeAdmonishment
+    Asciidoctor::Extensions.register do
       preprocessor ElasticCompatPreprocessor
       include_processor ElasticIncludeTagged
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   include_examples "doesn't break line numbers"
@@ -22,7 +24,7 @@ RSpec.describe ElasticCompatPreprocessor do
       %w[added added],
       %w[coming changed],
       %w[deprecated deleted],
-  ].each { |(name, revisionflag)|
+  ].each do |(name, revisionflag)|
     it "invokes the #{name} block macro when #{name}[version] starts a line" do
       actual = convert <<~ASCIIDOC
         == Example
@@ -53,7 +55,7 @@ RSpec.describe ElasticCompatPreprocessor do
       DOCBOOK
       expect(actual).to eq(expected.strip)
     end
-  }
+  end
 
   it "invokes include-tagged::" do
     actual = convert <<~ASCIIDOC

--- a/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require 'elastic_compat_tree_processor/extension'
 
 RSpec.describe ElasticCompatTreeProcessor do
   before(:each) do
-    Extensions.register do
+    Asciidoctor::Extensions.register do
       treeprocessor ElasticCompatTreeProcessor
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   it "fixes up asciidoc style listings" do

--- a/resources/asciidoctor/spec/elastic_include_tagged_spec.rb
+++ b/resources/asciidoctor/spec/elastic_include_tagged_spec.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 require 'elastic_include_tagged/extension'
 
 RSpec.describe ElasticIncludeTagged do
   before(:each) do
-    Extensions.register do
+    Asciidoctor::Extensions.register do
       include_processor ElasticIncludeTagged
     end
   end
 
   after(:each) do
-    Extensions.unregister_all
+    Asciidoctor::Extensions.unregister_all
   end
 
   it "includes a tag" do
@@ -114,7 +116,7 @@ RSpec.describe ElasticIncludeTagged do
       <simpara>System.err.println("this tag doesn&#8217;t have any end");</simpara>
       </preface>
     DOCBOOK
-    actual = convert input, {}, match(/resources\/elastic_include_tagged\/Example.java: line \d+: elastic-include-tagged missing end tag \[missing-end\]/)
+    actual = convert input, {}, match(%r{resources/elastic_include_tagged/Example.java: line \d+: elastic-include-tagged missing end tag \[missing-end\]})
     expect(actual).to eq(expected.strip)
   end
 

--- a/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
+++ b/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.shared_examples "doesn't break line numbers" do
   it "doesn't break line numbers" do
     input = <<~ASCIIDOC

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"
@@ -21,14 +23,13 @@ def convert(input, extra_attributes = {}, warnings_matcher = eq(''))
     'docdir' => File.dirname(__FILE__),
   }
   attributes.merge! extra_attributes
-  result = Asciidoctor.convert input, {
+  result = Asciidoctor.convert input,
       :safe       => :unsafe,  # Used to include "funny" files.
       :backend    => :docbook45,
       :logger     => logger,
       :doctype    => :book,
       :attributes => attributes,
-      :sourcemap  => true,
-  }
+      :sourcemap  => true
   warnings_string = logger.messages
         .map { |l| "#{l[:severity]}: #{l[:message].inspect}" }
         .join("\n")


### PR DESCRIPTION
Enables many of the currently disabled rubocop checks and fixes them. The
biggest change is in the `copy_images` extension which is now split into
two classes, on that processes blocks looking for candidates to copy and
one that does the actual copying. Beyond that I've converted many tests
from blocks into guards. Rubocop seems to really like guards and I find
them pretty readble, partially because they force you to create a new
method in some cases and those methods can have nice names.
