### PR TITLE
Integtest: Move the relative conf test to rspec

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -14,7 +14,6 @@ check: \
 	style \
 	missing_include_fails_asciidoc missing_include_fails_asciidoctor \
 	migration_warnings \
-	relative_conf_file \
 	new_repo new_book \
 	keep_hash keep_hash_new_repo keep_hash_new_book \
 	sub_dir keep_hash_and_sub_dir \
@@ -69,17 +68,6 @@ simple_all:
 	# Test the simplest possible `--all` invocation
 	rm -rf $(TMP)
 	$(BUILD_MINIMAL_ALL)
-	$(call MINIMAL_ALL_EXPECTED_FILES,init)
-
-.PHONY: relative_conf_file
-relative_conf_file:
-	# Make sure that using a relative referece to the --conf file works.
-	rm -rf $(TMP)
-	$(SETUP_MINIMAL_ALL)
-	cd $(TMP) && \
-		/docs_build/build_docs.pl --in_standard_docker --all --push \
-			--target_repo $(TMP)/dest.git \
-			--conf conf.yaml
 	$(call MINIMAL_ALL_EXPECTED_FILES,init)
 
 .PHONY: new_repo

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -103,4 +103,13 @@ RSpec.describe 'building all books' do
     include_examples 'book basics', 'First', 'first'
     include_examples 'book basics', 'Second', 'second'
   end
+  context 'for a relative config file' do
+    convert_all_before_context relative_conf: true do |src|
+      repo = src.repo_with_index 'repo', 'Some text.'
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+    end
+    let(:latest_revision) { 'init' }
+    include_examples 'book basics', 'Test', 'test'
+  end
 end

--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -8,10 +8,10 @@ module Dsl
     # uses it to:
     # 1. Create source repositories and write them
     # 2. Configure the books that should be built
-    def convert_all_before_context
+    def convert_all_before_context(relative_conf: false)
       convert_before do |src, dest|
         yield src
-        dest.convert_all src.conf
+        dest.convert_all src.conf(relative_path: relative_conf)
         dest.checkout_conversion
       end
       include_examples 'convert all'

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'pathname'
+
 require_relative 'book'
 require_relative 'repo'
 
@@ -86,14 +88,19 @@ class Source
 
   ##
   # Build the config file that can build all books declared in this source.
-  def conf
+  def conf(relative_path: false)
     # We can't use to_yaml here because it emits yaml 1.2 but the docs build
     # only supports 1.0.....
-    write 'conf.yaml', <<~YAML
+    path = write 'conf.yaml', <<~YAML
       #{common_conf}
       repos:#{repos_conf}
       contents:#{books_conf}
     YAML
+    return path unless relative_path
+
+    Pathname.new(path)
+            .relative_path_from(Pathname.new(Dir.getwd))
+            .to_s
   end
 
   private


### PR DESCRIPTION
This moves the "relative conf.yaml" test file from our Makefile to
rspec in an attempt to remove everything from the Makefile.
