### PR TITLE
Fixed js repository url

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -20,7 +20,7 @@ repos:
     cloud:                https://github.com/elastic/cloud.git
     curator:              https://github.com/elastic/curator.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
-    elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
+    elasticsearch-js:     https://github.com/elastic/elasticsearch-js-legacy.git
     elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
     elasticsearch-php:    https://github.com/elastic/elasticsearch-php
     elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git


### PR DESCRIPTION
Until https://github.com/elastic/docs/pull/701 gets merged, this is the correct URL to use for build the documentation.

/cc @spalger 