### PR TITLE
Fix up-to-date check when switching asciidoctor-ness

### DIFF
--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -8,10 +8,15 @@ class Book
   # is `index.asciidoc`.
   attr_writer :index
 
+  ##
+  # Should this book build with asciidoctor (true) or asciidoc (false).
+  attr_accessor :asciidoctor
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
     @index = 'index.asciidoc'
+    @asciidoctor = true
     @sources = {}
   end
 
@@ -39,7 +44,7 @@ class Book
       index:      #{@index}
       tags:       test tag
       subject:    Test
-      asciidoctor: true
+      asciidoctor: #{@asciidoctor}
       sources:
       #{sources_conf}
     YAML

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -77,7 +77,7 @@ sub has_changed {
 
     return $old_info ne $new_info if $self->{keep_hash};
     return if $old_info eq $new_info;
-    # If the asciidoctor-ness of the previous build dosen't match this one then
+    # If the asciidoctor-ness of the previous build doesn't match this one then
     # we've changed. It'd be nice if build-info were a class but we'll be
     # dropping asciidoctor as soon as we've migrated all of the books and this
     # is sort of a local minima of effort.

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -77,6 +77,11 @@ sub has_changed {
 
     return $old_info ne $new_info if $self->{keep_hash};
     return if $old_info eq $new_info;
+    # If the asciidoctor-ness of the previous build dosen't match this one then
+    # we've changed. It'd be nice if build-info were a class but we'll be
+    # dropping asciidoctor as soon as we've migrated all of the books and this
+    # is sort of a local minima of effort.
+    return 1 unless ($old_info =~ /\|asciidoctor$/) == $asciidoctor;
 
     my $changed;
     eval {


### PR DESCRIPTION
When I added support for asciidoctor I mistakenly caused all books built
by asciidoctor to be considered out of date when there was *any* change
made to any repo that builds them, even if the changes were to unrelated
files.

When I fixed that I mistakenly caused remove asciidoctor-ness from
consideration in the up-to-date check entirely. Programing is like that,
I guess. This fixes that by explicitly checking if asciidoctor-ness
changed.
