### PR TITLE
Add 2.2 doc builds for ECE

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -473,7 +473,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    2.1
-            branches:   [ 2.1, 2.0, 1.1, 1.0 ]
+            branches:   [ 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Needed to test our 2.2 docs this week before the release.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
