### PR TITLE
Switch ruby client docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -385,6 +385,7 @@ contents:
                 current:    master
                 tags:       Clients/Ruby
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -124,7 +124,7 @@ alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldepy='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single 1'
 
-alias docblderb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/ruby/index.asciidoc'
+alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/ruby/index.asciidoc'
 
 alias docbldecc='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single 1'
 


### PR DESCRIPTION
This switches building the ruby client docs from AsciiDoc to
Asciidoctor. The html that it produces isn't 100% the same, but most the
differences aren't relevant. Here is a diff of the relevant stuff:
https://gist.github.com/nik9000/92e098ca9d9ce113f5d795ee1b0017ce

That diff seems like a net positive.
