### PR TITLE
Switch legacy reporting docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1331,6 +1331,7 @@ contents:
             index:      docs/public/reporting/index.asciidoc
             branches:   [ 2.4 ]
             private:    1
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
Switches the core of the build for the legacy reporting docs from
AsciiDoc to Asciidoctor.
