### PR TITLE
Change current to release-ms-25

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -498,8 +498,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-24
-            branches:   [ release-ms-25, release-ms-24 ]
+            current:    release-ms-25
+            branches:   [ release-ms-25 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -516,8 +516,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-24
-            branches:   [ release-ms-24 ]
+            current:    release-ms-25
+            branches:   [ release-ms-25 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
With the release of `release-ms-25` imminent , we should update our doc builds to 

* change `current` to `release-ms-25 for both ESS and ECH (our newfangled Heroku docs); and
* remove `release-ms-24` from the doc builds

@elastic/cloud-writers I need one of you to review and approve, please.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
