### PR TITLE
Updates API reference example with attributes

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -8,9 +8,10 @@ Creates a cool thing.
 
 // TODO: Use the appropriate heading levels for your book.
 // TODO: Add anchors for each section
+// FYI: The section titles use attributes in case those terms change 
 [float]
 [[sample-api-request]]
-==== Request
+==== {api-request-title}
 // This section show the basic endpoint, without the body or optional parameters.
 // Variables should use <...> syntax
 // If an API supports both PUT and POST, include both here
@@ -19,8 +20,8 @@ Creates a cool thing.
 
 [float]
 [[sample-api-prereqs]]
-==== Prerequisites
-// Optional.
+==== {api-prereq-title}
+// Optional list of prerequisites.
 ////
 For example:
 
@@ -31,7 +32,7 @@ and `manage_follow_index` index privileges...
 
 [float]
 [[sample-api-desc]]
-==== Description
+==== {api-description-title}
 // Add a more detailed description the context.
 // Link to related APIs if appropriate.
 
@@ -50,8 +51,8 @@ and `manage_follow_index` index privileges...
 
 [float]
 [[sample-api-path-params]]
-==== Path parameters
-// A list of all parameters in the endpoint request
+==== {api-path-parms-title}
+// A list of all path parameters in the endpoint request
 
 ////
 For example:
@@ -61,8 +62,8 @@ For example:
 
 [float]
 [[sample-api-query-params]]
-==== Query parameters
-// A list of optional parameters 
+==== {api-query-parms-title}
+// A list of optional query parameters 
 
 ////
 For example:
@@ -76,7 +77,7 @@ the shards to be active.
 
 [float]
 [[sample-api-request-body]]
-==== Request body
+==== {api-request-body-title}
 // A list of the properties you can specify in the body of the request
 
 ////
@@ -91,13 +92,13 @@ index
 
 // ***************************************
 // [[sample-api-response-body]]
-// ==== Response body
+// ==== {api-response-body-title}
 // Response body is only required for detailed responses.
 // ***************************************
 
 [float]
 [[sample-api-example]]
-==== Example
+==== {api-example-title}
 // Optional brief example.
 // Use an 'Examples' heading if you include multiple examples.
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -142,3 +142,12 @@
 
 :default-dist:             default distribution
 :oss-dist:                 OSS-only distribution
+
+:api-request-title:        Request
+:api-prereq-title:         Prerequisites
+:api-description-title:    Description
+:api-path-parms-title:     Path parameters
+:api-query-parms-title:    Query parameters
+:api-request-body-title:   Request body
+:api-response-body-title:  Response body
+:api-example-title:        Example


### PR DESCRIPTION
This PR updates the API reference example to use attributes in its section headings, since our choices about those names might change and we don't want to have to correct all the pages that use out-dated labels.

Related to https://github.com/elastic/docs/issues/937