### PR TITLE
Adds redirect for upgrade assistant

### DIFF
--- a/resources/legacy_redirects.conf
+++ b/resources/legacy_redirects.conf
@@ -980,6 +980,12 @@ rewrite (?i)^/guide/en/elastic-stack-overview/6.x/xpack-reporting.html  $guide_r
 rewrite (?i)^/guide/en/elastic-stack-overview/master/xpack-graph.html   $guide_root/en/kibana/master/xpack-graph.html   permanent;
 rewrite (?i)^/guide/en/elastic-stack-overview/master/xpack-profiler.html    $guide_root/en/kibana/master/xpack-profiler.html   permanent;
 rewrite (?i)^/guide/en/elastic-stack-overview/master/xpack-reporting.html   $guide_root/en/kibana/master/xpack-reporting.html   permanent;
+rewrite (?i)^/guide/en/kibana/master/xpack-upgrade-assistant.html $guide_root/en/kibana/master/upgrade-assistant.html   permanent;
+rewrite (?i)^/guide/en/kibana/7.x/xpack-upgrade-assistant.html $guide_root/en/kibana/7.x/upgrade-assistant.html   permanent;
+rewrite (?i)^/guide/en/kibana/7.3/xpack-upgrade-assistant.html $guide_root/en/kibana/7.3/upgrade-assistant.html   permanent;
+rewrite (?i)^/guide/en/kibana/7.2/xpack-upgrade-assistant.html $guide_root/en/kibana/7.2/upgrade-assistant.html   permanent;
+rewrite (?i)^/guide/en/kibana/7.1/xpack-upgrade-assistant.html $guide_root/en/kibana/7.1/upgrade-assistant.html   permanent;
+rewrite (?i)^/guide/en/kibana/7.0/xpack-upgrade-assistant.html $guide_root/en/kibana/7.0/upgrade-assistant.html   permanent;
 rewrite (?i)^/guide/en/beats/filebeat/master/multiple-prospectors.html $guide_root/en/beats/filebeat/master/filebeat-input-log.html permanent;
 rewrite (?i)^/guide/en/beats/filebeat/current/multiple-prospectors.html $guide_root/en/beats/filebeat/current/filebeat-input-log.html permanent;
 rewrite (?i)^/guide/en/beats/filebeat/6.3/multiple-prospectors.html  $guide_root/en/beats/filebeat/6.3/filebeat-input-log.html permanent;


### PR DESCRIPTION
The following page ceases to exist after 6.2:
https://www.elastic.co/guide/en/kibana/6.2/xpack-upgrade-assistant.html
Instead, the new URL is:
https://www.elastic.co/guide/en/kibana/6.6/upgrade-assistant.html

https://github.com/elastic/kibana/pull/40432 adds deleted pages up to 6.8. This PR creates the redirects thereafter.
