### PR TITLE
Switch the groovy API to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -310,6 +310,7 @@ contents:
                 index:      docs/groovy-api/index.asciidoc
                 tags:       Clients/Groovy
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch

--- a/conf.yaml
+++ b/conf.yaml
@@ -301,25 +301,7 @@ contents:
                   -
                     repo:   elasticsearch-js
                     path:   docs/
-
-              -
-                title:      Groovy API
-                prefix:     groovy-api
-                current:    2.4
-                branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                index:      docs/groovy-api/index.asciidoc
-                tags:       Clients/Groovy
-                subject:    Clients
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/groovy-api
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
+                    
               -
                 title:      .NET API
                 prefix:     net-api
@@ -1294,6 +1276,23 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/graph
+          -
+            title:      Groovy API
+            prefix:     groovy-api
+            current:    2.4
+            branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            index:      docs/groovy-api/index.asciidoc
+            tags:       Clients/Groovy
+            subject:    Clients
+            asciidoctor: true
+            sources:
+              -
+                repo:   elasticsearch
+                path:   docs/groovy-api
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
 redirects:
     -

--- a/conf.yaml
+++ b/conf.yaml
@@ -1285,10 +1285,7 @@ contents:
             index:      docs/groovy-api/index.asciidoc
             tags:       Clients/Groovy
             subject:    Clients
-<<<<<<< HEAD
             asciidoctor: true
-=======
->>>>>>> master
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -114,7 +114,7 @@ alias docbldejv='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs
 
 alias docbldejs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
 
-alias docbldegr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
+alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
 alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the groovy API for Elasticsearch to Asciidoctor. The html has a
few spacing differences but is otherwise the same.
