### PR TITLE
k8s - change current to 0.9

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -557,7 +557,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    0.8
+            current:    0.9
             branches:   [ master, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Changed `current` to `0.9` for the upcoming K8s alpha release (July 30).