### PR TITLE
Add redirects for apache2 renaming in 7.0

### DIFF
--- a/resources/legacy_redirects.conf
+++ b/resources/legacy_redirects.conf
@@ -1068,3 +1068,5 @@ rewrite (?i)^/guide/en/beats/functionbeat/6.x/(.*) $guide_root/en/beats/function
 rewrite (?i)^/guide/en/beats/journalbeat/6.x/(.*) $guide_root/en/beats/journalbeat/6.7/$1;
 rewrite (?i)^/guide/en/infrastructure/guide/6.x/(.*) $guide_root/en/infrastructure/guide/6.7/$1;
 rewrite (?i)/guide/en/apm/get-started/6.x/index.html $guide_root/en/apm/get-started/6.7/index.html;
+rewrite (?i)^/guide/en/beats/filebeat/current/filebeat-module-apache2.html $guide_root/en/beats/filebeat/current/filebeat-module-apache.html  permanent;
+rewrite (?i)^/guide/en/beats/filebeat/7.0/filebeat-module-apache2.html $guide_root/en/beats/filebeat/7.0/filebeat-module-apache.html  permanent;


### PR DESCRIPTION
Add redirects for renaming of Filebeat apache2 module to apache in 7.0.