### PR TITLE
New value for {searchprofiler} attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -96,7 +96,7 @@
 :report-features:         reporting features
 :graph:                   X-Pack graph
 :graph-features:          graph analytics features
-:searchprofiler:          Query Profiler
+:searchprofiler:          Search Profiler
 :xpackml:                 X-Pack machine learning
 :ml:                      machine learning
 :ml-cap:                  Machine learning


### PR DESCRIPTION
The {searchprofiler} attribute prints as "Query Profiler" in the docs, but the name of this tool in the UI is "Search Profiler". Suggesting that we replace the value for this attribute to match what is in the UI. 

<img width="1281" alt="Screen Shot 2019-05-14 at 3 26 11 PM" src="https://user-images.githubusercontent.com/13408456/57726073-a2171000-765c-11e9-820c-3e1cbb00dccb.png">
