### PR TITLE
Remove edit link from links to bridgeheads

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'building a single book' do
         end
       end
     end
-    context 'for a book that a reference to a floating title' do
+    context 'for a book that has a reference to a floating title' do
       convert_single_before_context do |src|
         src.write 'index.asciidoc', <<~ASCIIDOC
           #{HEADER}

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'building a single book' do
     page_context 'chapter.html' do
       it 'has an "unknown" edit url' do
         expect(body).to include(<<~HTML.strip)
-          <a href="unknown/edit/master/index.asciidoc" class="edit_me"
+          <a href="unknown/edit/master/index.asciidoc" class="edit_me" title="Edit this page on GitHub" rel="nofollow">edit</a>
         HTML
       end
     end
@@ -142,6 +142,25 @@ RSpec.describe 'building a single book' do
           # We match on the empty cell followed by the non-empty cell so we
           # can be sure we're matching the right part of the table.
           expect(body).to include("<tr>#{empty_cell}#{non_empty_cell}</tr>")
+        end
+      end
+    end
+    context 'for a book that a reference to a floating title' do
+      convert_single_before_context do |src|
+        src.write 'index.asciidoc', <<~ASCIIDOC
+          #{HEADER}
+          <<floater>>
+
+          [float]
+          [[floater]]
+          == Floater
+        ASCIIDOC
+      end
+      page_context 'chapter.html' do
+        it "there isn't an edit me link in the link to the section" do
+          expect(body).to include(<<~HTML.strip)
+            <a class="xref" href="chapter.html#floater" title="Floater">Floater</a>
+          HTML
         end
       end
     end

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -98,6 +98,20 @@
 
   <xsl:template match="ulink[@role='edit_me']" mode="no.anchor.mode" />
 
+  <!-- Fix an issue where the links to bridgeheads render their edit_me links.-->
+  <xsl:template match="bridgehead" mode="title.markup">
+    <xsl:param name="allow-anchors" select="0"/>
+
+    <xsl:choose>
+      <xsl:when test="$allow-anchors != 0">
+        <xsl:apply-templates/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates mode="no.anchor.mode"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
  <!--  head title element with version -->
 
     <xsl:template name="user.header.content">


### PR DESCRIPTION
We had a bug where links to floating titles (aka bridgeheads) would
include the `edit_me` link in its contents like this:

```
<a class="xref" href="chapter.html#floater" title="Floateredit">
  Floater
  <a href="https://github.com/elastic/docs/edit/master/index.asciidoc" class="edit_me" title="Edit this page on GitHub" rel="nofollow">
    edit
  </a>
</a>
```

Because this is invalid html it'd cause the `edit` button to float to
the top of the page, and, confusingly, take you to edit the source of
the *link target* rather than the current page. Madness.

This removes the extra link.

Closes #903
