### PR TITLE
Omits beats and kibana repos from old Installation and Upgrade Guides

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -65,10 +65,12 @@ contents:
                 path:   docs/
               -
                 repo:   kibana
-                path:   docs/  
+                path:   docs/
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   beats
-                path:   libbeat/docs         
+                path:   libbeat/docs
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -38,15 +38,23 @@ alias docbldls=docbldlsx
 
 alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
-# Stack
+# Installation and Upgrade Guide 7.0 and later
 alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --chunk 1'
 
+# Installation and Upgrade Guide 6.7 and earlier
+alias docbldstkold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --chunk 1'
+
+
+# Glossary
 alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
+# Getting started
 alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
+# Stack Overview
 alias docbldso='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
+# Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR updates the conf.yaml to exclude the kibana and beats repos from the Installation and Upgrade Guide builds in 6.7 and earlier releases.  Those repos are only required when we added shared highlights and breaking changes in 7.0 and later releases.

It also adds a "docbldstkold" alias which omits the unnecessary --resource parameters.

Finally, it adds some comments in the aliases file, since we were missing descriptions of some of the aliases. 