### PR TITLE
Use more standard rspec for shared example

### DIFF
--- a/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
+++ b/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples "doesn't break line numbers" do
       end
       let(:input) { "include::#{included}[]" }
       let(:expected) { "WARN: #{included}: line 3: no callout found for <1>" }
-      it "reports the rigth line for the error" do
+      it "reports the right line for the error" do
         expect(logs).to eq(expected)
       end
     end

--- a/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
+++ b/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
@@ -1,19 +1,30 @@
 # frozen_string_literal: true
 
 RSpec.shared_examples "doesn't break line numbers" do
-  it "doesn't break line numbers" do
-    input = <<~ASCIIDOC
-      ---
-      ---
-      <1> callout
-    ASCIIDOC
-    convert input, {}, match(/<stdin>: line 3: no callout found for <1>/)
-  end
+  context "doesn't break line numbers" do
+    include_context 'convert'
+    context 'when there is an error in the main asciidoc file' do
+      let(:input) do
+        <<~ASCIIDOC
+          ---
+          ---
+          <1> callout
+        ASCIIDOC
+      end
+      it "reports the right line for the error" do
+        expect(logs).to eq('WARN: <stdin>: line 3: no callout found for <1>')
+      end
+    end
 
-  it "doesn't break line numbers in included files" do
-    input = <<~ASCIIDOC
-      include::resources/does_not_break_line_numbers/missing_callout.adoc[]
-    ASCIIDOC
-    convert input, {}, match(/missing_callout.adoc: line 3: no callout found for <1>/)
+    context 'when there is an error in an included file' do
+      let(:included) do
+        'resources/does_not_break_line_numbers/missing_callout.adoc'
+      end
+      let(:input) { "include::#{included}[]" }
+      let(:expected) { "WARN: #{included}: line 3: no callout found for <1>" }
+      it "reports the rigth line for the error" do
+        expect(logs).to eq(expected)
+      end
+    end
   end
 end


### PR DESCRIPTION
This switches our single shared example to use more standard rspec,
adding contexts to make it clear what is being tested and switching from
the `convert` method to the `convert` context.
