### PR TITLE
Asciidoctor: Fix cramped include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,36 +19,5 @@ asciidoctor_check:
 	$(MAKE) -C resources/asciidoctor
 
 .PHONY: integration_test
-integration_test: expected_files_check same_files_check
-
-.PHONY: expected_files_check
-expected_files_check: /tmp/readme_asciidoc
-	# Checking for expected html files
-	[ -s $^/index.html ]
-	[ -s $^/_conditions_of_use.html ]
-	# Checking for copied images
-	[ -s $^/resources/cat.jpg ]
-	[ -s $^/images/icons/caution.png ]
-	[ -s $^/images/icons/important.png ]
-	[ -s $^/images/icons/note.png ]
-	[ -s $^/images/icons/warning.png ]
-	[ -s $^/images/icons/callouts/1.png ]
-	[ -s $^/images/icons/callouts/2.png ]
-	[ -s $^/snippets/blocks/1.json ]
-
-.PHONY: same_files_check
-same_files_check: /tmp/readme_asciidoc /tmp/readme_asciidoctor
-	# The `grep -v snippets` is a known issue to be resolved "soon"
-	diff \
-		<(cd /tmp/readme_asciidoc    && find * -type f | sort \
-			| grep -v snippets/blocks \
-		) \
-		<(cd /tmp/readme_asciidoctor && find * -type f | sort)
-
-/tmp/readme_asciidoc:
-	./build_docs.pl --in_standard_docker \
-		--doc README.asciidoc --out /tmp/readme_asciidoc
-
-/tmp/readme_asciidoctor:
-	./build_docs.pl --in_standard_docker --asciidoctor \
-		--doc README.asciidoc --out /tmp/readme_asciidoctor
+integration_test:
+	$(MAKE) -C integtest

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -19,20 +19,13 @@ readme_expected_files: /tmp/readme_asciidoc
 	[ -s $^/images/icons/callouts/2.png ]
 	[ -s $^/snippets/blocks/1.json ]
 
-.PHONY: readme_same_files
-readme_same_files: /tmp/readme_asciidoc /tmp/readme_asciidoctor
-	# The `grep -v snippets` is a known issue to be resolved "soon"
+.PHONY: %_same_files
+%_same_files: /tmp/%_asciidoc /tmp/%_asciidoctor
 	diff \
-		<(cd /tmp/readme_asciidoc    && find * -type f | sort \
+		<(cd /tmp/$*_asciidoc    && find * -type f | sort \
 			| grep -v snippets/blocks \
 		) \
-		<(cd /tmp/readme_asciidoctor && find * -type f | sort)
-
-.PHONY: includes_same_files
-includes_same_files: /tmp/includes_asciidoc /tmp/includes_asciidoctor
-	diff \
-		<(cd /tmp/includes_asciidoc    && find * -type f | sort) \
-		<(cd /tmp/includes_asciidoctor && find * -type f | sort)
+		<(cd /tmp/$*_asciidoctor && find * -type f | sort)
 
 define BD=
 /docs_build/build_docs.pl --in_standard_docker --out $@
@@ -46,8 +39,10 @@ endef
 
 # These don't declare dependencies because we don't know in general which files
 # are needed to build which asciidoc files.
+.PRECIOUS: /tmp/%_asciidoc     # don't try to remove the directory. you can't
 /tmp/%_asciidoc:
 	$(BD) --doc $*.asciidoc
 
+.PRECIOUS: /tmp/%_asciidoctor  # don't try to remove the directory. you can't
 /tmp/%_asciidoctor:
 	$(BD) --asciidoctor --doc $*.asciidoc

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -34,18 +34,18 @@ includes_same_files: /tmp/includes_asciidoc /tmp/includes_asciidoctor
 		<(cd /tmp/includes_asciidoc    && find * -type f | sort) \
 		<(cd /tmp/includes_asciidoctor && find * -type f | sort)
 
+define BD=
+/docs_build/build_docs.pl --in_standard_docker --out $@
+endef
+
 /tmp/readme_asciidoc:
-	/docs_build/build_docs.pl --in_standard_docker \
-		--doc /docs_build/README.asciidoc --out $@
+	$(BD) --doc /docs_build/README.asciidoc
 
 /tmp/readme_asciidoctor:
-	/docs_build/build_docs.pl --in_standard_docker --asciidoctor \
-		--doc /docs_build/README.asciidoc --out $@
+	$(BD) --asciidoctor --doc /docs_build/README.asciidoc
 
 /tmp/%_asciidoc:
-	/docs_build/build_docs.pl --in_standard_docker \
-		--doc $*.asciidoc --out $@
+	$(BD) --doc $*.asciidoc
 
 /tmp/%_asciidoctor:
-	/docs_build/build_docs.pl --in_standard_docker --asciidoctor \
-		--doc $*.asciidoc --out $@
+	$(BD) --asciidoctor --doc $*.asciidoc

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -2,12 +2,21 @@ SHELL = /bin/bash -eux -o pipefail
 MAKEFLAGS += --silent
 
 .PHONY: check
-check: readme_expected_files readme_same_files includes_same_files
+check: \
+	readme_expected_files readme_same_files \
+	includes_expected_files includes_same_files
+
+define STANDARD_EXPECTED_FILES=
+	[ -s $^/index.html ]
+	[ -s $^/docs.js ]
+	[ -s $^/styles.css ]
+	[ -s $^/template.md5 ]
+endef
 
 .PHONY: readme_expected_files
 readme_expected_files: /tmp/readme_asciidoc
+	$(STANDARD_EXPECTED_FILES)
 	# Checking for expected html files
-	[ -s $^/index.html ]
 	[ -s $^/_conditions_of_use.html ]
 	# Checking for copied images
 	[ -s $^/resources/cat.jpg ]
@@ -18,6 +27,10 @@ readme_expected_files: /tmp/readme_asciidoc
 	[ -s $^/images/icons/callouts/1.png ]
 	[ -s $^/images/icons/callouts/2.png ]
 	[ -s $^/snippets/blocks/1.json ]
+
+.PHONY: %_expected_files
+%_expected_files: /tmp/%_asciidoc
+	$(STANDARD_EXPECTED_FILES)
 
 .PHONY: %_same_files
 %_same_files: /tmp/%_asciidoc /tmp/%_asciidoctor

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -1,0 +1,51 @@
+SHELL = /bin/bash -eux -o pipefail
+MAKEFLAGS += --silent
+
+.PHONY: check
+check: readme_expected_files readme_same_files includes_same_files
+
+.PHONY: readme_expected_files
+readme_expected_files: /tmp/readme_asciidoc
+	# Checking for expected html files
+	[ -s $^/index.html ]
+	[ -s $^/_conditions_of_use.html ]
+	# Checking for copied images
+	[ -s $^/resources/cat.jpg ]
+	[ -s $^/images/icons/caution.png ]
+	[ -s $^/images/icons/important.png ]
+	[ -s $^/images/icons/note.png ]
+	[ -s $^/images/icons/warning.png ]
+	[ -s $^/images/icons/callouts/1.png ]
+	[ -s $^/images/icons/callouts/2.png ]
+	[ -s $^/snippets/blocks/1.json ]
+
+.PHONY: readme_same_files
+readme_same_files: /tmp/readme_asciidoc /tmp/readme_asciidoctor
+	# The `grep -v snippets` is a known issue to be resolved "soon"
+	diff \
+		<(cd /tmp/readme_asciidoc    && find * -type f | sort \
+			| grep -v snippets/blocks \
+		) \
+		<(cd /tmp/readme_asciidoctor && find * -type f | sort)
+
+.PHONY: includes_same_files
+includes_same_files: /tmp/includes_asciidoc /tmp/includes_asciidoctor
+	diff \
+		<(cd /tmp/includes_asciidoc    && find * -type f | sort) \
+		<(cd /tmp/includes_asciidoctor && find * -type f | sort)
+
+/tmp/readme_asciidoc:
+	/docs_build/build_docs.pl --in_standard_docker \
+		--doc /docs_build/README.asciidoc --out $@
+
+/tmp/readme_asciidoctor:
+	/docs_build/build_docs.pl --in_standard_docker --asciidoctor \
+		--doc /docs_build/README.asciidoc --out $@
+
+/tmp/%_asciidoc:
+	/docs_build/build_docs.pl --in_standard_docker \
+		--doc $*.asciidoc --out $@
+
+/tmp/%_asciidoctor:
+	/docs_build/build_docs.pl --in_standard_docker --asciidoctor \
+		--doc $*.asciidoc --out $@

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -38,12 +38,14 @@ define BD=
 /docs_build/build_docs.pl --in_standard_docker --out $@
 endef
 
-/tmp/readme_asciidoc:
+/tmp/readme_asciidoc: /docs_build/README.asciidoc
 	$(BD) --doc /docs_build/README.asciidoc
 
-/tmp/readme_asciidoctor:
+/tmp/readme_asciidoctor: /docs_build/README.asciidoc
 	$(BD) --asciidoctor --doc /docs_build/README.asciidoc
 
+# These don't declare dependencies because we don't know in general which files
+# are needed to build which asciidoc files.
 /tmp/%_asciidoc:
 	$(BD) --doc $*.asciidoc
 

--- a/integtest/included.asciidoc
+++ b/integtest/included.asciidoc
@@ -1,0 +1,1 @@
+I am tiny.

--- a/integtest/includes.asciidoc
+++ b/integtest/includes.asciidoc
@@ -1,0 +1,9 @@
+= Title
+
+== Chapter
+
+I include simple between here
+
+include::included.asciidoc[]
+
+and here.

--- a/resources/asciidoctor/lib/cramped_include/extension.rb
+++ b/resources/asciidoctor/lib/cramped_include/extension.rb
@@ -18,7 +18,7 @@ require 'asciidoctor/extensions'
 class CrampedInclude < Asciidoctor::Extensions::Preprocessor
   def process(_document, reader)
     def reader.prepare_lines(data, opts = {})
-      super << ''
+      super << +''
     end
     reader
   end

--- a/resources/asciidoctor/spec/cramped_include_spec.rb
+++ b/resources/asciidoctor/spec/cramped_include_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'cramped_include/extension'
+require 'elastic_compat_preprocessor/extension'
 require 'shared_examples/does_not_break_line_numbers'
 
 RSpec.describe CrampedInclude do
   before(:each) do
     Asciidoctor::Extensions.register do
       preprocessor CrampedInclude
+      preprocessor ElasticCompatPreprocessor
     end
   end
 


### PR DESCRIPTION
Fixes the cramped include preprocessor to be compatible with the elastic
compat preprocessor. The trouble here is that the cramped include
preprocessor adds a frozen `''` to the stream of lines and the elastic
compat processor attempts to modify it. It is tempting to remove all of
the string mutation from the elastic compat preprocessor but that isn't
compatible with how preprocessors have to hook in to asciidoctor.
Asciidoctor expects them to mutate the strings they are given. Or, to be
more precise, it expects that it only needs to call `process` on each
line once, and that calling it will mutate the line in place. Which
isn't possible for the frozen empty line that the cramped include
preprocessor adds.

We instead fix the problem by adding a mutable empty line to the stream.
Making asciidoctor happy while slightly upsetting me.

A better integration test would have caught this, but for now we include
the compat preprocessor in the cramped include preprocessor's unit test
to check for it. I'll work on a better integration test presently.
