### PR TITLE
Use sparse checkout to speed up building all docs

### DIFF
--- a/lib/ES/BaseRepo.pm
+++ b/lib/ES/BaseRepo.pm
@@ -1,0 +1,132 @@
+package ES::BaseRepo;
+
+use strict;
+use warnings;
+use v5.10;
+
+use Path::Class();
+use URI();
+use Encode qw(decode_utf8);
+use ES::Util qw(run);
+
+#===================================
+sub new {
+#===================================
+    my ( $class, %args ) = @_;
+
+    my $name = $args{name} or die "No <name> specified";
+    my $url  = $args{url}  or die "No <url> specified for repo <$name>";
+    if ( my $user = $args{user} ) {
+        $url = URI->new($url);
+        $url->userinfo($user);
+    }
+
+    my $dir = $args{dir} or die "No <dir> specified for repo <$name>";
+
+    my $reference_dir = 0;
+    if ($args{reference}) {
+        my $reference_subdir = $url;
+        $reference_subdir =~ s|/$||;
+        $reference_subdir =~ s|:*/*\.git$||;
+        $reference_subdir =~ s/.*[\/:]//g;
+        $reference_dir = $args{reference}->subdir("$reference_subdir.git");
+    }
+
+    bless {
+        name          => $name,
+        git_dir       => $dir->subdir("$name.git"),
+        url           => $url,
+        reference_dir => $reference_dir,
+        sub_dirs      => {},
+    }, $class;
+}
+
+#===================================
+sub update_from_remote {
+#===================================
+    my $self = shift;
+
+    my $git_dir = $self->git_dir;
+    local $ENV{GIT_DIR} = $git_dir;
+
+    my $name = $self->name;
+    eval {
+        unless ( $self->_try_to_fetch ) {
+            my $url = $self->url;
+            printf(" - %20s: Cloning from <%s>\n", $name, $url);
+            run 'git', 'clone', '--bare', $self->_reference_args, $url, $git_dir;
+        }
+        1;
+    }
+    or die "Error updating repo <$name>: $@";
+}
+
+#===================================
+sub _try_to_fetch {
+#===================================
+    my $self    = shift;
+    my $git_dir = $self->git_dir;
+    return unless -e $git_dir;
+
+    my $alternates_file = $git_dir->file('objects', 'info', 'alternates');
+    if ( -e $alternates_file ) {
+        my $alternates = $alternates_file->slurp( iomode => '<:encoding(UTF-8)' );
+        chomp( $alternates );
+        unless ( -e $alternates ) {
+            printf(" - %20s: Missing reference. Deleting\n", $self->name);
+            $git_dir->rmtree;
+            return;
+        }
+    }
+
+    my $remote = eval { run qw(git remote -v) } || '';
+    $remote =~ /^origin\s+(\S+)/;
+
+    my $origin = $1;
+    unless ($origin) {
+        printf(" - %20s: Repo dir exists but is not a repo. Deleting\n", $self->name);
+        $git_dir->rmtree;
+        return;
+    }
+
+    my $name = $self->name;
+    my $url  = $self->url;
+    if ( $origin ne $url ) {
+        printf(" - %20s: Upstream has changed to <%s>. Deleting\n", $self->name, $url);
+        $git_dir->rmtree;
+        return;
+    }
+    printf(" - %20s: Fetching\n", $self->name);
+    run qw(git fetch --prune origin +refs/heads/*:refs/heads/*);
+    return 1;
+}
+
+#===================================
+sub _reference_args {
+#===================================
+    my $self = shift;
+    return () unless $self->{reference_dir};
+    return ('--reference', $self->{reference_dir}) if -e $self->{reference_dir};
+    say " - Reference missing so not caching: " . $self->{reference_dir};
+    $self->{reference_dir} = 0;  # NOCOMMIT check me
+    return ();
+}
+
+#===================================
+sub show_file {
+#===================================
+    my $self = shift;
+    my ( $branch, $file ) = @_;
+
+    local $ENV{GIT_DIR} = $self->git_dir;
+
+    return decode_utf8 run( qw (git show ), $branch . ':' . $file );
+}
+
+#===================================
+sub name          { shift->{name} }
+sub git_dir       { shift->{git_dir} }
+sub url           { shift->{url} }
+#===================================
+
+1

--- a/lib/ES/BaseRepo.pm
+++ b/lib/ES/BaseRepo.pm
@@ -32,7 +32,7 @@ sub new {
         $reference_dir = $args{reference}->subdir("$reference_subdir.git");
     }
 
-    bless {
+    return bless {
         name          => $name,
         git_dir       => $dir->subdir("$name.git"),
         url           => $url,

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -8,7 +8,7 @@ use Path::Class();
 use Encode qw(decode_utf8);
 use ES::Util qw(run sha_for);
 
-use base qw( ES::BaseRepo );
+use parent qw( ES::BaseRepo );
 
 my %Repos;
 
@@ -17,7 +17,7 @@ sub new {
 #===================================
     my ( $class, %args ) = @_;
 
-    my $self = shift->SUPER::new(%args);
+    my $self = $class->SUPER::new(%args);
 
     my $name = $self->name;
     $self->{tracker} = $args{tracker}

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -14,6 +14,12 @@ use base qw( ES::BaseRepo );
 my %Repos;
 
 #===================================
+# Create a repo for tracking *built* docs. This creation doesn't do anything
+# on disk and the repo should be prepared by calling `update_from_remote` and
+# `checkout_minimal`. The first call interacts with the network and can take
+# a long time, especially if the repo doesn't exist locally. The second call
+# is generally much quicker.
+#===================================
 sub new {
 #===================================
     my ( $class, %args ) = @_;
@@ -27,6 +33,9 @@ sub new {
     $self;
 }
 
+#===================================
+# Checks out the parts of this repo that are not built docs. This will make
+# sure that we have the tracker file that we need to check out other repos.
 #===================================
 sub checkout_minimal {
 #===================================
@@ -45,6 +54,9 @@ sub checkout_minimal {
 }
 
 #===================================
+# Checks out the rest of the repo. This must be finished before we can build
+# docs into the repo.
+#===================================
 sub checkout_all {
 #===================================
     my ( $self ) = @_;
@@ -60,6 +72,8 @@ sub checkout_all {
 }
 
 #===================================
+# Write a sparse checkout config for the repo.
+#===================================
 sub _write_sparse_config {
 #===================================
     my ( $self, $config ) = @_;
@@ -72,7 +86,6 @@ sub _write_sparse_config {
         or dir("Couldn't write sparse config");
     print $sparse $config;
     close $sparse;
-
 }
 
 1

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -1,0 +1,78 @@
+package ES::TargetRepo;
+
+use strict;
+use warnings;
+use v5.10;
+
+use Cwd;
+use Path::Class();
+use Encode qw(decode_utf8);
+use ES::Util qw(run sha_for);
+
+use base qw( ES::BaseRepo );
+
+my %Repos;
+
+#===================================
+sub new {
+#===================================
+    my ( $class, %args ) = @_;
+
+    $args{name} = 'target_repo';
+    my $self = shift->SUPER::new(%args);
+
+    $self->{destination} = $args{destination}
+        or die die "No <destination> specified for repo <target_repo>";
+
+    $self;
+}
+
+#===================================
+sub checkout_minimal {
+#===================================
+    my ( $self ) = @_;
+
+    my $original_pwd = Cwd::cwd();
+    eval {
+        run qw(git clone --no-checkout), $self->git_dir, $self->{destination};
+        chdir $self->{destination};
+        run qw(git config core.sparseCheckout true);
+        $self->_write_sparse_config("/*\n!html/*/\n");
+        run qw(git checkout master);
+        1;
+    } or die "Error checking out repo <target_repo>: $@";
+    chdir $original_pwd;
+}
+
+#===================================
+sub checkout_all {
+#===================================
+    my ( $self ) = @_;
+
+    my $original_pwd = Cwd::cwd();
+    chdir $self->{destination};
+    eval {
+        $self->_write_sparse_config("*\n");
+        run qw(git read-tree -mu HEAD);
+        1;
+    } or die "Error checking out repo <target_repo>: $@";
+    chdir $original_pwd;
+}
+
+#===================================
+sub _write_sparse_config {
+#===================================
+    my ( $self, $config ) = @_;
+
+    open(my $sparse, '>',
+        $self->{destination}
+             ->subdir( '.git' )
+             ->subdir( 'info' )
+             ->file( 'sparse-checkout' ))
+        or dir("Couldn't write sparse config");
+    print $sparse $config;
+    close $sparse;
+
+}
+
+1

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -9,7 +9,7 @@ use Path::Class();
 use Encode qw(decode_utf8);
 use ES::Util qw(run sha_for);
 
-use base qw( ES::BaseRepo );
+use parent qw( ES::BaseRepo );
 
 my %Repos;
 
@@ -25,10 +25,10 @@ sub new {
     my ( $class, %args ) = @_;
 
     $args{name} = 'target_repo';
-    my $self = shift->SUPER::new(%args);
+    my $self = $class->SUPER::new(%args);
 
     $self->{destination} = $args{destination}
-        or die die "No <destination> specified for repo <target_repo>";
+        or die "No <destination> specified for repo <target_repo>";
 
     $self;
 }


### PR DESCRIPTION
This begins to use sparse checkout to speed up building `--all` docs. It
does so in the simplest way possible at this point: instead of checking
out the entire target repo before checking out other repos we checkout
all of the target repo *except* the built docs before checking out the
other repos. This allows us to read the "tracker" file from the built
docs repo to pick which hashes to use for the other repos. We then
checkout the built docs in parallel with the other repos.

The bulk of changed code is around breaking out handling of the
"target" repo into a new class `TargetRepo` and creating a `BaseRepo`
that is shared between `TargetRepo` and `Repo`.

This doesn't save *that* much time locally but I expect it'll be
somewhat more substantial in CI because CI tends to spend more time
pulling changes. In addition, I think we can do better later by using
sparse checkout on the built docs. In most cases we're not actually
rebuilding all of the docs so we don't need to check them all out.
