### PR TITLE
Style: Fix toc line spacing

### DIFF
--- a/resources/web/styles.css
+++ b/resources/web/styles.css
@@ -132,15 +132,9 @@ h1, h2, h3, h4, h5, h6 {
     font-size: 0.85em;
 }
 
-#this_page li > a > span {
-	color: #00a9e5;
-  display: inherit;
-  font-size: inherit;
-  margin-top: inherit;
-  margin-bottom: inherit;
-  margin-left: inherit;
-  margin-right: inherit;
-  font-weight: inherit;
+#this_page li {
+    line-height: 1em;
+    margin-bottom: .5em;
 }
 
 /* Right hand TOC */
@@ -172,14 +166,15 @@ h1, h2, h3, h4, h5, h6 {
 
 #guide .toc span {
     display: block;
-    padding: 0.1em 0;
+    padding: 0.5em 0;
     font-size: 0.85em;
+    line-height: 1em;
 }
 
 #guide .toc > li > span {
     background-color: #efefef;
     border-bottom: 1px solid #ddd;
-    padding: 0.3em 0 0.3em 20px;
+    padding-left: 20px;
     font-size: 1em;
 }
 


### PR DESCRIPTION
Our table of contents and "on this page" section was using
`line-height: 26px` which looked fairly bad if the title broke to the
next line. This switches it to using `line-height: 1em` and uses
margin or padding to maintain the separation between items instead.

Closes #1006
