### PR TITLE
Add 7.x branch to .NET client branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -375,7 +375,7 @@ contents:
                 # The elasticsearch-net repo only keeps .x branches. Do not
                 # bump these with the rest of the stack.
                 current:    6.x
-                branches:   [ master, 6.x, 5.x, 2.x, 1.x ]
+                branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients


### PR DESCRIPTION
This PR adds the 7.x branch to the .NET client branches.

The 7.x .NET client is not quite yet GA, but we have released prereleases, so it'd be good to have supporting docs for these.