### PR TITLE
Update "For a local repo" section

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -77,8 +77,8 @@ cd path/to/your/repo
 ~/path/to/docs/repo/build_docs --doc path/to/index.asciidoc
 ----------------------------
 
-To use simplified aliases for the build commands for each book, see
-`doc_build_aliases.sh`. 
+Some documentation books require more complex build commands.
+https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] provides simplified aliases and the build commands for each book.
 
 === Specifying a different output dir
 


### PR DESCRIPTION
The "For a local repo" section has been confusing people on Slack recently. You can't build all of the documentation with just the `--doc` parameter. 

This PR turns `doc_build_aliases.sh` into a link and makes it clear that some documentation books require more complex build commands.
