### PR TITLE
Add observability header to doc landing page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -920,12 +920,155 @@ contents:
                 path:   docs/en
 
     -
-        title:      Infrastructure and Logs
+        title:      Observability: APM, Logs, Infrastructure, and Uptime
         sections:
+          -
+            title:      Application Performance Monitoring (APM)
+            base_dir:   en/apm
+            sections:
+              -
+                title:      APM Overview
+                prefix:     get-started
+                index:      docs/guide/index.asciidoc
+                current:    7.2
+                branches:   [ master, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                chunk:      1
+                tags:       APM Server/Reference
+                subject:    APM
+                asciidoctor: true
+                sources:
+                  -
+                    repo:   apm-server
+                    path:   docs/guide
+                  -
+                    repo:   apm-server
+                    path:   docs
+              -
+                title:      APM Server Reference
+                prefix:     server
+                index:      docs/index.asciidoc
+                current:    7.2
+                branches:   [ master, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                chunk:      1
+                tags:       APM Server/Reference
+                subject:    APM
+                sources:
+                  -
+                    repo:   apm-server
+                    path:   changelogs
+                    exclude_branches:   [ 6.0 ]
+                  -
+                    repo:   apm-server
+                    path:   docs
+                  -
+                    repo:   apm-server
+                    path:   CHANGELOG.asciidoc
+              -
+                title:      APM Agents
+                base_dir:   agent
+                sections:
+                  -
+                    title:      APM Node.js Agent
+                    prefix:     nodejs
+                    current:    2.x
+                    branches:   [ master, 2.x, 1.x, 0.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Node.js Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-nodejs
+                        path:   docs
+                  -
+                    title:      APM Python Agent
+                    prefix:     python
+                    current:    4.x
+                    branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Python Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-python
+                        path:   docs
+                  -
+                    title:      APM Ruby Agent
+                    prefix:     ruby
+                    current:    2.x
+                    branches:   [ master, 2.x, 1.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Ruby Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-ruby
+                        path:   docs
+                  -
+                    title:      APM Real User Monitoring JavaScript Agent
+                    prefix:     js-base
+                    current:    4.x
+                    branches:   [ master, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Real User Monitoring JavaScript Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-rum-js
+                        path:   docs
+                  -
+                    title:      APM Go Agent
+                    prefix:     go
+                    current:    1.x
+                    branches:   [ master, 1.x, 0.5 ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Go Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-go
+                        path:   docs
+                  -
+                    title:      APM Java Agent
+                    prefix:     java
+                    current:    1.x
+                    branches:   [ master, 1.x, 0.7, 0.6 ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Java Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-java
+                        path:   docs
+                  -
+                    title:      APM .NET Agent
+                    prefix:     dotnet
+                    current:    master
+                    branches:   [ master ]
+                    index:      docs/index.asciidoc
+                    tags:       APM .NET Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-dotnet
+                        path:   docs
           -
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
-            current:    7.2
+            current:    7.1
             branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
@@ -936,149 +1079,6 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
-
-    -
-        title:      APM
-        sections:
-          -
-            title:      APM Overview
-            prefix:     en/apm/get-started
-            index:      docs/guide/index.asciidoc
-            current:    7.2
-            branches:   [ master, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
-            asciidoctor: true
-            sources:
-              -
-                repo:   apm-server
-                path:   docs/guide
-              -
-                repo:   apm-server
-                path:   docs
-          -
-            title:      APM Server Reference
-            prefix:     en/apm/server
-            index:      docs/index.asciidoc
-            current:    7.2
-            branches:   [ master, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
-            sources:
-              -
-                repo:   apm-server
-                path:   changelogs
-                exclude_branches:   [ 6.0 ]
-              -
-                repo:   apm-server
-                path:   docs
-              -
-                repo:   apm-server
-                path:   CHANGELOG.asciidoc
-          -
-            title:      APM Agents
-            base_dir:   en/apm/agent
-            sections:
-              -
-                title:      APM Node.js Agent
-                prefix:     nodejs
-                current:    2.x
-                branches:   [ master, 2.x, 1.x, 0.x ]
-                index:      docs/index.asciidoc
-                tags:       APM Node.js Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-nodejs
-                    path:   docs
-              -
-                title:      APM Python Agent
-                prefix:     python
-                current:    4.x
-                branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
-                index:      docs/index.asciidoc
-                tags:       APM Python Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-python
-                    path:   docs
-              -
-                title:      APM Ruby Agent
-                prefix:     ruby
-                current:    2.x
-                branches:   [ master, 2.x, 1.x ]
-                index:      docs/index.asciidoc
-                tags:       APM Ruby Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-ruby
-                    path:   docs
-              -
-                title:      APM Real User Monitoring JavaScript Agent
-                prefix:     js-base
-                current:    4.x
-                branches:   [ master, 4.x, 3.x, 2.x, 1.x, 0.x ]
-                index:      docs/index.asciidoc
-                tags:       APM Real User Monitoring JavaScript Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-rum-js
-                    path:   docs
-              -
-                title:      APM Go Agent
-                prefix:     go
-                current:    1.x
-                branches:   [ master, 1.x, 0.5 ]
-                index:      docs/index.asciidoc
-                tags:       APM Go Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-go
-                    path:   docs
-              -
-                title:      APM Java Agent
-                prefix:     java
-                current:    1.x
-                branches:   [ master, 1.x, 0.7, 0.6 ]
-                index:      docs/index.asciidoc
-                tags:       APM Java Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-java
-                    path:   docs
-              -
-                title:      APM .NET Agent
-                prefix:     dotnet
-                current:    master
-                branches:   [ master ]
-                index:      docs/index.asciidoc
-                tags:       APM .NET Agent/Reference
-                subject:    APM
-                chunk:      1
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   apm-agent-dotnet
-                    path:   docs
     -
       title:     Docs in Your Native Tongue
       sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -920,7 +920,7 @@ contents:
                 path:   docs/en
 
     -
-        title:      Observability: APM, Logs, Infrastructure, and Uptime
+        title:      Observability: APM, Infrastructure, Logs, and Uptime
         sections:
           -
             title:      Application Performance Monitoring (APM)

--- a/conf.yaml
+++ b/conf.yaml
@@ -968,6 +968,48 @@ contents:
                 base_dir:   agent
                 sections:
                   -
+                    title:      APM Go Agent
+                    prefix:     go
+                    current:    1.x
+                    branches:   [ master, 1.x, 0.5 ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Go Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-go
+                        path:   docs
+                  -
+                    title:      APM Java Agent
+                    prefix:     java
+                    current:    1.x
+                    branches:   [ master, 1.x, 0.7, 0.6 ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Java Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-java
+                        path:   docs
+                  -
+                    title:      APM .NET Agent
+                    prefix:     dotnet
+                    current:    master
+                    branches:   [ master ]
+                    index:      docs/index.asciidoc
+                    tags:       APM .NET Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    asciidoctor: true
+                    sources:
+                      -
+                        repo:   apm-agent-dotnet
+                        path:   docs
+                  -
                     title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    2.x
@@ -1022,48 +1064,6 @@ contents:
                     sources:
                       -
                         repo:   apm-agent-rum-js
-                        path:   docs
-                  -
-                    title:      APM Go Agent
-                    prefix:     go
-                    current:    1.x
-                    branches:   [ master, 1.x, 0.5 ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Go Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    asciidoctor: true
-                    sources:
-                      -
-                        repo:   apm-agent-go
-                        path:   docs
-                  -
-                    title:      APM Java Agent
-                    prefix:     java
-                    current:    1.x
-                    branches:   [ master, 1.x, 0.7, 0.6 ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Java Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    asciidoctor: true
-                    sources:
-                      -
-                        repo:   apm-agent-java
-                        path:   docs
-                  -
-                    title:      APM .NET Agent
-                    prefix:     dotnet
-                    current:    master
-                    branches:   [ master ]
-                    index:      docs/index.asciidoc
-                    tags:       APM .NET Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    asciidoctor: true
-                    sources:
-                      -
-                        repo:   apm-agent-dotnet
                         path:   docs
           -
             title:      Infrastructure Monitoring Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1068,7 +1068,7 @@ contents:
           -
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
-            current:    7.1
+            current:    7.2
             branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1


### PR DESCRIPTION
There are plans to refresh and redesign the documentation landing page. In the meantime, this PR adds an Observability heading and moves Observability solutions underneath that heading. With our current build script, I've found two different ways to accomplish this. ~I like option two, but I've included screenshots of option one as well.~ After chatting with Gil, option 1 seems like the best path forward.

Closes https://github.com/elastic/observability-dev/issues/70.

### Option 1 (this PR)

1. **Observability heading added to main doc page** https://www.elastic.co/guide/index.html
    <img width="690" alt="Screen Shot 2019-06-20 at 1 53 15 PM" src="https://user-images.githubusercontent.com/5618806/59883662-ad9bdc00-936a-11e9-8df6-47eb518c6f49.png">
2. **Selecting APM brings you to a new APM subpage. From this page you can view Overview and Server docs.**
    <img width="791" alt="Screen Shot 2019-06-20 at 1 47 31 PM" src="https://user-images.githubusercontent.com/5618806/59883668-b096cc80-936a-11e9-931b-729a0965c76c.png">
3. **Clicking on APM Agents brings you to the Agents subpage**
    <img width="796" alt="Screen Shot 2019-06-20 at 1 47 36 PM" src="https://user-images.githubusercontent.com/5618806/59883663-ad9bdc00-936a-11e9-8f4b-f474f88eb529.png">

* Pro: All URLs remain the same
* Con: 3 clicks to actually view Agent docs

---

### Option 2 ~(this PR)~

1. **Observability heading added to main doc page. (Same as above)** https://www.elastic.co/guide/index.html
    <img width="690" alt="Screen Shot 2019-06-20 at 1 53 15 PM" src="https://user-images.githubusercontent.com/5618806/59883662-ad9bdc00-936a-11e9-8df6-47eb518c6f49.png">
2. **All APM content lives on one subpage.**
    <img width="792" alt="Screen Shot 2019-06-20 at 2 10 15 PM" src="https://user-images.githubusercontent.com/5618806/59883660-ad9bdc00-936a-11e9-9ac4-7deb211c1f5b.png">

* Pro: 2 clicks to view all APM docs
* Cons:
    * A URL redirect is needed for the APM Agent landing page:
    `/guide/en/apm/agent/index.html` moves to join all the conent on:
    `/guide/en/apm/index.html`'
    * The layout of the APM page is not pretty

---

End goal will be for this section to look like this:
<img width="687" alt="Screen Shot 2019-06-20 at 3 03 42 PM" src="https://user-images.githubusercontent.com/5618806/59884252-a7a6fa80-936c-11e9-8599-8231eedf3ef3.png">
