### PR TITLE
Added 7.0 branch for elasticsearch-php

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -394,8 +394,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    6.7.x
-                branches:   [ master, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
+                current:    7.0
+                branches:   [ master, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients
@@ -1287,7 +1287,7 @@ contents:
             index:      docs/en/index.asciidoc
             private:    1
             branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            asciidoctor: true            
+            asciidoctor: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
This PR updates the docs for elasticsearch-php client to 7.0 branch.