### PR TITLE
Always fork from master when targeting a branch

### DIFF
--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -51,7 +51,7 @@ sub checkout_minimal {
         my $out = run qw(git clone --no-checkout),
             $self->git_dir, $self->{destination};
 
-        # This if stement handles empty repositories in a way that works with
+        # This if statement handles empty repositories in a way that works with
         # different target branches. It always checks out the master
         # branch. If the target branch is `master` then it will return early.
         # If the target branch isn't master it'll delete the existing copy


### PR DESCRIPTION
Previously when you specified `--target_branch` we'd fork that branch
from master if it didn't exist and otherwise we'd build "on top" of that
branch. This isn't quite right for pull request testing. The trouble is
that you often want to merge master into your pull request branch. Doing
that introduces dependencies on other repos that touch the same books
you do. But if your target branch is old we'll reuse old commits from
that branch which might not have those dependencies. It can make a
somewhat simple PR totally fail to build if it sits for a week or two.

This change makes it so we always fork the `--target_branch` from the
master branch. We fork it from master even if it already exists. This
both fixes the "out of date" issue above and it better simulates when
merging the PR will be like because, after all, the docs built from the
PR will be built "on top of" the current master.
