### PR TITLE
Tests: Drop redundant returns

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -37,6 +37,3 @@ Style/NestedParenthesizedCalls:
 
 Style/StringLiterals:
   Enabled: false
-
-Style/RedundantReturn:
-  Enabled: false

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CopyImages do
   end
 
   def copy_attributes(copied)
-    return {
+    {
       'copy_image' => proc { |uri, source|
         copied << [uri, source]
       },

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -395,14 +395,14 @@ RSpec.describe ElasticCompatPreprocessor do
     expect(actual).to eq(expected.strip)
   end
 
-  def stub_file_opts
-    return {
-      'copy_snippet' => proc { |uri, source| },
-      'write_snippet' => proc { |uri, source| },
-    }
-  end
-
   shared_context 'general snippet' do |lang, override|
+    include_context 'convert with logs'
+    let(:convert_attributes) do
+      {
+        'copy_snippet' => proc { |uri, source| },
+        'write_snippet' => proc { |uri, source| },
+      }
+    end
     let(:snippet) do
       snippet = <<~ASCIIDOC
         [source,js]
@@ -425,9 +425,6 @@ RSpec.describe ElasticCompatPreprocessor do
   end
   shared_examples 'linked snippet' do |override, lang, path|
     let(:has_link_to_path) { %r{<ulink type="snippet" url="#{path}"/>} }
-    let(:converted) do
-      convert input, stub_file_opts, eq(expected_warnings.strip)
-    end
     shared_examples 'converted with override' do
       it "has the #{lang} language" do
         expect(converted).to match(has_lang)
@@ -478,9 +475,6 @@ RSpec.describe ElasticCompatPreprocessor do
   context 'for a snippet without an override' do
     include_context 'general snippet', 'js', nil
     let(:has_any_link) { /<ulink type="snippet"/ }
-    let(:converted) do
-      convert input, stub_file_opts
-    end
 
     it "has the js language" do
       expect(converted).to match(has_lang)

--- a/resources/asciidoctor/spec/open_in_widget_spec.rb
+++ b/resources/asciidoctor/spec/open_in_widget_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe OpenInWidget do
   spec_dir = File.dirname(__FILE__)
 
   def stub_file_opts(result)
-    return {
+    {
       'copy_snippet' => proc { |uri, source| result << [uri, source] },
       'write_snippet' => proc { |uri, snippet| result << [uri, snippet] },
     }


### PR DESCRIPTION
Enables and fixes the redundant return cop. In one case I was able to
remove the entire method.
