### PR TITLE
Edit me link improvements

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1508,6 +1508,27 @@ It's almost always better to use <<horizonta-defn-list>>
 instead, but if you really want to use tables, you
 can read about them http://www.methods.co.nz/asciidoc/userguide.html#_tables[here].
 
+[[edit_me]]
+== Edit links
+
+We automatically generate `edit` links for most sections to make it easier for
+folks to contribute simple fixes and to help folks find the asciidoc file that
+generated a particular section. It should appear next to ever title-like thing.
+
+Books built with AsciiDoc will automatically pick the correct url for files
+from the "root" repository. It guesses the wrong url for files from other
+repositories so you have to manually set `edit_url` at the top of each file.
+
+Books built with Asciidoctor will automatically pick the correct url for all
+files and by default doesn't support overriding `edit_url`. This is mostly a
+good thing because the overridden `edit_url`s were out of date in many cases.
+
+Some books override `edit_url` because the asciidoc files in them are not
+authoritative. In that case they set `edit_url` to the "real" place to make the
+change. Sometimes this is another repository and sometimes it is some code that
+generates the asciidoc files. These books should add
+`respect_edit_url_overrides` to their config. While it isn't required for
+AsciiDoc it is required for Asciidoctor.
 
 [[chunking]]
 == Controlling chunking

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -815,6 +815,7 @@ sub command_line_opts {
         'out=s',
         'pdf',
         'resource=s@',
+        'respect_edit_url_overrides',
         'single',
         'suppress_migration_warnings',
         'toc',
@@ -860,6 +861,8 @@ sub usage {
           --out dest/dir/   Defaults to ./html_docs.
           --pdf             Generate a PDF file instead of HTML
           --resource        Path to image dir - may be repeated
+          --respect_edit_url_overrides
+                            Respects `:edit_url:` overrides in the book.
           --single          Generate a single HTML page, instead of
                             a chunking into a file per chapter
           --suppress_migration_warnings
@@ -936,6 +939,7 @@ sub check_opts {
         die('--out only compatible with --doc') if $Opts->{out};
         die('--pdf only compatible with --doc') if $Opts->{pdf};
         die('--resource only compatible with --doc') if $Opts->{resource};
+        die('--respect_edit_url_overrides only compatible with --doc') if $Opts->{respect_edit_url_overrides};
         die('--single only compatible with --doc') if $Opts->{single};
         die('--toc only compatible with --doc') if $Opts->{toc};
     }

--- a/conf.yaml
+++ b/conf.yaml
@@ -579,6 +579,7 @@ contents:
             chunk:      1
             tags:       Logstash/Reference
             subject:    Logstash
+            respect_edit_url_overrides: true
             sources:
               -
                 repo:   logstash

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -30,7 +30,7 @@ alias docbldkb=docbldkbx
 alias docbldkbold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldlsx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
+alias docbldlsx='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
 
 alias docbldls=docbldlsx
 

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -153,6 +153,57 @@ RSpec.describe 'building all books' do
     end
   end
 
+  context 'when a book overrides edit_me' do
+    def self.index
+      <<~ASCIIDOC
+        = Test
+
+        :edit_url: overridden
+        [[chapter]]
+        == Chapter
+
+        Words.
+      ASCIIDOC
+    end
+
+    def self.override_edit_me(respect)
+      convert_all_before_context target_branch: 'new_branch' do |src|
+        repo = src.repo_with_file 'repo', 'index.asciidoc', index
+        book = src.book 'Test'
+        book.respect_edit_url_overrides = true if respect
+        book.source repo, 'index.asciidoc'
+      end
+    end
+    let(:edit_me) do
+      <<~HTML.lines.map { |l| ' ' + l.strip }.join.strip
+        <a href="#{edit_url}"
+           class="edit_me"
+           title="Edit this page on GitHub"
+           rel="nofollow">edit</a>
+      HTML
+    end
+    let(:latest_revision) { 'init' }
+    context "when respect_edit_url_overrides isn't specified" do
+      override_edit_me false
+      let(:repo) { @src.repo 'repo' }
+      let(:edit_url) { "#{repo.root}/edit/master/index.asciidoc" }
+      page_context 'the book index', 'html/test/master/chapter.html' do
+        it 'contains the standard edit_me link' do
+          expect(body).to include(edit_me)
+        end
+      end
+    end
+    context 'when respect_edit_url_overrides is specified' do
+      override_edit_me true
+      let(:edit_url) { 'overridden' }
+      page_context 'the book index', 'html/test/master/chapter.html' do
+        it 'contains the overridden edit_me link' do
+          expect(body).to include(edit_me)
+        end
+      end
+    end
+  end
+
   context 'when one source is private' do
     convert_all_before_context do |src|
       repo = src.repo_with_index 'repo', <<~ASCIIDOC

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -16,6 +16,10 @@ class Book
   # The list of branches to build
   attr_accessor :branches
 
+  ##
+  # Should this book allow overriding :edit_url:? Defaults to false.
+  attr_accessor :respect_edit_url_overrides
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -23,6 +27,7 @@ class Book
     @asciidoctor = true
     @sources = []
     @branches = ['master']
+    @respect_edit_url_overrides = false
   end
 
   ##
@@ -48,7 +53,17 @@ class Book
   def conf
     # We can't use to_yaml here because it emits yaml 1.2 but the docs build
     # only supports 1.0.....
-    indent(<<~YAML, '    ')
+    conf = standard_conf
+    conf += "respect_edit_url_overrides: true\n" if @respect_edit_url_overrides
+    conf += <<~YAML
+      sources:
+      #{sources_conf}
+    YAML
+    indent conf, '    '
+  end
+
+  def standard_conf
+    <<~YAML
       title:      #{@title}
       prefix:     #{@prefix}
       current:    master
@@ -57,8 +72,6 @@ class Book
       tags:       test tag
       subject:    Test
       asciidoctor: #{@asciidoctor}
-      sources:
-      #{sources_conf}
     YAML
   end
 

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -128,6 +128,17 @@ sub new {
             die 'asciidoctor must be true or false but was ' . $asciidoctor;
         }
     }
+    my $respect_edit_url_overrides = 0;
+    if (exists $args{respect_edit_url_overrides}) {
+        $respect_edit_url_overrides = $args{respect_edit_url_overrides};
+        if ($respect_edit_url_overrides eq 'true') {
+            $respect_edit_url_overrides = 1;
+        } elsif ($respect_edit_url_overrides eq 'false') {
+            $respect_edit_url_overrides = 0;
+        } else {
+            die 'respect_edit_url_overrides must be true or false but was ' . $respect_edit_url_overrides;
+        }
+    }
 
     bless {
         title         => $title,
@@ -148,6 +159,7 @@ sub new {
         noindex       => $args{noindex} || '',
         lang          => $lang,
         asciidoctor   => $asciidoctor,
+        respect_edit_url_overrides => $respect_edit_url_overrides,
     }, $class;
 }
 
@@ -273,6 +285,7 @@ sub _build_book {
                 resource      => [$checkout],
                 asciidoctor   => $self->asciidoctor,
                 latest        => $latest,
+                respect_edit_url_overrides => $self->{respect_edit_url_overrides},
             );
         }
         else {
@@ -294,6 +307,7 @@ sub _build_book {
                 resource      => [$checkout],
                 asciidoctor   => $self->asciidoctor,
                 latest        => $latest,
+                respect_edit_url_overrides => $self->{respect_edit_url_overrides},
             );
             $self->_add_title_to_toc( $branch, $branch_dir );
         }

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -48,6 +48,7 @@ sub build_chunked {
     my $page_header = custom_header($index) || $opts{page_header} || '';
     my $asciidoctor = $opts{asciidoctor} || 0;
     my $latest    = $opts{latest};
+    my $respect_edit_url_overrides = $opts{respect_edit_url_overrides} || '';
 
     die "Can't find index [$index]" unless -f $index;
 
@@ -107,6 +108,7 @@ sub build_chunked {
                 '-a' => 'copy-callout-images=png',
                 '-a' => 'copy-admonition-images=png',
                 $latest ? () : ('-a' => "migration-warnings=false"),
+                $respect_edit_url_overrides ? ('-a' => "respect_edit_url_overrides=true") : (),
                 '--destination-dir=' . $dest,
                 docinfo($index),
                 $index
@@ -188,6 +190,7 @@ sub build_single {
     my $page_header = custom_header($index) || $opts{page_header} || '';
     my $asciidoctor = $opts{asciidoctor} || 0;
     my $latest    = $opts{latest};
+    my $respect_edit_url_overrides = $opts{respect_edit_url_overrides} || '';
 
     die "Can't find index [$index]" unless -f $index;
 
@@ -238,6 +241,7 @@ sub build_single {
                 '-a' => 'copy-callout-images=png',
                 '-a' => 'copy-admonition-images=png',
                 $latest ? () : ('-a' => "migration-warnings=false"),
+                $respect_edit_url_overrides ? ('-a' => "respect_edit_url_overrides=true") : (),
                 # Disable warning on missing attributes because we have
                 # missing attributes!
                 # '-a' => 'attribute-missing=warn',

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -66,6 +66,7 @@ class EditMe < TreeProcessorScaffold
     def edit_url
       if @document.attributes['respect_edit_url_overrides']
         url = @document.attributes['edit_url']
+        return false if url == ''
         return url if url
       end
 

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -28,7 +28,8 @@ class EditMe < TreeProcessorScaffold
       url = url[0..-2] if url.end_with? '/'
       edit_urls << { toplevel: toplevel, url: url }
     end
-    edit_urls.reverse!
+    # Prefer the longest matching edit url
+    edit_urls = edit_urls.sort_by { |e| [-e[:toplevel].length, e[:toplevel]] }
     document.attributes['edit_urls'] = edit_urls
     super
   end
@@ -36,30 +37,7 @@ class EditMe < TreeProcessorScaffold
   def process_block(block)
     return unless %i[preamble section floating_title].include? block.context
 
-    def block.title
-      # || '<stdin>' allows us to not blow up when translating strings that
-      # aren't associated with any particular file. '<stdin>' is asciidoctor's
-      # standard name for such strings.
-      path = source_path || '<stdin>'
-
-      edit_urls = @document.attributes['edit_urls']
-      edit_url = edit_urls.find { |e| path.start_with? e[:toplevel] }
-      unless edit_url
-        logger.warn(
-          message_with_context(
-            "couldn't find edit url for #{path}",
-            source_location: source_location
-          )
-        )
-        return super
-      end
-
-      url = edit_url[:url]
-      return super if url == '<disable>'
-
-      url += path[edit_url[:toplevel].length..-1]
-      "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"
-    end
+    block.extend WithEditLink
     if block.context == :preamble
       def block.source_path
         # source_location.path doesn't work for relative includes outside of
@@ -72,6 +50,46 @@ class EditMe < TreeProcessorScaffold
         # the base_dir which we use when we build books from many repos.
         source_location.file
       end
+    end
+  end
+
+  ##
+  # Extension to blocks that need an "edit me" link.
+  module WithEditLink
+    def title
+      url = edit_url
+      return super unless url
+
+      "#{super}<ulink role=\"edit_me\" url=\"#{edit_url}\">Edit me</ulink>"
+    end
+
+    def edit_url
+      if @document.attributes['respect_edit_url_overrides']
+        url = @document.attributes['edit_url']
+        return url if url
+      end
+
+      # || '<stdin>' allows us to not blow up when translating strings that
+      # aren't associated with any particular file. '<stdin>' is asciidoctor's
+      # standard name for such strings.
+      path = source_path || '<stdin>'
+
+      edit_urls = @document.attributes['edit_urls']
+      entry = edit_urls.find { |e| path.start_with? e[:toplevel] }
+      unless entry
+        logger.warn(
+          message_with_context(
+            "couldn't find edit url for #{path}",
+            source_location: source_location
+          )
+        )
+        return false
+      end
+
+      url = entry[:url]
+      return false if url == '<disable>'
+
+      url + path[entry[:toplevel].length..-1]
     end
   end
 end

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -70,6 +70,10 @@ class EditMe < TreeProcessorScaffold
         return url if url
       end
 
+      edit_url_by_path
+    end
+
+    def edit_url_by_path
       # || '<stdin>' allows us to not blow up when translating strings that
       # aren't associated with any particular file. '<stdin>' is asciidoctor's
       # standard name for such strings.

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe EditMe do
       title_start ||= '<title>'
       title_end ||= '</title>'
       context "for a document with #{type}s" do
-        shared_examples 'has edit links' do
+        shared_examples 'has standard edit links' do
           it "adds a link to #{type} 1" do
             link = spec_dir_link "#{type}1.adoc"
             expect(converted).to include(
@@ -109,7 +109,7 @@ RSpec.describe EditMe do
               include::resources/edit_me/#{type}2.adoc[]
             ASCIIDOC
           end
-          include_examples 'has edit links'
+          include_examples 'has standard edit links'
         end
         context 'that overrides edit_url' do
           let(:input) do
@@ -140,9 +140,29 @@ RSpec.describe EditMe do
                 "#{title_start}#{type.capitalize} 2#{link}#{title_end}"
               )
             end
+            context 'when overriding to an empty string' do
+              let(:input) do
+                <<~ASCIIDOC
+                  :edit_url:
+                  include::resources/edit_me/#{type}1.adoc[]
+
+                  include::resources/edit_me/#{type}2.adoc[]
+                ASCIIDOC
+              end
+              it "doesn't add edit links to #{type} 1" do
+                expect(converted).to include(
+                  "#{title_start}#{type.capitalize} 1#{title_end}"
+                )
+              end
+              it "doesn't add edit links to #{type} 2" do
+                expect(converted).to include(
+                  "#{title_start}#{type.capitalize} 2#{title_end}"
+                )
+              end
+            end
           end
           context "when overriding the edit_url isn't allowed" do
-            include_examples 'has edit links'
+            include_examples 'has standard edit links'
           end
         end
       end

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -60,13 +60,13 @@ RSpec.describe EditMe do
   end
 
   context 'when edit_urls is configured' do
-    let(:convert_attributes) do
-      edit_urls = <<~CSV
+    let(:edit_urls) do
+      <<~CSV
         <stdin>,www.example.com/stdin
         #{spec_dir},www.example.com/spec_dir
       CSV
-      { 'edit_urls' => edit_urls }
     end
+    let(:convert_attributes) { { 'edit_urls' => edit_urls } }
     let(:stdin_link) do
       '<ulink role="edit_me" url="www.example.com/stdin">Edit me</ulink>'
     end
@@ -87,24 +87,63 @@ RSpec.describe EditMe do
       title_start ||= '<title>'
       title_end ||= '</title>'
       context "for a document with #{type}s" do
-        let(:input) do
-          <<~ASCIIDOC
-            include::resources/edit_me/#{type}1.adoc[]
+        shared_examples 'has edit links' do
+          it "adds a link to #{type} 1" do
+            link = spec_dir_link "#{type}1.adoc"
+            expect(converted).to include(
+              "#{title_start}#{type.capitalize} 1#{link}#{title_end}"
+            )
+          end
+          it "adds a link to #{type} 2" do
+            link = spec_dir_link "#{type}2.adoc"
+            expect(converted).to include(
+              "#{title_start}#{type.capitalize} 2#{link}#{title_end}"
+            )
+          end
+        end
+        context "that doesn't override edit_url" do
+          let(:input) do
+            <<~ASCIIDOC
+              include::resources/edit_me/#{type}1.adoc[]
 
-            include::resources/edit_me/#{type}2.adoc[]
-          ASCIIDOC
+              include::resources/edit_me/#{type}2.adoc[]
+            ASCIIDOC
+          end
+          include_examples 'has edit links'
         end
-        it "adds a link to #{type} 1" do
-          link = spec_dir_link "#{type}1.adoc"
-          expect(converted).to include(
-            "#{title_start}#{type.capitalize} 1#{link}#{title_end}"
-          )
-        end
-        it "adds a link to #{type} 2" do
-          link = spec_dir_link "#{type}2.adoc"
-          expect(converted).to include(
-            "#{title_start}#{type.capitalize} 2#{link}#{title_end}"
-          )
+        context 'that overrides edit_url' do
+          let(:input) do
+            <<~ASCIIDOC
+              :edit_url: foo
+              include::resources/edit_me/#{type}1.adoc[]
+
+              :edit_url: bar
+              include::resources/edit_me/#{type}2.adoc[]
+            ASCIIDOC
+          end
+          context 'when overriding the edit_url is allowed' do
+            let(:convert_attributes) do
+              {
+                'edit_urls' => edit_urls,
+                'respect_edit_url_overrides' => 'true',
+              }
+            end
+            it "adds a link to #{type} 1" do
+              link = '<ulink role="edit_me" url="foo">Edit me</ulink>'
+              expect(converted).to include(
+                "#{title_start}#{type.capitalize} 1#{link}#{title_end}"
+              )
+            end
+            it "adds a link to #{type} 2" do
+              link = '<ulink role="edit_me" url="bar">Edit me</ulink>'
+              expect(converted).to include(
+                "#{title_start}#{type.capitalize} 2#{link}#{title_end}"
+              )
+            end
+          end
+          context "when overriding the edit_url isn't allowed" do
+            include_examples 'has edit links'
+          end
         end
       end
     end
@@ -126,7 +165,7 @@ RSpec.describe EditMe do
           include::resources/edit_me/section2.adoc[]
         ASCIIDOC
       end
-      it 'uses the last match' do
+      it 'uses the longest match' do
         url = 'www.example.com/section2'
         link = %(<ulink role="edit_me" url="#{url}">Edit me</ulink>)
         expect(converted).to include("<title>Section 2#{link}</title>")


### PR DESCRIPTION
Makes two changes to the generation of "edit" links for asciidoctor:
1. Prefers the longest matching repository. This helps when repository
is `logtstash` and another is `logstash-docs`.
2. Create a setting to enable overriding `edit_me` links using an
attribute. Historically we've overridden this attribute in cases where
it is no longer needed for Asciidoctor and overriden it *incorrectly*.
But there are some cases where we really do want ot override it.
Specifically for logstash. So this allows us to turn it on when we want
it.
