### PR TITLE
Asciidoctor: Drop a few hash rockets

### DIFF
--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -36,8 +36,8 @@ class CareAdmonition < Asciidoctor::Extensions::Group
 
     def process(parent, _target, attrs)
       Asciidoctor::Block.new(parent, :admonition,
-          :source => attrs[:passtext],
-          :attributes => {
+          source: attrs[:passtext],
+          attributes: {
             'role' => @role,
             'name' => 'warning',
             'style' => 'warning',

--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -44,14 +44,16 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
       # We can *almost* go through the standard :admonition conversion but
       # that won't render the revisionflag or the revision. So we have to
       # go with this funny compound pass thing.
-      admon = Asciidoctor::Block.new(parent, :pass, :content_model => :compound)
+      admon = Asciidoctor::Block.new(parent, :pass, content_model: :compound)
       admon << Asciidoctor::Block.new(admon, :pass,
-          :source => "<#{@tag} revisionflag=\"#{@revisionflag}\" revision=\"#{version}\">",
-          :attributes => { 'revisionflag' => @revisionflag })
+        attributes: { 'revisionflag' => @revisionflag },
+        source: "<#{@tag} " \
+                "revisionflag=\"#{@revisionflag}\" " \
+                "revision=\"#{version}\">")
       admon << Asciidoctor::Block.new(admon, :paragraph,
-          :source => attrs[:passtext],
-          :subs => Asciidoctor::Substitutors::NORMAL_SUBS)
-      admon << Asciidoctor::Block.new(admon, :pass, :source => "</#{@tag}>")
+        source: attrs[:passtext],
+        subs: Asciidoctor::Substitutors::NORMAL_SUBS)
+      admon << Asciidoctor::Block.new(admon, :pass, source: "</#{@tag}>")
     end
   end
 

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -44,7 +44,8 @@ class EditMe < TreeProcessorScaffold
       edit_urls = @document.attributes['edit_urls']
       edit_url = edit_urls.find { |e| path.start_with? e[:toplevel] }
       unless edit_url
-        logger.warn message_with_context "couldn't find edit url for #{path}", :source_location => source_location
+        logger.warn message_with_context "couldn't find edit url for #{path}",
+          source_location: source_location
         return super
       end
       url = edit_url[:url]

--- a/resources/asciidoctor/lib/lang_override/extension.rb
+++ b/resources/asciidoctor/lib/lang_override/extension.rb
@@ -10,6 +10,6 @@ class LangOverride < Asciidoctor::Extensions::BlockMacroProcessor
   named :lang_override
   name_positional_attributes :override
   def process(parent, _target, attrs)
-    Asciidoctor::Block.new(parent, :pass, :source => "// #{attrs[:override]}")
+    Asciidoctor::Block.new(parent, :pass, source: "// #{attrs[:override]}")
   end
 end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -24,12 +24,12 @@ def convert(input, extra_attributes = {}, warnings_matcher = eq(''))
   }
   attributes.merge! extra_attributes
   result = Asciidoctor.convert input,
-      :safe       => :unsafe,  # Used to include "funny" files.
-      :backend    => :docbook45,
-      :logger     => logger,
-      :doctype    => :book,
-      :attributes => attributes,
-      :sourcemap  => true
+      safe:       :unsafe,  # Used to include "funny" files.
+      backend:    :docbook45,
+      logger:     logger,
+      doctype:    :book,
+      attributes: attributes,
+      sourcemap:  true
   warnings_string = logger.messages
         .map { |l| "#{l[:severity]}: #{l[:message].inspect}" }
         .join("\n")
@@ -56,12 +56,12 @@ RSpec.shared_context 'convert' do
     }
     attributes.merge! convert_attributes if defined?(convert_attributes)
     Asciidoctor.convert input,
-        :safe       => :unsafe,  # Used to include "funny" files.
-        :backend    => :docbook45,
-        :logger     => convert_logger,
-        :doctype    => :book,
-        :attributes => attributes,
-        :sourcemap  => true
+        safe:       :unsafe,  # Used to include "funny" files.
+        backend:    :docbook45,
+        logger:     convert_logger,
+        doctype:    :book,
+        attributes: attributes,
+        sourcemap:  true
   end
   let(:logs) do
     convert_logger.messages


### PR DESCRIPTION
It looks like it is more idiomatic in ruby to avoid hash rockets where
possible. This drops *some* of them.
