### PR TITLE
Add Azure Marketplace 7.1 to docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -149,11 +149,11 @@ contents:
                 repo:   ecs
                 path:   docs/
           -
-            title:      Deploying with Azure Marketplace and Resource Manager (ARM) template
+            title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    7.0
+            current:    7.1
             index:      docs/index.asciidoc
-            branches:   [ master, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.1 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This commit adds Azure Marketplace 7.1 to the docs and also updates the title to make it more succinct
