### PR TITLE
Asciidoctor: Freeze constants

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -57,9 +57,6 @@ Metrics/PerceivedComplexity:
 Style/HashSyntax:
   Enabled: false
 
-Style/MutableConstant:
-  Enabled: false
-
 Style/NestedParenthesizedCalls:
   Enabled: false
 

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -24,7 +24,7 @@ module CopyImages
       'added' => 'note',
       'changed' => 'note',
       'deleted' => 'warning',
-    }
+    }.freeze
 
     def initialize(name)
       super

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -92,9 +92,9 @@ require 'asciidoctor/extensions'
 class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
   include Asciidoctor::Logging
 
-  INCLUDE_TAGGED_DIRECTIVE_RX = /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/
-  SOURCE_WITH_SUBS_RX = /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
-  CODE_BLOCK_RX = /^-----*$/
+  INCLUDE_TAGGED_DIRECTIVE_RX = /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/.freeze
+  SOURCE_WITH_SUBS_RX = /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/.freeze
+  CODE_BLOCK_RX = /^-----*$/.freeze
 
   def process(_document, reader)
     reader.instance_variable_set :@in_attribute_only_block, false


### PR DESCRIPTION
Freezes all of the variables that have CONSTANT_CASE so we don't
accidentally mutate them and enables rubocop enforcement for this.
