### PR TITLE
Explicit error message if index missing

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -27,7 +27,8 @@ check: \
 	sub_dir \
 	keep_hash_and_sub_dir \
 	multi_branch \
-	open_all
+	open_all \
+	missing_index
 
 .PHONY: style
 style: html_diff
@@ -341,6 +342,24 @@ open_all:
 	$(call GREP,'301 Moved Permanently',$(TMP)/guide/rdir)
 	$(call GREP,'Location: http://localhost:8000/guide/en/elasticsearch/reference/current/setup.html',$(TMP)/guide/rdir)
 	kill -QUIT $$(cat /run/nginx/nginx.pid)
+
+.PHONY: missing_index
+missing_index:
+	rm -rf $(TMP)
+	$(call INIT_REPO_WITH_FILE,$(TMP)/source,minimal.asciidoc,docs/not_the_index.asciidoc)
+	git init --bare $(TMP)/dest.git
+	sed -e 's|--tmp--|$(TMP)|' \
+		-e 's|path:   index.asciidoc|path:   docs|' \
+		-e 's|index:      index.asciidoc|index:      foo/index.asciidoc|' \
+		small_conf.yaml > $(TMP)/conf.yaml
+	set +e; /docs_build/build_docs.pl --in_standard_docker --all \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml > $(TMP)/out 2>&1; \
+		\
+		test $$? -eq 2
+	$(call GREP,'Can'"'"'t find index',$(TMP)/out)
+	$(call GREP,'foo/index.asciidoc',$(TMP)/out)
+
 
 define SETUP_MINIMAL_ALL=
 	# First build a repository to use as the source.

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -49,6 +49,8 @@ sub build_chunked {
     my $asciidoctor = $opts{asciidoctor} || 0;
     my $latest    = $opts{latest};
 
+    die "Can't find index [$index]" unless -f $index;
+
     $dest->rmtree;
     $dest->mkpath;
 
@@ -185,6 +187,8 @@ sub build_single {
     my $page_header = custom_header($index) || $opts{page_header} || '';
     my $asciidoctor = $opts{asciidoctor} || 0;
     my $latest    = $opts{latest};
+
+    die "Can't find index [$index]" unless -f $index;
 
     my %xsltopts = (
             "generate.toc"             => $toc,


### PR DESCRIPTION
Adds an explicit error message if the "index" file is missing because
asciidoctor doesn't output anything in that case. It'll fail, but it
won't tell you *why* it failed.
