### PR TITLE
Preview: Add a diff endpoint

### DIFF
--- a/integtest/spec/helper/matcher/serve.rb
+++ b/integtest/spec/helper/matcher/serve.rb
@@ -10,7 +10,8 @@ RSpec::Matchers.define :serve do |expected|
   end
   failure_message do |actual|
     unless actual.code == '200'
-      return "expected status [200] but was [#{actual.code}]"
+      return "expected status [200] but was [#{actual.code}]. Body:\n" +
+             actual.body
     end
 
     "status was [200] but the body didn't match: #{expected.failure_message}"

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -602,7 +602,7 @@ http {
 
   server {
     listen 8000;
-    location /guide {
+    location ~/(guide|diff) {
       proxy_pass http://0.0.0.0:3000;
       proxy_http_version 1.1;
       proxy_set_header Host \$host;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,13 @@
 {
   "license": "SEE LICENSE IN README.asciidoc",
   "devDependencies": {
-    "dedent": "^0.7.0",
     "jest": "^24.8.0",
     "jquery": "^1.11.3",
     "nock": "^10.0.6",
     "rmfr": "^2.0.0"
+  },
+  "dependencies": {
+    "dedent": "^0.7.0"
   },
   "scripts": {
     "test": "jest"

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /*
  * Little server that listens for requests in the form of
  * `${branch}.host/guide/${doc}`, looks up the doc from git and streams
@@ -9,7 +11,9 @@
  */
 
 const child_process = require('child_process');
+const dedent = require('dedent');
 const http = require('http');
+const stream = require('stream');
 const url = require('url');
 
 const port = 3000;
@@ -22,17 +26,19 @@ const catOpts = {
 };
 
 const requestHandler = (request, response) => {
-  parsedUrl = url.parse(request.url);
+  const parsedUrl = url.parse(request.url);
+  const branch = gitBranch(request.headers['host']);
+  if (parsedUrl.pathname === '/diff') {
+    serve_diff(branch, response);
+    return;
+  }
   if (!parsedUrl.pathname.startsWith('/guide')) {
     response.statusCode = 404;
     response.end();
     return;
   }
   const path = 'html' + parsedUrl.pathname.substring('/guide'.length);
-  const branch = gitBranch(request.headers['host']);
   const requestedObject = `${branch}:${path}`;
-  // TODO keepalive?
-  // TODO include the commit info for the branch in a header
   child_process.execFile('git', ['cat-file', '-t', requestedObject], checkTypeOpts, (err, stdout, stderr) => {
     if (err) {
       if (err.message.includes('Not a valid object name')) {
@@ -54,51 +60,197 @@ const requestHandler = (request, response) => {
       return;
     }
 
-    response.setHeader('Transfer-Encoding', 'chunked');
     const child = child_process.spawn(
       'git', ['cat-file', 'blob', requestedObject], catOpts
     );
-
-    // We spool stderr into a string because it is never super big.
-    child.stderr.setEncoding('utf8');
-    let childstderr = '';
-    child.stderr.addListener('data', chunk => {
-      childstderr += chunk;
-    });
-
-    /* Let node handle all the piping because it handles backpressure properly.
-     * We don't let the pipe emit the `end` event though because we'd like to
-     * do that manually when the process exits. The chunk size seems looks like
-     * it is 4k which looks to come from the child_process. */
-    child.stdout.pipe(response, {end: false});
-
-    let exited = false;
-    child.addListener('close', (code, signal) => {
-      /* This can get invoked multiple times but we can only do anything
-       * the first time so we just drop the second time on the floor. */
-      if (exited) return;
-      exited = true;
-
-      if (code === 0 && signal === null) {
-        response.end();
-        return;
-      }
-      /* Note that we're playing a little fast and loose here with the status.
-       * If we've already sent a chunk we can't change the status code. We're
-       * out of luck. We just terminate the response anyway. The server log
-       * is the best we can do for tracking these. */
-      console.warn('unhandled error', code, signal, childstderr);
-      response.statusCode = 500;
-      response.end(childstderr);
-    });
-    child.addListener('error', err => {
-      child.stdout.destroy();
-      child.stderr.destroy();
-      console.warn('unhandled error', err);
-      response.statusCode = 500;
-      response.end(err.message);
-    });
+    rig_handlers(child, response, child.stdout, response => {});
   });
+}
+
+function serve_diff(branch, response) {
+  const child = child_process.spawn(
+    'git',
+    ['diff-tree', '-z', '--find-renames', '--numstat', branch, '--'],
+    catOpts
+  );
+
+  let chunk = '';
+  let first = true;
+  let completeSuccess = true;
+  const handleChunk = () => {
+    /*
+     * Parses output from `git diff-tree -z` which is in
+     * one of two formats:
+     * * added lines<tab>removed lines<tab>path<nul>
+     * * added lines<tab>removed lines<nul>source path<nul>destination path<nul>
+     * The second one is only used when git detects a rename.
+     */
+    let out = '';
+    let entryStart;
+    let nextNul = -1;
+    let added;
+    let removed;
+    let path;
+    let movedToPath;
+
+    while (true) {
+      /* When this loop starts nextNul is either -1 or the end of the last
+       * message so we can pick up from nextNul + 1. */
+      entryStart = nextNul + 1;
+      nextNul = chunk.indexOf('\0', entryStart);
+      if (nextNul === -1) {
+        chunk = chunk.substring(entryStart);
+        return out;
+      }
+      const parts = chunk.substring(entryStart, nextNul).trim().split('\t');
+      switch (parts.length) {
+      case 3:
+        [added, removed, path] = parts;
+        movedToPath = null;
+        break;
+      case 2:
+        [added, removed] = parts;
+        const pathStart = nextNul + 1;
+        nextNul = chunk.indexOf('\0', pathStart);
+        if (nextNul === -1) {
+          chunk = chunk.substring(entryStart);
+          return out;
+        }
+        path = chunk.substring(pathStart, nextNul);
+        const moveToPathStat = nextNul + 1;
+        nextNul = chunk.indexOf('\0', moveToPathStat);
+        if (nextNul === -1) {
+          chunk = chunk.substring(entryStart);
+          return out;
+        }
+        movedToPath = chunk.substring(moveToPathStat, nextNul);
+        out += 'asdfaf ' + path + ' ' + movedToPath + '  ';
+        break;
+      case 1:
+        // The commit hash. Ignore it.
+        continue;
+      default:
+        console.warn("Unknown message from git", parts);
+        completeSuccess = false;
+        continue;
+      }
+
+      // Skip boring files
+      if ([
+            'html/branches.yaml', 'html/sitemap.xml','html/revision.txt'
+          ].includes(path)) {
+        continue;
+      }
+
+      // Strip the prefix from the paths
+      path = path.substring('html/'.length);
+      movedToPath =
+        movedToPath === null ? null : movedToPath.substring('html/'.length);
+
+      // Build the output html
+      let prefix = '';
+      if (first) {
+        prefix = dedent `
+          <!DOCTYPE html>
+          <html>
+          <head>
+            <title>Diff for ${branch}</title>
+          </head>
+          <body><ul>\n`;
+        first = false;
+      }
+      const diff = `+${added} -${removed}`;
+      const linkText =
+        movedToPath === null ? path : `${path} -> ${movedToPath}`;
+      const linkTarget =
+        "/guide/" + (movedToPath === null ? path : movedToPath);
+      const link = `<a href="${linkTarget}">${linkText}</a>`;
+      out += `${prefix}  <li>${diff} ${link}\n`;
+    }
+  };
+
+  const handle = new stream.Transform({
+    writableObjectMode: true,
+    transform(chunkIn, encoding, callback) {
+      chunk += chunkIn;
+      callback(null, handleChunk());
+    }
+  });
+
+  const pipeline = child.stdout.pipe(handle);
+  rig_handlers(child, response, pipeline, response => {
+    response.write(handleChunk());
+    if (chunk !== '') {
+      console.error('unprocessed results from git', chunk);
+      response.write(`  <li>Unprocessed results from git: <pre>${chunk}</pre>`);
+      response.status = 500;
+    } else if (!completeSuccess) {
+      response.write(`  <li>Error processing some entries from git. See logs.`);
+      response.status = 500;
+    }
+    response.write('</ul></html>');
+  });
+}
+
+function rig_handlers(child, response, pipeline, endHandler) {
+  response.setHeader('Transfer-Encoding', 'chunked');
+
+  // We spool stderr into a string because it is never super big.
+  child.stderr.setEncoding('utf8');
+  let childstderr = '';
+  child.stderr.addListener('data', chunk => {
+    childstderr += chunk;
+  });
+
+  /* We end the response either when an error occurs or when *both* the child
+   * process *and* its pipeline have been consumed. If we didn't wait for the
+   * child process then we'd end early on failures. If we didn't wait for the
+   * pipeline we could throw out the end of the response. */
+  let childExited = false;
+  let pipelineEnded = false;
+  const checkForNormalEnd = () => {
+    if (childExited && pipelineEnded) {
+      endHandler(response);
+      response.end();
+    }
+  }
+
+  child.addListener('close', (code, signal) => {
+    /* This can get invoked multiple times but we can only do anything
+     * the first time so we just drop the second time on the floor. */
+    if (childExited) return;
+    childExited = true;
+
+    if (code === 0 && signal === null) {
+      checkForNormalEnd();
+      return;
+    }
+    if (childstderr.includes('bad revision')) {
+      response.statusCode = 404;
+      response.end();
+      return;
+    }
+    /* Note that we're playing a little fast and loose here with the status.
+     * If we've already sent a chunk we can't change the status code. We're
+     * out of luck. We just terminate the response anyway. The server log
+     * is the best we can do for tracking these. */
+    console.warn('unhandled error', code, signal, childstderr);
+    response.statusCode = 500;
+    response.end(childstderr);
+  });
+  child.addListener('error', err => {
+    child.stdout.destroy();
+    child.stderr.destroy();
+    console.warn('unhandled error', err);
+    response.statusCode = 500;
+    response.end(err.message);
+  });
+
+  pipeline.on('end', () => {
+    pipelineEnded = true;
+    checkForNormalEnd();
+  });
+  pipeline.pipe(response, {end: false});
 }
 
 function gitBranch(host) {

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -8,11 +8,11 @@
 set -e
 
 cd $(git rev-parse --show-toplevel)
-docker build -t docker.elastic.co/docs/preview:1 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:3 -f preview/Dockerfile .
 id=$(docker run --rm \
            --publish 8000:8000/tcp \
            -d \
-           docker.elastic.co/docs/preview:1)
+           docker.elastic.co/docs/preview:3)
 echo "Started the preview. Some useful commands:"
 echo "   docker kill $id"
 echo "   docker logs -tf $id"

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:2
+export PREVIEW=docker.elastic.co/docs/preview:3
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
I've found that it can be kind of annoying trying to find out which
files changed when looking up a docs preview. This adds a page at
`/diff` that contains links to all of the modified pages.

I used chunked transfer and stream parsing the result from git because
that felt like the right thing to do here but it did make the parsing a
bit more complex.

I also chose to use the `-z` flag when calling git because it emits a
format that isn't jumbled when files move. It has many ascii-nul
terminated records which means I couldn't really use any off the shelf
nodejs parsing libraries.
