### PR TITLE
Use updated path to PHP examples

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -239,7 +239,7 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   elasticsearch-php
-                path:   examples
+                path:   examples/docs/asciidoc
                 exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               # Coming soon!
               # -


### PR DESCRIPTION
Changed to _new_ path for the PHP examples.