### PR TITLE
Fail the build if there are any errors 

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -5,7 +5,8 @@ MAKEFLAGS += --silent
 check: \
 	style \
 	readme_expected_files readme_same_files \
-	includes_expected_files includes_same_files
+	includes_expected_files includes_same_files \
+	missing_include_fails_asciidoc missing_include_fails_asciidoctor
 
 .PHONY: style
 style: html_diff
@@ -50,9 +51,37 @@ readme_expected_files: /tmp/readme_asciidoc
 		./html_diff /tmp/$*_asciidoc/$$file /tmp/$*_asciidoctor/$$file; \
 	done
 
+# Build the docs into the target
 define BD=
 /docs_build/build_docs.pl --in_standard_docker --out $@
 endef
+
+# Build the docs into a temporary directory
+define BD_DUMMY=
+/docs_build/build_docs.pl --in_standard_docker --out /tmp/dummy
+endef
+
+define CHECK_IN=
+grep $(1) $(2) > /dev/null || { \
+	echo "Couldn't find $(1) in $(2)"; \
+	cat $(2); \
+	false; \
+}
+endef
+
+.PHONY: missing_include_fails_asciidoc
+missing_include_fails_asciidoc: missing_include.asciidoc
+	set +e; \
+		$(BD_DUMMY) --doc missing_include.asciidoc > /tmp/out 2>&1; \
+		test $$? -eq 255
+	$(call CHECK_IN,'WARNING: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
+
+.PHONY: missing_include_fails_asciidoctor
+missing_include_fails_asciidoctor: missing_include.asciidoc
+	set +e; \
+		$(BD_DUMMY) --asciidoctor --doc missing_include.asciidoc > /tmp/out 2>&1; \
+		test $$? -eq 255
+	$(call CHECK_IN,'ERROR: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
 
 /tmp/readme_asciidoc: /docs_build/README.asciidoc
 	$(BD) --doc /docs_build/README.asciidoc

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -61,7 +61,7 @@ define BD_DUMMY=
 /docs_build/build_docs.pl --in_standard_docker --out /tmp/dummy
 endef
 
-define CHECK_IN=
+define CHECK_FILE=
 grep $(1) $(2) > /dev/null || { \
 	echo "Couldn't find $(1) in $(2)"; \
 	cat $(2); \
@@ -74,14 +74,14 @@ missing_include_fails_asciidoc: missing_include.asciidoc
 	set +e; \
 		$(BD_DUMMY) --doc missing_include.asciidoc > /tmp/out 2>&1; \
 		test $$? -eq 255
-	$(call CHECK_IN,'WARNING: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
+	$(call CHECK_FILE,'WARNING: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
 
 .PHONY: missing_include_fails_asciidoctor
 missing_include_fails_asciidoctor: missing_include.asciidoc
 	set +e; \
 		$(BD_DUMMY) --asciidoctor --doc missing_include.asciidoc > /tmp/out 2>&1; \
 		test $$? -eq 255
-	$(call CHECK_IN,'ERROR: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
+	$(call CHECK_FILE,'ERROR: missing_include.asciidoc: line 7: include file not found: /docs_build/integtest/missing.asciidoc',/tmp/out)
 
 /tmp/readme_asciidoc: /docs_build/README.asciidoc
 	$(BD) --doc /docs_build/README.asciidoc

--- a/integtest/missing_include.asciidoc
+++ b/integtest/missing_include.asciidoc
@@ -1,0 +1,9 @@
+= Title
+
+== Chapter
+
+I include missing between here
+
+include::missing.asciidoc[]
+
+and here.

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -292,7 +292,7 @@ sub build_single {
 sub _check_build_error {
 #===================================
     my ( $output, $died, $lenient ) = @_;
-    my $warned = grep {/^(a2x|asciidoc(tor)?): (WARNING):/} split "\n", $output;
+    my $warned = grep {/^(a2x|asciidoc(tor)?): (WARNING|ERROR):/} split "\n", $output;
 
     return unless $died || $warned;
 


### PR DESCRIPTION
We used to fail when building a book resulted in any `WARNING`s or the
process the builds the book exits with a non-0 status. This was fine
when we were only using `AsciiDoc` because `a2x` would always exit with
a non-0 status if it output any `ERROR`s. But Asciidoctor will happily
exit with a 0 status after output errors! If that happens, we should
fail to build the book. This change does exactly that. And it adds an
integration test that attempt to build a file with a missing include.
That tests this change.