### PR TITLE
Switch es-hadoop docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -430,6 +430,7 @@ contents:
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch-hadoop

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -142,7 +142,7 @@ alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldecc='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 
-alias docbldesh='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
+alias docbldesh='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
 # X-Pack Reference 5.4 to 6.2
 


### PR DESCRIPTION
Switches the ES-hadoop based docs from the unmaintained AsciiDoc backend
to the actively maintained Asciidoctor backend. This makes them 3x
faster to build.
