### PR TITLE
Drop StringLiterals cop suppression

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -28,6 +28,3 @@ Metrics/PerceivedComplexity:
 
 Style/NestedParenthesizedCalls:
   Enabled: false
-
-Style/StringLiterals:
-  Enabled: false

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -11,18 +11,18 @@ class EditMe < TreeProcessorScaffold
   include Asciidoctor::Logging
 
   def process(document)
-    logger.error("sourcemap is required") unless document.sourcemap
+    logger.error('sourcemap is required') unless document.sourcemap
     edit_urls_string = document.attributes['edit_urls']
     return unless edit_urls_string
 
     edit_urls = []
     CSV.parse edit_urls_string do |toplevel, url|
       unless toplevel
-        logger.error message_with_context "invalid edit_urls, no toplevel"
+        logger.error message_with_context 'invalid edit_urls, no toplevel'
         next
       end
       unless url
-        logger.error message_with_context "invalid edit_urls, no url"
+        logger.error message_with_context 'invalid edit_urls, no url'
         next
       end
       url = url[0..-2] if url.end_with? '/'

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe CareAdmonition do
           expect(converted).to include(expected)
         end
       end
-      context "when written without the ::" do
+      context 'when written without the ::' do
         let(:input) do
           <<~ASCIIDOC
             == Example

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe CopyImages do
   let(:resources_dir) { "#{spec_dir}/resources/copy_images" }
 
   # Full relative path to example images
-  let(:example1) { "resources/copy_images/example1.png" }
-  let(:example2) { "resources/copy_images/example2.png" }
+  let(:example1) { 'resources/copy_images/example1.png' }
+  let(:example2) { 'resources/copy_images/example2.png' }
 
   ##
   # Asserts that a particular `image_command` copies the appropriate image
@@ -148,8 +148,8 @@ RSpec.describe CopyImages do
       let(:resolved) { 'example1.png' }
       it 'logs an error' do
         expect(logs).to include(
-          "ERROR: <stdin>: line 2: Error loading [resources]: " \
-          "Unclosed quoted field on line 1."
+          'ERROR: <stdin>: line 2: Error loading [resources]: ' \
+          'Unclosed quoted field on line 1.'
         )
       end
     end

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe EditMe do
     context 'for a document with a preface' do
       include_context 'preface'
       it "doesn't add a link to the preface" do
-        expect(converted).to include("<title>Preface</title>")
+        expect(converted).to include('<title>Preface</title>')
       end
     end
 

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -78,15 +78,15 @@ RSpec.describe ElasticCompatPreprocessor do
           expect(converted).to include("<phrase #{phrase}/>")
         end
       end
-      context "when the admonition is surrounded by other text" do
+      context 'when the admonition is surrounded by other text' do
         let(:input) { "words #{invocation} words" }
         include_examples 'invokes the inline macro'
       end
-      context "when the admonition has text before it" do
+      context 'when the admonition has text before it' do
         let(:input) { "words #{invocation}" }
         include_examples 'invokes the inline macro'
       end
-      context "when the admonition has text after it" do
+      context 'when the admonition has text after it' do
         let(:input) { "#{invocation} words" }
         include_examples 'invokes the inline macro'
       end
@@ -406,7 +406,7 @@ RSpec.describe ElasticCompatPreprocessor do
       it "has the #{lang} language" do
         expect(converted).to match(has_lang)
       end
-      it "have a link to the snippet" do
+      it 'have a link to the snippet' do
         expect(converted).to match(has_link_to_path)
       end
     end
@@ -453,10 +453,10 @@ RSpec.describe ElasticCompatPreprocessor do
     include_context 'general snippet', 'js', nil
     let(:has_any_link) { /<ulink type="snippet"/ }
 
-    it "has the js language" do
+    it 'has the js language' do
       expect(converted).to match(has_lang)
     end
-    it "not have a link to any snippet" do
+    it 'not have a link to any snippet' do
       expect(converted).not_to match(has_any_link)
     end
   end

--- a/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_tree_processor_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe ElasticCompatTreeProcessor do
           ASCIIDOC
         end
         include_examples 'has the expected language'
-        it "the paragraph is intact" do
+        it 'the paragraph is intact' do
           expect(converted).to match(%r{<simpara>Words words words.</simpara>})
         end
       end
@@ -113,7 +113,7 @@ RSpec.describe ElasticCompatTreeProcessor do
           ASCIIDOC
         end
         include_examples 'has the expected language'
-        it "has a working callout list" do
+        it 'has a working callout list' do
           expect(converted).to match(/<callout arearefs="CO1-1">\n<para>foo/)
         end
       end

--- a/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
+++ b/resources/asciidoctor/spec/shared_examples/does_not_break_line_numbers.rb
@@ -11,7 +11,7 @@ RSpec.shared_examples "doesn't break line numbers" do
           <1> callout
         ASCIIDOC
       end
-      it "reports the right line for the error" do
+      it 'reports the right line for the error' do
         expect(logs).to eq('WARN: <stdin>: line 3: no callout found for <1>')
       end
     end
@@ -22,7 +22,7 @@ RSpec.shared_examples "doesn't break line numbers" do
       end
       let(:input) { "include::#{included}[]" }
       let(:expected) { "WARN: #{included}: line 3: no callout found for <1>" }
-      it "reports the right line for the error" do
+      it 'reports the right line for the error' do
         expect(logs).to eq(expected)
       end
     end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
Removes the suppression of the `StringLiterals` cop and switches all
strings to the format the follows the cop: double quotes if using
interpolation or containing a single quote, single quotes otherwise. I
got this by running `bundle exec rubocop -a`.
