### PR TITLE
Add 6.7 Azure ARM template docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -133,9 +133,9 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    6.6
+            current:    6.7
             index:      docs/index.asciidoc
-            branches:   [ master, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This commit adds 6.7 Azure ARM template docs to the site documentation and makes it the current documentation.
