### PR TITLE
[DOCS] Adds Go client documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -301,7 +301,20 @@ contents:
                   -
                     repo:   elasticsearch-js
                     path:   docs/
-
+              -
+                title:      GO API
+                prefix:     go-api
+                current:    master
+                branches:   [ master ]
+                index:      docs/go/index.asciidoc
+                single:     1
+                tags:       Clients/Go
+                subject:    Clients
+                asciidoctor: true
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/go
               -
                 title:      .NET API
                 prefix:     net-api

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -116,6 +116,8 @@ alias docbldejs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-js/d
 
 alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
+alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc'
+
 alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
 alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -116,7 +116,7 @@ alias docbldejs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-js/d
 
 alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
-alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc'
+alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
 
 alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/39379, which must be merged first.

This PR adds documentation for the Go client in https://www.elastic.co/guide/en/elasticsearch/client/index.html

This new client documentation is generated via the Asciidoctor build options.