### PR TITLE
[DOCS] Switching ESS MS19 to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -435,7 +435,7 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-17
+            current:    release-ms-19
             branches:   [ release-ms-19, release-ms-17, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -436,7 +436,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-19
-            branches:   [ release-ms-19, release-ms-17, saas-release, saas-release-heroku ]
+            branches:   [ release-ms-19, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Changing the `current` branch from `release-ms-17` to `release-ms-19`. 