### PR TITLE
[DOCS] Copy glossary content from Stack Docs glossary

### DIFF
--- a/shared/glossary.asciidoc
+++ b/shared/glossary.asciidoc
@@ -1,0 +1,796 @@
+[[terms]]
+== Terminology
+
+ifdef::logstash-terms[]
+
+[[glossary-metadata]] @metadata ::
+
+A special field for storing content that you don't want to include in output
+<<glossary-event,events>>. For example, the `@metadata` field is useful for
+creating transient fields for use in <<glossary-conditional,conditional>>
+statements.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-admin-console]] administration console ::
+
+A component of {ece} that provides the API server for the
+<<glossary-cloud-ui,Cloud UI>>. Also syncs cluster and allocator data from
+ZooKeeper to {es}.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-allocator]] allocator ::
+
+Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
+nodes by creating new <<glossary-container,containers>> and managing the nodes
+within these containers when requested. Used to scale the capacity of your {ece}
+installation.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-analysis]] analysis ::
+
+Analysis is the process of converting <<glossary-text,full text>> to
+<<glossary-term,terms>>. Depending on which analyzer is used, these phrases:
+`FOO BAR`, `Foo-Bar`, `foo,bar` will probably all result in the
+terms `foo` and `bar`. These terms are what is actually stored in
+the index.
++
+A full text query (not a <<glossary-term,term>> query) for `FoO:bAR` will
+also be analyzed to the terms `foo`,`bar` and will thus match the
+terms stored in the index.
++
+It is this process of analysis (both at index time and at search time)
+that allows {es} to perform full text queries.
++
+Also see <<glossary-text,text>> and <<glossary-term,term>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-zone]] availability zone ::
+
+Contains resources available to a {ece} installation that are isolated from
+other availability zones to safeguard against failure. Could be a rack, a server
+zone or some other logical constraint that creates a failure boundary. In a
+highly available cluster, the nodes of a cluster are spread across two or three
+availability zones to ensure that the cluster can survive the failure of an
+entire availability zone. Also see
+{ece-ref}/ece-ha.html[Fault Tolerance (High Availability)].
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-beats-runner]] beats runner ::
+
+Used to send Filebeat and Metricbeat information to the logging cluster.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ml-bucket]] bucket ::
+
+The {ml-features} use the concept of a bucket to divide the time
+series into batches for processing. The _bucket span_ is part of the
+configuration information for a job. It defines the time interval that is used
+to summarize and model the data. This is typically between 5 minutes to 1 hour
+and it depends on your data characteristics. When you set the bucket span,
+take into account the granularity at which you want to analyze, the frequency
+of the input data, the typical duration of the anomalies, and the frequency at
+which alerting is required.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-client-forwarder]] client forwarder ::
+
+Used for secure internal communications between various components of {ece} and
+ZooKeeper.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-cloud-ui]] Cloud UI ::
+
+Provides web-based access to manage your {ece} installation, supported by the
+<<glossary-admin-console,administration console>>.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms,cloud-terms[]
+
+[[glossary-cluster]] cluster ::
+
+A cluster consists of one or more <<glossary-node,nodes>> which share the
+same cluster name. Each cluster has a single master node which is
+chosen automatically by the cluster and which can be replaced if the
+current master node fails.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms,cloud-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-codec-plugin]] codec plugin ::
+
+A Logstash <<glossary-plugin,plugin>> that changes the data representation
+of an <<glossary-event,event>>. Codecs are essentially stream filters that
+can operate as part of an input or output. Codecs enable you to separate the
+transport of messages from the serialization process. Popular codecs include
+json, msgpack, and plain (text).
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-conditional]] conditional ::
+
+A control flow that executes certain actions based on whether a statement
+(also called a condition) is true or false. Logstash supports `if`,
+`else if`, and `else` statements. You can use conditional statements to
+apply filters and send events to a specific output based on conditions that
+you specify.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-constructor]] constructor ::
+
+Directs <<glossary-allocator,allocators>> to manage containers of {es} and {kib}
+nodes and maximizes the utilization of allocators. Monitors plan change requests
+from the Cloud UI and determines how to transform the existing cluster. In a
+highly available installation, places cluster nodes within different
+availability zones to ensure that the cluster can survive the failure of an
+entire availability zone.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-container]] container ::
+
+Includes an instance of {ece} software and its dependencies. Used to provision
+similar environments, to assign a guaranteed share of host resources to nodes,
+and to simplify operational effort in {ece}.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-coordinator]] coordinator ::
+
+Consists of a logical grouping of some {ece} services and acts as a distributed
+coordination system and resource scheduler.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ccr]] {ccr} (CCR)::
+
+The {ccr} feature enables you to replicate indices in remote clusters to your
+local cluster. For more information, see {stack-ov}/xpack-ccr.html[{ccr-cap}].  
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-ccs]] {ccs} (CCS)::
+
+The {ccs} feature enables any node to act as a federated client across
+multiple clusters. See <<modules-cross-cluster-search>>.  
++
+//Source: X-Pack
+endif::elasticsearch-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ml-datafeed]] datafeed ::
+
+Machine learning jobs can analyze either a one-off batch of data or
+continuously in real time. {dfeeds-cap} retrieve data from {es} for analysis.
+Alternatively you can post data from any source directly to a {ml} API.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ml-detector]] detector ::
+
+As part of the configuration information that is associated with a
+{ml} job, detectors define the type of analysis that needs to be done. They
+also specify which fields to analyze. You can have more than one detector in a
+job, which is more efficient than running multiple jobs against the same data.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-director]] director ::
+
+Manages the <<glossary-zookeeper,ZooKeeper>> datastore. This role is often
+shared with the <<glossary-coordinator,coordinator>>, though in production
+deployments it can be separated.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-document]] document ::
+
+A document is a JSON document which is stored in {es}. It is
+like a row in a table in a relational database. Each document is
+stored in an <<glossary-index,index>> and has a <<glossary-type,type>> and an
+<<glossary-id,id>>.
++
+A document is a JSON object (also known in other languages as a hash /
+hashmap / associative array) which contains zero or more
+<<glossary-field,fields>>, or key-value pairs.
++
+The original JSON document that is indexed will be stored in the
+<<glossary-source_field,`_source` field>>, which is returned by default when
+getting or searching for a document.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-event]] event ::
+
+A single unit of information, containing a timestamp plus additional data. An
+event arrives via an input, and is subsequently parsed, timestamped, and
+passed through the Logstash <<glossary-pipeline,pipeline>>.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms,logstash-terms[]
+
+[[glossary-field]] field ::
+endif::elasticsearch-terms,logstash-terms[]
+ifdef::elasticsearch-terms[]
+A <<glossary-document,document>> contains a list of fields, or key-value
+pairs. The value can be a simple (scalar) value (for example, a string,
+integer, date), or a nested structure like an array or an object. A field is
+similar to a column in a table in a relational database.
++
+The <<glossary-mapping,mapping>> for each field has a field _type_ (not to
+be confused with document <<glossary-type,type>>) which indicates the type
+of data that can be stored in that field, eg `integer`, `string`,
+`object`. The mapping also allows you to define (amongst other things)
+how the value for a field should be analyzed.
++
+//Source: Elasticsearch
++
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+In Logstash, this term refers to an <<glossary-event,event>> property. For
+example, each event in an apache access log has properties, such as a status
+code (200, 404), request path ("/", "index.html"), HTTP verb (GET, POST), client
+IP address, and so on. Logstash uses the term "fields" to refer to these
+properties.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-field-reference]] field reference ::
+
+A reference to an event <<glossary-field,field>>. This reference may appear in
+an output block or filter block in the Logstash config file. Field references
+are typically wrapped in square (`[]`) brackets, for example `[fieldname]`. If
+you are referring to a top-level field, you can omit the `[]` and simply use
+the field name. To refer to a nested field, you specify the full path to that
+field: `[top-level field][nested field]`.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms[]
+[[glossary-filter]] filter ::
+
+A filter is a non-scoring <<glossary-query,query>>, meaning that it does not score documents.
+It is only concerned about answering the question - "Does this document match?". 
+The answer is always a simple, binary yes or no. This kind of query is said to be made 
+in a <<query-filter-context,filter context>>, 
+hence it is called a filter. Filters are simple checks for set inclusion or exclusion. 
+In most cases, the goal of filtering is to reduce the number of documents that have to be examined.
+
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-filter-plugin]] filter plugin ::
+
+A Logstash <<glossary-plugin,plugin>> that performs intermediary processing on
+an <<glossary-event,event>>. Typically, filters act upon event data after it
+has been ingested via inputs, by mutating, enriching, and/or modifying the
+data according to configuration rules. Filters are often applied conditionally
+depending on the characteristics of the event. Popular filter plugins include
+grok, mutate, drop, clone, and geoip. Filter stages are optional.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::xpack-terms[]
+[[glossary-follower-index]] follower index ::  
+  
+Follower indices are the target indices for <<glossary-ccr,{ccr}>>. They exist
+in your local cluster and replicate <<glossary-leader-index,leader indices>>.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-gem]] gem ::
+
+A self-contained package of code that's hosted on
+https://rubygems.org[RubyGems.org]. Logstash <<glossary-plugin,plugins>> are
+packaged as Ruby Gems. You can use the Logstash
+<<glossary-plugin-manager,plugin manager>> to manage Logstash gems.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-hot-thread]] hot thread ::
+
+A Java thread that has high CPU usage and executes for a longer than normal
+period of time.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-id]] ID ::
+
+The ID of a <<glossary-document,document>> identifies a document. The
+`index/id` of a document must be unique. If no ID is provided,
+then it will be auto-generated. (Also see <<glossary-routing,routing>>).
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-index]] index ::
+
+An index is like a _table_ in a relational database. It has a
+<<glossary-mapping,mapping>> which contains a <<glossary-type,type>>,
+which contains the <<glossary-field,fields>> in the index.
++
+An index is a logical namespace which maps to one or more
+<<glossary-primary-shard,primary shards>> and can have zero or more
+<<glossary-replica-shard,replica shards>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-indexer]] indexer ::
+
+A Logstash instance that is tasked with interfacing with an {es} cluster in
+order to index <<glossary-event,event>> data.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-input-plugin]] input plugin ::
+
+A Logstash <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
+from a specific source. Input plugins are the first stage in the Logstash
+event processing <<glossary-pipeline,pipeline>>. Popular input plugins include
+file, syslog, redis, and beats.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ml-job]] job ::
+
+Machine learning jobs contain the configuration information and metadata
+necessary to perform an analytics task.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::xpack-terms[]
+[[glossary-leader-index]] leader index ::  
+    
+Leader indices are the source indices for <<glossary-ccr,{ccr}>>. They exist
+on remote clusters and are replicated to 
+<<glossary-follower-index,follower indices>>.
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::xpack-terms[]
+
+[[glossary-ml-nodes]]
+machine learning node ::
+
+A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
+which is the default behavior. If you set `node.ml` to `false`, the node can
+service API requests but it cannot run jobs. If you want to use {ml-features},
+there must be at least one {ml} node in your cluster.
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-mapping]] mapping ::
+
+A mapping is like a _schema definition_ in a relational database. Each
+<<glossary-index,index>> has a mapping, which defines a <<glossary-type,type>>,
+plus a number of index-wide settings.
++
+A mapping can either be defined explicitly, or it will be generated
+automatically when a document is indexed.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-master-node]] master node ::
+
+Handles write requests for the cluster and publishes changes to other nodes in
+an ordered fashion. Each cluster has a single master node which is chosen
+automatically by the cluster and is replaced if the current master node fails.
+Also see <<glossary-node,node>>.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-merge]] merge ::
+
+The combining of Lucene segments, either automatically in the background or initiated using force merge.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-message-broker]] message broker ::
+
+Also referred to as a _message buffer_ or _message queue_, a message broker is
+external software (such as Redis, Kafka, or RabbitMQ) that stores messages
+from the Logstash shipper instance as an intermediate store, waiting to be
+processed by the Logstash indexer instance.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms,cloud-terms[]
+
+[[glossary-node]] node ::
+
+A node is a running instance of {es} or {kib} which belongs to a
+<<glossary-cluster,cluster>>. Multiple nodes can be started on a single server
+for testing purposes, but usually you should have one node per server.
++
+At startup, a node will use unicast to discover an existing cluster with
+the same cluster name and will try to join that cluster.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms,cloud-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-output-plugin]] output plugin ::
+
+A Logstash <<glossary-plugin,plugin>> that writes <<glossary-event,event>> data
+to a specific destination. Outputs are the final stage in the event
+<<glossary-pipeline,pipeline>>. Popular output plugins include elasticsearch,
+file, graphite, and statsd.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-pipeline]] pipeline ::
+
+A term used to describe the flow of <<glossary-event,events>> through the
+Logstash workflow. A pipeline typically consists of a series of input, filter,
+and output stages. <<glossary-input-plugin,Input>> stages get data from a source
+and generate events, <<glossary-filter-plugin,filter>> stages, which are
+optional, modify the event data, and <<glossary-output-plugin,output>> stages
+write the data to a destination. Inputs and outputs support
+<<glossary-codec-plugin,codecs>> that enable you to encode or decode the data as
+it enters or exits the pipeline without having to use a separate filter.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-plan]] plan ::
+
+Specifies the configuration and topology of an {es} or {kib} cluster, such as
+capacity, availability, and {es} version, for example. When changing a plan, the
+<<glossary-constructor,constructor>> determines how to transform the existing
+cluster into the pending plan.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-plugin]] plugin ::
+
+A self-contained software package that implements one of the stages in the
+Logstash event processing <<glossary-pipeline,pipeline>>. The list of available
+plugins includes <<glossary-input-plugin,input plugins>>,
+<<glossary-output-plugin,output plugins>>,
+<<glossary-codec-plugin,codec plugins>>, and
+<<glossary-filter-plugin,filter plugins>>. The plugins are implemented as Ruby
+<<glossary-gem,gems>> and hosted on https://rubygems.org[RubyGems.org]. You
+define the stages of an event processing <<glossary-pipeline,pipeline>>
+by configuring plugins.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-plugin-manager]] plugin manager ::
+
+Accessed via the `bin/logstash-plugin` script, the plugin manager enables
+you to manage the lifecycle of <<glossary-plugin,plugins>> in your Logstash
+deployment. You can install, remove, and upgrade plugins by using the
+plugin manager Command Line Interface (CLI).
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-primary-shard]] primary shard ::
+
+Each document is stored in a single primary <<glossary-shard,shard>>. When
+you index a document, it is indexed first on the primary shard, then
+on all <<glossary-replica-shard,replicas>> of the primary shard.
++
+By default, an <<glossary-index,index>> has 5 primary shards. You can
+specify fewer or more primary shards to scale the number of
+<<glossary-document,documents>> that your index can handle.
++
+You cannot change the number of primary shards in an index, once the
+index is created.
++
+See also <<glossary-routing,routing>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-proxy]] proxy ::
+
+A highly available, TLS-enabled proxy layer that routes user requests, mapping
+cluster IDs that are passed in request URLs for the container to the cluster
+nodes handling the user requests.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+[[glossary-query]] query ::
+
+A query is the basic component of a search. A search can be defined by one or
+more queries which can be mixed and matched in endless combinations. While
+<<glossary-filter,filters>> are queries that only determine if a document
+matches, those queries that also calculate how well the document matches are
+known as "scoring queries". Those queries assign it a score, which is later used
+to sort matched documents. Scoring queries take more resources than
+<<glossary-filter,non scoring queries>> and their query results are not
+cacheable. As a general rule, use query clauses for full-text search or for any
+condition that requires scoring, and use filters for everything else.
+
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-recovery]] recovery ::
+The process of syncing a shard copy from a source shard. Upon completion, the recovery process makes the shard copy available for queries.
++
+Recovery automatically occurs anytime a shard moves to a different node in the same cluster, including:
+
+* Node startup
+* Node failure
+* Index shard replication
+* Snapshot restoration
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-reindex]] reindex ::
+
+To cycle through some or all documents in one or more indices, re-writing them into the same or new index in a local or remote cluster. This is most commonly done to update mappings, or to upgrade Elasticsearch between two incompatible index versions.
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-replica-shard]] replica shard ::
+
+Each <<glossary-primary-shard,primary shard>> can have zero or more
+replicas. A replica is a copy of the primary shard, and has two
+purposes:
++
+1.  increase failover: a replica shard can be promoted to a primary
+shard if the primary fails
+2.  increase performance: get and search requests can be handled by
+primary or replica shards.
++
+By default, each primary shard has one replica, but the number of
+replicas can be changed dynamically on an existing index. A replica
+shard will never be started on the same node as its primary shard.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-roles-token]] roles token ::
+
+Enables a host to join an existing {ece} installation and grants permission to
+hosts to hold certain roles, such as the <<glossary-allocator,allocator>> role.
+Used when installing {ece} on additional hosts, a roles token helps secure {ece}
+by making sure that only authorized hosts become part of the installation.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-routing]] routing ::
+
+When you index a document, it is stored on a single
+<<glossary-primary-shard,primary shard>>. That shard is chosen by hashing
+the `routing` value. By default, the `routing` value is derived from
+the ID of the document or, if the document has a specified parent
+document, from the ID of the parent document (to ensure that child and
+parent documents are stored on the same shard).
++
+This value can be overridden by specifying a `routing` value at index
+time, or a {ref}/mapping-routing-field.html[routing field] in the
+<<glossary-mapping,mapping>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-runner]] runner ::
+
+A local control agent that runs on all hosts, used to deploy local containers
+based on role definitions. Ensures that containers assigned to it exist and are
+able to run, and creates or recreates the containers if necessary.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-services-forwarder]] services forwarder ::
+
+Routes data internally in an {ece} installation.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-shard]] shard ::
+
+A shard is a single Lucene instance. It is a low-level “worker” unit
+which is managed automatically by {es}. An index is a logical
+namespace which points to <<glossary-primary-shard,primary>> and
+<<glossary-replica-shard,replica>> shards.
++
+Other than defining the number of primary and replica shards that an
+index should have, you never need to refer to shards directly.
+Instead, your code should deal only with an index.
++
+{es} distributes shards amongst all <<glossary-node,nodes>> in the
+<<glossary-cluster,cluster>>, and can move shards automatically from one
+node to another in the case of node failure, or the addition of new
+nodes.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-shipper]] shipper ::
+
+An instance of Logstash that send events to another instance of Logstash, or
+some other application.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-shrink]] shrink ::
+
+To reduce the amount of shards in an index. See the {ref}/indices-shrink-index.html[shrink index API].
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-source_field]] source field ::
+
+By default, the JSON document that you index will be stored in the
+`_source` field and will be returned by all get and search requests.
+This allows you access to the original object directly from search
+results, rather than requiring a second step to retrieve the object
+from an ID.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-split]] split ::
+
+To grow the amount of shards in an index. See the {ref}/indices-split-index.html[split index API].
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-stunnel]] stunnel ::
+
+Securely tunnels all traffic in an {ece} installation.
++
+//Source: Cloud
+endif::cloud-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-term]] term ::
+
+A term is an exact value that is indexed in {es}. The terms
+`foo`, `Foo`, `FOO` are NOT equivalent. Terms (i.e. exact values) can
+be searched for using _term_ queries. +
+See also <<glossary-text,text>> and <<glossary-analysis,analysis>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-text]] text ::
+
+Text (or full text) is ordinary unstructured text, such as this
+paragraph. By default, text will be <<glossary-analysis,analyzed>> into
+<<glossary-term,terms>>, which is what is actually stored in the index.
++
+Text <<glossary-field,fields>> need to be analyzed at index time in order to
+be searchable as full text, and keywords in full text queries must be
+analyzed at search time to produce (and search for) the same terms
+that were generated at index time.
++
+See also <<glossary-term,term>> and <<glossary-analysis,analysis>>.
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-type]] type ::
+
+A type used to represent the _type_ of document, e.g. an `email`, a `user`, or a `tweet`.
+Types are deprecated and are in the process of being removed.  See
+{ref}/removal-of-types.html[Removal of mapping types].
++
+//Source: Elasticsearch
+endif::elasticsearch-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-worker]] worker ::
+
+The filter thread model used by Logstash, where each worker receives an
+<<glossary-event,event>> and applies all filters, in order, before emitting
+the event to the output queue. This allows scalability across CPUs because
+many filters are CPU intensive.
++
+//Source: Logstash
+endif::logstash-terms[]
+ifdef::cloud-terms[]
+
+[[glossary-zookeeper]] ZooKeeper ::
+
+A coordination service for distributed systems used by {ece} to store the state
+of the installation. Responsible for discovery of hosts, resource allocation,
+leader election after failure and high priority notifications.
++
+//Source: Cloud
+endif::cloud-terms[]


### PR DESCRIPTION
This PR copies content from the [Stack Docs glossary](https://github.com/elastic/stack-docs/blob/master/docs/en/glossary/glossary.asciidoc).

It also adds a few Elasticsearch definitions missing from the original Stack Docs glossary:
- [Cross-cluster search](https://github.com/elastic/elasticsearch/blame/master/docs/reference/glossary.asciidoc#L36)
- [Filter](https://github.com/elastic/elasticsearch/blame/master/docs/reference/glossary.asciidoc#L69)
- [Query](https://github.com/elastic/elasticsearch/blame/master/docs/reference/glossary.asciidoc#L140)

#### Why make this change?
The end goal is to use this file as a single source for both the Elasticsearch and Stack Docs glossaries.

After this PR is merged, I'll open separate PRs to:
1. Update the [Elasticsearch glossary](https://github.com/elastic/elasticsearch/blob/master/docs/reference/glossary.asciidoc) to include terms from this file.
2. Update the [Stack Docs glossary](https://github.com/elastic/stack-docs/blob/master/docs/en/glossary/glossary.asciidoc) to include terms from this file.

See elastic/elasticsearch#40560 for more discussion.