### PR TITLE
Switch legacy sense documentation to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1224,6 +1224,7 @@ contents:
             index:      docs/index.asciidoc
             tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
+            asciidoctor: true
             sources:
               -
                 repo:   sense


### PR DESCRIPTION
Switches the core of the docs build for the legacy sense application's
documentation from the unmaintained AsciiDoc to the actively developed
Asciidoctor. The html produced is different only by spacing.
