### PR TITLE
Change nginx layout of --open

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -234,7 +234,8 @@ def run_build_docs(args):
                 # is weird. If we tell it that the browser's name is `open`
                 # we'll get whatever the user set as their default browser.
                 environ['BROWSER'] = 'open'
-            webbrowser.open('http://localhost:8000/guide', new=1, autoraise=False)
+            webbrowser.open('http://localhost:8000/guide',
+                            new=1, autoraise=False)
         if should_forward_ssh_auth_into_container:
             match = re.match('Waiting for ssh auth to be forwarded to (.+)',
                              line)

--- a/build_docs
+++ b/build_docs
@@ -234,7 +234,7 @@ def run_build_docs(args):
                 # is weird. If we tell it that the browser's name is `open`
                 # we'll get whatever the user set as their default browser.
                 environ['BROWSER'] = 'open'
-            webbrowser.open('http://localhost:8000', new=1, autoraise=False)
+            webbrowser.open('http://localhost:8000/guide', new=1, autoraise=False)
         if should_forward_ssh_auth_into_container:
             match = re.match('Waiting for ssh auth to be forwarded to (.+)',
                              line)

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -125,7 +125,7 @@ sub build_local {
 
     if ( $Opts->{open} ) {
         say "Opening: " . $html;
-        serve_and_open_browser( $dir, 'index.html' );
+        serve_and_open_browser( $dir );
     }
     else {
         say "See: $html";
@@ -245,7 +245,7 @@ sub build_all {
         check_links($build_dir);
     }
     push_changes($build_dir, $target_repo, $target_repo_checkout) if $Opts->{push};
-    serve_and_open_browser( $build_dir, '/' ) if $Opts->{open};
+    serve_and_open_browser( $build_dir ) if $Opts->{open};
 
     $temp_dir->rmtree;
 }
@@ -710,7 +710,7 @@ sub serve_and_open_browser {
         if ( not $running_in_standard_docker ) {
             sleep 1;
             say "Press Ctrl-C to exit the web server";
-            open_browser("http://localhost:8000/$open_path");
+            open_browser("http://localhost:8000/");
         }
 
         wait;
@@ -738,8 +738,8 @@ http {
   access_log /dev/stdout short;
   server {
     listen 8000;
-    location / {
-      root $dir;
+    location /guide {
+      alias $dir;
       add_header 'Access-Control-Allow-Origin' '*';
       if (\$request_method = 'OPTIONS') {
         add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';


### PR DESCRIPTION
When you run a build with `--open` we start a web server locally and
open up a browser window for you to look at them. With the docker-based
`build_docs` that server is nginx. nginx is fancy, and one of the things
that we can do pretty easily is lay out the files that we serve so they
look fairly like the public web site. This change does just that and it
should come in handy to test future work we plan to do that generates an
nginx config to deploy to the site serving the docs.
