### PR TITLE
Added legacy js client to the doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -351,7 +351,7 @@ contents:
                 title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x
-                branches:   [ master, 7.x, 6.x, 5.x ]
+                branches:   [ master, 7.x, 6.x, 5.x, 16.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/JavaScript
                 subject:    Clients


### PR DESCRIPTION
The legacy js client has accidentally been removed from the build in #934, this pr fixes that.

Ref: https://github.com/elastic/docs/pull/934/files#diff-4a701a5adb4359c6abf9b8e1cb38819fL354
Fixes: https://github.com/elastic/elasticsearch-js-legacy/issues/3