### PR TITLE
Clean up Edit Me links

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -212,7 +212,7 @@ sub _guess_opts_from_file {
     $Opts->{root_dir} = $toplevel;
     local $ENV{GIT_DIR} = dir($toplevel)->subdir('.git');
     my $remotes = eval { run qw(git remote -v) } || '';
-    if ($remotes !~ /\s+(\S+[\/:]elastic\/\S+)/) {
+    if ($remotes !~ m|\s+(\S+[/:]elastic/\S+)|) {
         say "Couldn't find edit url because there isn't an Elastic clone";
         say "$remotes";
         return;

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -32,7 +32,6 @@ def normalize_html(html):
     # ellipsis. They don't hurt anything but asciidoc doesn't make them
     html = html.replace('\u2026\u200b', '\u2026')
     # Temporary workaround for known issues
-    html = html.replace('class="edit_me" href="/./', 'class="edit_me" href="')
     html = re.sub(
         r'(?m)^\s+<div class="console_widget" data-snippet="[^"]+">'
         r'\s+</div>\n', '', html)

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -26,7 +26,7 @@ class EditMe < TreeProcessorScaffold
       if repo_root
         repo_root = Pathname.new repo_root
         base_dir = Pathname.new @document.base_dir
-        url += "#{base_dir.relative_path_from(repo_root)}/"
+        url += "#{base_dir.relative_path_from(repo_root)}/" unless repo_root == base_dir
       end
       url += path
       "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -76,17 +76,13 @@ RSpec.describe EditMe do
 
       include::resources/edit_me/chapter2.adoc[]
     ASCIIDOC
-    expected = <<~DOCBOOK
-      <chapter id="_chapter_1">
-      <title>Chapter 1<ulink role="edit_me" url="www.example.com/docs/spec/resources/edit_me/chapter1.adoc">Edit me</ulink></title>
-      <simpara>Words.</simpara>
-      </chapter>
-      <chapter id="_chapter_2">
-      <title>Chapter 2<ulink role="edit_me" url="www.example.com/docs/spec/resources/edit_me/chapter2.adoc">Edit me</ulink></title>
-      <simpara>Words.</simpara>
-      </chapter>
-    DOCBOOK
-    expect(convert input, attributes).to eq(expected.strip)
+    expect(convert input, attributes).to match(%r{
+      ^.+
+      url="www\.example\.com/docs/spec/resources/edit_me/chapter1\.adoc"
+      .+
+      url="www\.example\.com/docs/spec/resources/edit_me/chapter2\.adoc"
+      .+$
+    }xm)
   end
 
   it "doesn't add extra path segments if repo_root is the base_dir" do
@@ -99,17 +95,13 @@ RSpec.describe EditMe do
 
       include::resources/edit_me/chapter2.adoc[]
     ASCIIDOC
-    expected = <<~DOCBOOK
-      <chapter id="_chapter_1">
-      <title>Chapter 1<ulink role="edit_me" url="www.example.com/docs/resources/edit_me/chapter1.adoc">Edit me</ulink></title>
-      <simpara>Words.</simpara>
-      </chapter>
-      <chapter id="_chapter_2">
-      <title>Chapter 2<ulink role="edit_me" url="www.example.com/docs/resources/edit_me/chapter2.adoc">Edit me</ulink></title>
-      <simpara>Words.</simpara>
-      </chapter>
-    DOCBOOK
-    expect(convert input, attributes).to eq(expected.strip)
+    expect(convert input, attributes).to match(%r{
+      ^.+
+      url="www\.example\.com/docs/resources/edit_me/chapter1\.adoc"
+      .+
+      url="www\.example\.com/docs/resources/edit_me/chapter2\.adoc"
+      .+$
+    }xm)
   end
 
   it "does not add a link to each chapter title if edit_link is not set" do

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -89,6 +89,29 @@ RSpec.describe EditMe do
     expect(convert input, attributes).to eq(expected.strip)
   end
 
+  it "doesn't add extra path segments if repo_root is the base_dir" do
+    attributes = {
+      'edit_url' => 'www.example.com/docs/',
+      'repo_root' => File.dirname(__FILE__),
+    }
+    input = <<~ASCIIDOC
+      include::resources/edit_me/chapter1.adoc[]
+
+      include::resources/edit_me/chapter2.adoc[]
+    ASCIIDOC
+    expected = <<~DOCBOOK
+      <chapter id="_chapter_1">
+      <title>Chapter 1<ulink role="edit_me" url="www.example.com/docs/resources/edit_me/chapter1.adoc">Edit me</ulink></title>
+      <simpara>Words.</simpara>
+      </chapter>
+      <chapter id="_chapter_2">
+      <title>Chapter 2<ulink role="edit_me" url="www.example.com/docs/resources/edit_me/chapter2.adoc">Edit me</ulink></title>
+      <simpara>Words.</simpara>
+      </chapter>
+    DOCBOOK
+    expect(convert input, attributes).to eq(expected.strip)
+  end
+
   it "does not add a link to each chapter title if edit_link is not set" do
     input = <<~ASCIIDOC
       include::resources/edit_me/chapter1.adoc[]


### PR DESCRIPTION
A minor fix and minor clean up for the "Edit Me" links that allow us to
remove the "temporary workaround" in our `html_diff`ing integration tests:
1. Switch detection of the root of the repository from a loop to a call
out to `git rev-parse --show-toplevel`, a trick Jarpy tought me when he
saw my loop in the docker code.
2. Do not add `./` to the url if the `base_dir` of the document is also
the root of the repository. This is *probably* only true of
`README.asciidoc` in the docs repo, but we test with that file so we
should get it right.

Closes #634