### PR TITLE
[DOCS] Bump 6.8 version attributes from 6.8.1 to 6.8.2

### DIFF
--- a/shared/versions68.asciidoc
+++ b/shared/versions68.asciidoc
@@ -1,7 +1,7 @@
-:version:                6.8.1
-:logstash_version:       6.8.1
-:elasticsearch_version:  6.8.1
-:kibana_version:         6.8.1
+:version:                6.8.2
+:logstash_version:       6.8.2
+:elasticsearch_version:  6.8.2
+:kibana_version:         6.8.2
 :branch:                 6.8
 :major-version:          6.x
 :prev-major-version:     5.x


### PR DESCRIPTION
Increments the shared 6.8 attributes for the 6.8.2 release.

Will merge on release day.