### PR TITLE
Switch APM Overview to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -838,6 +838,7 @@ contents:
             chunk:      1
             tags:       APM Server/Reference
             subject:    APM
+            asciidoctor: true
             sources:
               -
                 repo:   apm-server

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -78,7 +78,7 @@ alias docbldab='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/doc
 alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
 
 # APM
-alias docbldamg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
+alias docbldamg='$GIT_HOME/docs/build_docs --asciidoc --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 
 alias docbldamr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -78,7 +78,7 @@ alias docbldab='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/doc
 alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
 
 # APM
-alias docbldamg='$GIT_HOME/docs/build_docs --asciidoc --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
+alias docbldamg='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 
 alias docbldamr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the core of the docs build for the APM overview from the
unmaintained AsciiDoc to the actively maintained AsciiDoctor project. It
is marginally faster to build as well. The HTML output is the same
modulo some spacing differences and one real change to the tables on the
`install-and-run` page. The first element on the table gets the
"heading" formatting. Like this:
```
-                <a class="ulink" href="https://www.elastic.co/guide/en/apm/agent/js-base/current/intro.html" target="_top">
-                 Introduction
-                </a>
+                <span class="strong strong">
+                 <strong>
+                  <a class="ulink" href="https://www.elastic.co/guide/en/apm/agent/js-base/current/intro.html" target="_top">
+                   Introduction
+                  </a>
+                 </strong>
+                </span>
```

This is worth looking into. It isn't what we want but I can see *why*
Asciidoctor does it.
