### PR TITLE
Update APM meta tags

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -904,8 +904,8 @@ contents:
             current:    7.0
             branches:   [ master, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
+            tags:       APM/Elastic APM/APM Overview/APM Getting Started/Install APM/Run APM
+            subject:    Elastic APM Overview
             asciidoctor: true
             sources:
               -
@@ -921,8 +921,8 @@ contents:
             current:    7.0
             branches:   [ master, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
+            tags:       APM Server/APM Reference/Elastic APM
+            subject:    Elastic APM Server Reference
             sources:
               -
                 repo:   apm-server
@@ -944,8 +944,8 @@ contents:
                 current:    2.x
                 branches:   [ master, 2.x, 1.x, 0.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Node.js Agent/Reference
-                subject:    APM
+                tags:       APM Node.js Agent/APM Node agent reference
+                subject:    Elastic APM Node.js Agent
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -958,8 +958,8 @@ contents:
                 current:    4.x
                 branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Python Agent/Reference
-                subject:    APM
+                tags:       APM Python Agent/Elastic APM python agent reference
+                subject:    Elastic APM Python Agent
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -972,8 +972,8 @@ contents:
                 current:    2.x
                 branches:   [ master, 2.x, 1.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Ruby Agent/Reference
-                subject:    APM
+                tags:       APM Ruby Agent/Elastic APM Ruby agent reference
+                subject:    Elastic APM Ruby Agent
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -986,8 +986,8 @@ contents:
                 current:    4.x
                 branches:   [ master, 4.x, 3.x, 2.x, 1.x, 0.x ]
                 index:      docs/index.asciidoc
-                tags:       APM Real User Monitoring JavaScript Agent/Reference
-                subject:    APM
+                tags:       APM Real User Monitoring JavaScript Agent/Elastic RUM agent/Elastic JS agent
+                subject:    Elastic APM RUM JavaScript Agent 
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -1000,8 +1000,8 @@ contents:
                 current:    1.x
                 branches:   [ master, 1.x, 0.5 ]
                 index:      docs/index.asciidoc
-                tags:       APM Go Agent/Reference
-                subject:    APM
+                tags:       APM Go Agent/Elastic APM Go agent reference
+                subject:    Elastic APM Go Agent
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -1014,8 +1014,8 @@ contents:
                 current:    1.x
                 branches:   [ master, 1.x, 0.7, 0.6 ]
                 index:      docs/index.asciidoc
-                tags:       APM Java Agent/Reference
-                subject:    APM
+                tags:       APM Java Agent/Elastic APM Java agent reference
+                subject:    Elastic APM Java Agent
                 chunk:      1
                 asciidoctor: true
                 sources:
@@ -1028,8 +1028,8 @@ contents:
                 current:    master
                 branches:   [ master ]
                 index:      docs/index.asciidoc
-                tags:       APM .NET Agent/Reference
-                subject:    APM
+                tags:       APM .NET Agent/Elastic APM net agent reference
+                subject:    Elastic APM .NET Agent
                 chunk:      1
                 asciidoctor: true
                 sources:


### PR DESCRIPTION
I've just learned that some of the fields in `conf.yaml` control _some_ of the meta tags for our documentation. I'm not an SEO expert. I have no idea how important this is, but we might as well update these to something/anything better.

Unfortunately, it looks like the meta description is shared by all documentation. It does not mention APM, Observability, or other newer products: https://github.com/elastic/docs/blob/fd91e0e31650751f787a61e84617cb2d30a6b97e/resources/website-l10n.xsl#L54

`conf.yaml`-`tags` --> `DC.type`
`conf.yaml`-`subject` --> `DC.subject`
`conf.yaml`-`version` --> `DC.identifier`
<img width="432" alt="Screen Shot 2019-04-23 at 10 39 52 AM" src="https://user-images.githubusercontent.com/5618806/56603309-5c62ac80-65b4-11e9-840d-6879297f6439.png">
