### PR TITLE
Enable rubocop cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ vendor
 
 # Comes from running rspec tests
 .rspec_status
+
+# Comes from running rubocop
+.rubocop_cache

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,8 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.3
+  CacheRootDirectory: .rubocop_cache
+  MaxFilesInCache: 1000
 
 Style/ReturnNil:
   Enabled: true

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -31,7 +31,7 @@ pycodestyle: html_diff
 
 .PHONY: rubocop
 rubocop:
-	rubocop --cache false
+	rubocop
 
 .PHONY: rspec
 rspec:

--- a/resources/asciidoctor/Makefile
+++ b/resources/asciidoctor/Makefile
@@ -13,4 +13,4 @@ rspec:
 
 .PHONY: robucop
 rubocop:
-	rubocop --cache false
+	rubocop


### PR DESCRIPTION
Locally this saves a few second on every build and is super simple to
turn on. It does nothing for CI.
