### PR TITLE
[DOCS] Changes the styles of terms in definition lists

### DIFF
--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -281,7 +281,11 @@
 }
 
 #guide dt span {
-    color: #2b4590;
+    font-weight: bold;
+}
+
+#guide dt span code {
+    font-size: 16px;
 }
 
 #guide dd {


### PR DESCRIPTION
## Changes
* Changes font size of `<code>` text in a `<term>` to 16px. This ensures `<code>` text matches the size of other text in the `<term>`.

* Removes the blue text color from `<term>`s. Users sometimes mistake this formatting as a link. This bolds `<term>`s instead.

I'm not 100% convinced bolding is the best choice here so I'd love to hear feedback.

## Before
<details>
 <summary>ES Glossary - Before</summary>
<img width="766" alt="glossary-before" src="https://user-images.githubusercontent.com/40268737/59852571-11a7ab80-933d-11e9-9e31-bf7e1924e08f.png">
</details>

<details>
 <summary>Create follower API Parameters - Before</summary>
<img width="777" alt="api-params-before" src="https://user-images.githubusercontent.com/40268737/59852600-2421e500-933d-11e9-9891-a3f886a4d594.png">
</details>


## After
<details>
 <summary>ES Glossary - After</summary>
<img width="766" alt="glossary-after" src="https://user-images.githubusercontent.com/40268737/59852774-8975d600-933d-11e9-9578-3868582b5486.png">
</details>

<details>
 <summary>Create follower API Parameters - After</summary>
<img width="778" alt="api-params-after" src="https://user-images.githubusercontent.com/40268737/59852876-bc1fce80-933d-11e9-9df4-13bb08612fe4.png">
</details>

## Testing
| OS                         | Chrome                    | Firefox                      |
| ----------------- | ------------------- | --------------------| 
| Mac OS 10.14.5   | :white_check_mark: | :white_check_mark: |
| Windows 10         | :white_check_mark: | :white_check_mark: |

## Related Issues
Relates to https://github.com/elastic/docs/issues/937.