### PR TITLE
Updates hyphenation of CCR and CCS

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -93,7 +93,9 @@
 :ml-features:             machine learning features
 :stack-ml-features:       {stack} {ml-features}
 :ccr:                     cross cluster replication
+:ccr-cap:                 Cross cluster replication
 :ccs:                     cross cluster search
+:ccs-cap:                 Cross cluster search
 :ilm:                     index lifecycle management
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -92,7 +92,8 @@
 :ml:                      machine learning
 :ml-features:             machine learning features
 :stack-ml-features:       {stack} {ml-features}
-:ccr:                     cross-cluster replication
+:ccr:                     cross cluster replication
+:ccs:                     cross cluster search
 :ilm:                     index lifecycle management
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM


### PR DESCRIPTION
This PR removes the hyphen from the attribute for the "cross-cluster replication" feature. 
It also adds an attribute for cross cluster search.