### PR TITLE
Build tables of contents with Asciidoctor

### DIFF
--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -37,11 +37,12 @@ sub write {
     $adoc_file->spew( iomode => '>:utf8', $adoc );
 
     build_single( $adoc_file, $dir,
-            type      => 'article',
-            lang      => $self->lang,
-            root_dir  => '',
-            edit_urls => {'' => ''},
-            latest    => 1,
+            type        => 'article',
+            lang        => $self->lang,
+            asciidoctor => 1,
+            root_dir    => '',  # Required but thrown on the floor with asciidoctor
+            latest      => 1,   # Run all of our warnings
+            private     => 1,   # Don't generate edit me urls
     );
     $adoc_file->remove;
 }


### PR DESCRIPTION
We chain the books that make the all of the docs together into a web
site by making tables of content that link the whole thing together.
We make these by building asciidoc files and then building them like
single-page books. This switches from building them with AsciiDoc to
building them with Asciidoctor.
