### PR TITLE
Add 7.2 to Azure Marketplace docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -151,9 +151,9 @@ contents:
           -
             title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    7.1
+            current:    7.2
             index:      docs/index.asciidoc
-            branches:   [ master, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
Add 7.2 to the Azure Marketplace documentation and make 7.2 the current version.

This PR should be merged only when Azure Marketplace version 7.2.0 goes live; will update here when that happens.