### PR TITLE
Switch APM Agent for Go to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -930,6 +930,7 @@ contents:
                 tags:       APM Go Agent/Reference
                 subject:    APM
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   apm-agent-go

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -92,7 +92,7 @@ alias docbldamj='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-age
 
 alias docbldamjs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
 
-alias docbldamgo='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-go/docs/index.asciidoc --chunk 1'
+alias docbldamgo='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-go/docs/index.asciidoc --chunk 1'
 
 alias docbldamnet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-dotnet/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the core of the process that builds the docs for the APM Agent
for Go from the no-longer-supports AsciiDoc to the supported
Asciidoctor. The html output is slightly different - mostly spacing
which is generally ignored by the browser. It *does* change the spacing
in front of the go source from a leading eight spaces to a leading tab.
These look the same to me in the browser but copy-and-pasting them comes
out slightly differently.