### PR TITLE
Asciidoctor: Fix deprecation

### DIFF
--- a/resources/asciidoctor/spec/change_admonishment_spec.rb
+++ b/resources/asciidoctor/spec/change_admonishment_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe ChangeAdmonition do
   end
 
   [
-      %w[added added],
-      %w[coming changed],
-      %w[deprecated deleted],
-  ].each do |(name, revisionflag)|
-    it "#{name}'s block version creates a note" do
+      %w[added added note],
+      %w[coming changed note],
+      %w[deprecated deleted warning],
+  ].each do |(name, revisionflag, tag)|
+    it "#{name}'s block version creates a #{tag}" do
       actual = convert <<~ASCIIDOC
         == Example
         #{name}::[some_version]
@@ -24,9 +24,9 @@ RSpec.describe ChangeAdmonition do
       expected = <<~DOCBOOK
         <chapter id="_example">
         <title>Example</title>
-        <note revisionflag="#{revisionflag}" revision="some_version">
+        <#{tag} revisionflag="#{revisionflag}" revision="some_version">
         <simpara></simpara>
-        </note>
+        </#{tag}>
         </chapter>
       DOCBOOK
       expect(actual).to eq(expected.strip)
@@ -42,9 +42,9 @@ RSpec.describe ChangeAdmonition do
       expected = <<~DOCBOOK
         <chapter id="_example">
         <title>Example</title>
-        <note revisionflag="#{revisionflag}" revision="some_version">
+        <#{tag} revisionflag="#{revisionflag}" revision="some_version">
         <simpara>See <xref linkend="some-reference"/></simpara>
-        </note>
+        </#{tag}>
         <section id="some-reference">
         <title>Some Reference</title>
 

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe ElasticCompatPreprocessor do
   include_examples "doesn't break line numbers"
 
   [
-      %w[added added],
-      %w[coming changed],
-      %w[deprecated deleted],
-  ].each do |(name, revisionflag)|
+      %w[added added note],
+      %w[coming changed note],
+      %w[deprecated deleted warning],
+  ].each do |(name, revisionflag, tag)|
     it "invokes the #{name} block macro when #{name}[version] starts a line" do
       actual = convert <<~ASCIIDOC
         == Example
@@ -33,9 +33,9 @@ RSpec.describe ElasticCompatPreprocessor do
       expected = <<~DOCBOOK
         <chapter id="_example">
         <title>Example</title>
-        <note revisionflag="#{revisionflag}" revision="some_version">
+        <#{tag} revisionflag="#{revisionflag}" revision="some_version">
         <simpara></simpara>
-        </note>
+        </#{tag}>
         </chapter>
       DOCBOOK
       expect(actual).to eq(expected.strip)


### PR DESCRIPTION
When I added deprecations I created a `note` element but it should have
been a `warning` element. This is one of the things that the new
`html_diff`-based integration tests caught!
