### PR TITLE
Add 7.0 ARM template docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -150,9 +150,9 @@ contents:
           -
             title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    6.7
+            current:    7.0
             index:      docs/index.asciidoc
-            branches:   [ master, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This commit adds 7.0 to the ARM template docs, and makes them the default.