### PR TITLE
Allow building docs with an Elastic clone

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -171,14 +171,19 @@ sub _guess_edit_url {
 
     local $ENV{GIT_DIR} = dir($toplevel)->subdir('.git');
     my $remotes = eval { run qw(git remote -v) } || '';
-    if ($remotes !~ m|\s+(\S+[/:]elastic(?:search-cn)?/\S+)|) {
-        # We need either an elastic or elasticsearch-cn organization. All
+    my $remote;
+    if ($remotes =~ m|\s+(\S+[/:]elastic(?:search-cn)?/\S+)|) {
+        $remote = $1;
+        # We prefer either an elastic or elasticsearch-cn organization. All
         # but two books are in elastic but elasticsearch-cn is special.
-        say "Couldn't find edit url because there isn't an Elastic clone";
-        say "$remotes";
-        return;
+    } else {
+        say "Couldn't find edit url because there isn't an Elastic remote";
+        if ($remotes =~ m|\s+(\S+[/:]\S+/\S+)|) {
+            $remote = $1;
+        } else {
+            $remote = 'unknown';
+        }
     }
-    my $remote = $1;
     my $branch = eval {run qw(git rev-parse --abbrev-ref HEAD) } || 'master';
     return ES::Repo::edit_url_for_url_and_branch($remote, $branch);
 }

--- a/integtest/spec/helper/repo.rb
+++ b/integtest/spec/helper/repo.rb
@@ -11,9 +11,15 @@ class Repo
 
   attr_reader :name, :root
 
+  ##
+  # Set to false to prevent adding an Elastic clone when the repo
+  # is initialized
+  attr_accessor :add_elastic_remote
+
   def initialize(name, root)
     @name = name
     @root = root
+    @add_elastic_remote = true
   end
 
   ##
@@ -49,8 +55,10 @@ class Repo
       sh 'git init'
       sh 'git add .'
       sh "git commit -m 'init'"
-      # Add an Elastic remote so we get a nice edit url
-      sh 'git remote add elastic git@github.com:elastic/docs.git'
+      if @add_elastic_remote
+        # Add an Elastic remote so we get a nice edit url
+        sh 'git remote add elastic git@github.com:elastic/docs.git'
+      end
     end
   end
 end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe 'building a single book' do
     end
   end
 
+  context "when there isn't an elastic remote" do
+    convert_single_before_context do |src|
+      src.add_elastic_remote = false
+      src.write 'index.asciidoc', <<~ASCIIDOC
+        #{HEADER}
+        This is a minimal viable asciidoc file for use with build_docs. The
+        actual contents of this paragraph aren't important but having a
+        paragraph here is required.
+      ASCIIDOC
+    end
+
+    page_context 'chapter.html' do
+      it 'has an "unknown" edit url' do
+        expect(body).to include(<<~HTML.strip)
+          <a href="unknown/edit/master/index.asciidoc" class="edit_me"
+        HTML
+      end
+    end
+  end
+
   context 'when one file includes another' do
     convert_single_before_context do |src|
       src.write 'included.asciidoc', 'I am tiny.'


### PR DESCRIPTION
When you build docs with `--doc` we attempt to figure out the "edit me"
url. If we can't find an "elastic" clone we would log a warning and move
on. The trouble is that this warning upsets the docs build unless you
pass `--lenient`. This change fixes the problem by instead using the
first remote that it finds if it can't find the Elastic remote. And if
it can't find *any* remotes then it uses `unknown` as the remote. This
prevents the warning.

Closes #845
