### PR TITLE
Hyphenates CCR and CCS attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -94,10 +94,10 @@
 :ml-cap:                  Machine learning
 :ml-features:             machine learning features
 :stack-ml-features:       {stack} {ml-features}
-:ccr:                     cross cluster replication
-:ccr-cap:                 Cross cluster replication
-:ccs:                     cross cluster search
-:ccs-cap:                 Cross cluster search
+:ccr:                     cross-cluster replication
+:ccr-cap:                 Cross-cluster replication
+:ccs:                     cross-cluster search
+:ccs-cap:                 Cross-cluster search
 :ilm:                     index lifecycle management
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM


### PR DESCRIPTION
This PR updates the ccr, ccr-cap, ccs, and ccs-cap shared attributes so that they hyphenate the terms "cross-cluster search" and "cross-cluster replication".