### PR TITLE
Switch legacy watcher documentation to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1319,6 +1319,7 @@ contents:
             index:      docs/public/watcher/index.asciidoc
             private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
Switches the core of the documentation build from the unmaintained
AsciiDoc project to the actively developer Asciidoctor project.
