### PR TITLE
Switch build aliases script to use build_docs

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -12,31 +12,31 @@
 
 
 # Elasticsearch
-alias docbldesx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
 
 alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
-alias docbldkbx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
+alias docbldkbx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
 
 alias docbldkb=docbldkbx
 
 # Kibana 6.2 and earlier
 
-alias docbldkbold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
+alias docbldkbold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldlsx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
+alias docbldlsx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
 
 alias docbldls=docbldlsx
 
 # Logstash 6.2 and earlier
 
-alias docbldlsold='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
+alias docbldlsold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Installation and Upgrade Guide 7.0 and later
 alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --chunk 1'
@@ -63,36 +63,36 @@ alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-d
 alias docbldcr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
 # Cloud
-alias docbldec='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
-alias docbldece='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
 # Beats
-alias docbldbpr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'
+alias docbldbpr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldbdg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/docs/devguide/index.asciidoc --chunk 1'
+alias docbldbdg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/docs/devguide/index.asciidoc --chunk 1'
 
-alias docbldpb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/packetbeat/docs/index.asciidoc --chunk 1'
+alias docbldpb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/packetbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldfb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --chunk 1'
+alias docbldfb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --chunk 1'
 
-alias docbldwb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/winlogbeat/docs/index.asciidoc --chunk 1'
+alias docbldwb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/winlogbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldmb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/metricbeat/docs/index.asciidoc --chunk 1'
+alias docbldmb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/metricbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldhb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
+alias docbldhb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldab='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
-alias docbldabx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
+alias docbldab='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
+alias docbldabx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
 
-alias docbldfnb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/x-pack/functionbeat/docs/index.asciidoc --chunk 1'
+alias docbldfnb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/x-pack/functionbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldjb='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
+alias docbldjb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 
-alias docbldamr='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
+alias docbldamr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
 
 alias docbldamn='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1'
 
@@ -110,7 +110,7 @@ alias docbldamnet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-a
 
 
 # Definitive Guide
-alias docblddg='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/elasticsearch-definitive-guide/book.asciidoc --chunk 1'
+alias docblddg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-definitive-guide/book.asciidoc --chunk 1'
 
 
 # Elasticsearch Extras
@@ -146,7 +146,7 @@ alias docbldesh='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 # X-Pack Reference 5.4 to 6.2
 
-alias docbldx='$GIT_HOME/docs/build_docs.pl --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
+alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
 
 # ECS
 alias docbldecs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
There are many of us who use the build aliases script, but many of the aliases still seem to be using the about-to-be-deprecated `build_docs.pl` build script rather than the newfangled and preferred `build_docs`. This PR fixes that. Tested to work with the ESS and ECE docs.

@nik9000 and @lcawl I assume we want this change, unless the build aliases script is also about to be deprecated?

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->