### PR TITLE
Switch .net client to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -376,6 +376,7 @@ contents:
                 tags:       Clients/.Net
                 subject:    Clients
                 chunk:      1
+                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-net

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -130,7 +130,7 @@ alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
 
-alias docbldnet='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
+alias docbldnet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
 alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 


### PR DESCRIPTION
Switches the core of the docs build for the Elasticsearch client for
.net from the unmaintained AsciiDoc project to the actively maintained
Asciidoctor project.
