### PR TITLE
 [DOCS] Adds outlier scores to the attributes list.

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -141,6 +141,7 @@
 :dfanalytics-jobs-cap:       {dfanalytics-cap} jobs
 :oldetection:                outlier detection
 :olscore:                    outlier score
+:olscores:                   outlier scores
 :fiscore:                    feature influence score
 
 :pwd:             YOUR_PASSWORD

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -140,6 +140,8 @@
 :dfanalytics-jobs:           {dfanalytics} jobs
 :dfanalytics-jobs-cap:       {dfanalytics-cap} jobs
 :oldetection:                outlier detection
+:olscore:                    outlier score
+:fiscore:                    feature influence score
 
 :pwd:             YOUR_PASSWORD
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -143,6 +143,7 @@
 :dfanalytics-jobs:           {dfanalytics} jobs
 :dfanalytics-jobs-cap:       {dfanalytics-cap} jobs
 :oldetection:                outlier detection
+:oldetection-cap:            Outlier detection
 :olscore:                    outlier score
 :olscores:                   outlier scores
 :fiscore:                    feature influence score


### PR DESCRIPTION
This PR adds shared attribute for `olscores` and `oldetection-cap`.

Related to https://github.com/elastic/elasticsearch/pull/43972