### PR TITLE
[DOCS] Adds shared prev-major-version attribute

### DIFF
--- a/shared/versions.asciidoc
+++ b/shared/versions.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         8.0.0-alpha1
 :branch:                 master
 :major-version:          8.x
+:prev-major-version:     7.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions55.asciidoc
+++ b/shared/versions55.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         5.5.3
 :branch:                 5.5
 :major-version:          5.x
+:prev-major-version:     2.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         5.6.15
 :branch:                 5.6
 :major-version:          5.x
+:prev-major-version:     2.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions60.asciidoc
+++ b/shared/versions60.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.0.1
 :branch:                 6.0
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions61.asciidoc
+++ b/shared/versions61.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.1.4
 :branch:                 6.1
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions62.asciidoc
+++ b/shared/versions62.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.2.4
 :branch:                 6.2
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions63.asciidoc
+++ b/shared/versions63.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.3.2
 :branch:                 6.3
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.4.3
 :branch:                 6.4
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.5.4
 :branch:                 6.5
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.6.1
 :branch:                 6.6
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.7.0
 :branch:                 6.7
 :major-version:          6.x
+:prev-major-version:     5.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions70.asciidoc
+++ b/shared/versions70.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         7.0.0-beta1
 :branch:                 7.0
 :major-version:          7.x
+:prev-major-version:     6.x
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions71.asciidoc
+++ b/shared/versions71.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         7.1.0
 :branch:                 7.x
 :major-version:          7.x
+:prev-major-version:     6.x
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
This PR adds the `prev-major-version` attribute to the shared versions files, so that it can be used in the Installation and Upgrade Guide (and any other books that need it).