### PR TITLE
Fix output path for Groovy API

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1282,11 +1282,11 @@ contents:
                 path:   docs/public/graph
           -
             title:      Groovy API
-            prefix:     groovy-api
+            prefix:     en/elasticsearch/client/groovy-api
             current:    2.4
             branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/groovy-api/index.asciidoc
-            tags:       Clients/Groovy
+            tags:       Legacy/Clients/Groovy
             subject:    Clients
             asciidoctor: true
             sources:


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/697

This PR updates the conf.yaml so that the Groovy API output is still going to https://github.com/elastic/built-docs/tree/master/html/en/elasticsearch/client/groovy-api

It also adds the "Legacy" tag to this book.