### PR TITLE
Add attribute for 6.8 Elastic Stack Installation & Upgrade Guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -40,6 +40,7 @@
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
+:stack-ref-68:         http://www.elastic.co/guide/en/elastic-stack/6.8
 :stack-ref-70:         http://www.elastic.co/guide/en/elastic-stack/7.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}


### PR DESCRIPTION
Adds an attribute for the 6.8 branch of the [Elastic Stack Installation & Upgrade Guide](https://www.elastic.co/guide/en/elastic-stack/6.8/index.html).

This attribute is helpful when instructing users how to upgrade from 6.8 to 7.0.

Relates to elastic/elasticsearch#43685