### PR TITLE
Fix ECE product name

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -450,7 +450,7 @@ contents:
                 exclude_branches: [ saas-release-v2, saas-release-heroku ]
 
          -
-            title:      Cloud Enterprise - Elastic Cloud on your Infrastructure
+            title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE


### PR DESCRIPTION
"Cloud Enterprise" is not an accepted name for ECE. I suspect this has always been here, but we've just never noticed it. 😬

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
