### PR TITLE
Docs preview: fix two silly mistakes

### DIFF
--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -119,6 +119,32 @@ RSpec.describe 'previewing built docs', order: :defined do
       LOGS
     end
   end
+  shared_examples 'valid diff' do
+    it 'has the html5 doctype' do
+      expect(diff).to serve(include('<!DOCTYPE html>'))
+    end
+    it 'has the branch in the title' do
+      expect(diff).to serve(include("<title>Diff for #{branch}</title>"))
+    end
+    it "doesn't contain a link to the sitemap" do
+      expect(diff).not_to serve(include('sitemap.xml'))
+    end
+    it "doesn't contain a link to the revision file" do
+      expect(diff).not_to serve(include('revisions.txt'))
+    end
+    it "doesn't contain a link to the branch tracker file" do
+      expect(diff).not_to serve(include('branches.yaml'))
+    end
+    it "doesn't warn about unprocesed output" do
+      expect(diff).not_to serve(include('Unprocessed results from git'))
+    end
+    it 'logs access to the diff when it is accessed' do
+      wait_for_access watermark, branch, '/diff'
+      expect(logs).to include(<<~LOGS)
+        #{watermark} #{branch} GET /diff HTTP/1.1 200
+      LOGS
+    end
+  end
 
   describe 'for the master branch' do
     let(:branch) { 'master' }
@@ -171,18 +197,7 @@ RSpec.describe 'previewing built docs', order: :defined do
       include_context 'docs for branch'
       include_examples 'serves the docs root'
       context 'the diff' do
-        it 'has the branch in the title' do
-          expect(diff).to serve(include('<title>Diff for test</title>'))
-        end
-        it "doesn't contain a link to the sitemap" do
-          expect(diff).not_to serve(include('sitemap.xml'))
-        end
-        it "doesn't contain a link to the revision file" do
-          expect(diff).not_to serve(include('revisions.txt'))
-        end
-        it "doesn't contain a link to the branch tracker file" do
-          expect(diff).not_to serve(include('branches.yaml'))
-        end
+        include_examples 'valid diff'
         it 'contains a link to the index which has changed' do
           expect(diff).to serve(include(<<~HTML))
             +4 -4 <a href="/guide/test/master/index.html">test/master/index.html</a>
@@ -192,15 +207,6 @@ RSpec.describe 'previewing built docs', order: :defined do
           expect(diff).to serve(include(<<~HTML))
             +1 -1 <a href="/guide/test/master/moved_chapter.html">test/master/chapter.html -> test/master/moved_chapter.html</a>
           HTML
-        end
-        it "doesn't warn about unprocesed output" do
-          expect(diff).not_to serve(include('Unprocessed results from git'))
-        end
-        it 'logs access to the diff when it is accessed' do
-          wait_for_access watermark, branch, '/diff'
-          expect(logs).to include(<<~LOGS)
-            #{watermark} #{branch} GET /diff HTTP/1.1 200
-          LOGS
         end
       end
     end
@@ -222,6 +228,43 @@ RSpec.describe 'previewing built docs', order: :defined do
       let(:branch) { 'test' }
       include_context 'docs for branch'
       include_examples '404s'
+    end
+  end
+  describe 'when we commit a noop change' do
+    before(:context) do
+      repo = @src.repo 'repo'
+      repo.write 'index.asciidoc', <<~ASCIIDOC
+        = Title
+
+        [[chapter]]
+        == Chapter
+        Some text.
+
+        image::resources/cat.jpg[A cat]
+        image::resources/very_large.jpg[Not a jpg but very big]
+      ASCIIDOC
+      repo.commit 'test change for test_noop branch2'
+      @dest.convert_all @src.conf, target_branch: 'test_noop'
+    end
+    it 'logs the fetch' do
+      wait_for_logs(/\[new branch\]\s+test_noop\s+->\s+test_noop/)
+      # The leading space in the second line is important because it causes
+      # filebeat to group the two log lines.
+      expect(logs).to include("\n" + <<~LOGS)
+        From #{repo}
+         * [new branch]      test_noop  -> test_noop
+      LOGS
+    end
+    describe 'for the test branch' do
+      let(:branch) { 'test_noop' }
+      include_context 'docs for branch'
+      include_examples 'serves the docs root'
+      context 'the diff' do
+        include_examples 'valid diff'
+        it 'is empty' do
+          expect(diff).to serve(include("<ul>\n</ul>"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes two silly mistakes with the docs preview:
1. Removes a debugging output that I left in the path that handles
renames.
2. Handles empty diffs. Those should be rare, but we should produce
valid html when we have them.
