### PR TITLE
Switched ECE `current` to `2.2`

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -490,7 +490,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    2.1
+            current:    2.2
             branches:   [ 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1


### PR DESCRIPTION
In preparation for the ECE 2.2.0 release, changed `current` to `2.2`.