### PR TITLE
Switch the APM Agent for Java to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -942,6 +942,7 @@ contents:
                 tags:       APM Java Agent/Reference
                 subject:    APM
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   apm-agent-java

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -88,7 +88,7 @@ alias docbldamp='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-python/d
 
 alias docbldamry='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
 
-alias docbldamj='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
+alias docbldamj='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
 
 alias docbldamjs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-js-base/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the core of the documentation build infrasturcture for the APM
Agent for Java from the no-longer-living AsciiDoc project to the active
Asciidoctor project. The HTML differences are fairly small:
1. Empty table blocks no longer contain an `<p></p>`
2. Headings are now in a `<thead>` tag.
