### PR TITLE
Update current for ESS to milestone 21

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -494,8 +494,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-20
-            branches:   [ release-ms-20, saas-release, saas-release-heroku ]
+            current:    release-ms-21
+            branches:   [ release-ms-21, saas-release, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
This milestone is going out to production today, so we need to add `release-ms-21` as `current` and pull `release-ms-20` from the builds.

@elastic/cloud-writers - need an approval.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
