### PR TITLE
Clarify query and path parameters in API template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -60,7 +60,7 @@ Guidelines for parameter documentation
 [[sample-api-path-params]]
 ==== {api-path-parms-title}
 ////
-A list of all path parameters in the endpoint request.
+A list of all the parameters within the path of the endpoint (before the query string (?)).
 
 For example:
 `<follower_index>` (Required)::
@@ -71,7 +71,7 @@ For example:
 [[sample-api-query-params]]
 ==== {api-query-parms-title}
 ////
-A list of optional query parameters.
+A list of the parameters in the query string of the endpoint (after the ?).
 
 For example:
 `wait_for_active_shards` (Optional)::


### PR DESCRIPTION
This PR hopefully addresses some confusion about the difference between the query and path parameter sections in the API reference template.

It's based on the descriptions in https://swagger.io/docs/specification/describing-parameters/