### PR TITLE
Asciidoctor compatibility for part of readme

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -372,21 +372,21 @@ Longer `partintro` blocks should be wrapped in an
 http://www.methods.co.nz/asciidoc/userguide.html#X29[_open block_]
 which starts and ends with two dashes: `--`:
 
-[source,asciidoc]
+["source","asciidoc",subs="attributes,callouts,macros"]
 ----------------------------------
 = Part two                  # level 0
 
 [partintro]
 .A partintro title
--- <1>
+pass:[--] <1>
 This section may contain multiple paragraphs.
 
 [float]
-== A header should use `[float]`
+== A header should use [float]
 
 Everything up to the closing -- marker
 will be considered part of the partintro.
--- <1>
+pass:[--] <1>
 
 == Chapter title           # level 2
 

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -46,7 +46,7 @@ readme_expected_files: /tmp/readme_asciidoc
 		<(cd /tmp/$*_asciidoctor && find * -type f | sort)
 	# The grep -v below are for known issues with asciidoctor
 	for file in $$(cd /tmp/$*_asciidoc && find * -type f -name '*.html' \
-			| grep -v 'blocks\|changes\|experimental\|multi-part'); do \
+			| grep -v 'blocks\|changes\|experimental'); do \
 		./html_diff /tmp/$*_asciidoc/$$file /tmp/$*_asciidoctor/$$file; \
 	done
 


### PR DESCRIPTION
Our README.asciidoc file has source listing containing asciidoc code
which is rare for our books. Asciidoctor was rendering it incorrectly
because of its "automatic comment detection" that it uses with callouts.
It saw
```
-- <1>
```

And through "that is a SQL comment preceeding a callout so I will eat
the `--`". While *normally* helpful, this is wrong when commenting on
asciidoc source. I work around this by writing
```
pass:[--] <1>
```

Which spits out the desired `--` followed by a callout. To get that
working I had to poke the language declaration line some, especially
because AsciiDoc doesn't support the simpler Asciidoctor syntax for
enabling macros inside of listings.

This another thing that our `html_diff` based integration tests caught.
