### PR TITLE
Only mount and clean the /run/nginx directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ RUN install_packages \
 
 # We mount these directories with tmpfs so we can write to them so they
 # have to be empty. So we delete them.
-RUN rm -rf /var/log/nginx && rm -rf /run
+RUN rm -rf /var/log/nginx && rm -rf /run/nginx
 
 # Wheel inventory:
 # * Used to test the docs build

--- a/build_docs
+++ b/build_docs
@@ -133,7 +133,7 @@ def run_build_docs(args):
                 raise ArgError('--all requires an agent to be running and ' +
                                'SSH_AUTH_SOCK to be set')
             if not platform.startswith('linux'):
-                docker_args.extend(['--tmpfs', '/run'])
+                docker_args.extend(['--tmpfs', '/run/nginx'])
                 docker_args.extend(['--tmpfs', '/root'])
                 docker_args.extend(['--publish', '8022:22/tcp'])
                 docker_args.extend(


### PR DESCRIPTION
On Sles-12 and potentially other distros some extra stuff is
automatically mounted into `/run` making it impossible to remove them
and ultimately causing the build to fail as seen in https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request+docbldesx/12978/console

```
/ # mount | grep /run
tmpfs on /run/secrets/credentials.d type tmpfs (ro,relatime)
tmpfs on /run/secrets/SUSEConnect type tmpfs (ro,relatime)
```

However it looks like only `/run/nginx` is actually being used so there
doesn't seen to be a need to mount and wipe the whole of `/run`

