### PR TITLE
Switch the PHP client to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -343,6 +343,7 @@ contents:
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-php

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -118,7 +118,7 @@ alias docbldegr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs
 
 alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
-alias docbldphp='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
+alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 
 alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 


### PR DESCRIPTION
Switches the PHP client's doc to being built from Asciidoctor. The
resulting html has quite a few changes spacing changes that aren't
impactful and a couple of small changes that look fine visually. There
are a few changes to auto-generated IDs that we've grown to expect from
asciidoctor. They seem fine to me. Here is the diff:
https://gist.github.com/nik9000/72113b441f682b116b7b41a2b78baed6
