### PR TITLE
Fix name of the Go client on index page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -319,7 +319,7 @@ contents:
                     repo:   elasticsearch-js
                     path:   docs/
               -
-                title:      GO API
+                title:      Go API
                 prefix:     go-api
                 current:    master
                 branches:   [ master ]


### PR DESCRIPTION
This patch removes the capitalized version of the Go language — `GO` — and changes it to `Go`.

