### PR TITLE
Add asciidoctor to --self-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,10 @@ SHELL = /bin/bash -eux -o pipefail
 MAKEFLAGS += --silent
 
 .PHONY: check
-check: build_docs_check asciidoctor_check readme_check
+check: unit_test integration_test
+
+.PHONY: unit_test
+unit_test: build_docs_check asciidoctor_check
 
 .PHONY: build_docs_check
 build_docs_check:
@@ -15,10 +18,23 @@ build_docs_check:
 asciidoctor_check:
 	$(MAKE) -C resources/asciidoctor
 
-.PHONY: readme_check
-readme_check: /tmp/readme
-	[ -s /tmp/readme/index.html ]
-	[ -s /tmp/readme/_conditions_of_use.html ]
+.PHONY: integration_test
+integration_test: readme_asciidoc_check readme_asciidoctor_check
 
-/tmp/readme:
-	./build_docs.pl --in_standard_docker --doc README.asciidoc --out /tmp/readme
+.PHONY: readme_asciidoc_check
+readme_asciidoc_check: /tmp/readme_asciidoc
+	[ -s /tmp/readme_asciidoc/index.html ]
+	[ -s /tmp/readme_asciidoc/_conditions_of_use.html ]
+
+/tmp/readme_asciidoc:
+	./build_docs.pl --in_standard_docker \
+		--doc README.asciidoc --out /tmp/readme_asciidoc
+
+.PHONY: readme_asciidoctor_check
+readme_asciidoctor_check: /tmp/readme_asciidoctor
+	[ -s /tmp/readme_asciidoctor/index.html ]
+	[ -s /tmp/readme_asciidoctor/_conditions_of_use.html ]
+
+/tmp/readme_asciidoctor:
+	./build_docs.pl --in_standard_docker --asciidoctor \
+		--doc README.asciidoc --out /tmp/readme_asciidoctor

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -123,7 +123,7 @@ to a single XML file for DocBook to process.  _Chunking_ is the process of
 breaking that XML file up into multiple HTML pages.
 
 By default, each _part_ (`= Part Title`) and _chapter_ (`== Chapter Title`) is
-``chunked'' into a separate HTML file. However, for bigger books, such as the
+"chunked" into a separate HTML file. However, for bigger books, such as the
 Elasticsearch reference  docs, this results in enormous pages.  These bigger
 books are also chunked at the first _section_ level (`=== Section One Title`).
 This behaviour is specified in the https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`]
@@ -232,7 +232,7 @@ website is controlled by the
 https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`] file in the `docs` repo.
 
 You can add a new repository under the `repos` section, if it
-doesn't already exist, and you can add a new ``book'' under the
+doesn't already exist, and you can add a new "book" under the
 `contents` section.
 
 The `repos.$NAME.branches[]` key lists all of the branches which
@@ -241,7 +241,7 @@ website -- while `repos.$NAME.current` lists the branch which
 should be used as the default version on the site.
 
 NOTE: The `branches` and `current` settings can be overridden in
-the config for each book.  For instance, the ``Community Clients``
+the config for each book.  For instance, the "Community Clients"
 docs are built only from the `master` branch.
 
 When you release a new version of your code, you need to add
@@ -287,7 +287,7 @@ layout for books.  The most basic structure is as follows:
 ----------------------------------
 
 Usually this structure will be sufficient for most of your
-documentation needs. More complicated ``books'', such
+documentation needs. More complicated "books", such
 as the {ref}[Elasticsearch reference docs], however,
 require a few additional elements, described on the
 following pages.
@@ -437,7 +437,8 @@ and
 <1> Any headers in the appendix or in the preface start
     out-of-sequence at `level 2`, not at `level 1`.
 
-[sect3]
+ifdef::asciidoctor[[section]]
+ifndef::asciidoctor[[sect3]]
 === Glossary
 
 [source,asciidoc]
@@ -550,8 +551,6 @@ ifdef::env-github[]
 `&#x5f;emphasis_`::         _emphasis_
 `&#x2a;bold*`::             *bold*
 `&#x60;mono'`::             `mono`
-`&#x60;`double quoted''`::  ``double quoted''
-`&#x60;single quoted'`::    `single quoted'
 `&#x5e;superscript^`::      ^superscript^
 `&#x7e;subscript~`::        ~subscript~
 endif::[]
@@ -559,8 +558,6 @@ ifndef::env-github[]
 +&#x5f;emphasis_+::         _emphasis_
 +&#x2a;bold*+::             *bold*
 +&#x60;mono'+::             `mono`
-+&#x60;`double quoted''+::  ``double quoted''
-+&#x60;single quoted'+::    `single quoted'
 +&#x5e;superscript^+::      ^superscript^
 +&#x7e;subscript~+::        ~subscript~
 endif::[]
@@ -1007,7 +1004,7 @@ footnote to a particular line of code:
 [[console-snippets]]
 === View in Console
 
-Code blocks can be followed by a ``View in Console'' link which, when clicked,
+Code blocks can be followed by a "View in Console" link which, when clicked,
 will open the code snippet in Console.  The snippet can either be taken directly
 from the code block (`CONSOLE`), or be a link to a custom snippet.
 
@@ -1042,14 +1039,13 @@ GET /_search
 
 [NOTE]
 ================================
-The ``View in Console'' links will only work if the docs are viewed in web-browser mode, as follows:
+The "View in Console" links will only work if the docs are viewed in web-browser mode, as follows:
 
 [source,sh]
 ---------------
-build_docs -d my_doc.asciidoc --open <1> --web <2>
+build_docs -d my_doc.asciidoc --open <1>
 ---------------
 <1> The `--open` option usually opens the docs in the web browser, served directly from the file system.
-<2> The `--web` option will start a local web browser to serve the docs, which allows the Console links to work correctly.
 
 The local web browser can be stopped with `Ctrl-C`.
 
@@ -1533,7 +1529,7 @@ For instance, in the ES reference docs, we have:
 ... etc ...
 ----------------------------------
 
-There are too many parameters for ``Request body search''
+There are too many parameters for "Request body search"
 to list them all on one page.  In this case, it
 is worth turning on chunking for top level sections.
 
@@ -1572,7 +1568,7 @@ the same page.
 
 To do this, you can use the `[float]` marker before a
 section header, to tell Asciidoc that what follows isn't
-a ``real'' header:
+a "real" header:
 
 [source,asciidoc]
 ----------------------------------
@@ -1595,8 +1591,8 @@ named for their IDs:
 
 * `chapter-one.html`
 * `section-one.html` which would also contain
-  ``Section two''
+  "Section two"
 * `section-three.html`
 
-To link to ``Section two'' from an external
+To link to "Section two" from an external
 document, you would use the URL: `section-one.html#section-two`

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -64,6 +64,10 @@ sub build_chunked {
 
     my ( $output, $died );
     if ( $asciidoctor ) {
+        my $dest_xml = $index->basename;
+        $dest_xml =~ s/\.asciidoc$/\.xml/;
+        $dest_xml = $dest->file($dest_xml);
+
         %xsltopts = (%xsltopts,
                 'callout.graphics' => 1,
                 'navig.graphics'   => 1,
@@ -103,16 +107,16 @@ sub build_chunked {
                 $index
             );
             if ( !$lenient ) {
-                $output .= _xml_lint($dest);
+                $output .= _xml_lint($dest_xml);
             }
             $output .= run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
                 '--stringparam', 'base.dir', $chunks_path->absolute . '/',
                 file('resources/website_chunked.xsl')->absolute,
-                "$dest/index.xml"
+                $dest_xml
             );
-            unlink "$dest/index.xml";
+            unlink $dest_xml;
             1;
         } or do { $output = $@; $died = 1; };
     }
@@ -191,6 +195,10 @@ sub build_single {
 
     my ( $output, $died );
     if ( $asciidoctor ) {
+        my $dest_xml = $index->basename;
+        $dest_xml =~ s/\.asciidoc$/\.xml/;
+        $dest_xml = $dest->file($dest_xml);
+
         %xsltopts = (%xsltopts,
                 'callout.graphics' => 1,
                 'navig.graphics'   => 1,
@@ -228,16 +236,16 @@ sub build_single {
                 $index
             );
             if ( !$lenient ) {
-                $output .= _xml_lint($dest);
+                $output .= _xml_lint($dest_xml);
             }
             $output .= run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
                 '--output' => "$dest/index.html",
                 file('resources/website.xsl')->absolute,
-                "$dest/index.xml"
+                $dest_xml
             );
-            unlink "$dest/index.xml";
+            unlink $dest_xml;
             1;
         } or do { $output = $@; $died = 1; };
     }
@@ -302,13 +310,13 @@ sub _check_build_error {
 # to be safe and handle errors.
 sub _xml_lint {
 #===================================
-    my ( $dest ) = @_;
+    my ( $dest_xml ) = @_;
     return run(
             'xmllint',
             '--nonet',
             '--noout',
             '--valid',
-            "$dest/index.xml"
+            "$dest_xml"
     );
 }
 


### PR DESCRIPTION
Adds rendering the `README.asciidoc` with Asciidoctor in `--self-test`
as a test of Asciidoctor. These two renders can act as a basic
integration test of the docs build. Right now they just validate that
neither AsiiDoc nor Asciidoctor crash when rendering the
`README.asciidoc` file, but I expect to be able to flesh out the tests
in follow up changes.
