### PR TITLE
Switch the community clients book to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -398,6 +398,7 @@ contents:
                 single:     1
                 tags:       Clients/Community
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -126,7 +126,7 @@ alias docbldepy='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs
 
 alias docblderb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/ruby/index.asciidoc'
 
-alias docbldecc='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single 1'
+alias docbldecc='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 
 alias docbldesh='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 


### PR DESCRIPTION
Switches the community clients book in the Elasticsearch repo to
Asciidoctor. The generated html has some spacing differences but our
tuned html_diff tool doesn't think that there are any differences that
are impactful.
