### PR TITLE
Changes 7.2 branch attribute

### DIFF
--- a/shared/versions72.asciidoc
+++ b/shared/versions72.asciidoc
@@ -2,7 +2,7 @@
 :logstash_version:       7.2.0
 :elasticsearch_version:  7.2.0
 :kibana_version:         7.2.0
-:branch:                 7.x
+:branch:                 7.2
 :major-version:          7.x
 :prev-major-version:     6.x
 


### PR DESCRIPTION
This PR updates the `branch` attribute from 7.x to 7.2 in the shared `versions72.asciidoc` file.
