### PR TITLE
Update .NET client docs current to 7.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -379,7 +379,7 @@ contents:
                 prefix:     net-api
                 # The elasticsearch-net repo only keeps .x branches. Do not
                 # bump these with the rest of the stack.
-                current:    6.x
+                current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net


### PR DESCRIPTION
This commit updates the .NET client documentation to make 7.x the current version.