### PR TITLE
Updates to API template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -46,7 +46,7 @@ Guidelines for parameter documentation
 ***************************************
 * Use a definition list.
 * End each definition with a period.
-* Include the data type and whether the parameter is Optional or Required.
+* Include whether the parameter is Optional or Required and the data type.
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
 * If the parameter requires a specific delimiter for multiple values, say so.

--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -46,13 +46,12 @@ Guidelines for parameter documentation
 ***************************************
 * Use a definition list.
 * End each definition with a period.
-* Include the data type.
-* Include whether the parameter is Optional or Required.
+* Include the data type and whether the parameter is Optional or Required.
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
 * If the parameter requires a specific delimiter for multiple values, say so.
 * If the parameter supports wildcards, ditto.
-* For objects or nested objects, link to a separate definition list.
+* For large or nested objects, consider linking to a separate definition list.
 ***************************************
 ////
 
@@ -64,7 +63,7 @@ A list of all the parameters within the path of the endpoint (before the query s
 
 For example:
 `<follower_index>`::
-(string) Required. Name of the follower index
+(Required, string) Name of the follower index
 ////
 
 
@@ -75,7 +74,7 @@ A list of the parameters in the query string of the endpoint (after the ?).
 
 For example:
 `wait_for_active_shards`::
-(integer) Optional. Specifies the number of shards to wait on being active before
+(Optional, integer) Specifies the number of shards to wait on being active before
 responding. A shard must be restored from the leader index being active.
 Restoring a follower shard requires transferring all the remote Lucene segment
 files to the follower index. The default is `0`, which means waiting on none of
@@ -90,11 +89,11 @@ A list of the properties you can specify in the body of the request.
 
 For example:
 `remote_cluster`::
-(string) Required. The <<modules-remote-clusters,remote cluster>> that contains
+(Required, string) The <<modules-remote-clusters,remote cluster>> that contains
 the leader index.
 
 `leader_index`::
-(string) Required. The name of the index in the leader cluster to follow.
+(Required, string) The name of the index in the leader cluster to follow.
 ////
 
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/937

This PR updates the API reference template to change the location of the Required/Optional parameter qualifier (hopefully for the last time!).

I also modified the comment about the definitions list, since I think we should have some leeway for whether we create separate pages for all objects or not.  i.e. For small objects it might annoy users to be sent to a separate page.