### PR TITLE
Switch Painless reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -224,6 +224,7 @@ contents:
             chunk:      1
             tags:       Elasticsearch/Painless
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -116,7 +116,7 @@ alias docblddg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-defin
 # Elasticsearch Extras
 alias docbldres='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
 
-alias docbldpls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
+alias docbldpls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
 
 alias docbldepi='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
 


### PR DESCRIPTION
Switches the painless reference book from the no-longer-maintained
AsciiDoc backend to the actively-maintained Asciidoctor backend. In the
process this speeds up the build by a factor of three.
