### PR TITLE
Add ruby docs metadata to conf.yml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -450,19 +450,6 @@ contents:
                     path:   docs/python
 
               -
-                title:      Ruby API
-                prefix:     ruby-api
-                branches:   [master]
-                index:      docs/ruby/index.asciidoc
-                current:    master
-                tags:       Clients/Ruby
-                subject:    Clients
-                asciidoctor: true
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/ruby
-              -
                 title:      Community Contributed Clients
                 prefix:     community
                 branches:   [master]

--- a/conf.yaml
+++ b/conf.yaml
@@ -22,6 +22,7 @@ repos:
     ecs:                  https://github.com/elastic/ecs.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
+    elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
     elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
     elasticsearch-php:    https://github.com/elastic/elasticsearch-php
     elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
@@ -359,6 +360,19 @@ contents:
                 sources:
                   -
                     repo:   elasticsearch-js
+                    path:   docs/
+              -
+                title:      Ruby API
+                prefix:     ruby-api
+                current:    7.x
+                branches:   [ master, 7.x ]
+                index:      docs/index.asciidoc
+                tags:       Clients/Ruby
+                subject:    Clients
+                asciidoctor: true
+                sources:
+                  -
+                    repo:   elasticsearch-ruby
                     path:   docs/
               -
                 title:      Go API

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -136,6 +136,8 @@ alias docbldejv='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldejs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
 
+alias docbldejs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
+
 alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
 alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
@@ -147,8 +149,6 @@ alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
 alias docbldepy='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
-
-alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/ruby/index.asciidoc'
 
 alias docbldecc='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 


### PR DESCRIPTION
Following the pattern of other clients, I've taken the files [here](https://github.com/elastic/elasticsearch/tree/master/docs/ruby) and copied them into the `master` and `7.x` branches of the Ruby client repository.
This pull request add the metadata for building the Ruby client docs to the docs repo. 