### PR TITLE
Fix handling of copy-as-curl for HEAD requests

### DIFF
--- a/resources/web/docs.js
+++ b/resources/web/docs.js
@@ -313,7 +313,12 @@ jQuery(function() {
           curlText += comment + '\n';
         } else {
           path = path.replace(/^\//, '').replace(/\s+$/,'');
-          curlText += 'curl -X ' + method + ' "' + host + '/' + path + '"';
+          if (method === "HEAD") {
+            curlText += 'curl -I ';
+          } else {
+            curlText += 'curl -X ' + method + ' ';
+          }
+          curlText += '"' + host + '/' + path + '"';
 
           if (div.data('kibana')) {
             curlText += " -H 'kbn-xsrf: true'";


### PR DESCRIPTION
curl -X HEAD behaves in an unexpected way; namely, it behaves as a GET request so it sits there waiting for Content-Length bytes to be sent, but since the method was HEAD the server would never send these bytes. This makes curl hang forever. It is unfortunate that common sense has not prevailed so this remains unchanged in curl to this day. Instead, curl has a built-in flag for sending a HEAD request and not expecting Content-Length bytes to sent. This is -I or --head. This commit fixes the copy-as-curl behavior with HEAD requests to use the correct form of sending a HEAD request.

Relates #110
Relates elastic/elasticsearch#40114