### PR TITLE
Automatically clean up book metadata

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -220,7 +220,8 @@ sub build_all {
 
     say "Updating repositories";
     my $target_repo = init_target_repo( $repos_dir, $temp_dir, $reference_dir );
-    init_repos( $repos_dir, $temp_dir, $reference_dir, $target_repo );
+    my $tracker = init_repos(
+            $repos_dir, $temp_dir, $reference_dir, $target_repo );
 
     my $build_dir = $Conf->{paths}{build}
         or die "Missing <paths.build> in config";
@@ -259,6 +260,8 @@ sub build_all {
         say "Checking links";
         check_links($build_dir);
     }
+    $tracker->prune_out_of_date( @$contents );
+    $tracker->write;
     push_changes( $build_dir, $target_repo ) if $Opts->{push};
     serve_and_open_browser( $build_dir, $redirects ) if $Opts->{open};
 
@@ -553,7 +556,7 @@ sub init_repos {
         say "Removing old repo <" . $dir->basename . ">";
         $dir->rmtree;
     }
-    return $target_repo;
+    return $tracker;
 }
 
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -351,7 +351,7 @@ contents:
                 title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x
-                branches:   [ master, 7.x, 6.x, 5.x ]
+                branches:   [ master, 7.x, 6.x, 5.x, 16.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/JavaScript
                 subject:    Clients

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -288,8 +288,9 @@ RSpec.describe 'building all books' do
         context 'because we remove a branch from the book' do
           build_one_book_out_of_one_repo_twice(
             before_first_build: lambda do |src, _config|
+              repo = src.repo 'repo'
               book = src.book 'Test'
-              book.
+              book.branches.push 'foo'
             end,
             before_second_build: lambda do |src, _config|
               book = src.book 'Test'

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -285,6 +285,21 @@ RSpec.describe 'building all books' do
           let(:new_text) { 'Some text.' }
           include_examples 'second build is not a noop'
         end
+        context 'because we remove a branch from the book' do
+          build_one_book_out_of_one_repo_twice(
+            before_first_build: lambda do |src, _config|
+              book = src.book 'Test'
+              book.
+            end,
+            before_second_build: lambda do |src, _config|
+              book = src.book 'Test'
+              book.asciidoctor = true
+            end
+          )
+          let(:latest_revision) { 'init' }
+          let(:new_text) { 'Some text.' }
+          include_examples 'second build is not a noop'
+        end
       end
     end
 

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -285,21 +285,57 @@ RSpec.describe 'building all books' do
           let(:new_text) { 'Some text.' }
           include_examples 'second build is not a noop'
         end
+        context 'because we add a branch to the book' do
+          build_one_book_out_of_one_repo_twice(
+            before_second_build: lambda do |src, _config|
+              repo = src.repo 'repo'
+              repo.switch_to_new_branch 'foo'
+              book = src.book 'Test'
+              book.branches.push 'foo'
+            end
+          )
+          let(:latest_revision) { 'init' }
+          let(:new_text) { 'Some text.' }
+          context 'the second build' do
+            let(:out) { outputs[1] }
+            include_examples 'commits changes'
+          end
+          file_context 'html/branches.yaml' do
+            it 'includes the original branch' do
+              expect(contents).to include('Test/index.asciidoc/master')
+            end
+            it 'includes the added branch' do
+              expect(contents).to include('Test/index.asciidoc/foo')
+            end
+          end
+        end
         context 'because we remove a branch from the book' do
           build_one_book_out_of_one_repo_twice(
             before_first_build: lambda do |src, _config|
               repo = src.repo 'repo'
+              repo.switch_to_new_branch 'foo'
               book = src.book 'Test'
               book.branches.push 'foo'
             end,
             before_second_build: lambda do |src, _config|
               book = src.book 'Test'
-              book.asciidoctor = true
+              book.branches.delete 'foo'
             end
           )
           let(:latest_revision) { 'init' }
           let(:new_text) { 'Some text.' }
-          include_examples 'second build is not a noop'
+          context 'the second build' do
+            let(:out) { outputs[1] }
+            include_examples 'commits changes'
+          end
+          file_context 'html/branches.yaml' do
+            it 'includes the built branch' do
+              expect(contents).to include('Test/index.asciidoc/master')
+            end
+            it "doesn't include the removed branch" do
+              expect(contents).not_to include('Test/index.asciidoc/foo')
+            end
+          end
         end
       end
     end

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -66,7 +66,9 @@ class Book
   # The html for a link to a particular branch of this book.
   def link_to(branch)
     url = "#{@prefix}/#{branch}/index.html"
-    %(<a class="ulink" href="#{url}" target="_top">#{@title}</a>)
+    decoration = ''
+    decoration = ' [master]' unless @branches.length == 1
+    %(<a class="ulink" href="#{url}" target="_top">#{@title}#{decoration}</a>)
   end
 
   private

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -12,12 +12,17 @@ class Book
   # Should this book build with asciidoctor (true) or asciidoc (false).
   attr_accessor :asciidoctor
 
+  ##
+  # The list of branches to build
+  attr_accessor :branches
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
     @index = 'index.asciidoc'
     @asciidoctor = true
     @sources = []
+    @branches = ['master']
   end
 
   ##
@@ -47,7 +52,7 @@ class Book
       title:      #{@title}
       prefix:     #{@prefix}
       current:    master
-      branches:   [ master ]
+      branches:   [ #{@branches.join ', '} ]
       index:      #{@index}
       tags:       test tag
       subject:    Test

--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -64,7 +64,6 @@ sub prune_out_of_date {
     while ( my ($repo, $branches) = each %{ $self->{shas} } ) {
         my $allowed_for_repo = $allowed{$repo} || '';
         unless ($allowed_for_repo) {
-            say "Pruning for $repo";
             delete $self->{shas}->{$repo};
             next;
         }
@@ -74,11 +73,10 @@ sub prune_out_of_date {
             # tell if it'll be needed again. It is a problem, but not a big one
             # right now.
             unless ($allowed_for_repo->{$branch} || $branch =~ /^link-check/) {
-                say "Pruning for $repo $branch";
                 delete $branches->{$branch};
             }
         }
-        # Empty can show up because there is a new book that weren't not
+        # Empty can show up because there is a new book that were not
         # building at this time and we don't want that to force a commit so we
         # clean them up while we're purging here.
         delete $self->{shas}->{$repo} unless keys %{ $branches };

--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -58,7 +58,8 @@ sub prune_out_of_date {
 # Prunes tracker entries for books that are no longer built.
 #===================================
     my ( $self, @entries ) = @_;
-    my %allowed = $self->_allowed_entries_from_books( @entries );
+    my %allowed;
+    $self->_allowed_entries_from_books( \%allowed, @entries );
 
     while (my ($repo, $branches) = each %{ $self->{shas} } ) {
         my $allowed_for_repo = $allowed{$repo} || '';
@@ -78,15 +79,12 @@ sub prune_out_of_date {
             }
         }
     }
-
-    # Here is where you'd check if it worked
 }
 
 #===================================
 sub _allowed_entries_from_books {
 #===================================
-    my ( $self, @entries ) = @_;
-    my %allowed;
+    my ( $self, $allowed, @entries ) = @_;
 
     foreach my $book ( @entries ) {
         my $title = $book->{title};
@@ -94,16 +92,13 @@ sub _allowed_entries_from_books {
             foreach my $source ( @{ $book->{sources} } ) {
                 my $repo = $source->{repo};
                 my $path = $source->{path};
-                my $branch_mapping = $source->{map_branches} || ();
                 my $mapped_branch = $source->{map_branches}{$branch} || $branch;
-                $allowed{$repo}{"$title/$path/$mapped_branch"} = 1;
+                $allowed->{$repo}{"$title/$path/$mapped_branch"} = 1;
             }
         }
     }
 
     # NOCOMMIT recur with sections
-
-    return %allowed;
 }
 
 #===================================

--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -26,9 +26,8 @@ sub new {
         file => $file,
         shas => \%shas,
     }, $class;
-    
-    return $self;
 
+    return $self;
 }
 
 #===================================


### PR DESCRIPTION
We keep information about which branches contribute to which books but
before this change we didn't automatically remove the metadata when
a branch is no longer involved in building a book we never cleared that
metadata. For the most part this just left lines in a YAML file that
aren't used except when we remove a branch from a book and then re-add
it. In that case since we only use the branch data to figure out if we
should rebuild a book we *wouldn't* start to build the book when it is
added back unless the branch that it is built from changes. This happened
to us recently so it makes sense to clean up these files automatically
so it never happens again.

Closes #973
