### PR TITLE
Drop template.md5 file

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -363,7 +363,7 @@ sub build_entries {
             temp_dir => $temp_dir,
             %$entry
         );
-        $toc->add_entry( $book->build( $Opts->{rebuild} , $Opts->{keep_hash} ) );
+        $toc->add_entry( $book->build( $Opts->{rebuild} ) );
     }
 
     return $toc;

--- a/fetch_template.sh
+++ b/fetch_template.sh
@@ -2,5 +2,7 @@
 
 # Fetch the production templates for the guide.
 # Run this from the root of the docs repo.
+# After running this you have to force a `--all --rebuild` to pick up the
+# new template.
 
 curl https://www.elastic.co/guide_template > resources/web/template.html

--- a/integtest/spec/helper/dsl/convert_single.rb
+++ b/integtest/spec/helper/dsl/convert_single.rb
@@ -29,9 +29,6 @@ module Dsl
       it 'prints the path to the html index' do
         expect(out).to include(dest_file('index.html'))
       end
-      it 'creates the template hash' do
-        expect(dest_file('template.md5')).to file_exist
-      end
       it 'creates the css' do
         expect(dest_file('styles.css')).to file_exist
       end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -154,7 +154,7 @@ sub new {
 #===================================
 sub build {
 #===================================
-    my ( $self, $rebuild, $keep_hash ) = @_;
+    my ( $self, $rebuild ) = @_;
 
     my $toc = ES::Toc->new( $self->title );
     my $dir = $self->dir;
@@ -174,7 +174,7 @@ sub build {
     my $rebuilding_any_branch = 0;
     my $rebuilding_current_branch = 0;
     for my $branch ( @{ $self->branches } ) {
-        my $building = $self->_build_book( $branch, $pm, $rebuild, $keep_hash, $latest );
+        my $building = $self->_build_book( $branch, $pm, $rebuild, $latest );
         $rebuilding_any_branch ||= $building;
         $latest = 0;
 
@@ -234,7 +234,7 @@ sub build {
 #===================================
 sub _build_book {
 #===================================
-    my ( $self, $branch, $pm, $rebuild, $keep_hash, $latest ) = @_;
+    my ( $self, $branch, $pm, $rebuild, $latest ) = @_;
 
     my $branch_dir    = $self->dir->subdir($branch);
     my $source        = $self->source;
@@ -244,23 +244,8 @@ sub _build_book {
     my $subject       = $self->subject;
     my $lang          = $self->lang;
 
-    unless ( $rebuild ) {
-        if ( $keep_hash ) {
-            # If we're preserving the hash for previously built books then we
-            # can't build new books so we should skip them.
-            return 0 unless -e $branch_dir;
-            # And we don't want to build books if the source hasn't changed.
-            return 0 unless $source->has_changed( $self->title, $branch, $self->asciidoctor );
-        } else {
-            # Otherwise we can *only* skip books if their destination directory
-            # exists, the template version is up to date, and the source hasn't
-            # changed.
-            return 0 if
-                   -e $branch_dir
-                && !$template->md5_changed($branch_dir)
-                && !$source->has_changed( $self->title, $branch, $self->asciidoctor );
-        }
-    }
+    return 0 unless $rebuild ||
+        $source->has_changed( $self->title, $branch, $self->asciidoctor );
 
     my ( $checkout, $edit_urls, $first_path ) = $source->prepare($self->title, $branch);
 

--- a/lib/ES/Template.pm
+++ b/lib/ES/Template.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 use v5.10;
 use Encode qw(encode_utf8);
-use Digest::MD5 qw(md5_hex);
 use Path::Class qw(file);
 use File::Copy::Recursive qw(fcopy);
 
@@ -62,8 +61,6 @@ sub apply {
     # Copy javascript
     fcopy( 'resources/web/docs.js', $dir )
         or die "Couldn't copy <docs.js> to <$dir>: $!";
-
-    $dir->file('template.md5')->spew( $self->{md5} );
 }
 
 my $Autosense_RE = qr{
@@ -105,15 +102,6 @@ sub _autosense_snippets {
         $counter++;
     }
     return $contents;
-}
-
-#===================================
-sub md5_changed {
-#===================================
-    my $self = shift;
-    my $dir  = shift;
-    my $file = $dir->file('template.md5');
-    return !eval { $file->slurp eq $self->{md5}; };
 }
 
 #===================================
@@ -196,7 +184,6 @@ sub _init {
 
     $self->{map}   = \%map;
     $self->{parts} = \@parts;
-    $self->{md5}   = md5_hex( join "", map { encode_utf8 $_} @parts );
     return $self;
 }
 


### PR DESCRIPTION
Now that we're not automatically fetching the template there isn't a
nead to store its md5 with every book. Instead we leave a note to users
that they'll have to manually force a rebuild after updating the
template. This saves us a few files which is nice but it allows us to
significantly simplify the code around up-to-date checking.
