### PR TITLE
Add an option to comment about a preview

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -626,6 +626,10 @@ sub push_changes {
         $target_repo->commit;
         say "Pushing changes";
         $target_repo->push_changes;
+        if ( $Opts->{announce_preview} ) {
+            say "A preview will soon be available at " .
+                $Opts->{announce_preview};
+        }
     } else {
         say "No changes to push";
     }
@@ -816,6 +820,7 @@ sub command_line_opts {
         'toc',
         # Options only compatible with --all
         'all',
+        'announce_preview=s',
         'target_branch=s',
         'target_repo=s',
         'keep_hash',
@@ -871,6 +876,9 @@ sub usage {
           --keep_hash       Build docs from the same commit hash as last time
           --linkcheckonly   Skips the documentation builds. Checks links only.
           --push            Commit the updated docs and push to origin
+          --announce_preview <host>
+                            Causes the build to log a line about where to find
+                            a preview of the build if anything is pushed.
           --rebuild         Rebuild all branches of every book regardless of
                             what has changed
           --reference       Directory of `--mirror` clones to use as a
@@ -935,6 +943,7 @@ sub check_opts {
         die('--keep_hash only compatible with --all') if $Opts->{keep_hash};
         die('--linkcheckonly only compatible with --all') if $Opts->{linkcheckonly};
         die('--push only compatible with --all') if $Opts->{push};
+        die('--announce_preview only compatible with --all') if $Opts->{announce_preview};
         die('--rebuild only compatible with --all') if $Opts->{rebuild};
         die('--reference only compatible with --all') if $Opts->{reference};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -217,6 +217,25 @@ RSpec.describe 'building all books' do
     end
   end
 
+  context 'when run with --announce_preview' do
+    target_branch = 'foo_1'
+    preview_location = "http://#{target_branch}.docs-preview.app.elstc.co/guide"
+    convert_before do |src, dest|
+      repo = src.repo_with_index 'repo', 'Some text.'
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      dest.prepare_convert_all(src.conf)
+          .target_branch(target_branch)
+          .announce_preview(preview_location)
+          .convert
+    end
+    it 'logs the location of the preview' do
+      expect(outputs[0]).to include(
+        "A preview will soon be available at #{preview_location}"
+      )
+    end
+  end
+
   context "when the index for the book isn't in the repo" do
     convert_before do |src, dest|
       repo = src.repo_with_index 'src', 'words'

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -167,6 +167,11 @@ class Dest
       self
     end
 
+    def announce_preview(preview_location)
+      @cmd += ['--announce_preview', preview_location]
+      self
+    end
+
     def skip_link_check
       @cmd += ['--skiplinkcheck']
       self


### PR DESCRIPTION
Adds an option to the build that causes it to comment that a preview of
the docs changes are available after it pushes a change. We'll use this
on the pull request builds to make it obvious where the previews are.
