### PR TITLE
Fix mysterious Perl warnings

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -141,13 +141,13 @@ sub _guess_opts_from_file {
     }
     $Opts->{root_dir} = $doc_toplevel;
     my $edit_url = _guess_edit_url($doc_toplevel);
-    @edit_urls{ $doc_toplevel } = $edit_url if $edit_url;
+    $edit_urls{ $doc_toplevel } = $edit_url if $edit_url;
     for my $resource ( @{ $Opts->{resource} } ) {
         my $resource_toplevel = _find_toplevel($resource);
         next unless $resource_toplevel;
 
         my $resource_edit_url = _guess_edit_url($resource_toplevel);
-        @edit_urls{ $resource_toplevel } = $resource_edit_url if $resource_edit_url;
+        $edit_urls{ $resource_toplevel } = $resource_edit_url if $resource_edit_url;
     }
     $Opts->{edit_urls} = { %edit_urls };
 }


### PR DESCRIPTION
Today, building the docs emits the following warnings:

    Scalar value @edit_urls{ $doc_toplevel } better written as $edit_urls{ $doc_toplevel } at /Users/davidturner/src/docs/build_docs.pl line 144.
    Scalar value @edit_urls{ $resource_toplevel } better written as $edit_urls{ $resource_toplevel } at /Users/davidturner/src/docs/build_docs.pl line 150.

This commit implements these suggestions to suppress these warnings.