### PR TITLE
Add Cloud release MS24

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -498,7 +498,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-21
-            branches:   [ release-ms-21, saas-release-heroku ]
+            branches:   [ release-ms-24, release-ms-21, saas-release-heroku ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Adds the Cloud milestone release 24 to the doc builds. Changing `current` will be done in a separate PR.
