### PR TITLE
Updates data frame attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -130,7 +130,6 @@
 :dataframes:                 data frames
 :dataframe-cap:              Data frame
 :dataframes-cap:             Data frames
-//:dataframe-job:              {dataframe} analytics job
 //:dataframe-jobs:             {dataframe} analytics jobs
 //:dataframe-jobs-cap:         {dataframe-cap} analytics jobs
 :dataframe-transform:        {dataframe} transform

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -130,7 +130,6 @@
 :dataframes:                 data frames
 :dataframe-cap:              Data frame
 :dataframes-cap:             Data frames
-//:dataframe-jobs-cap:         {dataframe-cap} analytics jobs
 :dataframe-transform:        {dataframe} transform
 :dataframe-transforms:       {dataframe} transforms
 :dataframe-transforms-cap:   {dataframe-cap} transforms

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -130,7 +130,6 @@
 :dataframes:                 data frames
 :dataframe-cap:              Data frame
 :dataframes-cap:             Data frames
-//:dataframe-jobs:             {dataframe} analytics jobs
 //:dataframe-jobs-cap:         {dataframe-cap} analytics jobs
 :dataframe-transform:        {dataframe} transform
 :dataframe-transforms:       {dataframe} transforms

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -130,13 +130,19 @@
 :dataframes:                 data frames
 :dataframe-cap:              Data frame
 :dataframes-cap:             Data frames
-:dataframe-job:              {dataframe} analytics job
-:dataframe-jobs:             {dataframe} analytics jobs
-:dataframe-jobs-cap:         {dataframe-cap} analytics jobs
-:dataframe-analytics-config: {dataframe} analytics config
+//:dataframe-job:              {dataframe} analytics job
+//:dataframe-jobs:             {dataframe} analytics jobs
+//:dataframe-jobs-cap:         {dataframe-cap} analytics jobs
 :dataframe-transform:        {dataframe} transform
 :dataframe-transforms:       {dataframe} transforms
 :dataframe-transforms-cap:   {dataframe-cap} transforms
+:dfanalytics-cap:            {dataframe-cap} analytics
+:dfanalytics:                {dataframe} analytics
+:dataframe-analytics-config: {dfanalytics} config
+:dfanalytics-job:            {dfanalytics} job
+:dfanalytics-jobs:           {dfanalytics} jobs
+:dfanalytics-jobs-cap:       {dfanalytics-cap} jobs
+:oldetection:                outlier detection
 
 :pwd:             YOUR_PASSWORD
 


### PR DESCRIPTION
This PR adds some shared attributes for data frame analytics.

Related to https://github.com/elastic/elasticsearch/pull/43875/files

NOTE: The dataframe-job attributes are commented out in this PR but if they're not used, they should be removed to avoid confusion.