### PR TITLE
Switch "deploying with ARM" to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -156,6 +156,7 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template
+            asciidoctor: true
             sources:
               -
                 repo:   azure-marketplace

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -55,7 +55,7 @@ alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-do
 alias docbldso='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
 # Deploying Azure
-alias docbldaz='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
+alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Switches the "deploying elasticsearch azure" docs from the unmaintained
AsciiDoc project to the actively maintained Asciidoctor project.
