### PR TITLE
Asciidoctor: Remove some magic $ variable usage

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -25,7 +25,7 @@ module CopyImages
       'changed' => 'note',
       'deleted' => 'warning',
     }.freeze
-    CALLOUT_RX = /CO\d+-(\d+)/.freeze
+    CALLOUT_RX = /CO\d+-(\d+)/
 
     def initialize(name)
       super

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -25,6 +25,7 @@ module CopyImages
       'changed' => 'note',
       'deleted' => 'warning',
     }.freeze
+    CALLOUT_RX = /CO\d+-(\d+)/.freeze
 
     def initialize(name)
       super
@@ -54,8 +55,8 @@ module CopyImages
       coids = block.attr('coids')
       return unless coids
 
-      coids.scan(/CO(?:\d+)-(\d+)/) do
-        @copier.copy_image block, "images/icons/callouts/#{$1}.#{callout_extension}"
+      coids.scan(CALLOUT_RX) do |(index)|
+        @copier.copy_image block, "images/icons/callouts/#{index}.#{callout_extension}"
       end
     end
 

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -151,6 +151,9 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
         return nil if line.nil?
 
         SOURCE_WITH_SUBS_RX.match(line) do |m|
+          # AsciiDoc would automatically add `subs` to every source block but
+          # Asciidoctor does not and we have thousands of blocks that rely on
+          # this behavior.
           old_subs = m[1]
           line.sub! "subs=\"#{old_subs}\"", "subs=\"#{old_subs},callouts\"" unless old_subs.include? 'callouts'
         end

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -150,8 +150,9 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
         line = super
         return nil if line.nil?
 
-        if SOURCE_WITH_SUBS_RX =~ line
-          line.sub! "subs=\"#{$1}\"", "subs=\"#{$1},callouts\"" unless $1.include? 'callouts'
+        SOURCE_WITH_SUBS_RX.match(line) do |m|
+          old_subs = m[1]
+          line.sub! "subs=\"#{old_subs}\"", "subs=\"#{old_subs},callouts\"" unless old_subs.include? 'callouts'
         end
         if CODE_BLOCK_RX =~ line
           if @code_block_start


### PR DESCRIPTION
This makes some headaway into our usage of "magic $ variables" which are
so common in perl but discouraged in ruby. It doesn't remove all of
them, but it removes that ones that are simple to get at and aren't
already being addressed in another ongoing change.
