### PR TITLE
Add Curator 5.8 again

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -510,7 +510,7 @@ contents:
             title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
             current:    5.7
-            branches:   [ 5.x, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
+            branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
             subject:    Clients


### PR DESCRIPTION
Adding Curator 5.8 again, as something weird happened with the build. It works for me on the same branch, and the error isn't a cross-doc link issue.
