### PR TITLE
[DOCS] Adds optional response codes section to API reference template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -6,23 +6,28 @@
 
 Creates a cool thing.
 
-// TODO: Use the appropriate heading levels for your book.
-// TODO: Add anchors for each section
-// FYI: The section titles use attributes in case those terms change 
+////
+Use the appropriate heading levels for your book.
+Add anchors for each section.
+FYI: The section titles use attributes in case those terms change.
+////
 [float]
 [[sample-api-request]]
 ==== {api-request-title}
-// This section show the basic endpoint, without the body or optional parameters.
-// Variables should use <...> syntax
-// If an API supports both PUT and POST, include both here
+////
+This section show the basic endpoint, without the body or optional parameters.
+Variables should use <...> syntax.
+If an API supports both PUT and POST, include both here.
+////
 
 `PUT /<follower_index>/_ccr/follow`
 
 [float]
 [[sample-api-prereqs]]
 ==== {api-prereq-title}
-// Optional list of prerequisites.
 ////
+Optional list of prerequisites.
+
 For example:
 
 * A snapshot of an index created in 5.x can be restored to 6.x. You must...
@@ -33,28 +38,30 @@ and `manage_follow_index` index privileges...
 [float]
 [[sample-api-desc]]
 ==== {api-description-title}
-// Add a more detailed description the context.
-// Link to related APIs if appropriate.
+////
+Add a more detailed description the context.
+Link to related APIs if appropriate.
 
-// Guidelines for parameter documentation
-// ***************************************
-// * Use a definition list.
-// * End each definition with a period.
-// * Each parameter should be marked as Optional or Required.
-// * Include the data type.
-// * Include default values as the last sentence of the first paragraph.
-// * Include a range of valid values, if applicable.
-// * If the parameter requires a specific delimiter for multiple values, say so
-// * If the parameter supports wildcards, ditto
-// * For objects or nested objects, link to a separate definition list.
-// ***************************************
+Guidelines for parameter documentation
+***************************************
+* Use a definition list.
+* End each definition with a period.
+* Each parameter should be marked as Optional or Required.
+* Include the data type.
+* Include default values as the last sentence of the first paragraph.
+* Include a range of valid values, if applicable.
+* If the parameter requires a specific delimiter for multiple values, say so.
+* If the parameter supports wildcards, ditto.
+* For objects or nested objects, link to a separate definition list.
+***************************************
+////
 
 [float]
 [[sample-api-path-params]]
 ==== {api-path-parms-title}
-// A list of all path parameters in the endpoint request
-
 ////
+A list of all path parameters in the endpoint request.
+
 For example:
 `<follower_index>` (Required)::
 (string) Name of the follower index
@@ -63,9 +70,9 @@ For example:
 [float]
 [[sample-api-query-params]]
 ==== {api-query-parms-title}
-// A list of optional query parameters 
-
 ////
+A list of optional query parameters.
+
 For example:
 `wait_for_active_shards` (Optional)::
 (integer) Specifies the number of shards to wait on being active before
@@ -78,31 +85,45 @@ the shards to be active.
 [float]
 [[sample-api-request-body]]
 ==== {api-request-body-title}
-// A list of the properties you can specify in the body of the request
-
 ////
+A list of the properties you can specify in the body of the request.
+
 For example:
 `remote_cluster` (Required)::
 (string) <<modules-remote-clusters,Remote cluster>> containing the leader
-index
+index.
 
 `leader_index` (Required)::
-(string) the name of the index in the leader cluster to follow
+(string) the name of the index in the leader cluster to follow.
 ////
 
-// ***************************************
-// [[sample-api-response-body]]
-// ==== {api-response-body-title}
-// Response body is only required for detailed responses.
-// ***************************************
+////
+[[sample-api-response-body]]
+==== {api-response-body-title}
+Response body is only required for detailed responses.
+////
+
+////
+[[sample-api-response-codes]]
+==== {api-response-codes-title}
+Response codes are only required when needed to understand the response body.
+
+For example:
+`200`::
+Indicates all listed indices or index aliases exist.
+
+ `404`::
+Indicates one or more listed indices or index aliases **do not** exist.
+////
 
 [float]
 [[sample-api-example]]
 ==== {api-example-title}
-// Optional brief example.
-// Use an 'Examples' heading if you include multiple examples.
-
 ////
+Optional brief example.
+Use an 'Examples' heading if you include multiple examples.
+
+
 [source,js]
 ----
 PUT /follower_index/_ccr/follow?wait_for_active_shards=1

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -149,5 +149,6 @@
 :api-path-parms-title:     Path parameters
 :api-query-parms-title:    Query parameters
 :api-request-body-title:   Request body
+:api-response-codes-title: Response codes
 :api-response-body-title:  Response body
 :api-example-title:        Example


### PR DESCRIPTION
Adds an optional response codes section to the API reference template. I needed this section while migrating the index exists API to the template with elastic/elasticsearch#43546.

Also makes a few other changes for consistency:
- Simplifies the comment structure to use multiline comments.
- Adds missing punctuation in several places.