### PR TITLE
Asciidoctor: Rename change admonition

### DIFF
--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -55,7 +55,7 @@ class ChangeAdmonition < Extensions::Group
   end
 
   ##
-  # Inline change admonishment.
+  # Inline change admonition.
   class ChangeAdmonitionInline < Extensions::InlineMacroProcessor
     use_dsl
     name_positional_attributes :version, :text

--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -15,21 +15,21 @@ include Asciidoctor
 #   Foo coming:[6.0.0-beta1]
 #   Foo deprecated:[6.0.0-beta1]
 #
-class ChangeAdmonishment < Extensions::Group
+class ChangeAdmonition < Extensions::Group
   def activate(registry)
     [
         [:added, 'added'],
         [:coming, 'changed'],
         [:deprecated, 'deleted'],
     ].each { |(name, revisionflag)|
-      registry.block_macro ChangeAdmonishmentBlock.new(revisionflag), name
-      registry.inline_macro ChangeAdmonishmentInline.new(revisionflag), name
+      registry.block_macro ChangeAdmonitionBlock.new(revisionflag), name
+      registry.inline_macro ChangeAdmonitionInline.new(revisionflag), name
     }
   end
 
   ##
-  # Block change admonishment.
-  class ChangeAdmonishmentBlock < Extensions::BlockMacroProcessor
+  # Block change admonition.
+  class ChangeAdmonitionBlock < Extensions::BlockMacroProcessor
     use_dsl
     name_positional_attributes :version, :passtext
 
@@ -56,7 +56,7 @@ class ChangeAdmonishment < Extensions::Group
 
   ##
   # Inline change admonishment.
-  class ChangeAdmonishmentInline < Extensions::InlineMacroProcessor
+  class ChangeAdmonitionInline < Extensions::InlineMacroProcessor
     use_dsl
     name_positional_attributes :version, :text
     with_format :short

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -1,4 +1,4 @@
-require_relative 'change_admonishment/extension'
+require_relative 'change_admonition/extension'
 require_relative 'copy_images/extension'
 require_relative 'cramped_include/extension'
 require_relative 'edit_me/extension'
@@ -6,7 +6,7 @@ require_relative 'elastic_compat_tree_processor/extension'
 require_relative 'elastic_compat_preprocessor/extension'
 require_relative 'elastic_include_tagged/extension'
 
-Extensions.register ChangeAdmonishment
+Extensions.register ChangeAdmonition
 Extensions.register do
   # Enable storing the source locations so we can look at them. This is required
   # for EditMe to get a nice location.

--- a/resources/asciidoctor/spec/change_admonishment_spec.rb
+++ b/resources/asciidoctor/spec/change_admonishment_spec.rb
@@ -1,8 +1,8 @@
-require 'change_admonishment/extension'
+require 'change_admonition/extension'
 
-RSpec.describe ChangeAdmonishment do
+RSpec.describe ChangeAdmonition do
   before(:each) do
-    Extensions.register ChangeAdmonishment
+    Extensions.register ChangeAdmonition
   end
 
   after(:each) do

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -1,4 +1,4 @@
-require 'change_admonishment/extension'
+require 'change_admonition/extension'
 require 'copy_images/extension'
 require 'fileutils'
 require 'tmpdir'
@@ -7,7 +7,7 @@ RSpec.describe CopyImages do
   RSpec::Matchers.define_negated_matcher :not_match, :match
 
   before(:each) do
-    Extensions.register ChangeAdmonishment
+    Extensions.register ChangeAdmonition
     Extensions.register do
       tree_processor CopyImages
     end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -1,11 +1,11 @@
-require 'change_admonishment/extension'
+require 'change_admonition/extension'
 require 'elastic_compat_preprocessor/extension'
 require 'elastic_include_tagged/extension'
 require 'shared_examples/does_not_break_line_numbers'
 
 RSpec.describe ElasticCompatPreprocessor do
   before(:each) do
-    Extensions.register ChangeAdmonishment
+    Extensions.register ChangeAdmonition
     Extensions.register do
       preprocessor ElasticCompatPreprocessor
       include_processor ElasticIncludeTagged


### PR DESCRIPTION
The "change admonitions" are "admonitions" not "admonishments". They are
"authoritative council" not "firm warnings". Words are hard. For what it
is worth, the AsciiDoc source also has this error in some places.
Asciidoctor gets right every time.
