### PR TITLE
Docker: Fix --all on macOS

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -107,6 +107,7 @@ def run_build_docs(args):
 
     open_browser = False
     args = Args(args)
+    saw_doc = False
     saw_out = False
     should_forward_ssh_auth_into_container = False
     arg = args.next_arg()
@@ -117,6 +118,7 @@ def run_build_docs(args):
             if not exists(doc_file):
                 raise ArgError("Can't find --doc %s" % doc_file)
             mount_docs_repo_and_dockerify_path(dirname(doc_file), doc_file)
+            saw_doc = True
         elif arg == '--open':
             docker_args.extend(['--publish', '8000:8000/tcp'])
             # Ritual to make nginx run on the readonly filesystem
@@ -187,9 +189,9 @@ def run_build_docs(args):
             mount_docs_repo_and_dockerify_path(resource_dir, resource_dir)
         arg = args.next_arg()
 
-    if not saw_out:
+    if saw_doc and not saw_out:
         # If you don't specify --out then we dump the output into
-        # $cwd/html_docsto keep backwards compatibility with build_docs.pl.
+        # $pwd/html_docs to keep backwards compatibility with build_docs.pl.
         docker_args.extend(['-v', '%s:/out:delegated' % realpath('.')])
         build_docs_args.extend(['--out', "/out/html_docs"])
 
@@ -411,9 +413,6 @@ def standard_docker_args():
     if uid == 0:
         raise ArgError("This process isn't likely to suceed if run as root")
     docker_args.extend(['--user', '%d:%d' % (uid, getgid())])
-    # Running read-only with a proper tmp directory gives us a little
-    # performance boost and it is simple enough to do.
-    docker_args.extend(['--read-only', '--tmpfs', '/tmp'])
     # Mount the docs build code so we can run it!
     docker_args.extend(['-v', '%s:/docs_build:cached' % DIR])
     # Seccomp adds a *devestating* performance overhead if you happen

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -468,7 +468,7 @@ sub init_repos {
 
     my %child_dirs = map { $_ => 1 } $repos_dir->children;
 
-    my $temp_dir = $repos_dir->subdir('.temp');
+    my $temp_dir = $running_in_standard_docker ? dir('/tmp/docsbuild') : $repos_dir->subdir('.temp');
     $temp_dir->rmtree;
     $temp_dir->mkpath;
     delete $child_dirs{ $temp_dir->absolute };

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -58,6 +58,7 @@ GetOptions(
     'open',    'skiplinkcheck', 'linkcheckonly', 'staging', 'procs=i',         'user=s', 'lang=s',
     'lenient', 'verbose', 'reload_template', 'resource=s@', 'asciidoctor', 'in_standard_docker',
 ) || exit usage();
+check_args();
 
 our $Conf = LoadFile('conf.yaml');
 # The script supports running outside of docker, in any docker container *and*
@@ -797,6 +798,32 @@ sub restart {
     say "Restarting";
     chdir $Old_Pwd;
     exec( $^X, $bin, @Old_ARGV );
+}
+
+#===================================
+sub check_args {
+#===================================
+    if ( $Opts->{doc} ) {
+        die('--target_repo not compatible with --doc') if $Opts->{target_repo};
+        die('--push not compatible with --doc') if $Opts->{push};
+        die('--user not compatible with --doc') if $Opts->{user};
+        die('--reference not compatible with --doc') if $Opts->{reference};
+        die('--rely_on_ssh_auth not compatible with --doc') if $Opts->{rely_on_ssh_auth};
+        die('--rebuild not compatible with --doc') if $Opts->{rebuild};
+        die('--no_fetch not compatible with --doc') if $Opts->{no_fetch};
+    } else {
+        die('--single not compatible with --all') if $Opts->{single};
+        die('--pdf not compatible with --all') if $Opts->{pdf};
+        die('--toc not compatible with --all') if $Opts->{toc};
+        die('--out not compatible with --all') if $Opts->{out};
+        die('--chunk not compatible with --all') if $Opts->{chunk};
+        die('--lenient not compatible with --all') if $Opts->{lenient};
+        # Lang will be 'en' even if it isn't specified so we don't check it.
+        die('--resource not compatible with --all') if $Opts->{resource};
+        die('--skiplinkcheck not compatible with --all') if $Opts->{skiplinkcheck};
+        die('--linkcheckonly not compatible with --all') if $Opts->{linkcheckonly};
+        die('--asciidoctor not compatible with --all') if $Opts->{asciidoctor};
+    }
 }
 
 #===================================


### PR DESCRIPTION
The root problem is that the docker-based build is busted with `--all`
on macOS because we use a `cached` mounted directory as scratch space.
Building individual books works fine. `--all` works fine on Linux because
bind mounts are fast. But it is slow on macOS because `cached` forces
those writes to be consistent to the macOS filesystem and it causes
crashes because `git checkout` complains that  there are "too many open
files". The latter seems to happen outside of the docker based build,
but I'm not sure when it started or, really, why. I don't really care
why, though, because this change fixes it.

I considered allowing you to specify the temp directory and making sure
it is mounted with the `delegated` flag which should improve performance
but this doesn't really fix the problem of "too many open files" and it
adds the extra overhead of having to pick a tmp directory. And if you
pick on inside one of the directories that we are already mounting as
`cached` then you lose all of the performance improvements. This feels
like more complexity then it is worth.

I considered using the host-OS's tmp directory creation mechanism for the
scratch directory and mounting that with the `delegated` flag. That'd be
faster on macOS and fine on Linux. It has the disadvantage of keeping the
scratch files around for longer than we need them if the build process
terminats abnormally, before it can clean up. Also, on Linux, tmp
directories are sometimes in tmpfs and sometimes not, which is confusing.

The next thing I tried experimenting with was tmpfs in the docker
container. This works super well in Linux and is fast on macOS, but
unfortunately crashes on macOS unless you bump the swap space given to the
VM that hosts the docker containers. This is because we need about 5GB of
scratch space at the moment tmpfs will spill to *swap* when it grows large
but won't spill to the rest of the filesystem. It is quite fast when it
fits in memory.

On the other hand, a normal filesystem is also quite fast if it fits in
memory. Unfortunately, Docker doesn't *have* a normal filesystem. At best
it has an "overlay" filesystem that the docker folks explicitly say is not
for writing a lot of data to. The thing is, though, it is faster on macOS
to write there then it is to write to a `delegated` mount. On Linux the
performance is "fine". I *suspect* this is because we never really fsync
these files.

So I've switch the scratch space from the `cached` mount to the docker
image's filesystem. To do that I had to disabled `--read-only` which feels
like shame, but I really only had it because it made me feel good. One of
the big reasons I did this is the whole "tmpfs only spills to swap" thing.
Right now we only need 5GB of scratch space. But we'll need more
eventually and I don't feel like locking this to folks with with huge swap
partitions or lots of memory. This is super bad on macOS, again, where the
default docker VM only has a couple of GB of memory and 512MB of swap. It
is too small to use the tmpfs solution *by* *default*. Which isn't nice.

There are some followup changes I can make now that the docker image is no
loner running readonly, but I didn't want to mix them into this change and
muddy the waters.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
