### PR TITLE
Adds CCR link to shared settings

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -1,24 +1,27 @@
-You configure settings for {xpack} features in the `elasticsearch.yml`,
-`kibana.yml`, and `logstash.yml` configuration files.
+You can configure settings for {xpack} features in the `elasticsearch.yml`,
+`kibana.yml`, and `logstash.yml` configuration files. You can also update some
+settings dynamically with the
+{ref}/cluster-update-settings.html[cluster update settings API].
 
 [options="header", cols="a,d,d,d"]
 |=======================
-|{xpack} Feature    |{es} Settings                         |{kib} Settings                                |Logstash Settings
-|APM UI             |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]        |No
-|Development Tools  |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]        |No
-|Graph              |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]      |No
-|Infrastructure UI  |No                                    |{kibana-ref}/infrastructure-ui-settings-kb.html[Yes]  |No
-|Logs UI            |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]            |No
-|Machine learning   |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]         |No
-|Management         |No                                    |No                                            |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
-|Monitoring         |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes] |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
-|Reporting          |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]  |No
+|{xpack} Feature           |{es} Settings                         |{kib} Settings                                       |Logstash Settings
+|APM UI                    |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]               |No
+|Cross cluster replication |{ref}/ccr-settings.html[Yes]          |No                                                   |No
+|Development Tools         |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]               |No
+|Graph                     |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]             |No
+|Infrastructure UI         |No                                    |{kibana-ref}/infrastructure-ui-settings-kb.html[Yes] |No
+|Logs UI                   |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]           |No
+|Machine learning          |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]                |No
+|Management                |No                                    |No                                                   |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring                |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes]        |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting                 |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]         |No
 .2+|Security
 
 * Auditing
-                    |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]   |No
-                    |{ref}/auditing-settings.html[Yes]     |No                                            |No
-|Watcher            |{ref}/notification-settings.html[Yes] |No                                            |No
+                           |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]          |No
+                           |{ref}/auditing-settings.html[Yes]     |No                                                   |No
+|Watcher                   |{ref}/notification-settings.html[Yes] |No                                                   |No
 |=======================
 
 There are also {ref}/license-settings.html[{xpack} license settings] in the

--- a/shared/settings65.asciidoc
+++ b/shared/settings65.asciidoc
@@ -1,0 +1,27 @@
+You can configure settings for {xpack} features in the `elasticsearch.yml`,
+`kibana.yml`, and `logstash.yml` configuration files. You can also update some
+settings dynamically with the
+{ref}/cluster-update-settings.html[cluster update settings API].
+
+[options="header", cols="a,d,d,d"]
+|=======================
+|{xpack} Feature           |{es} Settings                         |{kib} Settings                                       |Logstash Settings
+|APM UI                    |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]               |No
+|Development Tools         |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]               |No
+|Graph                     |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]             |No
+|Infrastructure UI         |No                                    |{kibana-ref}/infrastructure-ui-settings-kb.html[Yes] |No
+|Logs UI                   |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]           |No
+|Machine learning          |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]                |No
+|Management                |No                                    |No                                                   |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
+|Monitoring                |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes]        |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Reporting                 |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]         |No
+.2+|Security
+
+* Auditing
+                           |{ref}/security-settings.html[Yes]     |{kibana-ref}/security-settings-kb.html[Yes]          |No
+                           |{ref}/auditing-settings.html[Yes]     |No                                                   |No
+|Watcher                   |{ref}/notification-settings.html[Yes] |No                                                   |No
+|=======================
+
+There are also {ref}/license-settings.html[{xpack} license settings] in the
+`elasticsearch.yml` file.


### PR DESCRIPTION
This PR adds a link to the cross cluster replication settings (https://www.elastic.co/guide/en/elasticsearch/reference/master/ccr-settings.html) in the X-Pack settings table (https://www.elastic.co/guide/en/elasticsearch/reference/master/settings-xpack.html) for 6.7 and later releases.

It also adds mention of the cluster update settings API and fixes some spacing in the table.