### PR TITLE
self-test: remove last temporary workaround

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -997,7 +997,8 @@ footnote to a particular line of code:
 }
 ----------------------------------
 
-\<1> Here's the explanation
+ifdef::asciidoctor[<1> Here's the explanation]
+ifndef::asciidoctor[\<1> Here's the explanation]
 --
 
 [source,js]
@@ -1044,7 +1045,8 @@ GET /_search
 ----------------------------------
 // CONSOLE <1>
 
-\<1> Here's the explanation
+ifdef::asciidoctor[<1> Here's the explanation]
+ifndef::asciidoctor[\<1> Here's the explanation]
 --
 ==================================
 <1> The `// CONSOLE` line must follow immediately after the code block, before any callouts.
@@ -1061,7 +1063,8 @@ GET /_search
 }
 ----------------------------------
 
-\<1> Here's the explanation
+ifdef::asciidoctor[<1> Here's the explanation]
+ifndef::asciidoctor[\<1> Here's the explanation]
 --
 ==================================
 

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -41,8 +41,6 @@ def normalize_html(html):
                         '"programlisting prettyprint lang-console"')
     # The URL for the console snippets has changed
     html = re.sub(r'data-snippet="[^"]+"', 'data-snippet="snippet"', html)
-    # Temporary work around for known issue
-    html = html.replace('\\&lt;1&gt;', '&lt;1&gt;')
     return html
 
 


### PR DESCRIPTION
Remove the last "temporary workaround" in `html_diff` for issues
building the readme. I fix the readme by using `ifdef` to write
different source text for AsciiDoc vs Asciidoctor. This would be a bad
solution if these things were common in normal books, but the constructs
that need this are when you have snippets of asciidoc inside the
asciidoc. This is a thing that will probably only happen in the readme.
