### PR TITLE
Flip current to MS 18 - DO NOT MERGE UNTIL READY

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -429,8 +429,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-17
-            branches:   [ release-ms-18, release-ms-17, saas-release, saas-release-heroku ]
+            current:    release-ms-18
+            branches:   [ release-ms-18, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
As part of the roll-out of Milestone 18 we need to flip `current` to `release-ms-18` and remove the previous `release-ms-17` build. Ergo, this PR.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
