### PR TITLE
Switch the Infra Monitoring Guide to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -836,6 +836,7 @@ contents:
             chunk:      1
             tags:       Infrastructure/Guide
             subject:    Infrastructure
+            asciidoctor: true
             sources:
               -
                 repo:   stack-docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -49,7 +49,7 @@ alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/
 
 alias docbldaz='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
-alias docbldinf='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
+alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Switches the Infrastructure Monitoring Guide to Asciidoctor. There are a
few spacing changes that are noops in HTML and there are a few changes
that look like this:
```
-            <img alt="monitoring-architecture.png" src="monitoring-architecture.png"/>
+            <img alt="monitoring architecture" src="monitoring-architecture.png"/>
```

They switch the alt tag on an image from the name of the image to a
"more English" version of the name of the image. I'm not sure if this is
really an improvement because the alt tag is still being automatically
generated so it isn't going to be particularly descriptive. But I don't
*think* this is a problem either.
