### PR TITLE
Add Kibana to Installation and Upgrade dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -61,6 +61,9 @@ contents:
               -
                 repo:   elasticsearch
                 path:   docs/
+              -
+                repo:   kibana
+                path:   docs/                
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -39,7 +39,7 @@ alias docbldls=docbldlsx
 alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Stack
-alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/'
+alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/'
 
 alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/197 and https://github.com/elastic/kibana/pull/30155

This PR adds the kibana repo as a resource for the Installation and Upgrade Guide, so that it can pull notable breaking changes from that repo.