### PR TITLE
Switch Python APM Agent docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -891,6 +891,7 @@ contents:
                 tags:       APM Python Agent/Reference
                 subject:    APM
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   apm-agent-python

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -84,7 +84,7 @@ alias docbldamr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/in
 
 alias docbldamn='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1'
 
-alias docbldamp='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
+alias docbldamp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
 
 alias docbldamry='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the core of the docs generation pipeline from the
no-longer-maintained AsciiDoc project to the actively-maintained
Asciidoctor project. The HTML that it produces isn't 100% the same but
it looks to only differ in three ways:
1. Spacing that the browser will ignore anyway.
2. AsciiDoc was producing `<p></p>` inside of empty table cells.
Asciidoctor does not.
3. In the 1.x docs there are some attribute references that do not
resolve and they are rendered differently by Asciidoctor. Either way,
they should probably be fixed in the 1.x branch of the docs.
