### PR TITLE
Adds shared attributes for distribution types

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -140,4 +140,4 @@
 :esh: 	ES-Hadoop
 
 :default-dist:             default distribution
-:oss-dist:                 pure Apache 2.0 licensed distribution
+:oss-dist:                 OSS-only distribution

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -138,3 +138,6 @@
 :pwd:             YOUR_PASSWORD
 
 :esh: 	ES-Hadoop
+
+:default-dist:             default distribution
+:oss-dist:                 pure Apache 2.0 licensed distribution


### PR DESCRIPTION
This PR adds attributes that can be used to differentiate between the two main types of distributions listed on https://www.elastic.co/downloads/elasticsearch

These terms are sometimes used in the documentation to differentiate between environments where X-Pack is installed or not, so it would be nice to have uniform terminology.