### PR TITLE
Add xpack libbeat path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -800,6 +800,10 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
           -
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat


### PR DESCRIPTION
The exclude path will need to be updated again when the doc changes that caused the build to break are backported to other branches.
