### PR TITLE
Adds redirects for pivot resource

### DIFF
--- a/resources/legacy_redirects.conf
+++ b/resources/legacy_redirects.conf
@@ -1076,3 +1076,7 @@ rewrite (?i)^/guide/en/infrastructure/guide/6.x/(.*) $guide_root/en/infrastructu
 rewrite (?i)/guide/en/apm/get-started/6.x/index.html $guide_root/en/apm/get-started/6.8/index.html;
 rewrite (?i)^/guide/en/beats/filebeat/current/filebeat-module-apache2.html $guide_root/en/beats/filebeat/current/filebeat-module-apache.html  permanent;
 rewrite (?i)^/guide/en/beats/filebeat/7.0/filebeat-module-apache2.html $guide_root/en/beats/filebeat/7.0/filebeat-module-apache.html  permanent;
+rewrite (?i)^/guide/en/elasticsearch/reference/master/data-frame-transform-pivot.html $guide_root/en/elasticsearch/reference/master/data-frame-transform.html permanent;
+rewrite (?i)^/guide/en/elasticsearch/reference/7.x/data-frame-transform-pivot.html $guide_root/en/elasticsearch/reference/7.x/data-frame-transform.html permanent;
+rewrite (?i)^/guide/en/elasticsearch/reference/7.3/data-frame-transform-pivot.html $guide_root/en/elasticsearch/reference/7.3/data-frame-transform.html permanent;
+rewrite (?i)^/guide/en/elasticsearch/reference/7.2/data-frame-transform-pivot.html $guide_root/en/elasticsearch/reference/7.2/data-frame-transform.html permanent;


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/43996

This PR creates a redirect for the URLs
https://www.elastic.co/guide/en/elasticsearch/reference/7.2/data-frame-transform-pivot.html
https://www.elastic.co/guide/en/elasticsearch/reference/7.3/data-frame-transform-pivot.html
https://www.elastic.co/guide/en/elasticsearch/reference/7.x/data-frame-transform-pivot.html
https://www.elastic.co/guide/en/elasticsearch/reference/master/data-frame-transform-pivot.html

... since they will cease to exist when the aforementioned PR is merged.