### PR TITLE
Only push to new target branches if there changes

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -555,20 +555,11 @@ sub push_changes {
     $build_dir->file('revision.txt')
         ->spew( iomode => '>:utf8', ES::Repo->all_repo_branches );
 
-    # Check if there are changes before committing and save that because if
-    # there are changes we'll commit them. Once we've committed them checking
-    # if there are changes will say "no" because there aren't changes
-    # *any more*. Thus we build $has_changes and $should_push here and not
-    # in the `if` statements below.
-    my $has_changes = $target_repo->outstanding_changes;
-    my $should_push = $has_changes || $target_repo->new_branch;
-    if ( $has_changes ) {
+    if ( $target_repo->outstanding_changes ) {
         say 'Preparing commit';
         build_sitemap($build_dir);
         say "Commiting changes";
         $target_repo->commit;
-    }
-    if ( $should_push ) {
         say "Pushing changes";
         $target_repo->push_changes;
     } else {

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -75,7 +75,6 @@ sub checkout_minimal {
         printf(" - %20s: Forking <%s> from master\n",
             'target_repo', $self->{branch});
         run qw(git checkout -b), $self->{branch};
-        $self->{new_branch} = 1;
         1;
     } or die "Error checking out repo <target_repo>: $@";
     chdir $original_pwd;
@@ -138,13 +137,6 @@ sub push_changes {
     local $ENV{GIT_DIR} = $self->{git_dir};
     run qw(git push origin master) if $self->{initialized_empty_master};
     run qw(git push origin), $self->{branch};
-}
-
-#===================================
-# Is this a new branch?
-#===================================
-sub new_branch {
-    return shift->{new_branch};
 }
 
 #===================================


### PR DESCRIPTION
Before this commit if you add `--target_branch` and the branch is *new*
then we pushed to it regardless of if there were changes. This felt nice
and consistent but we're going to end up with a lot of branches that
way.
