### PR TITLE
More edits to the API template

### DIFF
--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -30,7 +30,8 @@ Is a cool thing.
 
 [float]
 [[sample-object-properties]]
-==== Properties
+==== {api-definitions-title}
+// A list of the properties of the API object
 
 ////
 For example:
@@ -45,9 +46,10 @@ For example:
   must start and end with alphanumeric characters.
 ////
 
+// ***************************************
 [float]
 [[sample-object-example]]
-==== Example
+==== {api-example-title}
 // Optional. Be aware that if you add examples they need to be kept up-to-date.
 
 ////
@@ -71,3 +73,4 @@ For example:
     }
 ----
 ////
+// ***************************************

--- a/shared/api-definitions-ex.asciidoc
+++ b/shared/api-definitions-ex.asciidoc
@@ -49,7 +49,7 @@ For example:
 // ***************************************
 [float]
 [[sample-object-example]]
-==== {api-example-title}
+==== {api-examples-title}
 // Optional. Be aware that if you add examples they need to be kept up-to-date.
 
 ////

--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -11,7 +11,7 @@ Use the appropriate heading levels for your book.
 Add anchors for each section.
 FYI: The section titles use attributes in case those terms change.
 ////
-[float]
+
 [[sample-api-request]]
 ==== {api-request-title}
 ////
@@ -22,7 +22,7 @@ If an API supports both PUT and POST, include both here.
 
 `PUT /<follower_index>/_ccr/follow`
 
-[float]
+
 [[sample-api-prereqs]]
 ==== {api-prereq-title}
 ////
@@ -35,7 +35,7 @@ For example:
 and `manage_follow_index` index privileges...
 ////
 
-[float]
+
 [[sample-api-desc]]
 ==== {api-description-title}
 ////
@@ -56,7 +56,7 @@ Guidelines for parameter documentation
 ***************************************
 ////
 
-[float]
+
 [[sample-api-path-params]]
 ==== {api-path-parms-title}
 ////
@@ -67,7 +67,7 @@ For example:
 (string) Name of the follower index
 ////
 
-[float]
+
 [[sample-api-query-params]]
 ==== {api-query-parms-title}
 ////
@@ -82,7 +82,7 @@ files to the follower index. The default is `0`, which means waiting on none of
 the shards to be active.
 ////
 
-[float]
+
 [[sample-api-request-body]]
 ==== {api-request-body-title}
 ////
@@ -129,9 +129,9 @@ Indicates all listed indices or index aliases exist.
 Indicates one or more listed indices or index aliases **do not** exist.
 ////
 
-[float]
+
 [[sample-api-example]]
-==== {api-example-title}
+==== {api-examples-title}
 ////
 Optional brief example.
 Use an 'Examples' heading if you include multiple examples.

--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -97,15 +97,28 @@ index.
 (string) the name of the index in the leader cluster to follow.
 ////
 
-////
+
 [[sample-api-response-body]]
 ==== {api-response-body-title}
-Response body is only required for detailed responses.
 ////
+Response body is only required for detailed responses.
+
+For example:
+`auto_follow_stats`::
+  (object) An object representing stats for the auto-follow coordinator. This
+  object consists of the following fields:
+
+`auto_follow_stats.number_of_successful_follow_indices`:::
+  (long) the number of indices that the auto-follow coordinator successfully
+  followed
+...
 
 ////
+
+
 [[sample-api-response-codes]]
 ==== {api-response-codes-title}
+////
 Response codes are only required when needed to understand the response body.
 
 For example:

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -154,4 +154,6 @@
 :api-response-codes-title: Response codes
 :api-response-body-title:  Response body
 :api-example-title:        Example
-:api-examples-title:        Examples
+:api-examples-title:       Examples
+:api-definitions-title:    Properties
+   


### PR DESCRIPTION
This PR updates the API reference template as follows:
* adds an attribute for the "Properties" title
* removes float attributes from the template (so the "On this page" navigation works)
* uncomments the Response body since it's the only optional one we were commenting out that way
* changes the template to use "Examples" instead of "Example" by default