### PR TITLE
Asciidoctor: Support adoc files

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -17,6 +17,7 @@ check: \
 	beta_expected_files beta_same_files \
 	experimental_expected_files experimental_same_files \
 	missing_include_fails_asciidoc missing_include_fails_asciidoctor \
+	adoc_expected_files adoc_same_files \
 	migration_warnings \
 	readme_expected_files readme_same_files \
 	simple_all \
@@ -116,6 +117,12 @@ migration_warnings: migration_warnings.asciidoc
 
 /tmp/readme_asciidoctor: /docs_build/README.asciidoc
 	$(BD) --asciidoctor --doc /docs_build/README.asciidoc
+
+/tmp/adoc_asciidoc: minimal.adoc
+	$(BD) --doc $^
+
+/tmp/adoc_asciidoctor: minimal.adoc
+	$(BD) --asciidoctor --doc $^
 
 # These don't declare dependencies because we don't know in general which files
 # are needed to build which asciidoc files.

--- a/integtest/minimal.adoc
+++ b/integtest/minimal.adoc
@@ -1,0 +1,7 @@
+= Title
+
+== Chapter
+
+This is a minimal viable asciidoc file for use with build_docs. The actual
+contents of this paragraph aren't important but having a paragraph here
+is required.

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -68,7 +68,7 @@ sub build_chunked {
     my ( $output, $died );
     if ( $asciidoctor ) {
         my $dest_xml = $index->basename;
-        $dest_xml =~ s/\.asciidoc$/\.xml/;
+        $dest_xml =~ s/\.a(scii)?doc$/\.xml/;
         $dest_xml = $dest->file($dest_xml);
 
         %xsltopts = (%xsltopts,
@@ -201,7 +201,7 @@ sub build_single {
     my ( $output, $died );
     if ( $asciidoctor ) {
         my $dest_xml = $index->basename;
-        $dest_xml =~ s/\.asciidoc$/\.xml/;
+        $dest_xml =~ s/\.a(scii)?doc$/\.xml/;
         $dest_xml = $dest->file($dest_xml);
 
         %xsltopts = (%xsltopts,


### PR DESCRIPTION
The `adoc` extension is fairly common instead for asciidoc files. Most
of our files use `asciidoc` but a few of them, notable
elasticsearch-hadoop, uses `adoc`. This fixes support for them and adds
a test for it.
