### PR TITLE
Self-Test: Ignore width space after em dash

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -5,6 +5,7 @@ MAKEFLAGS += --silent
 check: \
 	style \
 	readme_expected_files readme_same_files \
+	emdash_expected_files emdash_same_files \
 	includes_expected_files includes_same_files
 
 .PHONY: style

--- a/integtest/emdash.asciidoc
+++ b/integtest/emdash.asciidoc
@@ -1,0 +1,5 @@
+= Title
+
+== Chapter
+
+I have an em dash between some--words.

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -31,6 +31,10 @@ def normalize_html(html):
     # Remove the zero width space that asciidoctor adds after each horizontal
     # ellipsis. They don't hurt anything but asciidoc doesn't make them
     html = html.replace('\u2026\u200b', '\u2026')
+    # Remove the zero width space that asciidoctor adds after each em dash that
+    # is between words. They are actively nice to have but asciidoc doesn't
+    # make them.
+    html = html.replace('\u2014\u200b', '\u2014')
     # Temporary workaround for known issues
     html = html.replace('class="edit_me" href="/./', 'class="edit_me" href="')
     html = re.sub(


### PR DESCRIPTION
AsciiDoctor spits out an em dash when there is an em dash between two
words. This is kind of a pleasant surprise because it makes it clear
that we can break words after the em dash. This change teaches the
`html_diff` utility that we use for finding differences in pages that
this particular zero width space doesn't count as a difference.
