### PR TITLE
Switches Elasticsearch Ref doc build to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -187,6 +187,7 @@ contents:
             chunk:      1
             tags:       Elasticsearch/Reference
             subject:    Elasticsearch
+            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -12,13 +12,13 @@
 
 
 # Elasticsearch
-alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
 
 alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
 alias docbldkbx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR switches the [Elasticsearch Reference ](https://www.elastic.co/guide/en/elasticsearch/reference/master/index.html)to use asciidoctor.

It depends on fixes being backported in the Elasticsearch repo first: elastic/elasticsearch#41128