### PR TITLE
Set noindex on the legacy docs to block Google from indexing

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -852,6 +852,7 @@ contents:
             current:    1.3
             branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
             chunk:      1
+            noindex:    1
             tags:       Legacy/Topbeat/Reference
             subject:    Topbeat
             sources:
@@ -1257,6 +1258,7 @@ contents:
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack
             chunk:      1
+            noindex:    1
             tags:       Legacy/XPack/Reference
             current:    6.2
             subject:    X-Pack
@@ -1298,6 +1300,7 @@ contents:
             current:    master
             branches:   [ master ]
             index:      docs/index.asciidoc
+            noindex:    1
             tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
             asciidoctor: true
@@ -1309,6 +1312,7 @@ contents:
             title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1
+            noindex:    1
             tags:       Legacy/Marvel/Reference
             subject:    Marvel
             current:    2.4
@@ -1324,6 +1328,7 @@ contents:
             title:      Shield Reference for 2.x and 1.x
             prefix:     en/shield
             chunk:      1
+            noindex:    1
             tags:       Legacy/Shield/Reference
             subject:    Shield
             current:    2.4
@@ -1339,6 +1344,7 @@ contents:
             title:      Watcher Reference for 2.x and 1.x
             prefix:     en/watcher
             chunk:      1
+            noindex:    1
             tags:       Legacy/Watcher/Reference
             subject:    Watcher
             current:    2.4
@@ -1354,6 +1360,7 @@ contents:
             title:      Reporting Reference for 2.x
             prefix:     en/reporting
             chunk:      1
+            noindex:    1
             tags:       Legacy/Reporting/Reference
             subject:    Reporting
             current:    2.4
@@ -1370,6 +1377,7 @@ contents:
             prefix:     en/graph
             repo:       x-pack
             chunk:      1
+            noindex:    1
             tags:       Legacy/Graph/Reference
             subject:    Graph
             current:    2.4
@@ -1387,6 +1395,7 @@ contents:
             current:    2.4
             branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/groovy-api/index.asciidoc
+            noindex:    1
             tags:       Legacy/Clients/Groovy
             subject:    Clients
             asciidoctor: true


### PR DESCRIPTION
This will prevent folks from getting directed to the obsolete docs over the current docs. 

This does not set noindex on the Definitive Guide. We'll wait to do that until we've incorporated equivalent content into the ES docs.

@jonasll Need to verify that this will not prevent our site search from indexing these pages. Since we already set noindex on the Logstash Versioned Plugins doc, I think we're ok?