### PR TITLE
Switch legacy marvel docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1296,6 +1296,7 @@ contents:
             index:      docs/public/marvel/index.asciidoc
             private:    1
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
Switches the legacy marvel docs from the unmaintained AsciiDoc project
to the actively maintained Asciidoctor project.
