### PR TITLE
Asciidoctor: Copy images for inline image macro

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -69,7 +69,7 @@ module CopyImages
     end
 
     def process_image(block, uri)
-      return if uri == ''
+      return unless uri
       return if Asciidoctor::Helpers.uriish? uri # Skip external images
 
       @copier.copy_image block, uri

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -26,6 +26,7 @@ module CopyImages
       'deleted' => 'warning',
     }.freeze
     CALLOUT_RX = /CO\d+-(\d+)/
+    INLINE_IMAGE_RX = /(\\)?image:([^:\s\[](?:[^\n\[]*[^\s\[])?)\[/m
 
     def initialize(name)
       super
@@ -33,15 +34,42 @@ module CopyImages
     end
 
     def process_block(block)
-      process_image block
+      process_inline_image block
+      process_block_image block
       process_callout block
       process_admonition block
     end
 
-    def process_image(block)
+    def process_block_image(block)
       return unless block.context == :image
 
       uri = block.image_uri(block.attr 'target')
+      process_image block, uri
+    end
+
+    def process_inline_image(block)
+      return unless block.content_model == :simple
+
+      # One day Asciidoc will parse inline things into the AST and we can
+      # get at them nicely. Today, we have to scrape them from the source
+      # of the node.
+      block.source.scan(INLINE_IMAGE_RX) do |(escape, target)|
+        next if escape
+
+        # We have to resolve attributes inside the target. But there is a
+        # "funny" ritual for that because attribute substitution is always
+        # against the document. We have to play the block's attributes against
+        # the document, then clear them on the way out.
+        block.document.playback_attributes block.attributes
+        target = block.sub_attributes target
+        block.document.clear_playback_attributes block.attributes
+        uri = block.image_uri target
+        process_image block, uri
+      end
+    end
+
+    def process_image(block, uri)
+      return if uri == ''
       return if Asciidoctor::Helpers.uriish? uri # Skip external images
 
       @copier.copy_image block, uri

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -46,11 +46,11 @@ RSpec.describe CopyImages do
     include_context 'convert'
     it 'copies the image' do
       expect(copied).to eq([
-          [image_uri, "#{spec_dir}/resources/copy_images/example1.png"],
+          [resolved, "#{spec_dir}/resources/copy_images/example1.png"],
       ])
     end
     it 'logs that it copied the image' do
-      expect(logs).to eq("INFO: <stdin>: line #{include_line}: copying #{spec_dir}\/resources\/copy_images\/example1.png")
+      expect(logs).to eq("INFO: <stdin>: line #{include_line}: copying #{spec_dir}/resources/copy_images/example1.png")
     end
   end
   shared_examples 'copies images' do
@@ -61,25 +61,24 @@ RSpec.describe CopyImages do
       ASCIIDOC
     end
     let(:include_line) { 2 }
-    # NOCOMMIT rename image_ref and image_uri. target and resolved?
     context 'when the image ref matches that path exactly' do
-      let(:image_ref) { 'resources/copy_images/example1.png' }
-      let(:image_uri) { 'resources/copy_images/example1.png' }
+      let(:target)   { 'resources/copy_images/example1.png' }
+      let(:resolved) { 'resources/copy_images/example1.png' }
       include_examples 'copies the image'
     end
     context 'when the image ref is just the name of the image' do
-      let(:image_ref) { 'example1.png' }
-      let(:image_uri) { 'example1.png' }
+      let(:target)   { 'example1.png' }
+      let(:resolved) { 'example1.png' }
       include_examples 'copies the image'
     end
     context 'when the image ref matches the end of the path' do
-      let(:image_ref) { 'copy_images/example1.png' }
-      let(:image_uri) { 'copy_images/example1.png' }
+      let(:target)   { 'copy_images/example1.png' }
+      let(:resolved) { 'copy_images/example1.png' }
       include_examples 'copies the image'
     end
     context 'when the image contains attributes' do
-      let(:image_ref) { 'example1.{ext}' }
-      let(:image_uri) { 'example1.png' }
+      let(:target)   { 'example1.{ext}' }
+      let(:resolved) { 'example1.png' }
       let(:input) do
         <<~ASCIIDOC
           == Example
@@ -94,20 +93,18 @@ RSpec.describe CopyImages do
   end
 
   context 'for the image block macro' do
-    let(:image_command) { "image::#{image_ref}[]" }
+    let(:image_command) { "image::#{target}[]" }
     include_examples 'copies images'
   end
   context 'for the image inline macro' do
-    # NOCMOMIT rename image_ref to target
-    # NOCOMMIT replace parameters with let
-    let(:image_command) { "Words image:#{image_ref}[] words" }
+    let(:image_command) { "Words image:#{target}[] words" }
     include_examples 'copies images'
     context 'when the macro is escaped' do
-      let(:image_ref) { 'example1.jpg' }
+      let(:target) { 'example1.jpg' }
       let(:input) do
         <<~ASCIIDOC
           == Example
-          "Words \\image:#{image_ref}[] words"
+          "Words \\image:#{target}[] words"
         ASCIIDOC
       end
       include_context 'convert'
@@ -118,7 +115,31 @@ RSpec.describe CopyImages do
         expect(copied).to eq([])
       end
     end
-    # NOCOMMIT multiple images in one line
+    context 'when there are multiple images on a line' do
+      let(:input) do
+        <<~ASCIIDOC
+          == Example
+
+          words image:example1.png[] words words image:example2.png[] words
+        ASCIIDOC
+      end
+      let(:expected_warnings) do
+        <<~WARNINGS
+          INFO: <stdin>: line 3: copying #{spec_dir}/resources/copy_images/example1.png
+          INFO: <stdin>: line 3: copying #{spec_dir}/resources/copy_images/example2.png
+        WARNINGS
+      end
+      include_context 'convert'
+      it 'copies the image' do
+        expect(copied).to eq([
+            ['example1.png', "#{spec_dir}/resources/copy_images/example1.png"],
+            ['example2.png', "#{spec_dir}/resources/copy_images/example2.png"],
+        ])
+      end
+      it 'logs that it copied the image' do
+        expect(logs).to eq(expected_warnings.strip)
+      end
+    end
   end
 
   it "warns when it can't find a file" do

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -38,22 +38,33 @@ def convert(input, extra_attributes = {}, warnings_matcher = eq(''))
 end
 
 ##
-# Convert an asciidoc string into docbook returning the result and any warnings.
-def convert_with_logs(input, extra_attributes = {})
-  logger = Asciidoctor::MemoryLogger.new
-  attributes = {
-    'docdir' => File.dirname(__FILE__),
-  }
-  attributes.merge! extra_attributes
-  converted = Asciidoctor.convert input,
-      :safe       => :unsafe,  # Used to include "funny" files.
-      :backend    => :docbook45,
-      :logger     => logger,
-      :doctype    => :book,
-      :attributes => attributes,
-      :sourcemap  => true
-  logs = logger.messages
+# Converts asciidoc to docbook
+#
+# In:
+#   input            - asciidoc text to convert
+#   extra_attributes - attributes added to the conversion - defaults to {}
+#
+# Out:
+#   converted        - converted docbook text
+#   logs             - lines logged
+RSpec.shared_context 'convert' do
+  let(:convert_logger) { Asciidoctor::MemoryLogger.new }
+  let!(:converted) do
+    attributes = {
+      'docdir' => File.dirname(__FILE__),
+    }
+    attributes.merge! convert_attributes if defined?(convert_attributes)
+    Asciidoctor.convert input,
+        :safe       => :unsafe,  # Used to include "funny" files.
+        :backend    => :docbook45,
+        :logger     => convert_logger,
+        :doctype    => :book,
+        :attributes => attributes,
+        :sourcemap  => true
+  end
+  let(:logs) do
+    convert_logger.messages
       .map { |l| "#{l[:severity]}: #{l[:message].inspect}" }
       .join("\n")
-  [converted, logs]
+  end
 end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -36,3 +36,24 @@ def convert(input, extra_attributes = {}, warnings_matcher = eq(''))
   expect(warnings_string).to warnings_matcher
   result
 end
+
+##
+# Convert an asciidoc string into docbook returning the result and any warnings.
+def convert_with_logs(input, extra_attributes = {})
+  logger = Asciidoctor::MemoryLogger.new
+  attributes = {
+    'docdir' => File.dirname(__FILE__),
+  }
+  attributes.merge! extra_attributes
+  converted = Asciidoctor.convert input,
+      :safe       => :unsafe,  # Used to include "funny" files.
+      :backend    => :docbook45,
+      :logger     => logger,
+      :doctype    => :book,
+      :attributes => attributes,
+      :sourcemap  => true
+  logs = logger.messages
+      .map { |l| "#{l[:severity]}: #{l[:message].inspect}" }
+      .join("\n")
+  [converted, logs]
+end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -50,6 +50,7 @@ end
 RSpec.shared_context 'convert' do
   let(:convert_logger) { Asciidoctor::MemoryLogger.new }
   let!(:converted) do
+    # We use let! here to force the conversion because it populates the logger
     attributes = {
       'docdir' => File.dirname(__FILE__),
     }


### PR DESCRIPTION
This copies images declared "inline". Asciidoctor doesn't give a good
way of hooking into these images so we have to scan for them when we
walk the tree. It isn't the best solution, but at least we don't have to
scan for them after the document is rendered! If we did that we wouldn't
get line number information when we can't find images....

Closes #730
