### PR TITLE
Switch ES plugins docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -254,6 +254,7 @@ contents:
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -118,7 +118,7 @@ alias docbldres='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldpls='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
 
-alias docbldepi='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
+alias docbldepi='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
 
 alias docbldjvr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/java-rest/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the ES "Plugins and Integrations" book's documentation build
core from the unmaintained AsciiDoc project to the actively maintained
Asciidoctor project. It also speeds up building it by a factor of about
2.5.
