### PR TITLE
Switch legacy graph docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1346,6 +1346,7 @@ contents:
             index:      docs/public/graph/index.asciidoc
             branches:   [ 2.4, 2.3 ]
             private:    1
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
Switches the core of the docs build for the legacy graph docs from the
unmaintained AsciiDoc project to the actively maintained Asciidoctor
project.
