### PR TITLE
Drop unused code

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -531,17 +531,7 @@ sub init_repos {
         }
         else {
             $pm->start($name) and next;
-            eval {
-                $repo->update_from_remote();
-                1;
-            } or do {
-                # If creds are invalid, explicitly reject them to try to clear the cache
-                my $error = $@;
-                if ( $error =~ /Invalid username or password/ ) {
-                    revoke_github_creds();
-                }
-                die $error;
-            };
+            $repo->update_from_remote();
             $pm->finish;
         }
     }


### PR DESCRIPTION
We no longer use password-based authentication and so we no longer need
to clear the github credentials.
