### PR TITLE
self-test: File list matches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,21 +19,35 @@ asciidoctor_check:
 	$(MAKE) -C resources/asciidoctor
 
 .PHONY: integration_test
-integration_test: readme_asciidoc_check readme_asciidoctor_check
+integration_test: expected_files_check same_files_check
 
-.PHONY: readme_asciidoc_check
-readme_asciidoc_check: /tmp/readme_asciidoc
-	[ -s /tmp/readme_asciidoc/index.html ]
-	[ -s /tmp/readme_asciidoc/_conditions_of_use.html ]
+.PHONY: expected_files_check
+expected_files_check: /tmp/readme_asciidoc
+	# Checking for expected html files
+	[ -s $^/index.html ]
+	[ -s $^/_conditions_of_use.html ]
+	# Checking for copied images
+	[ -s $^/resources/cat.jpg ]
+	[ -s $^/images/icons/caution.png ]
+	[ -s $^/images/icons/important.png ]
+	[ -s $^/images/icons/note.png ]
+	[ -s $^/images/icons/warning.png ]
+	[ -s $^/images/icons/callouts/1.png ]
+	[ -s $^/images/icons/callouts/2.png ]
+	[ -s $^/snippets/blocks/1.json ]
+
+.PHONY: same_files_check
+same_files_check: /tmp/readme_asciidoc /tmp/readme_asciidoctor
+	# The `grep -v snippets` is a known issue to be resolved "soon"
+	diff \
+		<(cd /tmp/readme_asciidoc    && find * -type f | sort \
+			| grep -v snippets/blocks \
+		) \
+		<(cd /tmp/readme_asciidoctor && find * -type f | sort)
 
 /tmp/readme_asciidoc:
 	./build_docs.pl --in_standard_docker \
 		--doc README.asciidoc --out /tmp/readme_asciidoc
-
-.PHONY: readme_asciidoctor_check
-readme_asciidoctor_check: /tmp/readme_asciidoctor
-	[ -s /tmp/readme_asciidoctor/index.html ]
-	[ -s /tmp/readme_asciidoctor/_conditions_of_use.html ]
 
 /tmp/readme_asciidoctor:
 	./build_docs.pl --in_standard_docker --asciidoctor \


### PR DESCRIPTION
Adds a test that asserts that building with `Asciidoctor` produces the
same files as building with `AsciiDoc`. It doesn't actually pass right
now which is wonderful! Tests that find problems are great. We add a
`grep -v` line to the test to ignore the parts that don't pass for now
and we'll fix the failing part in a follow up.
