### PR TITLE
Switch legacy shield docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1310,6 +1310,7 @@ contents:
             index:      docs/public/shield/index.asciidoc
             private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
Switches the legacy shield docs from the unmaintained AsciiDoc project
to the actively maintained Asciidoctor project.
