### PR TITLE
Rollback to 6.0 branch for elasticsearch-php

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,7 +70,7 @@ contents:
                 exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   elasticsearch
-                path:   docs/     
+                path:   docs/
               -
                 repo:   elasticsearch-hadoop
                 path:   docs/src/reference/asciidoc
@@ -119,7 +119,7 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
-            asciidoctor: true            
+            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -169,11 +169,11 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Google
             subject:    Elastic Stack
-            asciidoctor: true            
+            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
-                path:   docs/en/gke-on-prem               
+                path:   docs/en/gke-on-prem
     -
         title:      Elasticsearch: Store, Search, and Analyze
         sections:
@@ -388,8 +388,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    6.5.x
-                branches:   [ master, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
+                current:    6.0
+                branches:   [ master, 6.0, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients


### PR DESCRIPTION
This PR rollback the 6.0 branch for `elasticsearch-php`. I decided to continue to use the 6.0 name for consistency with the past. Sorry for these changes :(
