### PR TITLE
Adds logstash repo as resource for Install Upgrade Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -75,6 +75,10 @@ contents:
                 repo:   apm-server
                 path:   docs/guide
                 exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   logstash
+                path:   docs/
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -39,7 +39,7 @@ alias docbldls=docbldlsx
 alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Installation and Upgrade Guide 7.0 and later
-alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --chunk 1'
+alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/logstash/docs/ --chunk 1'
 
 # Installation and Upgrade Guide 6.7 and earlier
 alias docbldstkold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --chunk 1'


### PR DESCRIPTION
This PR updates the conf.yaml and the build aliases such that the logstash repo is a resource for the Installation and Upgrade Guide. This enables us to use tagged regions to re-use content from the logstash repo, such as the breaking changes and highlights.
