### PR TITLE
Docs preview: Skip repos we don't own

### DIFF
--- a/preview/__test__/clean.test.js
+++ b/preview/__test__/clean.test.js
@@ -86,6 +86,12 @@ describe('Cleaner.is_pr_closed', () => {
     mock_github().reply(200, github_result(false));
     await expect(cleaner.is_pr_closed({repo: 'r', number: 1})).resolves.toBe(false);
   });
+  test("returns false if github doesn't return repo", async () => {
+    mock_github().reply(200, JSON.stringify({
+      data: {}
+    }));
+    await expect(cleaner.is_pr_closed({branch: 'r_1', repo: 'r', number: 1})).resolves.toBe(false);
+  });
   test('complains if github returns invalid json', async () => {
     mock_github().reply(200, 'pure garbage');
     await expect(cleaner.is_pr_closed({repo: 'r', number: 1})).rejects
@@ -94,11 +100,11 @@ describe('Cleaner.is_pr_closed', () => {
   test('complains if github returns unexpect json', async () => {
     mock_github().reply(200, JSON.stringify({
       data: {
-        whatever: 'asdf'
+        repository: 'asdf'
       }
     }));
     await expect(cleaner.is_pr_closed({repo: 'r', number: 1})).rejects
-      .toThrow(/Cannot read property 'pullRequest'/);
+      .toThrow(/Cannot read property 'closed' of undefined/);
   });
   test("backs off if there aren't many requests remaining", async () => {
     // Mock setTimeout to immediately run. We don't use jest.useFakeTimers

--- a/preview/clean.js
+++ b/preview/clean.js
@@ -111,7 +111,15 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
             let closed;
             try {
               const parsed = JSON.parse(data);
-              closed = parsed.data.repository.pullRequest.closed;
+              const repo = parsed.data.repository;
+              if (repo) {
+                closed = repo.pullRequest.closed;
+              } else {
+                console.warn(pr.branch,
+                  "looks like a PR but isn't for a repo we manage so we assume",
+                  'it is open');
+                closed = false;
+              }
             } catch (e) {
               reject(e);
               return;
@@ -123,7 +131,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
             if (res.headers['x-ratelimit-remaining'] < 100) {
               const until = res.headers['x-ratelimit-reset'];
               const millis = until * 1000 - Date.now().getTime();
-              console.info('rate limited for', millis, 'milliseconds');
+              console.info('Rate limited for', millis, 'milliseconds');
               setTimeout(() => resolve(closed), millis);
             } else {
               resolve(closed);


### PR DESCRIPTION
Our pattern for pull request branches is a little broad so sometimes
normal looking branches will match it and we'll *think* they are for a
pull request when they really aren't. This change makes it so that when
we can't find the pull request information for a branch we log a warning
and keep it open rather than crash. That seems sensible.
