### PR TITLE
Remove master groovy client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1394,7 +1394,7 @@ contents:
             title:      Groovy API
             prefix:     en/elasticsearch/client/groovy-api
             current:    2.4
-            branches:   [ master, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/groovy-api/index.asciidoc
             noindex:    1
             tags:       Legacy/Clients/Groovy


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/42731

This PR removes the master branch of the Groovy API documentation: 
https://www.elastic.co/guide/en/elasticsearch/client/groovy-api/master/index.html