### PR TITLE
Switch resiliency status to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -188,6 +188,7 @@ contents:
             single:     1
             tags:       Elasticsearch/Resiliency Status
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -102,7 +102,7 @@ alias docblddg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-defin
 
 
 # Elasticsearch Extras
-alias docbldres='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
+alias docbldres='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
 
 alias docbldpls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the Elasticsearch resiliency status page to asciidoctor. It
doesn't look 100% the same but the differences are minor and look ok to
me.
