### PR TITLE
Enable line length cop

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -23,9 +23,6 @@ Metrics/BlockNesting:
 Metrics/CyclomaticComplexity:
   Enabled: false
 
-Metrics/LineLength:
-  Enabled: false
-
 Metrics/MethodLength:
   Enabled: false
 

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -79,7 +79,8 @@ module CopyImages
     # using this code but I feel like that'd be slower. For now, we'll stick
     # with this.
     def process_inline_image_from_converted(block)
-      return unless block.context == :list_item && block.parent.context == :olist
+      return unless block.context == :list_item &&
+                    block.parent.context == :olist
 
       block.text.scan(DOCBOOK_IMAGE_RX) do |(target)|
         # We have to resolve attributes inside the target. But there is a

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -5,7 +5,8 @@ require_relative 'copier.rb'
 
 module CopyImages
   ##
-  # Copies images that are referenced into the same directory as the output files.
+  # Copies images that are referenced into the same directory as the
+  # output files.
   #
   # It finds the images by looking in a comma separated list of directories
   # defined by the `resources` attribute.
@@ -84,7 +85,8 @@ module CopyImages
       return unless coids
 
       coids.scan(CALLOUT_RX) do |(index)|
-        @copier.copy_image block, "images/icons/callouts/#{index}.#{callout_extension}"
+        @copier.copy_image block,
+          "images/icons/callouts/#{index}.#{callout_extension}"
       end
     end
 
@@ -103,7 +105,8 @@ module CopyImages
       style = block.attr 'style'
       return unless style
 
-      @copier.copy_image block, "images/icons/#{style.downcase}.#{admonition_extension}"
+      @copier.copy_image block,
+        "images/icons/#{style.downcase}.#{admonition_extension}"
     end
 
     def process_change_admonition(admonition_extension, block)
@@ -112,7 +115,8 @@ module CopyImages
 
       admonition_image = ADMONITION_IMAGE_FOR_REVISION_FLAG[revisionflag]
       if admonition_image
-        @copier.copy_image block, "images/icons/#{admonition_image}.#{admonition_extension}"
+        @copier.copy_image block,
+          "images/icons/#{admonition_image}.#{admonition_extension}"
       else
         logger.warn message_with_context "unknow revisionflag #{revisionflag}",
           source_location: block.source_location

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -51,27 +51,27 @@ require 'asciidoctor/extensions'
 # Turns
 #   ["source","sh",subs="attributes"]
 #   --------------------------------------------
-#   wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip
-#   wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip.sha512
+#   wget https://artifacts.elastic.co//elasticsearch-{version}.zip
+#   wget https://artifacts.elastic.co//elasticsearch-{version}.zip.sha512
 #   shasum -a 512 -c elasticsearch-{version}.zip.sha512 <1>
 #   unzip elasticsearch-{version}.zip
 #   cd elasticsearch-{version}/ <2>
 #   --------------------------------------------
-#   <1> Compares the SHA of the downloaded `.zip` archive and the published checksum, which should output
-#       `elasticsearch-{version}.zip: OK`.
+#   <1> Compares the SHA of the downloaded `.zip` archive and the published
+#       checksum, which should output `elasticsearch-{version}.zip: OK`.
 #   <2> This directory is known as `$ES_HOME`.
 #
 # Into
 #   ["source","sh",subs="attributes,callouts"]
 #   --------------------------------------------
-#   wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip
-#   wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{version}.zip.sha512
+#   wget https://artifacts.elastic.co/elasticsearch-{version}.zip
+#   wget https://artifacts.elastic.co/elasticsearch-{version}.zip.sha512
 #   shasum -a 512 -c elasticsearch-{version}.zip.sha512 <1>
 #   unzip elasticsearch-{version}.zip
 #   cd elasticsearch-{version}/ <2>
 #   --------------------------------------------
-#   <1> Compares the SHA of the downloaded `.zip` archive and the published checksum, which should output
-#       `elasticsearch-{version}.zip: OK`.
+#   <1> Compares the SHA of the downloaded `.zip` archive and the published
+#       checksum, which should output `elasticsearch-{version}.zip: OK`.
 #   <2> This directory is known as `$ES_HOME`.
 # Because asciidoc adds callouts to all "source" blocks. We'd *prefer* to do
 # this in the tree processor because it is less messy but we can't because
@@ -110,8 +110,10 @@ require 'asciidoctor/extensions'
 class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
   include Asciidoctor::Logging
 
-  INCLUDE_TAGGED_DIRECTIVE_RX = /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/
-  SOURCE_WITH_SUBS_RX = /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
+  INCLUDE_TAGGED_DIRECTIVE_RX =
+    /^include-tagged::([^\[][^\[]*)\[(#{Asciidoctor::CC_ANY}+)?\]$/
+  SOURCE_WITH_SUBS_RX =
+    /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
   CODE_BLOCK_RX = /^-----*$/
   SNIPPET_RX = %r{^//\s*(AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)$}
   LEGACY_MACROS = 'added|beta|coming|deprecated|experimental'
@@ -159,7 +161,9 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
           # Asciidoctor does not and we have thousands of blocks that rely on
           # this behavior.
           old_subs = m[1]
-          line.sub! "subs=\"#{old_subs}\"", "subs=\"#{old_subs},callouts\"" unless old_subs.include? 'callouts'
+          unless old_subs.include? 'callouts'
+            line.sub! "subs=\"#{old_subs}\"", "subs=\"#{old_subs},callouts\""
+          end
         end
         if CODE_BLOCK_RX =~ line
           if @code_block_start

--- a/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
+++ b/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
@@ -103,21 +103,6 @@ class ElasticIncludeTagged < Asciidoctor::Extensions::IncludeProcessor
         @start_of_include = lineno
       end
     end
-<<<<<<< HEAD
-    if start_of_include.nil?
-      warn reader.cursor, "missing start tag [#{tag}]"
-      return path
-    end
-    if found_end == false
-      cursor = Asciidoctor::Reader::Cursor.new(
-        path, relpath, relpath, start_of_include
-      )
-      warn cursor, "missing end tag [#{tag}]"
-    end
-    reader.push_include included_lines, path, relpath, start_of_include, attrs
-  end
-=======
->>>>>>> master
 
     def warn(message, cursor = @reader.cursor)
       logger.warn message_with_context message, source_location: cursor

--- a/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
+++ b/resources/asciidoctor/lib/elastic_include_tagged/extension.rb
@@ -8,7 +8,7 @@ require 'asciidoctor/extensions'
 #
 # Usage
 #
-#   include:elastic-include-tagged:{doc-tests}/RestClientDocumentation.java[rest-client-init]
+#   include:elastic-include-tagged:{doc-tests}/Foo.java[tag]
 #
 class ElasticIncludeTagged < Asciidoctor::Extensions::IncludeProcessor
   include Asciidoctor::Logging
@@ -28,7 +28,8 @@ class ElasticIncludeTagged < Asciidoctor::Extensions::IncludeProcessor
     start_match = /^(\s*).+tag::#{tag}\b/
     end_match = /end::#{tag}\b/
 
-    path, target_type, relpath = reader.resolve_include_path target, attrs, attrs
+    path, target_type, relpath =
+      reader.resolve_include_path target, attrs, attrs
     # resolve_include_path returns a nil target_type if it can't find the file
     # and it logs a nice error for us
     return path unless target_type
@@ -70,8 +71,10 @@ class ElasticIncludeTagged < Asciidoctor::Extensions::IncludeProcessor
       return path
     end
     if found_end == false
-      warn Asciidoctor::Reader::Cursor.new(path, relpath, relpath, start_of_include),
-          "missing end tag [#{tag}]"
+      cursor = Asciidoctor::Reader::Cursor.new(
+        path, relpath, relpath, start_of_include
+      )
+      warn cursor, "missing end tag [#{tag}]"
     end
     reader.push_include included_lines, path, relpath, start_of_include, attrs
   end

--- a/resources/asciidoctor/lib/scaffold.rb
+++ b/resources/asciidoctor/lib/scaffold.rb
@@ -7,7 +7,8 @@ require 'asciidoctor/extensions'
 #
 class TreeProcessorScaffold < Asciidoctor::Extensions::TreeProcessor
   def process_block(_document)
-    raise ::NotImplementedError, %(TreeProcessorScaffold subclass must implement ##{__method__} method)
+    raise ::NotImplementedError,
+      %(TreeProcessorScaffold subclass must implement ##{__method__} method)
   end
 
   def process(document)
@@ -17,11 +18,12 @@ class TreeProcessorScaffold < Asciidoctor::Extensions::TreeProcessor
 
   def process_blocks(block)
     process_block block
-    (block.context == :dlist ? block.blocks.flatten : block.blocks).each do |subblock|
+    sub_blocks = block.context == :dlist ? block.blocks.flatten : block.blocks
+    sub_blocks.each do |sub_block|
       # subblock can be nil for definition lists without a definition.
       # this is weird, but it is safe to skip nil here because subclasses
       # can't change it anyway.
-      process_blocks subblock if subblock
+      process_blocks sub_block if sub_block
     end
   end
 end

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe CopyImages do
     end
     let(:include_line) { 2 }
     ##
-    # Asserts that some `input` causes just the `example1.png` image to be copied.
+    # Asserts that some `input` causes just the `example1.png` image to
+    # be copied.
     shared_examples 'copies example1' do
       include_context 'convert intercepting images'
       it 'copies the image' do
@@ -376,10 +377,10 @@ RSpec.describe CopyImages do
       let(:expected_warnings) do
         %r{
           WARN:\ <stdin>:\ line\ 7:\ can't\ read\ image\ at\ any\ of\ \[
-          "#{spec_dir}/images/icons/callouts/3.#{copy_callout_images}",\s
-          "#{spec_dir}/resources/images/icons/callouts/3.#{copy_callout_images}",\s
+          "#{spec_dir}/#{relative_path}/3.#{copy_callout_images}",\s
+          "#{spec_dir}/resources/#{relative_path}/3.#{copy_callout_images}",\s
           .+
-          "#{spec_dir}/resources/copy_images/images/icons/callouts/3.#{copy_callout_images}"
+          "#{absolute_path}/3.#{copy_callout_images}"
           .+
         \]}x
         # Comment to fix syntax highlighting bug in VSCode....'
@@ -414,6 +415,7 @@ RSpec.describe CopyImages do
   end
 
   it "only copies callout images one time" do
+    relative_path = 'images/icons/callouts'
     copied = []
     attributes = copy_attributes copied
     attributes['copy-callout-images'] = 'png'
@@ -430,15 +432,16 @@ RSpec.describe CopyImages do
       <1> words
     ASCIIDOC
     expected_warnings = <<~WARNINGS
-      INFO: <stdin>: line 5: copying #{spec_dir}/resources/copy_images/images/icons/callouts/1.png
+      INFO: <stdin>: line 5: copying #{resources_dir}/#{relative_path}/1.png
     WARNINGS
     convert input, attributes, eq(expected_warnings.strip)
     expect(copied).to eq([
-        ["images/icons/callouts/1.png", "#{spec_dir}/resources/copy_images/images/icons/callouts/1.png"],
+        ["#{relative_path}/1.png", "#{resources_dir}/#{relative_path}/1.png"],
     ])
   end
 
   it "supports callout lists with multiple callouts per item" do
+    relative_path = 'images/icons/callouts'
     # This is a *super* weird case but we have it in Elasticsearch.
     # The only way I can make callout lists be for two things is by making
     # blocks with callouts but only having a single callout list below both.
@@ -457,17 +460,18 @@ RSpec.describe CopyImages do
       <1> words
     ASCIIDOC
     expected_warnings = <<~WARNINGS
-      INFO: <stdin>: line 9: copying #{spec_dir}/resources/copy_images/images/icons/callouts/1.png
-      INFO: <stdin>: line 9: copying #{spec_dir}/resources/copy_images/images/icons/callouts/2.png
+      INFO: <stdin>: line 9: copying #{resources_dir}/#{relative_path}/1.png
+      INFO: <stdin>: line 9: copying #{resources_dir}/#{relative_path}/2.png
     WARNINGS
     convert input, attributes, eq(expected_warnings.strip)
     expect(copied).to eq([
-        ["images/icons/callouts/1.png", "#{spec_dir}/resources/copy_images/images/icons/callouts/1.png"],
-        ["images/icons/callouts/2.png", "#{spec_dir}/resources/copy_images/images/icons/callouts/2.png"],
+        ["#{relative_path}/1.png", "#{resources_dir}/#{relative_path}/1.png"],
+        ["#{relative_path}/2.png", "#{resources_dir}/#{relative_path}/2.png"],
     ])
   end
 
   it "doesn't blow up when the callout can't be found" do
+    relative_path = 'images/icons/callouts'
     copied = []
     attributes = copy_attributes copied
     attributes['copy-callout-images'] = 'png'
@@ -481,35 +485,40 @@ RSpec.describe CopyImages do
     ASCIIDOC
     expected_warnings = <<~WARNINGS
       WARN: <stdin>: line 6: no callout found for <2>
-      INFO: <stdin>: line 5: copying #{spec_dir}/resources/copy_images/images/icons/callouts/1.png
+      INFO: <stdin>: line 5: copying #{resources_dir}/#{relative_path}/1.png
     WARNINGS
     convert input, attributes, eq(expected_warnings.strip)
     expect(copied).to eq([
-        ["images/icons/callouts/1.png", "#{spec_dir}/resources/copy_images/images/icons/callouts/1.png"],
+        ["#{relative_path}/1.png", "#{resources_dir}/#{relative_path}/1.png"],
     ])
   end
 
   %w[note tip important caution warning].each do |(name)|
     it "copies images for the #{name} admonition when requested" do
       copied = []
+      relative_path = 'images/icons'
+      absolute_path = "#{resources_dir}/#{relative_path}"
       attributes = copy_attributes copied
       attributes['copy-admonition-images'] = 'png'
       input = <<~ASCIIDOC
         #{name.upcase}: Words words words.
       ASCIIDOC
       expected_warnings = <<~WARNINGS
-        INFO: <stdin>: line 1: copying #{spec_dir}/resources/copy_images/images/icons/#{name}.png
+        INFO: <stdin>: line 1: copying #{absolute_path}/#{name}.png
       WARNINGS
       convert input, attributes, eq(expected_warnings.strip)
       expect(copied).to eq([
-          ["images/icons/#{name}.png", "#{spec_dir}/resources/copy_images/images/icons/#{name}.png"],
+        ["#{relative_path}/#{name}.png", "#{absolute_path}/#{name}.png"],
       ])
     end
   end
 
   %w[beta experimental].each do |(name)|
-    it "copies images for the block formatted #{name} care admonition when requested" do
+    it "copies images for the block formatted #{name} care admonition " \
+        "when requested" do
       copied = []
+      relative_path = 'images/icons'
+      absolute_path = "#{resources_dir}/#{relative_path}"
       attributes = copy_attributes copied
       attributes['copy-admonition-images'] = 'png'
       input = <<~ASCIIDOC
@@ -518,11 +527,11 @@ RSpec.describe CopyImages do
       # We can't get the location of the blocks because asciidoctor doesn't
       # make it available to us here!
       expected_warnings = <<~WARNINGS
-        INFO: <stdin>: line 1: copying #{spec_dir}/resources/copy_images/images/icons/warning.png
+        INFO: <stdin>: line 1: copying #{absolute_path}/warning.png
       WARNINGS
       convert input, attributes, eq(expected_warnings.strip)
       expect(copied).to eq([
-          ["images/icons/warning.png", "#{spec_dir}/resources/copy_images/images/icons/warning.png"],
+        ["#{relative_path}/warning.png", "#{absolute_path}/warning.png"],
       ])
     end
   end
@@ -532,8 +541,11 @@ RSpec.describe CopyImages do
       %w[coming note],
       %w[deprecated warning],
   ].each do |(name, admonition)|
-    it "copies images for the block formatted #{name} change admonition when requested" do
+    it "copies images for the block formatted #{name} change admonition" \
+        " when requested" do
       copied = []
+      relative_path = 'images/icons'
+      absolute_path = "#{resources_dir}/#{relative_path}"
       attributes = copy_attributes copied
       attributes['copy-admonition-images'] = 'png'
       input = <<~ASCIIDOC
@@ -542,28 +554,32 @@ RSpec.describe CopyImages do
       # We can't get the location of the blocks because asciidoctor doesn't
       # make it available to us here!
       expected_warnings = <<~WARNINGS
-        INFO: copying #{spec_dir}/resources/copy_images/images/icons/#{admonition}.png
+        INFO: copying #{absolute_path}/#{admonition}.png
       WARNINGS
       convert input, attributes, eq(expected_warnings.strip)
       expect(copied).to eq([
-          ["images/icons/#{admonition}.png", "#{spec_dir}/resources/copy_images/images/icons/#{admonition}.png"],
+        ["#{relative_path}/#{admonition}.png",
+         "#{absolute_path}/#{admonition}.png"],
       ])
     end
   end
 
-  it "copies images for admonitions when requested with a different file extension" do
+  it "copies images for admonitions when requested with a different " \
+      "file extension" do
     copied = []
+    relative_path = 'images/icons'
+    absolute_path = "#{resources_dir}/#{relative_path}"
     attributes = copy_attributes copied
     attributes['copy-admonition-images'] = 'gif'
     input = <<~ASCIIDOC
       NOTE: Words words words.
     ASCIIDOC
     expected_warnings = <<~WARNINGS
-      INFO: <stdin>: line 1: copying #{spec_dir}/resources/copy_images/images/icons/note.gif
+      INFO: <stdin>: line 1: copying #{absolute_path}/note.gif
     WARNINGS
     convert input, attributes, eq(expected_warnings.strip)
     expect(copied).to eq([
-        ["images/icons/note.gif", "#{spec_dir}/resources/copy_images/images/icons/note.gif"],
+      ["#{relative_path}/note.gif", "#{absolute_path}/note.gif"],
     ])
   end
 

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -82,8 +82,9 @@ RSpec.describe EditMe do
       end
     end
 
-    shared_examples 'standard document part' \
-        do |type, title_start = '<title>', title_end = '</title>'|
+    shared_examples 'standard document part' do |type, title_start, title_end|
+      title_start ||= '<title>'
+      title_end ||= '</title>'
       context "for a document with #{type}s" do
         let(:input) do
           <<~ASCIIDOC
@@ -117,8 +118,9 @@ RSpec.describe EditMe do
       end
     end
 
-    shared_examples 'standard document part' \
-        do |type, title_start = '<title>', title_end = '</title>'|
+    shared_examples 'standard document part' do |type, title_start, title_end|
+      title_start ||= '<title>'
+      title_end ||= '</title>'
       context "for a document with #{type}s" do
         let(:input) do
           <<~ASCIIDOC

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -55,7 +55,8 @@ RSpec.describe EditMe do
     include_examples 'standard document part', 'bibliography'
     include_examples 'standard document part', 'dedication'
     include_examples 'standard document part', 'colophon'
-    include_examples 'standard document part', 'float', %(renderas="sect2">), %(</bridgehead>)
+    include_examples 'standard document part', 'float',
+                     %(renderas="sect2">), %(</bridgehead>)
   end
 
   context 'when edit_urls is configured' do
@@ -81,7 +82,8 @@ RSpec.describe EditMe do
       end
     end
 
-    shared_examples 'standard document part' do |type, title_start = '<title>', title_end = '</title>'|
+    shared_examples 'standard document part' \
+        do |type, title_start = '<title>', title_end = '</title>'|
       context "for a document with #{type}s" do
         let(:input) do
           <<~ASCIIDOC
@@ -115,7 +117,8 @@ RSpec.describe EditMe do
       end
     end
 
-    shared_examples 'standard document part' do |type, title_start = '<title>', title_end = '</title>'|
+    shared_examples 'standard document part' \
+        do |type, title_start = '<title>', title_end = '</title>'|
       context "for a document with #{type}s" do
         let(:input) do
           <<~ASCIIDOC

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -245,31 +245,21 @@ RSpec.describe ElasticCompatPreprocessor do
     expect(actual).to eq(expected.strip)
   end
 
-  it "attribute only blocks don't pick up blocks with attributes and other stuff" do
-    actual = convert <<~ASCIIDOC
-      == Header
+  context 'when a block contains things other than attributes' do
+    include_context 'convert without logs'
+    let(:input) do
+      <<~ASCIIDOC
+        --
+        :attr: test
+        added::[some_version]
+        --
 
-      --
-      :attr: test
-      added[some_version]
-      --
-
-      [id="{attr}"]
-      == Header
-    ASCIIDOC
-    expected = <<~DOCBOOK
-      <chapter id="_header">
-      <title>Header</title>
-      <note revisionflag="added" revision="some_version">
-      <simpara></simpara>
-      </note>
-      </chapter>
-      <chapter id="test">
-      <title>Header</title>
-
-      </chapter>
-    DOCBOOK
-    expect(actual).to eq(expected.strip)
+        {attr}
+      ASCIIDOC
+    end
+    it "doesn't remove the block" do
+      expect(converted).to include('<simpara>{attr}</simpara>')
+    end
   end
 
   it "adds callouts to substitutions for source blocks if there aren't any" do
@@ -349,7 +339,9 @@ RSpec.describe ElasticCompatPreprocessor do
       <screen>foo</screen>
       </chapter>
     DOCBOOK
-    actual = convert input, {}, match(/WARN: <stdin>: line 4: MIGRATION: code block end doesn't match start/)
+    actual = convert input, {}, match(
+      /WARN: <stdin>: line 4: MIGRATION: code block end doesn't match start/
+    )
     expect(actual).to eq(expected.strip)
   end
 

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -258,6 +258,8 @@ RSpec.describe ElasticCompatPreprocessor do
       ASCIIDOC
     end
     it "doesn't remove the block" do
+      # The point here is that the attribute setting *doesn't* apply to the
+      # text because we haven't doctored the block.
       expect(converted).to include('<simpara>{attr}</simpara>')
     end
   end

--- a/resources/asciidoctor/spec/open_in_widget_spec.rb
+++ b/resources/asciidoctor/spec/open_in_widget_spec.rb
@@ -125,6 +125,8 @@ RSpec.describe OpenInWidget do
     # TODO: finish converting this to standard rspec
     context "when the document contains an override snippet in #{lang}" do
       include_context 'convert intercepting copies'
+      let(:relative_path) { "snippets/snippet.#{lang}" }
+      let(:absolue_path) { "#{spec_dir}/#{relative_path}" }
       let(:input) do
         <<~ASCIIDOC
           == Example
@@ -136,18 +138,18 @@ RSpec.describe OpenInWidget do
       end
       it 'includes a link to the overridden path' do
         expect(converted).to include(
-          %(<ulink type="snippet" url="snippets/snippet.#{lang}"/>)
+          %(<ulink type="snippet" url="#{relative_path}"/>)
         )
       end
       it 'logs that it copies the snippet' do
         expect(logs).to include(
-          "INFO: <stdin>: line 3: copying snippet #{spec_dir}/snippets/snippet.#{lang}"
+          "INFO: <stdin>: line 3: copying snippet #{absolue_path}"
         )
       end
       it 'logs a warning about how bad of an idea this is' do
-        expect(logs).to include(
-          "WARN: <stdin>: line 3: MIGRATION: reading snippets from a path makes the book harder to read"
-        )
+        expect(logs).to include(<<~LOG.strip)
+          WARN: <stdin>: line 3: MIGRATION: reading snippets from a path makes the book harder to read
+        LOG
       end
       it 'copies the file' do
         expect(copied).to eq([
@@ -166,9 +168,9 @@ RSpec.describe OpenInWidget do
           ASCIIDOC
         end
         it 'does not log a warning about how bad an idea this is' do
-          expect(logs).not_to include(
-            "MIGRATION: reading snippets from a path makes the book harder to read"
-          )
+          expect(logs).not_to include(<<~LOG.strip)
+            MIGRATION: reading snippets from a path makes the book harder to read
+          LOG
         end
       end
     end

--- a/resources/asciidoctor/spec/open_in_widget_spec.rb
+++ b/resources/asciidoctor/spec/open_in_widget_spec.rb
@@ -47,7 +47,8 @@ RSpec.describe OpenInWidget do
       ])
     end
 
-    it "supports automatic snippet extraction for many snippets with #{lang} language" do
+    it "supports automatic snippet extraction for many snippets " \
+        "with #{lang} language" do
       input = <<~ASCIIDOC
         == Example
         [source,#{lang}]


### PR DESCRIPTION
Enables the line length cop on the asciidoctor customizations. I'd
entended to do this slowly while reworking other things but not having
this enabled has started getting in the way.
