### PR TITLE
Add --conf option and test for --all

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -140,6 +140,12 @@ def run_build_docs(args):
                 docker_args.extend([
                         '-v',
                         '%s:/tmp/.ssh/known_hosts:ro,cached' % known_hosts])
+        elif arg == '--conf':
+            conf_file = realpath(args.next_arg_or_err())
+            if not exists(conf_file):
+                raise ArgError("Can't find --conf %s" % conf_file)
+            docker_args.extend(['-v', '%s:/conf.yaml:delegated' % conf_file])
+            build_docs_args.append('/conf.yaml')
         elif arg == '--doc':
             doc_file = realpath(args.next_arg_or_err())
             if not exists(doc_file):

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -1,11 +1,19 @@
 SHELL = /bin/bash -eux -o pipefail
 MAKEFLAGS += --silent
 
+# Used by the test for --all
+export GIT_AUTHOR_NAME=Test
+export GIT_AUTHOR_EMAIL=test@example.com
+export GIT_COMMITTER_NAME=Test
+export GIT_COMMITTER_EMAIL=test@example.com
+
 .PHONY: check
 check: \
 	style \
+	minimal_expected_files minimal_same_files \
+	includes_expected_files includes_same_files \
 	readme_expected_files readme_same_files \
-	includes_expected_files includes_same_files
+	small_all_expected_files
 
 .PHONY: style
 style: html_diff
@@ -69,3 +77,35 @@ endef
 .PRECIOUS: /tmp/%_asciidoctor  # don't try to remove the directory. you can't
 /tmp/%_asciidoctor:
 	$(BD) --asciidoctor --doc $*.asciidoc
+
+.PHONY: small_all_expected_files
+small_all_expected_files: /tmp/small_all
+	[ -s $^/html/branches.yaml ]
+	grep '<a class="ulink" href="test/current/index.html" target="_top">Test book</a>' $^/html/index.html > /dev/null
+	grep '<meta http-equiv="refresh" content="0; url=current/index.html">' $^/html/test/index.html > /dev/null
+	[ -s $^/html/test/current/index.html ]
+
+.PRECIOUS: /tmp/small_all
+/tmp/small_all:
+	# Builds "--all" documentation specified by by the "small_conf.yaml" file.
+
+	# First build a repository to use as the source.
+	rm -rf /tmp/source
+	git init /tmp/source
+	cp minimal.asciidoc /tmp/source/
+	cd /tmp/source && \
+		git add . && \
+		git commit -m 'minimal'
+
+	# Initialize a bare repository that the docs build process can use as a
+	# remote. It is used to pushing to github but it can push to a remote on
+	# the filesystem just fine.
+	git init --bare /tmp/small_all.git
+
+	# Actually build the docs
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo /tmp/small_all.git \
+		--conf small_conf.yaml
+
+	# Check out the files we just built
+	git clone /tmp/small_all.git /tmp/small_all

--- a/integtest/minimal.asciidoc
+++ b/integtest/minimal.asciidoc
@@ -1,0 +1,7 @@
+= Title
+
+== Chapter
+
+This is a minimal viable asciidoc file for use with build_docs. The actual
+contents of this paragraph aren't important but having a paragraph here
+is required.

--- a/integtest/small_conf.yaml
+++ b/integtest/small_conf.yaml
@@ -1,0 +1,53 @@
+# This is a small config file for build_docs.pl used for testing
+
+# This block is required even when building a single doc
+template:
+    path:               .template/
+    branch:
+        default:
+            base_url:       'https://www.elastic.co/'
+            template_url:   'https://www.elastic.co/guide_template'
+        staging:
+            base_url:       'https://stag-www.elastic.co/'
+            template_url:   'https://stag-www.elastic.co/guide_template'
+    defaults:
+        POSTHEAD: |
+            <link rel="stylesheet" type="text/css" href="styles.css" />
+        FINAL: |
+            <script type="text/javascript" src="docs.js"></script>
+            <script type='text/javascript' src='https://cdn.rawgit.com/google/code-prettify/master/loader/run_prettify.js?lang=yaml'></script>
+
+paths:
+    # These two configure where to put things in the --target_repo. The
+    # paths are resolved relative to the root of the --target_repo.
+    build:          html/
+    branch_tracker: html/branches.yaml
+    # This configures which directory to use for cloning repos. Because
+    # these are big we tend to want them to be in a non-temporary but
+    # .gitignored spot. The path is resolved relative to the root of the
+    # docs repo.
+    repos:          /tmp/repos/
+
+# This configures all of the repositories used to build the docs
+repos:
+    # Normally we use the `https://` prefix to clone from github but this file
+    # is for testing so we pick a repo on the filesystem.
+    source:           /tmp/source
+
+# The title to use for the table of contents
+contents_title:     Elastic Stack and Product Documentation
+
+# The actual books to build
+contents:
+    -
+        title:      Test book
+        prefix:     test
+        current:    master
+        branches:   [ master ]
+        index:      minimal.asciidoc
+        tags:       test tag
+        subject:    Test
+        sources:
+            -
+                repo:   source
+                path:   .


### PR DESCRIPTION
Adds support for `--conf` to specify the config file used by the docs
build and uses that to add a test for `--all`. This will allow us to add
more features with more confidence that we're not breaking `--all`. It
makes my life less terrifying.
