### PR TITLE
Add Azure Marketplace 7.3 to docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -151,9 +151,9 @@ contents:
           -
             title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    7.2
+            current:    7.3
             index:      docs/index.asciidoc
-            branches:   [ master, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This PR adds the 7.3 version of Azure Marketplace and ARM template to the docs, and marks as the current version.

It must be committed only after 7.3 is made available on the Azure Marketplace. I'll comment when this is the case.

