### PR TITLE
Enable ECK doc build for 0.9

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -536,7 +536,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    0.8
-            branches:   [ master, 0.8 ]
+            branches:   [ master, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             public:     1


### PR DESCRIPTION
Adds the new 0.9 branch to the docs build.