### PR TITLE
[DOCS] Bump 7.2 version attributes from 7.2.0 to 7.2.1

### DIFF
--- a/shared/versions72.asciidoc
+++ b/shared/versions72.asciidoc
@@ -1,7 +1,7 @@
-:version:                7.2.0
-:logstash_version:       7.2.0
-:elasticsearch_version:  7.2.0
-:kibana_version:         7.2.0
+:version:                7.2.1
+:logstash_version:       7.2.1
+:elasticsearch_version:  7.2.1
+:kibana_version:         7.2.1
 :branch:                 7.2
 :major-version:          7.x
 :prev-major-version:     6.x


### PR DESCRIPTION
Increments the shared 7.2 attributes for the 7.2.1 release.

Will merge on release day.