### PR TITLE
Update Curator docs to 5.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -474,8 +474,8 @@ contents:
           -
             title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
-            current:    5.6
-            branches:   [ 5.x, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
+            current:    5.7
+            branches:   [ 5.x, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
             subject:    Clients


### PR DESCRIPTION
Adds the 5.7 branch and updates the current version to resolve a bad link in the 5.x Curator docs.

