### PR TITLE
Update APM Python Agent versioning

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1057,8 +1057,8 @@ contents:
                   -
                     title:      APM Python Agent
                     prefix:     python
-                    current:    4.x
-                    branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
+                    current:    5.x
+                    branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Version 5.0 of the APM Python Agent is now the current version

**Needs to be merged concurrently with https://github.com/elastic/apm-server/pull/2519**

Other related PRs: https://github.com/elastic/apm-server/pull/2520, https://github.com/elastic/apm-server/pull/2521