### PR TITLE
Adds cloud to attributes62.asciidoc

### DIFF
--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -23,6 +23,7 @@
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/master
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
+:cloud:                https://www.elastic.co/guide/en/cloud/current
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
 :glossary:             http://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/244

This PR copies the "cloud" attribute from https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc to https://github.com/elastic/docs/blob/master/shared/attributes62.asciidoc so that it can be used in earlier releases too.
