### PR TITLE
Switch APM Agent for RUM JavaScript

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -917,6 +917,7 @@ contents:
                 tags:       APM Real User Monitoring JavaScript Agent/Reference
                 subject:    APM
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   apm-agent-rum-js

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -90,7 +90,7 @@ alias docbldamry='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-ruby/do
 
 alias docbldamj='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
 
-alias docbldamjs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
+alias docbldamjs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
 
 alias docbldamgo='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-go/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the docs build core for the APM Agent for RUM JavaScript from
the no-longer-supported AsciiDoc to the actively maintained Asciidoctor.
The generated HTML is the same modulo whitespace which the browser
ignores.
