### PR TITLE
Switches Stack Overview to asciidoctor builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -119,6 +119,7 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
+            asciidoctor: true            
             sources:
               -
                 repo:   stack-docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -52,7 +52,7 @@ alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-d
 alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
 # Stack Overview
-alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
 # Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR updates the Stack Overview (https://www.elastic.co/guide/en/elastic-stack-overview/master/index.html) such that it's built via Asciidoctor.

Related to #606