### PR TITLE
Bump stack version to 5.6.15

### DIFF
--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,7 +1,7 @@
-:version:                5.6.14
-:logstash_version:       5.6.14
-:elasticsearch_version:  5.6.14
-:kibana_version:         5.6.14
+:version:                5.6.15
+:logstash_version:       5.6.15
+:elasticsearch_version:  5.6.15
+:kibana_version:         5.6.15
 :branch:                 5.6
 :major-version:          5.x
 


### PR DESCRIPTION
5.6.15 is on its way out.
