### PR TITLE
Remove apm 7.x branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -834,7 +834,7 @@ contents:
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
             current:    6.6
-            branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
@@ -850,7 +850,7 @@ contents:
             prefix:     en/apm/server
             index:      docs/index.asciidoc
             current:    6.6
-            branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM


### PR DESCRIPTION
This PR removes APM's `7.x` documentation from the build process. See elastic/apm-server#1993 for more information. 