### PR TITLE
Drop animated scrolling

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -513,42 +513,6 @@ $(document).ready(function(){
 <script type="text/javascript" src="/static/js/slick.min.js"></script>
 <script src="/static/js/nav-v5.js"></script>
 <script src="/static/js/script.js"></script>
- 
-     
-<script type="text/javascript">
-$(document).ready(function(){
-	if (window.location.hash.length) {
-	      var target = $(window.location.hash);
-	      target = target.length ? target : $(window.location.hash);
-	      if (target.length) {
-	        setTimeout(function(){ $(window).scrollTop(target.offset().top - 60); }, 1200);        
-	      }
-	}
-	$('#guide').on('click','a[href*=#]:not([href=#])',function(e) {
-			var flag=true;
-		      if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
-		          var target = $(this.hash);
-		          target = target.length ? target :$(this.hash);
-		          if (target.length) {
-		            if(flag){
-		              flag=false;
-		              var heightScroll=($('.tertiary-nav.navbar-fixed-top').height())?60:110;
-		              $('html,body').animate({
-		                  scrollTop: target.offset().top - heightScroll
-		                }, 2000, function(){
-		                  flag=true;
-		                });
-		            }                    
-		          }
-		      }
-		    
-	});
 
-})
-
-</script>
-
-     <style></style>
-     
   </body>
 </html>


### PR DESCRIPTION
We had animated the scroll when you click on an ID or load a page with
an id to make sure we didn't cover up a "floating" pane at the top of
the page. We don't have such a pane anymore so we can fall back to the
browser's default behavior.

Closes #950
