### PR TITLE
Add ML data frame transform short cut

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -102,17 +102,18 @@
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM
 
-:dfeed:              datafeed
-:dfeeds:             datafeeds
-:dfeed-cap:          Datafeed
-:dfeeds-cap:         Datafeeds
-:ml-jobs:            {ml} jobs
-:ml-jobs-cap:        {ml-cap} jobs
-:anomaly-job:        anomaly detection job
-:anomaly-jobs:       anomaly detection jobs
-:anomaly-jobs-cap:   Anomaly detection jobs
-:dataframe-job:      data frame analytics job
-:dataframe-jobs:     data frame analytics jobs
-:dataframe-jobs-cap: Data frame analytics jobs
+:dfeed:                 datafeed
+:dfeeds:                datafeeds
+:dfeed-cap:             Datafeed
+:dfeeds-cap:            Datafeeds
+:ml-jobs:               {ml} jobs
+:ml-jobs-cap:           {ml-cap} jobs
+:anomaly-job:           anomaly detection job
+:anomaly-jobs:          anomaly detection jobs
+:anomaly-jobs-cap:      Anomaly detection jobs
+:dataframe-job:         data frame analytics job
+:dataframe-jobs:        data frame analytics jobs
+:dataframe-jobs-cap:    Data frame analytics jobs
+:dataframe-transform:   data frame transform
 
 :pwd:             YOUR_PASSWORD

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -102,18 +102,20 @@
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM
 
-:dfeed:                 datafeed
-:dfeeds:                datafeeds
-:dfeed-cap:             Datafeed
-:dfeeds-cap:            Datafeeds
-:ml-jobs:               {ml} jobs
-:ml-jobs-cap:           {ml-cap} jobs
-:anomaly-job:           anomaly detection job
-:anomaly-jobs:          anomaly detection jobs
-:anomaly-jobs-cap:      Anomaly detection jobs
-:dataframe-job:         data frame analytics job
-:dataframe-jobs:        data frame analytics jobs
-:dataframe-jobs-cap:    Data frame analytics jobs
-:dataframe-transform:   data frame transform
+:dfeed:                    datafeed
+:dfeeds:                   datafeeds
+:dfeed-cap:                Datafeed
+:dfeeds-cap:               Datafeeds
+:ml-jobs:                  {ml} jobs
+:ml-jobs-cap:              {ml-cap} jobs
+:anomaly-job:              anomaly detection job
+:anomaly-jobs:             anomaly detection jobs
+:anomaly-jobs-cap:         Anomaly detection jobs
+:dataframe-job:            data frame analytics job
+:dataframe-jobs:           data frame analytics jobs
+:dataframe-jobs-cap:       Data frame analytics jobs
+:dataframe-transform:      data frame transform
+:dataframe-transforms:     data frame transforms
+:dataframe-transforms-cap: Data frame transforms
 
 :pwd:             YOUR_PASSWORD


### PR DESCRIPTION
Follow up to #688.

Adds `:dataframe-transform:   data frame transform` which is not obvious with the indenting changes

@hendrikmuhs any more we need? A CAPS version?
