### PR TITLE
Switch the perl client docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -357,6 +357,7 @@ contents:
                 single:     1
                 tags:       Clients/Perl
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -120,7 +120,7 @@ alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/
 
 alias docbldphp='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 
-alias docbldepl='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single 1'
+alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
 alias docbldepy='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single 1'
 


### PR DESCRIPTION
Switches the perl client docs to asciidoctor. `html_diff` says
asciidoctor produces exactly the same output modulo new lines.
