### PR TITLE
Moves Groovy client to legacy documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -301,24 +301,6 @@ contents:
                   -
                     repo:   elasticsearch-js
                     path:   docs/
-
-              -
-                title:      Groovy API
-                prefix:     groovy-api
-                current:    2.4
-                branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                index:      docs/groovy-api/index.asciidoc
-                tags:       Clients/Groovy
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/groovy-api
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
               -
                 title:      .NET API
                 prefix:     net-api
@@ -1293,6 +1275,22 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/graph
+          -
+            title:      Groovy API
+            prefix:     groovy-api
+            current:    2.4
+            branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            index:      docs/groovy-api/index.asciidoc
+            tags:       Clients/Groovy
+            subject:    Clients
+            sources:
+              -
+                repo:   elasticsearch
+                path:   docs/groovy-api
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
 redirects:
     -


### PR DESCRIPTION
This PR moves the Groovy API documentation from the Elasticsearch Clients page to the https://www.elastic.co/guide/en/elasticsearch/client/index.html to the "Legacy Documentation" section.