### PR TITLE
Adds shared attribute for Elasticsearch Hadoop

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -126,3 +126,5 @@
 :dataframe-transforms-cap: {dataframe-cap} transforms
 
 :pwd:             YOUR_PASSWORD
+
+:esh: 	ES-Hadoop


### PR DESCRIPTION
This PR adds the "esh" attribute to the list of shared attributes.

It is used in the breaking changes in https://www.elastic.co/guide/en/elasticsearch/hadoop/7.0/breaking-changes.html#breaking-changes-7.0 , which are in turn used in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/7.0/elastic-stack-breaking-changes.html)