### PR TITLE
[DO NOT MERGE]  Add x-pack/filebeat/module to clone path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -631,6 +631,10 @@ contents:
                 exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
+                path:   x-pack/filebeat/module
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
                 path:   CHANGELOG.asciidoc
               -
                 repo:   beats


### PR DESCRIPTION
DO NOT MERGE THIS PR (because I'm not 100% confident in the fix at this time).

We have been adding images to `x-pack/filebeat/module` and referencing them correctly from the docs.  Currently, the path isn't being cloned as part of the doc build, and we're breaking the build. 
I believe this is the general approach, but I'm not sure about particulars such as branches to skip, etc. 

@dedemorton  I would appreciate your expertise on this. 
@nik9000 @alakahakai @adriansr  tagging you FYI because of recent conversations. 
