### PR TITLE
Added chunk:1 for Elastic Cloud on Kubernetes

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -538,6 +538,7 @@ contents:
             current:    0.8
             branches:   [ 0.8, master ]
             index:      docs/index.asciidoc
+            chunk:      1
             public:     1
             sources:
               -


### PR DESCRIPTION
To restore the standard index page.