### PR TITLE
Add ECS Reference to stack docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -118,7 +118,7 @@ contents:
             title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.0
-            branches:   [ master, 1.x, 1.0 ]
+            branches:   [ master, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Elastic Common Schema (ECS)/Reference

--- a/conf.yaml
+++ b/conf.yaml
@@ -19,6 +19,7 @@ repos:
     beats:                https://github.com/elastic/beats.git
     cloud:                https://github.com/elastic/cloud.git
     curator:              https://github.com/elastic/curator.git
+    ecs:                  https://github.com/elastic/ecs.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js-legacy.git
     elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
@@ -113,6 +114,19 @@ contents:
               -
                 repo:   kibana
                 path:   docs
+          -            
+            title:      Elastic Common Schema (ECS) Reference
+            prefix:     en/ecs
+            current:    1.0
+            branches:   [ master, 1.x, 1.0 ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       Elastic Common Schema (ECS)/Reference
+            subject:    Elastic Common Schema (ECS)
+            sources:
+              -
+                repo:   ecs
+                path:   docs/
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy

--- a/conf.yaml
+++ b/conf.yaml
@@ -114,7 +114,7 @@ contents:
               -
                 repo:   kibana
                 path:   docs
-          -            
+          -
             title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.0

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -135,3 +135,6 @@ alias docbldesh='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-hado
 # X-Pack Reference 5.4 to 6.2
 
 alias docbldx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
+
+# ECS
+alias docbldecs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR adds the Elastic Common Schema (ECS) Reference to the list of docs available from the website