### PR TITLE
Remove legacy saas-release from ESS doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -498,7 +498,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-21
-            branches:   [ release-ms-21, saas-release, saas-release-heroku ]
+            branches:   [ release-ms-21, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Last year, we switched to the `release-ms-nn` doc builds for `current`. At the time, we decided to keep `saas-release` around for a while to prevent breaking bookmarks and links for people; a header encourages people to move to current docs. We've now been operating under the new milestone release builds for some time and I think it's time to remove the old legacy `saas-release` docs after giving folks a heads-up in the next weekly update. 

Just today, I looked at a recent doc issue that referenced some docs from `saas-release`, but at this point they are at least six or seven months out of date. I think it's time to rip off the bandaid.

@elastic/cloud-writers please approve--we'll discuss tomorrow as well.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->