### PR TITLE
Drafts a template for API object definitions

### DIFF
--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -6,9 +6,13 @@
 // ***************************************
 // These pages complement API reference pages. They provide details about the
 // objects in API request bodies or response bodies.
+// They do not need to map 1:1 to API response bodies unless these pages are
+// automatically generated. 
 // These pages are typically nested under an API definitions page.
-// For example, see
+// For an example of definitions that map specific objects to APIs, see:
 // https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html
+// For an example of definitions that apply to multiple APIs, see:
+// https://www.elastic.co/guide/en/elasticsearch/reference/master/api-definitions.html
 // ***************************************
 
 //Provide a brief description

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -41,3 +41,30 @@ For example:
   lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It
   must start and end with alphanumeric characters.
 ////
+
+[float]
+[[sample-object-example]]
+==== Example
+// Optional. Be aware that if you add examples they need to be kept up-to-date.
+
+////
+[source,js]
+----
+{
+      "job_id": "total-requests",
+      "analysis_config": {
+        "bucket_span": "10m",
+        "detectors": [
+          {
+            "detector_description": "Sum of total",
+            "function": "sum",
+            "field_name": "total",
+            "detector_index": 0
+          }
+        ],
+        "influencers": [ ]
+      },
+      ...
+    }
+----
+////

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -1,0 +1,30 @@
+[[sample-object]]
+=== Object1 API objects
+++++
+<titleabbrev>Object1</titleabbrev>
+++++
+
+//Provide a brief description
+
+Is a cool thing.
+
+// Guidelines for API object documentation
+// ***************************************
+// * Use a definition list.
+// * Each property should be marked as Optional or Required.
+// * Include the data type.
+// * Include default values as the last sentence of the first paragraph.
+// * Include a range of valid values, if applicable.
+// * For nested objects, link to a separate definition list.
+// ***************************************
+
+[float]
+==== Properties
+
+////
+For example:
+
+`analysis_config`::
+  (object) The analysis configuration, which specifies how to analyze the data.
+  See <<ml-analysisconfig, analysis configuration objects>>.
+////

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -22,7 +22,6 @@ Is a cool thing.
 // Guidelines for API object documentation
 // ***************************************
 // * Use a definition list.
-// * Each property should be marked as Optional or Required.
 // * Include the data type.
 // * Include default values as the last sentence of the first paragraph.
 // * Include a range of valid values, if applicable.

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -3,6 +3,13 @@
 ++++
 <titleabbrev>Object1</titleabbrev>
 ++++
+// ***************************************
+// These pages complement API reference pages. They provide details about the
+// objects in API request bodies or response bodies.
+// These pages are typically nested under an API definitions page.
+// For example, see
+// https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html
+// ***************************************
 
 //Provide a brief description
 
@@ -28,4 +35,9 @@ For example:
 `analysis_config`::
   (object) The analysis configuration, which specifies how to analyze the data.
   See <<ml-analysisconfig, analysis configuration objects>>.
+  
+`job_id`::
+  (string) The unique identifier for the job. This identifier can contain
+  lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It
+  must start and end with alphanumeric characters.
 ////

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -19,6 +19,7 @@ Is a cool thing.
 // ***************************************
 
 [float]
+[[sample-object-properties]]
 ==== Properties
 
 ////


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/937

This PR creates a template for the pages that contain definitions for API objects. Similar to pages like https://www.elastic.co/guide/en/cloud-enterprise/current/definitions.html#AllocatorBuildInfo and https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-job-resource.html