### PR TITLE
Update build all instructions.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -193,45 +193,41 @@ NOTE: You should still build the whole book without the `--lenient` parameter
 before committing, to be sure that you haven't broken any links.
 
 [[website]]
-== For the website
+== Building all of the Elastic docs
 
-Usually you don't need to build all the docs that will be uploaded
-to the website, but if you are linking between documents (e.g.
-between the Java API docs and the main reference documentation),
-then building all of the docs will report any missing links.
+Building all of the docs runs a link checker to validate cross-document links.
+While it isn't generally necessary, if you know the book you are working on
+has links to/from other books, you can build with `--all` to validate
+the links. 
 
-You can build all the docs with:
+NOTE: To build everything, you must have access to all of the repositories
+referenced in `conf.yaml`. If you don't have the required access privileges,
+an error will occur during the cloning phase.
 
-[source,bash]
+To check links before you merge your changes:
+
+. Make sure you have the branch with your changes checked out. 
+. Specify the branch you are targeting and the directory that contains your local clone
+  with the `--sub_dir` option. For example, if you are working on changes that will be merged
+  into the master branch of the `elasticsearch` repo, run:
++
 ----------------------------
-build_docs --all
+./docs/build_docs --all --target_repo git@github.com:elastic/built-docs.git --open --sub_dir elasticsearch:master:./elasticsearch 
 ----------------------------
 
-The first time you run this will be slow as it needs to:
+To run a full build to mimic the website build, omit the `--sub_dir` option:
+
+----------------------------
+build_docs --all --target_repo git@github.com:elastic/built-docs.git --open
+----------------------------
+
+The first time you run a full build is slow as it needs to:
 
 * clone each repository
 * build the docs for each branch
 
 Subsequent runs will pull any changes to the repos and only build the
 branches that have changed.
-
-NOTE: If you do not have authority to access all of the necessary repositories,
-an error occurs during the cloning phase. 
-
-
-=== Checking your changes
-
-Because the docs are built from the remote repositories, you will
-need to push your changes to the main repo before running
-`build_docs --all`.
-
-Assuming you have already checked that your docs build correctly
-using the <<local,local build process>>, the only other errors
-that might occur at this stage are bad cross-document links.
-
-Once the docs build correctly, you don't need to do anything more.
-The changes that you have pushed to your repository will be
-picked up automatically by the docs build service.
 
 [[config]]
 == Adding new docs or new branches

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -166,7 +166,8 @@ alias docbldgke='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-d
 
 # Build all
 alias docbldall='GIT_HOME/docs/build_docs --all --target_repo git@github.com:elastic/built-docs.git'
-# NOTE: To build with your local changes before merging, use the --sub_dir 
-# option to specify the repo and branch you want to merge to and the directory
-# that contains your clone of the repo. For example:
+# NOTE: To build all books and pick up un-merged changes from your local repos,
+# use one or more --sub_dir options. Specify the repo and branch you want to
+# override and the directory that contains your changes.
+# For example:
 # --sub_dir elasticsearch:master:./elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -57,7 +57,7 @@ alias docbldso='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-do
 # Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
-# Solutions 
+# Solutions
 alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
 
 alias docbldup='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
@@ -161,5 +161,12 @@ alias docbldx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/x-pack/do
 # ECS
 alias docbldecs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'
 
-# GKE 
+# GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
+
+# Build all
+alias docbldall='GIT_HOME/docs/build_docs --all --target_repo git@github.com:elastic/built-docs.git'
+# NOTE: To build with your local changes before merging, use the --sub_dir 
+# option to specify the repo and branch you want to merge to and the directory
+# that contains your clone of the repo. For example:
+# --sub_dir elasticsearch:master:./elasticsearch


### PR DESCRIPTION
You now need to specify the `--target_repo` when building with the `--all` option and can use the `--sub_dir` option to pick up local changes. (So you can check for broken links *before* you merge!)