### PR TITLE
Switches Getting Started Guide to asciidoctor builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,6 +70,7 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
+            asciidoctor: true
             sources:
               -
                 repo:   stack-docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -43,7 +43,7 @@ alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-d
 
 alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
-alias docbldgs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
+alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
 alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 


### PR DESCRIPTION
This PR updates the Getting Started Guide (https://www.elastic.co/guide/en/elastic-stack-get-started/master/index.html) such that it's built via Asciidoctor.

Related to #606

This PR must not be merged until https://github.com/elastic/docs/pull/643 is complete.