### PR TITLE
self-test: Ignore empty paragraphs inside of td

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -18,6 +18,7 @@ check: \
 	experimental_expected_files experimental_same_files \
 	missing_include_fails_asciidoc missing_include_fails_asciidoctor \
 	adoc_expected_files adoc_same_files \
+	empty_table_cell_expected_files empty_table_cell_same_files \
 	migration_warnings \
 	readme_expected_files readme_same_files \
 	simple_all \

--- a/integtest/empty_table_cell.asciidoc
+++ b/integtest/empty_table_cell.asciidoc
@@ -1,0 +1,8 @@
+= Title
+
+== Chapter
+
+|=== 
+| Title | Other Title
+|       | Empty cell before this one
+|=== 

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -26,6 +26,12 @@ def normalize_html(html):
                 crunched = NavigableString(re.sub(r'\s+', ' ', part))
                 if crunched != part:
                     part.replace_with(crunched)
+    # Remove empty paragraph tags inside of table cells. AsciiDoc fills empty
+    # table cells with these empty tags. Asciidoctor doesn't. Either way
+    # is fine.
+    for e in soup.select('td>p'):
+        if e.contents == []:
+            e.extract()
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # Remove the zero width space that asciidoctor adds after each horizontal


### PR DESCRIPTION
AsciiDoc spits out `<td><p></p></td>` for an empty table cell. Asciidoctor
spits out `<td></td>` which is just fine. This ignores the empty `<p>`
tags that are children of `<td>`.
