### PR TITLE
Adds version-specific URLs for Installation and Upgrade Guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -34,6 +34,8 @@
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
+:stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
+:stack-ref-70:         http://www.elastic.co/guide/en/elastic-stack/7.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}


### PR DESCRIPTION
This PR adds attributes that can be used to link to specific versions of the Installation and Upgrade Guide from the upgrade instructions in the Elasticsearch Reference.