### PR TITLE
Add shared refs for APM Server 7.0

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -17,10 +17,12 @@
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x


### PR DESCRIPTION
APM Server's `7.x` documentation branch is going away. See https://github.com/elastic/apm-server/issues/1993 for more details. This PR allows us to cross doc link to `7.0` documentation from `7.x`.
