### PR TITLE
Fix sharing docs built with firebase

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -66,7 +66,10 @@ init_env();
 
 $Opts->{template} = ES::Template->new(
     %{ $Conf->{template} },
-    abs_urls => ! $running_in_standard_docker && $Opts->{doc},
+    # We'd like to remove abs_urls entirely but we need it to support
+    # --open without docker and we need it to support sharing docs over
+    # firebase. Both of those are coming, but not here yet!
+    abs_urls => $Opts->{doc},
 );
 
 $Opts->{doc}       ? build_local( $Opts->{doc} )


### PR DESCRIPTION
Sometimes we want to share the docs that we've built with firebase or a
similar too. I broke that a while back when I turns off `abs_url` when
you build with `--doc` inside docker because I *thought* `abs_url` was
only there to support the built in python web server that we use with
`--open` outside of docker. But it also supports sharing docs with
firebase.

Eventually we'd like something more automatic than firebase but firebase
is what we have right now....
