### PR TITLE
Refine --keep_hash behavior for new things

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -355,7 +355,7 @@ sub build_entries {
             temp_dir => $temp_dir,
             %$entry
         );
-        $toc->add_entry( $book->build($Opts->{rebuild}) );
+        $toc->add_entry( $book->build( $Opts->{rebuild} , $Opts->{keep_hash} ) );
     }
 
     return $toc;
@@ -550,6 +550,7 @@ sub push_changes {
     run qw(git add -A);
 
     if ( run qw(git status -s --) ) {
+        # say "ASDFDSF " . run qw(git diff --cached);   # NOCOMMIT
         build_sitemap($build_dir);
         run qw(git add -A);
         say "Commiting changes";

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -550,7 +550,6 @@ sub push_changes {
     run qw(git add -A);
 
     if ( run qw(git status -s --) ) {
-        # say "ASDFDSF " . run qw(git diff --cached);   # NOCOMMIT
         build_sitemap($build_dir);
         run qw(git add -A);
         say "Commiting changes";

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -210,7 +210,7 @@ new_repo:
 		--target_repo $(TMP)/dest.git \
 		--conf $(TMP)/conf.yaml | tee $(TMP)/out
 	$(call GREP,'Test book',$(TMP)/out)
-	$(call GREP_V,'No changes to push',$(TMP)/out)
+	$(call NOT_CONTAIN,'No changes to push',$(TMP)/out)
 
 	git clone $(TMP)/dest.git $(TMP)/dest
 	$(call GREP,'I am tiny.',$(TMP)/dest/html/test/current/_chapter.html)
@@ -240,7 +240,7 @@ new_book:
 		--target_repo $(TMP)/dest.git \
 		--conf $(TMP)/conf.yaml | tee $(TMP)/out
 	$(call GREP,'Test book 2',$(TMP)/out)
-	$(call GREP_V,'No changes to push',$(TMP)/out)
+	$(call NOT_CONTAIN,'No changes to push',$(TMP)/out)
 
 	git clone $(TMP)/dest.git $(TMP)/dest
 	$(call GREP,'minimal viable asciidoc',$(TMP)/dest/html/test2/current/_chapter.html)
@@ -287,7 +287,7 @@ keep_hash_new_repo:
 		--target_repo $(TMP)/dest.git \
 		--conf $(TMP)/conf.yaml \
 		--keep_hash | tee $(TMP)/out
-	$(call GREP_V,'Test book',$(TMP)/out)
+	$(call NOT_CONTAIN,'Test book',$(TMP)/out)
 	$(call GREP,'No changes to push',$(TMP)/out)
 
 	# We expact the same files as the minimal because we didn't make
@@ -320,7 +320,7 @@ keep_hash_new_book:
 		--target_repo $(TMP)/dest.git \
 		--conf $(TMP)/conf.yaml \
 		--keep_hash | tee $(TMP)/out
-	$(call GREP_V,'Test book 2',$(TMP)/out)
+	$(call NOT_CONTAIN,'Test book 2',$(TMP)/out)
 	# But we *will* rebuild the table of contents so we get the book in the
 	# list. That is unfortunate but isn't too big a deal.
 	$(call GREP,'Pushing changes',$(TMP)/out)
@@ -417,7 +417,7 @@ keep_hash_and_sub_dir:
 	$(call GREP,'Test book: Copying master to current',$(TMP)/out)
 	# Except git will pick up that we didn't change anything, so we won't push.
 	$(call GREP,'No changes to push',$(TMP)/out)
-	$(call GREP_V,'Pushing changes',$(TMP)/out)
+	$(call NOT_CONTAIN,'Pushing changes',$(TMP)/out)
 
 .PHONY: multi_branch
 multi_branch:

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -23,9 +23,9 @@ check: \
 	readme_expected_files readme_same_files \
 	simple_all \
 	relative_conf_file \
-	keep_hash \
-	sub_dir \
-	keep_hash_and_sub_dir \
+	new_repo new_book \
+	keep_hash keep_hash_new_repo keep_hash_new_book \
+	sub_dir keep_hash_and_sub_dir \
 	multi_branch \
 	open_all \
 	missing_index
@@ -156,6 +156,67 @@ relative_conf_file:
 			--conf conf.yaml
 	$(call MINIMAL_ALL_EXPECTED_FILES,init)
 
+.PHONY: new_repo
+new_repo:
+	# Test that `--all` works when you add a new repo to a book that used to
+	# only have a single repo
+	rm -rf $(TMP)
+	$(BUILD_MINIMAL_ALL)
+
+	# Replace the minimal documentation in the source repo with one that
+	# references the second repo
+	sed -e 's|../||' includes_source2.asciidoc > $(TMP)/source/index.asciidoc
+	cat $(TMP)/source/index.asciidoc
+	cd $(TMP)/source && \
+		git add . && \
+		git commit -m 'includes source2'
+	# Add new repo to conf file
+	$(call INIT_REPO_WITH_FILE,$(TMP)/source2,included.asciidoc,index.asciidoc)
+	sed -riE 's|^(\s+)source:|\1source2: $(TMP)/source2\n\1source:|' $(TMP)/conf.yaml
+	echo "            -"                          >> $(TMP)/conf.yaml
+	echo "                repo:   source2"        >> $(TMP)/conf.yaml
+	echo "                path:   index.asciidoc" >> $(TMP)/conf.yaml
+
+	# Build the book wit hthe new repo
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml | tee $(TMP)/out
+	$(call GREP,'Test book',$(TMP)/out)
+	$(call GREP_V,'No changes to push',$(TMP)/out)
+
+	git clone $(TMP)/dest.git $(TMP)/dest
+	$(call GREP,'I am tiny.',$(TMP)/dest/html/test/current/_chapter.html)
+
+.PHONY: new_book
+new_book:
+	# Test that `--all` works when you add a new book to the list
+	rm -rf $(TMP)
+	$(BUILD_MINIMAL_ALL)
+
+	# Add a new book
+	echo "    -"                                  >> $(TMP)/conf.yaml
+	echo "        title:      Test book 2"        >> $(TMP)/conf.yaml
+	echo "        prefix:     test2"              >> $(TMP)/conf.yaml
+	echo "        current:    master"             >> $(TMP)/conf.yaml
+	echo "        branches:   [ master ]"         >> $(TMP)/conf.yaml
+	echo "        index:      index.asciidoc"     >> $(TMP)/conf.yaml
+	echo "        tags:       test tag"           >> $(TMP)/conf.yaml
+	echo "        subject:    Test"               >> $(TMP)/conf.yaml
+	echo "        sources:"                       >> $(TMP)/conf.yaml
+	echo "            -"                          >> $(TMP)/conf.yaml
+	echo "                repo:   source"         >> $(TMP)/conf.yaml
+	echo "                path:   index.asciidoc" >> $(TMP)/conf.yaml
+
+	# Adding a new book should cause that book to build
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml | tee $(TMP)/out
+	$(call GREP,'Test book 2',$(TMP)/out)
+	$(call GREP_V,'No changes to push',$(TMP)/out)
+
+	git clone $(TMP)/dest.git $(TMP)/dest
+	$(call GREP,'minimal viable asciidoc',$(TMP)/dest/html/test2/current/_chapter.html)
+
 .PHONY: keep_hash
 keep_hash:
 	# Test that `--all --keep_hash` doesn't pull new updates
@@ -176,9 +237,65 @@ keep_hash:
 	$(call GREP_V,'Test book',$(TMP)/out)
 	$(call GREP,'No changes to push',$(TMP)/out)
 
-	# We expact the same files as the minimal because we the changes that we
-	# make shouldn't be included
+	# We expact the same files as the minimal because the changes that we
+	# made shouldn't be included
 	$(call MINIMAL_ALL_EXPECTED_FILES,init)
+
+.PHONY: keep_hash_new_repo
+keep_hash_new_repo:
+	# Test that `--all --keep_hash` doesn't pull new updates
+	rm -rf $(TMP)
+	$(BUILD_MINIMAL_ALL)
+
+	# Add new repo to conf file
+	$(call INIT_REPO_WITH_FILE,$(TMP)/source2,minimal.asciidoc,totally_not_used.asciidoc)
+	sed -riE 's|^(\s+)source:|\1source2: $(TMP)/source2\n\1source:|' $(TMP)/conf.yaml
+	echo "            -"                          >> $(TMP)/conf.yaml
+	echo "                repo:   source2"        >> $(TMP)/conf.yaml
+	echo "                path:   not_used.asciidoc" >> $(TMP)/conf.yaml
+
+	# Rebuild the docs with --keep_hash which should ignore the new repo
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml \
+		--keep_hash | tee $(TMP)/out
+	$(call GREP_V,'Test book',$(TMP)/out)
+	$(call GREP,'No changes to push',$(TMP)/out)
+
+	# We expact the same files as the minimal because we didn't make
+	# any changes
+	$(call MINIMAL_ALL_EXPECTED_FILES,init)
+
+.PHONY: keep_hash_new_book
+keep_hash_new_book:
+	# Test that `--all --keep_hash` doesn't pull new updates
+	rm -rf $(TMP)
+	$(BUILD_MINIMAL_ALL)
+
+	# Add a new book
+	echo "    -"                                  >> $(TMP)/conf.yaml
+	echo "        title:      Test book 2"        >> $(TMP)/conf.yaml
+	echo "        prefix:     test2"              >> $(TMP)/conf.yaml
+	echo "        current:    master"             >> $(TMP)/conf.yaml
+	echo "        branches:   [ master ]"         >> $(TMP)/conf.yaml
+	echo "        index:      index.asciidoc"     >> $(TMP)/conf.yaml
+	echo "        tags:       test tag"           >> $(TMP)/conf.yaml
+	echo "        subject:    Test"               >> $(TMP)/conf.yaml
+	echo "        sources:"                       >> $(TMP)/conf.yaml
+	echo "            -"                          >> $(TMP)/conf.yaml
+	echo "                repo:   source"         >> $(TMP)/conf.yaml
+	echo "                path:   index.asciidoc" >> $(TMP)/conf.yaml
+
+	# If we build the all the books with --keep_hash we shouldn't rebuild
+	# any books because the new book wasn't built last time.
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml \
+		--keep_hash | tee $(TMP)/out
+	$(call GREP_V,'Test book 2',$(TMP)/out)
+	# But we *will* rebuild the table of contents so we get the book in the
+	# list. That is unfortunate but isn't too big a deal.
+	$(call GREP,'Pushing changes',$(TMP)/out)
 
 .PHONY: sub_dir
 sub_dir:
@@ -255,6 +372,24 @@ keep_hash_and_sub_dir:
 
 	git clone $(TMP)/dest.git $(TMP)/dest
 	$(call GREP,'extra extra extra',$(TMP)/dest/html/test/current/_chapter.html)
+
+	# Add new repo to conf file and rebuild. We shouldn't use the repo but
+	# should still get a forced rebuild.
+	$(call INIT_REPO_WITH_FILE,$(TMP)/source3,minimal.asciidoc,totally_not_used.asciidoc)
+	sed -riE 's|^(\s+)source2:|\1source3: $(TMP)/source3\n\1source2:|' $(TMP)/conf.yaml
+	echo "            -"                          >> $(TMP)/conf.yaml
+	echo "                repo:   source3"        >> $(TMP)/conf.yaml
+	echo "                path:   not_used.asciidoc" >> $(TMP)/conf.yaml
+	/docs_build/build_docs.pl --in_standard_docker --all --push \
+		--target_repo $(TMP)/dest.git \
+		--conf $(TMP)/conf.yaml \
+		--keep_hash --sub_dir source1:master:$(TMP)/to_sub | tee $(TMP)/out
+	$(call GREP,'Test book: Building master...',$(TMP)/out)
+	$(call GREP,'Test book: Finished master',$(TMP)/out)
+	$(call GREP,'Test book: Copying master to current',$(TMP)/out)
+	# Except git will pick up that we didn't change anything, so we won't push.
+	$(call GREP,'No changes to push',$(TMP)/out)
+	$(call GREP_V,'Pushing changes',$(TMP)/out)
 
 .PHONY: multi_branch
 multi_branch:

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -154,7 +154,7 @@ sub new {
 #===================================
 sub build {
 #===================================
-    my ( $self, $rebuild ) = @_;
+    my ( $self, $rebuild, $keep_hash ) = @_;
 
     my $toc = ES::Toc->new( $self->title );
     my $dir = $self->dir;
@@ -174,7 +174,7 @@ sub build {
     my $rebuilding_any_branch = 0;
     my $rebuilding_current_branch = 0;
     for my $branch ( @{ $self->branches } ) {
-        my $building = $self->_build_book( $branch, $pm, $rebuild, $latest );
+        my $building = $self->_build_book( $branch, $pm, $rebuild, $keep_hash, $latest );
         $rebuilding_any_branch ||= $building;
         $latest = 0;
 
@@ -234,7 +234,7 @@ sub build {
 #===================================
 sub _build_book {
 #===================================
-    my ( $self, $branch, $pm, $rebuild, $latest ) = @_;
+    my ( $self, $branch, $pm, $rebuild, $keep_hash, $latest ) = @_;
 
     my $branch_dir    = $self->dir->subdir($branch);
     my $source        = $self->source;
@@ -244,11 +244,23 @@ sub _build_book {
     my $subject       = $self->subject;
     my $lang          = $self->lang;
 
-    return 0
-           if -e $branch_dir
-        && !$rebuild
-        && !$template->md5_changed($branch_dir)
-        && !$source->has_changed( $self->title, $branch, $self->asciidoctor );
+    unless ( $rebuild ) {
+        if ( $keep_hash ) {
+            # If we're preserving the hash for previously built books then we
+            # can't build new books so we should skip them.
+            return 0 unless -e $branch_dir;
+            # And we don't want to build books if the source hasn't changed.
+            return 0 unless $source->has_changed( $self->title, $branch, $self->asciidoctor );
+        } else {
+            # Otherwise we can *only* skip books if their destination directory
+            # exists, the template version is up to date, and the source hasn't
+            # changed.
+            return 0 if
+                   -e $branch_dir
+                && !$template->md5_changed($branch_dir)
+                && !$source->has_changed( $self->title, $branch, $self->asciidoctor );
+        }
+    }
 
     my ( $checkout, $edit_urls, $first_path ) = $source->prepare($self->title, $branch);
 

--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -79,8 +79,8 @@ sub write {
     my $to_save = dclone( $self->shas );
     # Empty hashes are caused by new repos that are unused which shouldn't
     # force a commit.
-    for my $repo ( keys %{ $to_save } ) {
-        unless ( keys %{ $to_save->{$repo} } ) {
+    while (my ($repo, $branches) = each %{ $to_save } ) {
+        unless ( keys %{ $branches } ) {
             delete $to_save->{$repo};
         }
     }


### PR DESCRIPTION
Now that we're using a combination of `--keep_hash --sub_dir` as pull
request tests we've hit some snags, namely that when we add new books or
new repos to existing books `--keep_hash` complained about those books.
This makes it so that new repos and new books are skipped if you use
`--keep_hash`. It also adds test cases for adding new repos to existing
books and adding new books *without* `--keep_hash`.

Note that this work spawned a fierce desire to replace `make` with `rspec`
that I'm tracking in #757. I think I'd like to add these tests and then have
a look at switching from `make` to `rspec`.

Closes #749
