### PR TITLE
Renames Google Cloud Anthos book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -159,7 +159,7 @@ contents:
                 repo:   azure-marketplace
                 path:   docs
           -
-            title:      Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
+            title:      Elastic Stack and Google Cloud Anthos
             prefix:     en/elastic-stack-gke
             current:    master
             index:      docs/en/gke-on-prem/index.asciidoc


### PR DESCRIPTION
This PR shortens the name of the "Combining logs and metrics from Google Cloud’s Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack" book on the documentation landing page.