### PR TITLE
Switch Elasticsearch Reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -170,6 +170,7 @@ contents:
             chunk:      1
             tags:       Elasticsearch/Reference
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -12,13 +12,13 @@
 
 
 # Elasticsearch
-alias docbldesx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
 
 alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
 alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
Switches the core of the docs build for the Elasticsearch Reference from the unmaintained AsciiDoc to the actively developed Asciidoctor. 

Related to https://github.com/elastic/elasticsearch/issues/41128