### PR TITLE
Create a docker image for previewing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,10 @@
 *
 !.docker
+!build_docs.pl
+!conf.yaml
 !Gemfile*
+!lib
 !package.json
+!preview
+!resources/web
 !yarn.lock

--- a/build_docs
+++ b/build_docs
@@ -37,6 +37,9 @@ from sys import platform, version_info
 import time
 import webbrowser
 
+# The tag we use for our docker image. This should line up with the tags
+# in preview/Dockerfile and publish_docker.sh
+DOCKER_TAG = 'docker.elastic.co/docs/build:1'
 DOCKER_BUILD_QUIET_TIME = 3  # seconds
 SSH_AGENT_HELP = 'https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent'  # noqa
 
@@ -67,7 +70,7 @@ def build_docker_image():
             else:
                 acc.append(line)
 
-        cmd = ["docker", "image", "build", "-t", "elastic/docs_build", DIR]
+        cmd = ["docker", "image", "build", "-t", DOCKER_TAG, DIR]
         build = common_popen(cmd, dockerfile)
         handle_popen(build, handle_line)
         if build.returncode != 0:
@@ -225,7 +228,7 @@ def run_build_docs(args):
     cmd = []
     cmd.extend(['docker', 'run'])
     cmd.extend(docker_args)
-    cmd.extend(['elastic/docs_build', '/docs_build/build_docs.pl'])
+    cmd.extend([DOCKER_TAG, '/docs_build/build_docs.pl'])
     cmd.extend(build_docs_args)
     # Use a PIPE for stdin so if our process dies then the docs build  sees
     # stdin close which it will use as a signal to die.
@@ -484,7 +487,7 @@ if __name__ == '__main__':
             cmd.extend(['--workdir', docker_cwd])
             if stdout.isatty():
                 cmd.append('-t')
-            cmd.extend(['elastic/docs_build', 'make'])
+            cmd.extend([DOCKER_TAG, 'make'])
             cmd.extend(['--no-builtin-rules'])
             cmd.extend(argv[2:])
             returncode = subprocess.call(cmd)

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -844,36 +844,6 @@ sub command_line_opts {
 }
 
 #===================================
-sub check_opts {
-#===================================
-    if ( !$Opts->{doc} ) {
-        die('--asciidoctor only compatible with --doc') if $Opts->{asciidoctor};
-        die('--chunk only compatible with --doc') if $Opts->{chunk};
-        # Lang will be 'en' even if it isn't specified so we don't check it.
-        die('--lenient only compatible with --doc') if $Opts->{lenient};
-        die('--out only compatible with --doc') if $Opts->{out};
-        die('--pdf only compatible with --doc') if $Opts->{pdf};
-        die('--resource only compatible with --doc') if $Opts->{resource};
-        die('--single only compatible with --doc') if $Opts->{single};
-        die('--toc only compatible with --doc') if $Opts->{toc};
-    }
-    if ( !$Opts->{all} ) {
-        die('--keep_hash only compatible with --all') if $Opts->{keep_hash};
-        die('--linkcheckonly only compatible with --all') if $Opts->{linkcheckonly};
-        die('--push only compatible with --all') if $Opts->{push};
-        die('--rebuild only compatible with --all') if $Opts->{rebuild};
-        die('--reference only compatible with --all') if $Opts->{reference};
-        die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
-        die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
-        die('--user only compatible with --all') if $Opts->{user};
-    }
-    if ( !$Opts->{all} && !$Opts->{preview} ) {
-        die('--target_branch only compatible with --all or --preview') if $Opts->{target_branch};
-        die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
-    }
-}
-
-#===================================
 sub usage {
 #===================================
     my $name = $Opts->{in_standard_docker} ? 'build_docs' : $0;
@@ -950,5 +920,35 @@ USAGE
         $name --self-test -C resources/asciidoctor rubocop
     
 USAGE
+    }
+}
+
+#===================================
+sub check_opts {
+#===================================
+    if ( !$Opts->{doc} ) {
+        die('--asciidoctor only compatible with --doc') if $Opts->{asciidoctor};
+        die('--chunk only compatible with --doc') if $Opts->{chunk};
+        # Lang will be 'en' even if it isn't specified so we don't check it.
+        die('--lenient only compatible with --doc') if $Opts->{lenient};
+        die('--out only compatible with --doc') if $Opts->{out};
+        die('--pdf only compatible with --doc') if $Opts->{pdf};
+        die('--resource only compatible with --doc') if $Opts->{resource};
+        die('--single only compatible with --doc') if $Opts->{single};
+        die('--toc only compatible with --doc') if $Opts->{toc};
+    }
+    if ( !$Opts->{all} ) {
+        die('--keep_hash only compatible with --all') if $Opts->{keep_hash};
+        die('--linkcheckonly only compatible with --all') if $Opts->{linkcheckonly};
+        die('--push only compatible with --all') if $Opts->{push};
+        die('--rebuild only compatible with --all') if $Opts->{rebuild};
+        die('--reference only compatible with --all') if $Opts->{reference};
+        die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
+        die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
+        die('--user only compatible with --all') if $Opts->{user};
+    }
+    if ( !$Opts->{all} && !$Opts->{preview} ) {
+        die('--target_branch only compatible with --all or --preview') if $Opts->{target_branch};
+        die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
     }
 }

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -741,10 +741,10 @@ sub init_env {
         $ENV{LD_PRELOAD} = '/usr/lib/libnss_wrapper.so';
         $ENV{NSS_WRAPPER_PASSWD} = '/tmp/passwd';
         $ENV{NSS_WRAPPER_GROUP} = '/etc/group';
-    } else {
-        eval { run( 'xsltproc', '--version' ) }
-            or die "Please install <xsltproc>";
     }
+
+    eval { run( 'xsltproc', '--version' ) }
+        or die "Please install <xsltproc>";
 }
 
 #===================================

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -33,6 +33,7 @@ use ES::Util qw(
     write_html_redirect
     write_nginx_redirects
     write_nginx_test_config
+    write_nginx_preview_config
 );
 
 use Getopt::Long qw(:config no_auto_abbrev no_ignore_case no_getopt_compat);
@@ -71,14 +72,16 @@ $Opts->{template} = ES::Template->new(
     abs_urls => $Opts->{doc},
 );
 
-$Opts->{doc}       ? build_local( $Opts->{doc} )
-    : $Opts->{all} ? build_all()
-    :                usage();
+$Opts->{doc}           ? build_local()
+    : $Opts->{all}     ? build_all()
+    : $Opts->{preview} ? preview()
+    :                    usage();
 
 #===================================
 sub build_local {
 #===================================
-    my $doc = shift;
+    my $doc = $Opts->{doc};
+
 
     my $index = file($doc)->absolute($Old_Pwd);
     die "File <$doc> doesn't exist" unless -f $index;
@@ -207,23 +210,28 @@ sub build_local_pdf {
         say "See: $pdf";
     }
 }
+
 #===================================
 sub build_all {
 #===================================
     die "--target_repo is required with --all" unless ( $Opts->{target_repo} );
 
-    my ($repos_dir, $temp_dir, $target_repo, $target_repo_checkout) = init_repos();
+    my ( $repos_dir, $temp_dir, $reference_dir ) = init_dirs();
+
+    say "Updating repositories";
+    my $target_repo = init_target_repo( $repos_dir, $temp_dir, $reference_dir );
+    init_repos( $repos_dir, $temp_dir, $reference_dir, $target_repo );
 
     my $build_dir = $Conf->{paths}{build}
         or die "Missing <paths.build> in config";
-    $build_dir = dir("$target_repo_checkout/$build_dir");
+    $build_dir = $target_repo->destination->subdir( $build_dir );
     $build_dir->mkpath;
 
     my $contents = $Conf->{contents}
         or die "Missing <contents> configuration section";
 
     my $toc = ES::Toc->new( $Conf->{contents_title} || 'Guide' );
-    my $redirects = dir( $target_repo_checkout )->file( 'redirects.conf' );
+    my $redirects = $target_repo->destination->file( 'redirects.conf' );
 
     if ( $Opts->{linkcheckonly} ){
         say "Skipping documentation builds."
@@ -251,7 +259,7 @@ sub build_all {
         say "Checking links";
         check_links($build_dir);
     }
-    push_changes($build_dir, $target_repo, $target_repo_checkout) if $Opts->{push};
+    push_changes( $build_dir, $target_repo ) if $Opts->{push};
     serve_and_open_browser( $build_dir, $redirects ) if $Opts->{open};
 
     $temp_dir->rmtree;
@@ -430,34 +438,21 @@ ENTRY
 
     say $fh "</urlset>";
     close $fh or die "Couldn't close $sitemap: $!"
-
 }
 
 #===================================
-sub init_repos {
+sub init_dirs {
 #===================================
-    say "Updating repositories";
-
     my $repos_dir = $Conf->{paths}{repos}
         or die "Missing <paths.repos> in config";
 
     $repos_dir = dir($repos_dir)->absolute;
     $repos_dir->mkpath;
 
-    my %child_dirs = map { $_ => 1 } $repos_dir->children;
-
     my $temp_dir = $running_in_standard_docker ? dir('/tmp/docsbuild') : $repos_dir->subdir('.temp');
+    $temp_dir = $temp_dir->absolute;
     $temp_dir->rmtree;
     $temp_dir->mkpath;
-    delete $child_dirs{ $temp_dir->absolute };
-
-    my $conf = $Conf->{repos}
-        or die "Missing <repos> in config";
-
-    my @repo_names = sort keys %$conf;
-
-    my $tracker_path = $Conf->{paths}{branch_tracker}
-        or die "Missing <paths.branch_tracker> in config";
 
     my $reference_dir = dir($Opts->{reference});
     if ( $reference_dir ) {
@@ -465,32 +460,47 @@ sub init_repos {
         die "Missing reference directory $reference_dir" unless -e $reference_dir;
     }
 
-    # Check out the target repo before the other repos so that
-    # we can use the tracker file that it contains.
-    my $target_repo_checkout = "$temp_dir/target_repo";
+    return ( $repos_dir, $temp_dir, $reference_dir );
+}
+
+#===================================
+sub init_target_repo {
+#===================================
+    my ( $repos_dir, $temp_dir, $reference_dir ) = @_;
+
     my $target_repo = ES::TargetRepo->new(
         dir         => $repos_dir,
         user        => $Opts->{user},
         url         => $Opts->{target_repo},
         reference   => $reference_dir,
-        destination => dir( $target_repo_checkout ),
+        destination => dir( "$temp_dir/target_repo" ),
         branch      => $Opts->{target_branch} || 'master',
     );
+    $target_repo->update_from_remote;
+    return $target_repo;
+}
+
+#===================================
+sub init_repos {
+#===================================
+    my ( $repos_dir, $temp_dir, $reference_dir, $target_repo ) = @_;
+
+    printf(" - %20s: Checking out minimal\n", 'target_repo');
+    $target_repo->checkout_minimal();
+
+    my %child_dirs = map { $_ => 1 } $repos_dir->children;
+    delete $child_dirs{ $temp_dir->absolute };
+
+    my $conf = $Conf->{repos}
+        or die "Missing <repos> in config";
+
+    my @repo_names = sort keys %$conf;
+
     delete $child_dirs{ $target_repo->git_dir->absolute };
-    $tracker_path = "$target_repo_checkout/$tracker_path";
-    eval {
-        $target_repo->update_from_remote();
-        printf(" - %20s: Checking out minimal\n", 'target_repo');
-        $target_repo->checkout_minimal();
-        1;
-    } or do {
-        # If creds are invalid, explicitly reject them to try to clear the cache
-        my $error = $@;
-        if ( $error =~ /Invalid username or password/ ) {
-            revoke_github_creds();
-        }
-        die $error;
-    };
+
+    my $tracker_path = $Conf->{paths}{branch_tracker}
+        or die "Missing <paths.branch_tracker> in config";
+    $tracker_path = $target_repo->destination . "/$tracker_path";
 
     # check out all remaining repos in parallel
     my $tracker = ES::BranchTracker->new( file($tracker_path), @repo_names );
@@ -553,16 +563,64 @@ sub init_repos {
         say "Removing old repo <" . $dir->basename . ">";
         $dir->rmtree;
     }
-    return ($repos_dir, $temp_dir, $target_repo, $target_repo_checkout);
+    return $target_repo;
+}
+
+
+#===================================
+sub preview {
+#===================================
+    die "--target_repo is required with --preview" unless $Opts->{target_repo};
+    die "--preview is only supported by build_docs and not by build_docs.pl"
+        unless $running_in_standard_docker;
+
+    my $nginx_config = file('/tmp/nginx.conf');
+    write_nginx_preview_config( $nginx_config );
+
+    if ( my $node_pid = fork ) {
+        my ( $repos_dir, $temp_dir, $reference_dir ) = init_dirs();
+
+        say "Cloning built docs";
+        my $target_repo = init_target_repo( $repos_dir, $temp_dir, $reference_dir );
+        say "Built docs are ready";
+
+        if ( my $nginx_pid = fork ) {
+            $SIG{TERM} = sub {
+                # We should be a good citizen and shut down the subprocesses.
+                # This isn't so important in k8s or docker because we shoot
+                # the entire container when we're done, but it is nice when
+                # testing.
+                say 'Terminating preview services...nginx';
+                kill 'TERM', $nginx_pid;
+                wait;
+                say 'Terminating preview services...node';
+                kill 'TERM', $node_pid;
+                wait;
+                say 'Terminated preview services';
+                exit 0;
+            };
+            while (1) {
+                sleep 1;
+                my $fetch_result = $target_repo->fetch;
+                say "$fetch_result" if ( $fetch_result );
+            }
+            exit;
+        } else {
+            close STDIN;
+            open( STDIN, "</dev/null" );
+            exec( qw(node /docs_build/preview/preview.js) );
+        }
+    } else {
+        close STDIN;
+        open( STDIN, "</dev/null" );
+        exec( qw(nginx -c), $nginx_config );
+    }
 }
 
 #===================================
 sub push_changes {
 #===================================
-    my ($build_dir, $target_repo, $target_repo_checkout) = @_;
-
-    local $ENV{GIT_WORK_TREE} = $target_repo_checkout;
-    local $ENV{GIT_DIR} = $ENV{GIT_WORK_TREE} . '/.git';
+    my ($build_dir, $target_repo ) = @_;
 
     say 'Building revision.txt';
     $build_dir->file('revision.txt')
@@ -608,6 +666,13 @@ sub init_env {
             die '/tmp/forwarded_ssh_auth is missing' unless (-e '/tmp/forwarded_ssh_auth');
             print "Found ssh auth\n";
         }
+
+        if ( $Opts->{preview} ) {
+            # `--preview` is run in k8s it doesn't *want* a tty
+            # so it should avoid doing housekeeping below.
+            return;
+        }
+
         # If we're in docker we're relying on closing stdin to cause an orderly
         # shutdown because it is really the only way for us to know for sure
         # that the python build_docs process thats on the host is dead.
@@ -676,10 +741,10 @@ sub init_env {
         $ENV{LD_PRELOAD} = '/usr/lib/libnss_wrapper.so';
         $ENV{NSS_WRAPPER_PASSWD} = '/tmp/passwd';
         $ENV{NSS_WRAPPER_GROUP} = '/etc/group';
+    } else {
+        eval { run( 'xsltproc', '--version' ) }
+            or die "Please install <xsltproc>";
     }
-
-    eval { run( 'xsltproc', '--version' ) }
-        or die "Please install <xsltproc>";
 }
 
 #===================================
@@ -767,13 +832,45 @@ sub command_line_opts {
         'skiplinkcheck',
         'sub_dir=s@',
         'user=s',
-        # Options that do *something* for either --doc or --all
+        # Options only compatible with --preview
+        'preview',
+        # Options that do *something* for either --doc or --all or --preview
         'conf=s',
         'in_standard_docker',
         'open',
         'procs=i',
         'verbose',
     ];
+}
+
+#===================================
+sub check_opts {
+#===================================
+    if ( !$Opts->{doc} ) {
+        die('--asciidoctor only compatible with --doc') if $Opts->{asciidoctor};
+        die('--chunk only compatible with --doc') if $Opts->{chunk};
+        # Lang will be 'en' even if it isn't specified so we don't check it.
+        die('--lenient only compatible with --doc') if $Opts->{lenient};
+        die('--out only compatible with --doc') if $Opts->{out};
+        die('--pdf only compatible with --doc') if $Opts->{pdf};
+        die('--resource only compatible with --doc') if $Opts->{resource};
+        die('--single only compatible with --doc') if $Opts->{single};
+        die('--toc only compatible with --doc') if $Opts->{toc};
+    }
+    if ( !$Opts->{all} ) {
+        die('--keep_hash only compatible with --all') if $Opts->{keep_hash};
+        die('--linkcheckonly only compatible with --all') if $Opts->{linkcheckonly};
+        die('--push only compatible with --all') if $Opts->{push};
+        die('--rebuild only compatible with --all') if $Opts->{rebuild};
+        die('--reference only compatible with --all') if $Opts->{reference};
+        die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
+        die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
+        die('--user only compatible with --all') if $Opts->{user};
+    }
+    if ( !$Opts->{all} && !$Opts->{preview} ) {
+        die('--target_branch only compatible with --all or --preview') if $Opts->{target_branch};
+        die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
+    }
 }
 
 #===================================
@@ -853,32 +950,5 @@ USAGE
         $name --self-test -C resources/asciidoctor rubocop
     
 USAGE
-    }
-}
-
-#===================================
-sub check_opts {
-#===================================
-    if ( $Opts->{doc} ) {
-        die('--keep_hash not compatible with --doc') if $Opts->{keep_hash};
-        die('--linkcheckonly not compatible with --doc') if $Opts->{linkcheckonly};
-        die('--push not compatible with --doc') if $Opts->{push};
-        die('--rebuild not compatible with --doc') if $Opts->{rebuild};
-        die('--reference not compatible with --doc') if $Opts->{reference};
-        die('--skiplinkcheck not compatible with --doc') if $Opts->{skiplinkcheck};
-        die('--sub_dir not compatible with --doc') if $Opts->{sub_dir};
-        die('--target_branch not compatible with --doc') if $Opts->{target_branch};
-        die('--target_repo not compatible with --doc') if $Opts->{target_repo};
-        die('--user not compatible with --doc') if $Opts->{user};
-    } else {
-        die('--asciidoctor not compatible with --all') if $Opts->{asciidoctor};
-        die('--chunk not compatible with --all') if $Opts->{chunk};
-        # Lang will be 'en' even if it isn't specified so we don't check it.
-        die('--lenient not compatible with --all') if $Opts->{lenient};
-        die('--out not compatible with --all') if $Opts->{out};
-        die('--pdf not compatible with --all') if $Opts->{pdf};
-        die('--resource not compatible with --all') if $Opts->{resource};
-        die('--single not compatible with --all') if $Opts->{single};
-        die('--toc not compatible with --all') if $Opts->{toc};
     }
 }

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -17,7 +17,7 @@ class Book
     @prefix = prefix
     @index = 'index.asciidoc'
     @asciidoctor = true
-    @sources = {}
+    @sources = []
   end
 
   ##
@@ -28,7 +28,7 @@ class Book
   # map_branches - optional hash that overrides which branch is used for this
   #                repo when the book is building a particular branch
   def source(repo, path, map_branches: nil)
-    @sources[repo.name] = { path: path, map_branches: map_branches }
+    @sources.push repo: repo.name, path: path, map_branches: map_branches
   end
 
   ##
@@ -61,10 +61,10 @@ class Book
 
   def sources_conf
     yaml = ''
-    @sources.each_pair do |repo_name, config|
+    @sources.each do |config|
       yaml += <<~YAML
         -
-          repo:   #{repo_name}
+          repo:   #{config[:repo]}
           path:   #{config[:path]}
       YAML
       yaml += map_branches_conf config[:map_branches]

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -2,6 +2,7 @@
 
 require 'open3'
 
+require_relative 'preview'
 require_relative 'sh'
 
 ##
@@ -102,6 +103,18 @@ class Dest
     branch_cmd = ''
     branch_cmd = "--branch #{branch} " if branch
     sh "git clone #{branch_cmd}#{bare_repo} #{@dest}"
+  end
+
+  ##
+  # Start the preview service.
+  def start_preview
+    Preview.new(bare_repo)
+  end
+
+  def remove_target_brach(branch_name)
+    Dir.chdir bare_repo do
+      sh "git branch -D #{branch_name}"
+    end
   end
 
   ##

--- a/integtest/spec/helper/matcher/doc_body.rb
+++ b/integtest/spec/helper/matcher/doc_body.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+##
+# Matches extracts the "body" of a docs page, removing its template.
+RSpec::Matchers.define :doc_body do |expected|
+  match do |actual|
+    body = actual.sub(/.+<!-- start body -->/m, '')
+                 .sub(/<!-- end body -->.+/m, '')
+
+    expected.matches? body
+  end
+  failure_message do
+    "doc_body didn't match: #{expected.failure_message}"
+  end
+end

--- a/integtest/spec/helper/matcher/have_same_keys.rb
+++ b/integtest/spec/helper/matcher/have_same_keys.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+##
+# Match the keys in two hashes, printing the extra or missing keys when there
+# is a failure.
+RSpec::Matchers.define :have_same_keys do |expected|
+  match do |actual|
+    expected_keys = expected.keys.sort
+    actual_keys = actual.keys.sort
+    expected_keys == actual_keys
+  end
+  failure_message do |actual|
+    expected_keys = expected.keys.sort
+    actual_keys = actual.keys.sort
+
+    missing = expected_keys - actual_keys
+    extra = actual_keys - expected_keys
+
+    msg = 'expected keys to match exactly but'
+    if missing
+      msg += " missed:\n"
+      missing.each { |k| msg += "#{k} => #{expected[k]}" }
+      msg += "\nand" if extra
+    end
+    msg += " had extra:\n"
+    extra.each { |k| msg += "#{k} => #{actual[k]}" }
+
+    msg
+  end
+end

--- a/integtest/spec/helper/matcher/serve.rb
+++ b/integtest/spec/helper/matcher/serve.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# Matches http responses.
+RSpec::Matchers.define :serve do |expected|
+  match do |actual|
+    return false unless actual.code == '200'
+
+    expected.matches? actual.body
+  end
+  failure_message do |actual|
+    unless actual.code == '200'
+      return "expected status [200] but was [#{actual.code}]"
+    end
+
+    "status was [200] but the body didn't match: #{expected.failure_message}"
+  end
+end

--- a/integtest/spec/helper/preview.rb
+++ b/integtest/spec/helper/preview.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+class Preview
+  ##
+  # Reads the logs of the preview without updating them from the subprocess.
+  attr_reader :logs
+
+  def initialize(bare_repo)
+    _stdin, @out, @wait_thr = Open3.popen2e(
+      '/docs_build/build_docs.pl', '--in_standard_docker', '--preview',
+      '--target_repo', bare_repo
+    )
+    @logs = ''
+
+    wait_for_logs(/^preview server is listening on 3000$/, 10)
+  end
+
+  ##
+  # Waits for the logs to match a regex. The timeout is in seconds.
+  def wait_for_logs(regexp, timeout)
+    start = Time.now
+    loop do
+      return if regexp =~ read_preview_logs
+      if Time.now - start > timeout
+        raise "Logs don't match [#{regexp}]:\n#{logs}"
+      end
+
+      sleep 0.1
+    end
+  end
+
+  ##
+  # Kill the preview.
+  def exit
+    Process.kill 'TERM', @wait_thr.pid
+    @wait_thr.exit
+    wait_for_logs(/^Terminated preview services$/, 10)
+  end
+
+  private
+
+  ##
+  # Reads some preview logs from the preview subprocess if there are any ready
+  # and returns all logs we've read.
+  def read_preview_logs
+    @logs += @out.read_nonblock(10_000)
+  rescue IO::WaitReadable
+    # There isn't any data available, just return what we have
+    @logs
+  end
+end

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     #    branch.
     raise "branches can't contain [.]" if branch.include? '.'
 
-    req['Watermark'] = watermark
+    req['X-Opaque-Id'] = watermark
     req['Host'] = branch
     Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
   end

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'net/http'
+require 'securerandom'
+
+##
+# Test for the `--preview` functionality that is usually deployed in
+# Elastic Apps. It previews all branches of the `--target_repo`. The test runs
+# everything in the defined order because starting the preview is fairly heavy
+# and the preview is designed to update itself as its target repo changes so
+# we start it once and play with the target repo during the tests.
+RSpec.describe 'previewing built docs', order: :defined do
+  repo_root = File.expand_path '../../', __dir__
+  convert_before do |src, dest|
+    repo = src.repo_with_index 'repo', <<~ASCIIDOC
+      Some text.
+
+      image::resources/cat.jpg[A cat]
+    ASCIIDOC
+    repo.cp "#{repo_root}/resources/cat.jpg", 'resources/cat.jpg'
+    repo.commit 'add cat image'
+    book = src.book 'Test'
+    book.source repo, 'index.asciidoc'
+    book.source repo, 'resources'
+    dest.convert_all src.conf
+  end
+  before(:context) do
+    @preview = @dest.start_preview
+  end
+  after(:context) do
+    @preview.exit
+  end
+  let(:repo) { @dest.bare_repo.sub '.git', '' }
+  let(:preview) { @preview }
+  let(:logs) { preview.logs }
+
+  def wait_for_logs(regexp, timeout: 10)
+    preview.wait_for_logs(regexp, timeout)
+  rescue Timeout::Error
+    expect(preview.logs).to match(regexp)
+  end
+
+  def wait_for_access(watermark, branch, path)
+    wait_for_logs(/^#{watermark} #{branch}.+#{path}.+$/)
+  end
+
+  def get(watermark, branch, path)
+    uri = URI("http://localhost:8000/#{path}")
+    req = Net::HTTP::Get.new(uri)
+    # The preview server reads the branch from the `Host` header. It throws out
+    # everything after and including the first `.` so you can hit a branch
+    # at urls like `http://master.docs-preview.app.elstc.co/`. That implies
+    # two things:
+    # 1. It won't work for branches with `.` in them.
+    # 2. If you don't send a `.` then the entire `Host` header is read as the
+    #    branch.
+    raise "branches can't contain [.]" if branch.include? '.'
+
+    req['Watermark'] = watermark
+    req['Host'] = branch
+    Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+  end
+
+  shared_context 'docs for branch' do
+    watermark = SecureRandom.uuid
+    let(:watermark) { watermark }
+    let(:root) { get watermark, branch, 'guide/index.html' }
+    let(:current_url) { 'guide/test/current' }
+    let(:cat_image) do
+      get watermark, branch, "#{current_url}/resources/cat.jpg"
+    end
+  end
+
+  it 'logs that the built docs are ready' do
+    wait_for_logs(/Built docs are ready/)
+  end
+
+  shared_examples 'serves the docs root' do
+    it 'serves the docs root' do
+      expect(root).to serve(doc_body(include(<<~HTML.strip)))
+        <a class="ulink" href="test/current/index.html" target="_top">Test</a>
+      HTML
+    end
+    it 'logs the access to the docs root' do
+      wait_for_access watermark, branch, '/guide/index.html'
+      expect(logs).to include(<<~LOGS)
+        #{watermark} #{branch} GET /guide/index.html HTTP/1.1 200
+      LOGS
+    end
+  end
+  shared_examples '404s' do
+    it '404s for the docs root' do
+      expect(root.code).to eq('404')
+    end
+    it 'logs the access to the docs root' do
+      wait_for_access watermark, branch, '/guide/index.html'
+      expect(logs).to include(<<~LOGS)
+        #{watermark} #{branch} GET /guide/index.html HTTP/1.1 404
+      LOGS
+    end
+  end
+
+  describe 'for the master branch' do
+    let(:branch) { 'master' }
+    include_context 'docs for branch'
+    include_examples 'serves the docs root'
+    it 'serves an image' do
+      bytes = File.open("#{repo_root}/resources/cat.jpg", 'rb', &:read)
+      expect(cat_image).to serve(doc_body(eq(bytes)))
+    end
+  end
+  describe 'for the test branch' do
+    let(:branch) { 'test' }
+    include_context 'docs for branch'
+    include_examples '404s'
+  end
+
+  describe 'when we commit to the test branch of the target repo' do
+    before(:context) do
+      repo = @src.repo 'repo'
+      repo.write 'index.asciidoc', 'Some text.'
+      repo.commit 'test change for test branch'
+      @dest.convert_all @src.conf, target_branch: 'test'
+    end
+    it 'logs the fetch' do
+      wait_for_logs(/\[new branch\]\s+test\s+->\s+test/)
+      # The leading space in the second line is important because it causes
+      # filebeat to group the two log lines.
+      expect(logs).to include("\n" + <<~LOGS)
+        From #{repo}
+         * [new branch]      test       -> test
+      LOGS
+    end
+    describe 'for the test branch' do
+      let(:branch) { 'test' }
+      include_context 'docs for branch'
+      include_examples 'serves the docs root'
+    end
+  end
+  describe 'after we remove the test branch from the target repo' do
+    before(:context) do
+      @dest.remove_target_brach 'test'
+    end
+    it 'logs the fetch' do
+      wait_for_logs(/\[deleted\]\s+\(none\)\s+->\s+test/)
+      # The leading space in the second line is important because it causes
+      # filebeat to group the two log lines.
+      expect(logs).to include("\n" + <<~LOGS)
+        From #{repo}
+         - [deleted]         (none)     -> test
+      LOGS
+    end
+    describe 'for the test branch' do
+      let(:branch) { 'test' }
+      include_context 'docs for branch'
+      include_examples '404s'
+    end
+  end
+end

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require_relative 'helper/matcher/doc_body'
+require_relative 'helper/matcher/have_same_keys'
+require_relative 'helper/matcher/serve'
 require_relative 'helper/dest'
 require_relative 'helper/dsl'
 require_relative 'helper/sh'
@@ -46,6 +49,7 @@ end
 # Prefer this instead of `expect(File).to exist('path')` because the failure
 # message is worlds better
 RSpec::Matchers.define :file_exist do
+  # TODO: move to helper/matcher/file_exists.rb
   match do |actual|
     File.exist? actual
   end
@@ -56,34 +60,5 @@ RSpec::Matchers.define :file_exist do
 
     entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
     msg + " but only #{entries.sort} exist"
-  end
-end
-
-##
-# Match the keys in two hashes, printing the extra or missing keys when there
-# is a failure.
-RSpec::Matchers.define :have_same_keys do |expected|
-  match do |actual|
-    expected_keys = expected.keys.sort
-    actual_keys = actual.keys.sort
-    expected_keys == actual_keys
-  end
-  failure_message do |actual|
-    expected_keys = expected.keys.sort
-    actual_keys = actual.keys.sort
-
-    missing = expected_keys - actual_keys
-    extra = actual_keys - expected_keys
-
-    msg = 'expected keys to match exactly but'
-    if missing
-      msg += " missed:\n"
-      missing.each { |k| msg += "#{k} => #{expected[k]}" }
-      msg += "\nand" if extra
-    end
-    msg += " had extra:\n"
-    extra.each { |k| msg += "#{k} => #{actual[k]}" }
-
-    msg
   end
 end

--- a/lib/ES/BaseRepo.pm
+++ b/lib/ES/BaseRepo.pm
@@ -45,7 +45,6 @@ sub new {
 sub update_from_remote {
 #===================================
     my $self = shift;
-
     my $git_dir = $self->git_dir;
     local $ENV{GIT_DIR} = $git_dir;
 
@@ -59,6 +58,15 @@ sub update_from_remote {
         1;
     }
     or die "Error updating repo <$name>: $@";
+}
+
+#===================================
+sub fetch {
+#===================================
+    my $self = shift;
+    local $ENV{GIT_DIR} = $self->git_dir;
+
+    return run qw(git fetch --prune origin +refs/heads/*:refs/heads/*);
 }
 
 #===================================
@@ -97,7 +105,7 @@ sub _try_to_fetch {
         return;
     }
     printf(" - %20s: Fetching\n", $self->name);
-    run qw(git fetch --prune origin +refs/heads/*:refs/heads/*);
+    $self->fetch();
     return 1;
 }
 

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -166,4 +166,8 @@ sub _branch_exists {
     return eval { run qw(git rev-parse --verify), $branch };
 }
 
+#===================================
+sub destination { shift->{destination} }
+#===================================
+
 1

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -579,7 +579,13 @@ sub write_nginx_preview_config {
     my ( $dest ) = @_;
 
     # TODO pull redirects from branches
-    # NOCOMMIT drop the time
+
+    # We log the X-Opaque-Id which is a header that Elasticsearch uses to mark
+    # requests with an id that is opaque to Elasticsearch. Presumably this is
+    # a standard. Either way we follow along. We us it in our tests so we can
+    # figure out which request came from which test. That is the only reason
+    # we *need* it right now. Presumably we'll find some other use for it later
+    # though. Think of it as a distributed trace id.
     my $nginx_conf = <<"CONF";
 daemon off;
 error_log /dev/stdout info;
@@ -591,7 +597,7 @@ events {
 
 http {
   error_log /dev/stdout crit;
-  log_format short '\$http_watermark \$http_host \$request \$status';
+  log_format short '\$http_x_opaque_id \$http_host \$request \$status';
   access_log /dev/stdout short;
 
   server {

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -582,7 +582,7 @@ sub write_nginx_preview_config {
 
     # We log the X-Opaque-Id which is a header that Elasticsearch uses to mark
     # requests with an id that is opaque to Elasticsearch. Presumably this is
-    # a standard. Either way we follow along. We us it in our tests so we can
+    # a standard. Either way we follow along. We use it in our tests so we can
     # figure out which request came from which test. That is the only reason
     # we *need* it right now. Presumably we'll find some other use for it later
     # though. Think of it as a distributed trace id.

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -1,0 +1,13 @@
+from docker.elastic.co/docs/build:1
+
+RUN mkdir /var/log/nginx
+RUN mkdir -p /run/nginx
+
+COPY build_docs.pl /docs_build/
+COPY conf.yaml /docs_build/
+COPY lib /docs_build/lib
+COPY preview /docs_build/preview
+COPY resources /docs_build/resources
+
+CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
+     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -1,0 +1,87 @@
+const child_process = require('child_process');
+const http = require('http');
+const url = require('url');
+
+const port = 3000;
+const checkTypeOpts = {
+  'cwd': '/docs_build/.repos/target_repo.git',
+  'max_buffer': 64,
+};
+const catOpts = {
+  'cwd': '/docs_build/.repos/target_repo.git',
+  'encoding': 'buffer',
+  'max_buffer': 1024 * 1024 * 20,
+};
+
+const requestHandler = (request, response) => {
+  parsedUrl = url.parse(request.url);
+  if (false == parsedUrl.pathname.startsWith('/guide')) {
+    response.statusCode = 404;
+    response.end();
+    return;
+  }
+  const path = 'html' + parsedUrl.pathname.substring('/guide'.length);
+  const branch = gitBranch(request.headers['host']);
+  const requestedObject = `${branch}:${path}`;
+  // TODO include the commit info for the branch in a header
+  child_process.execFile('git', ['cat-file', '-t', requestedObject], checkTypeOpts, (err, stdout, stderr) => {
+    if (err) {
+      if (err.message.includes('Not a valid object name')) {
+        response.statusCode = 404;
+        response.end(`Can't find ${requestedObject}\n`);
+      } else {
+        console.warn('unhandled error', err);
+        response.statusCode = 500;
+        response.end(err.message);
+      }
+      return;
+    }
+    const showGitObject = gitShowObject(requestedObject, stdout.trim());
+    child_process.execFile('git', ['cat-file', 'blob', showGitObject], catOpts, (err, stdout, stderr) => {
+      if (err) {
+        console.warn('unhandled error', err);
+        response.statusCode = 500;
+        response.end(err.message);
+        return;
+      }
+      response.end(stdout);
+    });
+  });
+}
+
+function gitShowObject(requestedObject, type) {
+  switch (type) {
+    case 'tree':
+      const sep = requestedObject.endsWith('/') ? '' : '/';
+      return `${requestedObject}${sep}index.html`;
+    case 'blob':
+      return requestedObject;
+    default:
+      console.warn('received request for object of type', type, 'at', requestedObject);
+      return 'HEAD:html/en/index.html';
+  }
+}
+
+function gitBranch(host) {
+  if (!host) {
+    return 'master';
+  }
+  return host.split('.')[0];
+}
+
+const server = http.createServer(requestHandler);
+
+server.listen(port, (err) => {
+  if (err) {
+    return console.info("preview server couldn't listen", err);
+  }
+
+  console.info(`preview server is listening on ${port}`);
+});
+
+process.on('SIGTERM', () => {
+  console.info('preview server shutting down');
+  server.close(() => {
+    process.exit();
+  });
+});

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -15,7 +15,7 @@ const catOpts = {
 
 const requestHandler = (request, response) => {
   parsedUrl = url.parse(request.url);
-  if (false == parsedUrl.pathname.startsWith('/guide')) {
+  if (!parsedUrl.pathname.startsWith('/guide')) {
     response.statusCode = 404;
     response.end();
     return;

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Performs a quick and dirty local test on the preview. Because this runs as
+# it would in k8s you'll need to `docker kill` it when you are done. We do
+# have integration tests for this in integtest/spec/preview_spec.rb which are
+# much faster because they don't use real data.
+
+set -e
+
+cd $(git rev-parse --show-toplevel)
+docker build -t docker.elastic.co/docs/preview:1 -f preview/Dockerfile .
+id=$(docker run --rm \
+           --publish 8000:8000/tcp \
+           -d \
+           docker.elastic.co/docs/preview:1)
+echo "Started the preview. Some useful commands:"
+echo "   docker kill $id"
+echo "   docker logs -tf $id"
+echo "You should eventually be able to access:"
+echo "   http://master.localhost:8000/guide/index.html"

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+export BUILD=docker.elastic.co/docs/build:1
+export PREVIEW=docker.elastic.co/docs/preview:1
+
+cd $(git rev-parse --show-toplevel)
+./build_docs --just-build-image
+docker build -t $PREVIEW -f preview/Dockerfile .
+docker tag $BUILD push.$BUILD
+docker push push.$BUILD
+docker tag $PREVIEW push.$PREVIEW
+docker push push.$PREVIEW


### PR DESCRIPTION
This modifies build_docs.pl to support `--preview` which serves preview of
any branch of the `--target_repo`. It works by forking nginx to handle
the incoming traffic, pulling the target repo locally, and then forking
a nodejs process that can read directly from the git repo without
checking it out. You can test this locally with `./preview/test.sh`.

It picks the branch to preview by grabbing the first "chunk" of the
requested host. So if you run `./preview/test.sh` you should be able to
go to `master.localhost:8000/guide/index.html` to see the docs from the
master branch. When you first run `./preview/test.sh` it'll 503 but
*eventually* we'll have cloned the branch locally and we'll be able to
serve it.

`./preview/test.sh` works by booting building a docker image for the
preview and running it locally. This mirrors the way we intend to run
this in production with k8s. The idea is that k8s can deploy the docker
image as a pod and run `GET` `localhost:8000` for a "liveness" check
and `GET` `master.localhost:8000/guide/index.html` for its readiness
check. k8s will be responsible for configuring an ingress from a
convenient url, say `http://*.docs-preview.app.elstc.co/guide/index.html`,
that resolves to port 8000 on the node. Folks can replace the `*` with
the branch that they want to see.

This combines nicely with a recent change we made to the pull request
configuration which pushes the results of pull request to the
`{repo_name}_{pr_number}` branch. So you can see a preview of you pull
request, at, for example,
`http://stack-docs_332.docs-preview.app.elstc.co/guide/index.html`.

I decided on using a separate process to serve the pages instead of
using a git work tree because it saves a huge amount of disk space and
makes the process of receiving new branches much faster. It seems like
the right tradeoff because I expect we'll rarely need *all* of the files
in the preview. And it is fast enough. Like 20ms. And! It gives us the
ability to do fancy stuff with git on the way in like add the commit
hash or the message to in a header. We don't do that now, but we can.

I decided not to expose `--preview` in the `build_docs` python script
that folks run to build docs. Instead, the only way to run this is with
the docker image that it builds. This feels like the realest sort of
testing.

I include some fairly bare-bones testing in
`integtest/spec/preview_spec.rb` that mostly just verifies that we
successfully serve both html and images and appropriately pick up
changes to the `--target_repo`, adding branches when they are created
and deleting them when they are removed.

Left to do is to handle redirects. Every branch contains its nginx
config file containing redirects. When we test with `--all --open`
locally we *do* handle that redirects file but this preview *doesn't*
yet handle it. That feels complex enough that it is worth saving for a
follow up change.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
