### PR TITLE
Preview: More closely mimick nginx on dir request

### DIFF
--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -76,6 +76,9 @@ RSpec.describe 'previewing built docs', order: :defined do
     let(:very_large) do
       get watermark, branch, "#{current_url}/resources/very_large.jpg"
     end
+    let(:directory) do
+      get watermark, branch, 'guide'
+    end
   end
 
   it 'logs that the built docs are ready' do
@@ -117,6 +120,12 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
     it 'serves a very large file' do
       expect(very_large).to serve(eq(very_large_text))
+    end
+    context 'when you request a directory' do
+      it 'redirects to index.html' do
+        expect(directory.code).to eq('301')
+        expect(directory['Location']).to eq('/guide/index.html')
+      end
     end
   end
   describe 'for the test branch' do

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -46,10 +46,17 @@ const requestHandler = (request, response) => {
       return;
     }
 
+    if (stdout.trim() === 'tree') {
+      response.statusCode = 301;
+      const sep = requestedObject.endsWith('/') ? '' : '/';
+      response.setHeader('Location', `${parsedUrl.pathname}${sep}index.html`);
+      response.end();
+      return;
+    }
+
     response.setHeader('Transfer-Encoding', 'chunked');
-    const showGitObject = gitShowObject(requestedObject, stdout.trim());
     const child = child_process.spawn(
-      'git', ['cat-file', 'blob', showGitObject], catOpts
+      'git', ['cat-file', 'blob', requestedObject], catOpts
     );
 
     // We spool stderr into a string because it is never super big.
@@ -92,19 +99,6 @@ const requestHandler = (request, response) => {
       response.end(err.message);
     });
   });
-}
-
-function gitShowObject(requestedObject, type) {
-  switch (type) {
-    case 'tree':
-      const sep = requestedObject.endsWith('/') ? '' : '/';
-      return `${requestedObject}${sep}index.html`;
-    case 'blob':
-      return requestedObject;
-    default:
-      console.warn('received request for object of type', type, 'at', requestedObject);
-      return 'HEAD:html/en/index.html';
-  }
 }
 
 function gitBranch(host) {


### PR DESCRIPTION
When you request a directory on the public web site we redirect your
request to `{path}/index.html`. The preview *was* just serving that
index file instead. This sounds good but breaks relative links in the
`index.html` file. Sadly, we have some of those. This change teaches the
preview to do the same redirect as the public site.
