### PR TITLE
Self-Test: Generalize wrapping and document

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -434,14 +434,20 @@ if __name__ == '__main__':
     try:
         logging.basicConfig(level=logging.INFO)
         build_docker_image()
-        if ['--self-test'] == argv[1:]:
+        if len(argv) > 2 and '--self-test' == argv[1]:
+            cwd = realpath('.')
+            if not cwd.startswith(DIR):
+                raise ArgError(
+                    '--self-test must be invoked from within the repo')
+            docker_cwd = '/docs_build/' + cwd[len(DIR):]
             cmd = ['docker', 'run']
             cmd.extend(standard_docker_args())
+            cmd.extend(['--workdir', docker_cwd])
             if stdout.isatty():
                 cmd.append('-t')
             cmd.extend(['elastic/docs_build', 'make'])
             cmd.extend(['--no-builtin-rules'])
-            cmd.extend(['-C', '/docs_build', 'check'])
+            cmd.extend(argv[2:])
             returncode = subprocess.call(cmd)
             exit(returncode)
         elif not ['--just-build-image'] == argv[1:]:

--- a/build_docs
+++ b/build_docs
@@ -434,7 +434,7 @@ if __name__ == '__main__':
     try:
         logging.basicConfig(level=logging.INFO)
         build_docker_image()
-        if len(argv) > 2 and '--self-test' == argv[1]:
+        if len(argv) >= 2 and '--self-test' == argv[1]:
             cwd = realpath('.')
             if not cwd.startswith(DIR):
                 raise ArgError(

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -802,11 +802,12 @@ sub restart {
 #===================================
 sub usage {
 #===================================
+    my $name = $Opts->{in_standard_docker} ? 'build_docs' : $0;
     say <<USAGE;
 
     Build local docs:
 
-        $0 --doc path/to/index.asciidoc [opts]
+        $name --doc path/to/index.asciidoc [opts]
 
         Opts:
           --single          Generate a single HTML page, instead of
@@ -827,7 +828,7 @@ sub usage {
 
     Build docs from all repos in conf.yaml:
 
-        $0 --all --target_repo <target> [opts]
+        $name --all --target_repo <target> [opts]
 
         Opts:
           --target_repo     Repository to which to commit docs
@@ -848,4 +849,25 @@ sub usage {
                             Specified by build_docs when running in its container
 
 USAGE
+    if ( $Opts->{in_standard_docker} ) {
+        say <<USAGE;
+    Self Test:
+
+        $name --self-test <args to pass to make>
+
+    `--self-test` is a wrapper around `make` which is used exclusively for
+    testing. Like `make`, the current directory selects the `Makefile` and
+    you can make specific targets. Some examples:
+
+    Execute all tests:
+        $name --self-test
+
+    Execute all of the tests for our extensions to Asciidoctor:
+        $name --self-test -C resources/asciidoctor
+
+    Run rubocop on our extensions to Asciidoctor:
+        $name --self-test -C resources/asciidoctor rubocop
+    
+USAGE
+    }
 }

--- a/resources/asciidoctor/Makefile
+++ b/resources/asciidoctor/Makefile
@@ -5,6 +5,12 @@ SHELL = /bin/bash -eux -o pipefail
 MAKEFLAGS += --silent
 
 .PHONY: check
-check:
+check: rspec rubocop
+
+.PHONY: rspec
+rspec:
 	rspec
+
+.PHONY: robucop
+rubocop:
 	rubocop --cache false


### PR DESCRIPTION
Allows you to send arbitrary arguments to make. This makes it possible to
do things like "only run rubocop" with:

```
./build_docs --self-test -C resources/asciidoctor rubocop
```

While it doesn't take *that* long to run the entire `--self-test`
sequence, it is wonderful to be able to selectively run tests.
