### PR TITLE
Remove remaining easy rubocop suppressions

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -16,6 +16,3 @@ Metrics/BlockLength:
 
 Metrics/MethodLength:
   Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false

--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -5,9 +5,6 @@ inherit_from: ../../.rubocop.yml
 Layout/AlignParameters:
   Enabled: false
 
-Layout/BlockAlignment:
-  Enabled: false
-
 Layout/IndentArray:
   Enabled: false
 
@@ -17,16 +14,7 @@ Metrics/AbcSize:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/BlockNesting:
-  Enabled: false
-
 Metrics/MethodLength:
-  Enabled: false
-
-Metrics/PerceivedComplexity:
-  Enabled: false
-
-Style/NestedParenthesizedCalls:
   Enabled: false
 
 Style/StringLiterals:

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -46,7 +46,7 @@ module CopyImages
     def process_block_image(block)
       return unless block.context == :image
 
-      uri = block.image_uri(block.attr 'target')
+      uri = block.image_uri(block.attr('target'))
       process_image block, uri
     end
 


### PR DESCRIPTION
Removes the remaining "easy to fix" rubocop suppressions from the
asciidoctor extension code base.
