### PR TITLE
Ruby Style: Treat regexps as immutable

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -1,3 +1,8 @@
+require:
+  # Pretend that regexps aren't mutable. They *mostly* aren't already and
+  # we think it is more idiomatic not to freeze them all over the place.
+  - ./style/pretend_regexp_isnt_mutable.rb
+
 AllCops:
   TargetRubyVersion: 2.3
 

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -110,13 +110,13 @@ require 'asciidoctor/extensions'
 class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
   include Asciidoctor::Logging
 
-  INCLUDE_TAGGED_DIRECTIVE_RX = /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/.freeze
-  SOURCE_WITH_SUBS_RX = /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/.freeze
-  CODE_BLOCK_RX = /^-----*$/.freeze
-  SNIPPET_RX = %r{//\s*(?:AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)}.freeze
+  INCLUDE_TAGGED_DIRECTIVE_RX = /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/
+  SOURCE_WITH_SUBS_RX = /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
+  CODE_BLOCK_RX = /^-----*$/
+  SNIPPET_RX = %r{//\s*(?:AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)}
   LEGACY_MACROS = 'added|beta|coming|deprecated|experimental'
-  LEGACY_BLOCK_MACRO_RX = /^(#{LEGACY_MACROS})\[([^\]]*)\]/.freeze
-  LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[([^\]]*)\]/.freeze
+  LEGACY_BLOCK_MACRO_RX = /^(#{LEGACY_MACROS})\[([^\]]*)\]/
+  LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[([^\]]*)\]/
 
   def process(_document, reader)
     reader.instance_variable_set :@in_attribute_only_block, false

--- a/resources/asciidoctor/lib/open_in_widget/extension.rb
+++ b/resources/asciidoctor/lib/open_in_widget/extension.rb
@@ -39,7 +39,7 @@ require_relative '../scaffold.rb'
 class OpenInWidget < TreeProcessorScaffold
   include Asciidoctor::Logging
 
-  CALLOUT_SCAN_RX = / ?#{Asciidoctor::CalloutScanRx}/.freeze
+  CALLOUT_SCAN_RX = / ?#{Asciidoctor::CalloutScanRx}/
 
   def process_block(block)
     return unless block.context == :listing && block.style == 'source'

--- a/resources/asciidoctor/style/pretend_regexp_isnt_mutable.rb
+++ b/resources/asciidoctor/style/pretend_regexp_isnt_mutable.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module AST
+    # Patches rubocop's Node so it considers regexps immutable. They already
+    # are *mostly* immutable and we find it more idiomatic to pretend that
+    # they are actually immutable.
+    class Node
+      MUTABLE_LITERALS = remove_const(:MUTABLE_LITERALS) - [:regexp]
+      remove_const :IMMUTABLE_LITERALS
+      IMMUTABLE_LITERALS = (LITERALS - MUTABLE_LITERALS).freeze
+    end
+  end
+end


### PR DESCRIPTION
In ruby regular expressions aren't frozen by default *but* they don't have
any methods to mutate them. You *can* still mutate them with standard ruby
monkey patching, but we find it more idiomatic to treat them as immutable
for style purposes.
