### PR TITLE
Correct doc build alias for es ruby client

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -136,7 +136,7 @@ alias docbldejv='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elastic
 
 alias docbldejs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
 
-alias docbldejs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
+alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
 
 alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 


### PR DESCRIPTION
Corrects a copy/paste error from #1026.

I'd say this is a dependency for elastic/elasticsearch#45227