### PR TITLE
Add SIEM Guide to docs landing page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -909,7 +909,7 @@ contents:
             prefix:     en/siem/guide
             current:    7.2
             branches:   [ master, 7.x, 7.2 ]
-            index:      docs/en/infraops/index.asciidoc
+            index:      docs/en/siem/index.asciidoc
             chunk:      1
             tags:       SIEM/Guide
             subject:    SIEM

--- a/conf.yaml
+++ b/conf.yaml
@@ -902,6 +902,24 @@ contents:
                 repo:   swiftype
                 path:   docs
     -
+        title:      SIEM: Security Operations with the Elastic Stack
+        sections:
+          -
+            title:      SIEM Guide
+            prefix:     en/siem/guide
+            current:    7.2
+            branches:   [ master, 7.x, 7.2 ]
+            index:      docs/en/infraops/index.asciidoc
+            chunk:      1
+            tags:       SIEM/Guide
+            subject:    SIEM
+            asciidoctor: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+
+    -
         title:      Infrastructure and Logs
         sections:
           -

--- a/conf.yaml
+++ b/conf.yaml
@@ -907,7 +907,7 @@ contents:
           -
             title:      SIEM Guide
             prefix:     en/siem/guide
-            current:    7.2
+            current:    master
             branches:   [ master, 7.x, 7.2 ]
             index:      docs/en/siem/index.asciidoc
             chunk:      1

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -57,7 +57,10 @@ alias docbldso='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-do
 # Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
+# Solutions 
 alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
+
+alias docbldsec='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/siem/index.asciidoc --chunk 1'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Include SIEM Guide in elastic.co docs builds, and add to docs landing page. 
