### PR TITLE
Add gke-on-prem docs to conf.yaml and aliases

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -158,6 +158,19 @@ contents:
               -
                 repo:   azure-marketplace
                 path:   docs
+          -
+            title:      Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
+            prefix:     en/elastic-stack-gke
+            current:    master
+            index:      docs/en/gke-on-prem/index.asciidoc
+            branches:   [ master ]
+            chunk:      1
+            tags:       Elastic Stack/Google
+            subject:    Elastic Stack
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/gke-on-prem               
     -
         title:      Elasticsearch: Store, Search, and Analyze
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -167,6 +167,7 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Google
             subject:    Elastic Stack
+            asciidoctor: true            
             sources:
               -
                 repo:   stack-docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -150,3 +150,6 @@ alias docbldx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/x-pack/docs/en/index
 
 # ECS
 alias docbldecs='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'
+
+# GKE 
+alias docbldgke='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/284