### PR TITLE
Update current to 6.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -48,7 +48,7 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    6.6
+            current:    6.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             tags:       Elastic Stack/Installation and Upgrade
@@ -67,7 +67,7 @@ contents:
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
-            current:    6.6
+            current:    6.7
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
@@ -94,7 +94,7 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    6.6
+            current:    6.7
             index:      docs/en/stack/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
@@ -132,7 +132,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -199,7 +199,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -216,7 +216,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    6.6
+            current:    6.7
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
@@ -241,7 +241,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    6.6
+                current:    6.7
                 branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
@@ -262,7 +262,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    6.6
+                current:    6.7
                 branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -405,7 +405,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -474,7 +474,7 @@ contents:
           -
             title:      Kibana Reference
             prefix:     en/kibana
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -496,7 +496,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -536,7 +536,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
@@ -574,7 +574,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
@@ -596,7 +596,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
@@ -622,7 +622,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -644,7 +644,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
@@ -675,7 +675,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    6.6
+            current:    6.7
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
@@ -698,7 +698,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
@@ -729,7 +729,7 @@ contents:
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    6.6
+            current:    6.7
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5 ]
             chunk:      1
@@ -751,7 +751,7 @@ contents:
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    6.6
+            current:    6.7
             index:      journalbeat/docs/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5 ]
             chunk:      1
@@ -827,7 +827,7 @@ contents:
           -
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
-            current:    6.6
+            current:    6.7
             branches:   [ master, 7.x, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
@@ -846,7 +846,7 @@ contents:
             title:      APM Overview
             prefix:     en/apm/get-started
             index:      docs/guide/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference
@@ -863,7 +863,7 @@ contents:
             title:      APM Server Reference
             prefix:     en/apm/server
             index:      docs/index.asciidoc
-            current:    6.6
+            current:    6.7
             branches:   [ master, { 7.0: 7.0.0-beta1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       APM Server/Reference

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -10,4 +10,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released


### PR DESCRIPTION
**Do not merge until the 6.7 release**

* Updates current to `6.7`.
* Updates release state for `6.7` to `released`.

_Deploying with Azure Marketplace and Resource Manager (ARM) template_ remains at `6.6` as there is no `6.7` branch (confirmed with repo owner)