### PR TITLE
Update current version of elasticsearch-php docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -388,8 +388,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    6.0
-                branches:   [ master, 6.0, 5.0, 2.0, 1.0, 0.4 ]
+                current:    6.5.x
+                branches:   [ master, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients


### PR DESCRIPTION
The 6.0 branch no longer exists. Changing current to 6.5.x.
