### PR TITLE
Asciidoctor: Change invocation rules for macros

### DIFF
--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -115,7 +115,7 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
   CODE_BLOCK_RX = /^-----*$/
   SNIPPET_RX = %r{^//\s*(AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)$}
   LEGACY_MACROS = 'added|beta|coming|deprecated|experimental'
-  LEGACY_BLOCK_MACRO_RX = /^(#{LEGACY_MACROS})\[([^\]]*)\]/
+  LEGACY_BLOCK_MACRO_RX = /^\s*(#{LEGACY_MACROS})\[([^\]]*)\]\s*$/
   LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[([^\]]*)\]/
 
   def process(_document, reader)
@@ -175,7 +175,7 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
         end
 
         # First convert the "block" version of these macros. We convert them
-        # to block macros because they are at the start of the line....
+        # to block macros because they are alone on a line
         line&.gsub!(LEGACY_BLOCK_MACRO_RX, '\1::[\2]')
         # Then convert the "inline" version of these macros. We convert them
         # to inline macros because they are *not* at the start of the line....

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -115,8 +115,8 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
   CODE_BLOCK_RX = /^-----*$/
   SNIPPET_RX = %r{^//\s*(AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)$}
   LEGACY_MACROS = 'added|beta|coming|deprecated|experimental'
-  LEGACY_BLOCK_MACRO_RX = /^\s*(#{LEGACY_MACROS})\[([^\]]*)\]\s*$/
-  LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[([^\]]*)\]/
+  LEGACY_BLOCK_MACRO_RX = /^\s*(#{LEGACY_MACROS})\[(.*)\]\s*$/
+  LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[(.*)\]/
 
   def process(_document, reader)
     reader.instance_variable_set :@in_attribute_only_block, false

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -58,6 +58,17 @@ RSpec.describe ElasticCompatPreprocessor do
         let(:input) { "#{name}[some_version]   " }
         include_examples 'invokes the block macro'
       end
+      context 'when the admonition has a `]` in it' do
+        let(:input) { "#{name}[some_version, link:link.html[Title]]" }
+        include_examples 'invokes the block macro'
+        let(:expected) do
+          <<~DOCBOOK
+            <#{tag} revisionflag="#{revisionflag}" revision="some_version">
+            <simpara><ulink url="link.html">Title</ulink></simpara>
+            </#{tag}>
+          DOCBOOK
+        end
+      end
 
       shared_examples 'invokes the inline macro' do
         it 'invokes the inline macro' do


### PR DESCRIPTION
Changes the invocation rules for legacy style admonition macros to only
invoke the block version if it is alone on a line. This more closely
mirrors the customizations that Elastic did to AsciiDoc.
