### PR TITLE
Fix build when pointed at a worktree

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -133,13 +133,15 @@ sub _guess_opts_from_file {
 
     my %edit_urls = ();
     my $doc_toplevel = _find_toplevel($index->parent);
-    if ( $doc_toplevel ) {
-        $Opts->{root_dir} = $doc_toplevel;
-        my $edit_url = _guess_edit_url($doc_toplevel);
-        @edit_urls{ $doc_toplevel } = $edit_url if $edit_url;
-    } else {
+    unless ( $doc_toplevel ) {
         $Opts->{root_dir} = $index->parent;
+        # If we can't find the edit url for the document then we're never
+        # going to find it for anyone.
+        return;
     }
+    $Opts->{root_dir} = $doc_toplevel;
+    my $edit_url = _guess_edit_url($doc_toplevel);
+    @edit_urls{ $doc_toplevel } = $edit_url if $edit_url;
     for my $resource ( @{ $Opts->{resource} } ) {
         my $resource_toplevel = _find_toplevel($resource);
         next unless $resource_toplevel;

--- a/integtest/spec/helper/repo.rb
+++ b/integtest/spec/helper/repo.rb
@@ -72,4 +72,12 @@ class Repo
       end
     end
   end
+
+  ##
+  # Create a worktree at `dest` for the branch `branch`.
+  def create_worktree(dest, branch)
+    Dir.chdir @root do
+      sh "git worktree add #{dest} #{branch}"
+    end
+  end
 end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -369,6 +369,9 @@ RSpec.describe 'building a single book' do
     file_context 'images/icons/callouts/2.png'
   end
 
+  ##
+  # When you point `build_docs` to a worktree it doesn't properly share the
+  # worktree's parent into the docker container. This test simulates *that*.
   context 'when building a book in a worktree without its parent' do
     convert_before do |src, dest|
       repo = src.repo('src')

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -96,7 +96,7 @@ sub build_chunked {
                 # Use ` to delimit monospaced literals because our docs
                 # expect that
                 '-a' => 'compat-mode=legacy',
-                $private ? () : ( '-a' => "edit_urls=" .
+                $private || !$edit_urls ? () : ( '-a' => "edit_urls=" .
                     edit_urls_for_asciidoctor($edit_urls) ),
                 # Disable warning on missing attributes because we have
                 # missing attributes!
@@ -230,7 +230,7 @@ sub build_single {
                 '-d' => $type,
                 '-a' => 'showcomments=1',
                 '-a' => "lang=$lang",
-                $private ? () : ( '-a' => "edit_urls=" .
+                $private || !$edit_urls ? () : ( '-a' => "edit_urls=" .
                     edit_urls_for_asciidoctor($edit_urls) ),
                 '-a' => 'asciidoc-dir=' . $asciidoc_dir,
                 '-a' => 'resources=' . join(',', @$resources),


### PR DESCRIPTION
When you do `build_docs --doc ../foo/index.asciidoc` and `foo` is a git
worktree then we blew up. This prevents that.

Closes #833
