### PR TITLE
Adds 7.3 branches to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -52,7 +52,7 @@ contents:
             prefix:     en/elastic-stack
             current:    7.2
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -89,7 +89,7 @@ contents:
             prefix:     en/elastic-stack-get-started
             current:    7.2
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
@@ -116,7 +116,7 @@ contents:
             prefix:     en/elastic-stack-overview
             current:    7.2
             index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
@@ -183,7 +183,7 @@ contents:
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -198,13 +198,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
                 private: true
-                exclude_branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -230,7 +230,7 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/qa/sql
                 # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/plugin/sql/qa
@@ -254,7 +254,7 @@ contents:
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -273,7 +273,7 @@ contents:
             repo:       elasticsearch
             current:    7.2
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -298,7 +298,7 @@ contents:
                 title:      Java REST Client
                 prefix:     java-rest
                 current:    7.2
-                branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients
@@ -320,7 +320,7 @@ contents:
                 title:      Java API
                 prefix:     java-api
                 current:    7.2
-                branches:   [ 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients
@@ -466,7 +466,7 @@ contents:
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -552,7 +552,7 @@ contents:
             title:      Kibana Reference
             prefix:     en/kibana
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -565,7 +565,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
     -
         title:      Logstash: Collect, Enrich, and Transport
@@ -574,7 +574,7 @@ contents:
             title:      Logstash Reference
             prefix:     en/logstash
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -587,7 +587,7 @@ contents:
                 repo:   x-pack-logstash
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
-                exclude_branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -616,7 +616,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -632,7 +632,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats
@@ -654,7 +654,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Packetbeat/Reference
             subject:    Packetbeat
@@ -676,7 +676,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             chunk:      1
             tags:       Filebeat/Reference
             subject:    Filebeat
@@ -702,7 +702,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             chunk:      1
             tags:       Winlogbeat/Reference
             subject:    Winlogbeat
@@ -724,7 +724,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             chunk:      1
             tags:       Metricbeat/Reference
             subject:    Metricbeat
@@ -756,7 +756,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    7.2
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             chunk:      1
             tags:       Heartbeat/Reference
             subject:    Heartbeat
@@ -778,7 +778,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             chunk:      1
             tags:       Auditbeat/Reference
             subject:    Auditbeat
@@ -810,7 +810,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    7.2
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             chunk:      1
             tags:       Functionbeat/Reference
             subject:    Functionbeat
@@ -832,7 +832,7 @@ contents:
             prefix:     en/beats/journalbeat
             current:    7.2
             index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             chunk:      1
             tags:       Journalbeat/Reference
             subject:    Journalbeat
@@ -908,7 +908,7 @@ contents:
             title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.2
-            branches:   [ master, 7.x, 7.2 ]
+            branches:   [ master, 7.x, 7.3, 7.2 ]
             index:      docs/en/siem/index.asciidoc
             chunk:      1
             tags:       SIEM/Guide
@@ -1069,7 +1069,7 @@ contents:
             title:      Infrastructure Monitoring Guide
             prefix:     en/infrastructure/guide
             current:    7.2
-            branches:   [ master, 7.x, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
             tags:       Infrastructure/Guide


### PR DESCRIPTION
This PR updates the conf.yaml file to start building the 7.3 branches of the documentation.
