### PR TITLE
Switch the ES Python Client to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -356,6 +356,7 @@ contents:
                 single:     1
                 tags:       Clients/Python
                 subject:    Clients
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -122,7 +122,7 @@ alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
-alias docbldepy='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single 1'
+alias docbldepy='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
 
 alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/ruby/index.asciidoc'
 


### PR DESCRIPTION
This switches the Elasticsearch Python Client's stub book to
Asciidoctor. `html_diff` claims that the html is the same modulo
whitespace. This book is small because it points folks at the canonical
docs at `readthedocs.org`.
