### PR TITLE
Switch APM Agent for Ruby to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -904,6 +904,7 @@ contents:
                 tags:       APM Ruby Agent/Reference
                 subject:    APM
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   apm-agent-ruby

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -86,7 +86,7 @@ alias docbldamn='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-nodejs/d
 
 alias docbldamp='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
 
-alias docbldamry='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
+alias docbldamry='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
 
 alias docbldamj='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the core of the build for the APM Agent for Ruby docs from the
end-of-life AsciiDoc to the actively maintained Asciidoctor. The HTML
differences are mostly whitespace but there are two "real" differences:
1. The edit url for the section at `api.html#api-context` goes to
`index.asciidoc` in AsciiDoc and `api.asciidoc` in AsciiDoctor.
AsciiDoctor seems more right here.
2. Empty table cells do not have an empty paragraph tag in them.
