### PR TITLE
Adds chunk level for Installation and upgrade guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -52,6 +52,7 @@ contents:
             current:    6.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, { 7.0: 7.0.0-rc1 }, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
             asciidoctor: true

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -39,7 +39,7 @@ alias docbldls=docbldlsx
 alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Stack
-alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/'
+alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --chunk 1'
 
 alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 


### PR DESCRIPTION
Per https://github.com/elastic/docs#chunking-in-the-right-place:

> By default, each part (= Part Title) and chapter (== Chapter Title) is "chunked" into a separate HTML file. However, for bigger books, such as the Elasticsearch reference docs, this results in enormous pages. These bigger books are also chunked at the first section level (=== Section One Title). 

The "Breaking changes" page in the Installation and Upgrade Guide is getting quite large as we add more products' information.

This PR proposes to add --chunk 1 to the Installation and Upgrade Guide, which will result in the following layout:

![image](https://user-images.githubusercontent.com/26471269/55368463-d072ce80-54a6-11e9-9cf3-61420e01c230.png)

