### PR TITLE
Adds CCS attributes to earlier releases

### DIFF
--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -70,6 +70,8 @@
 :ml:                      machine learning
 :ml-features:             machine learning features
 :stack-ml-features:       {stack} {ml-features}
+:ccs:                     cross-cluster search
+:ccs-cap:                 Cross-cluster search
 :dfeed:                   datafeed
 :dfeeds:                  datafeeds
 :dfeed-cap:               Datafeed


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/657

CCS exists in the Elasticsearch Reference going back to version 5.3, so this PR adds the ccs and ccs-cap attributes to shared/attributes62.asciidoc too.