### PR TITLE
Add the node name to the commit message

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -471,6 +471,9 @@ def standard_docker_args():
     # Keep stdin open so the docs build can use closing it as a signal that
     # it needs to die.
     docker_args.append('-i')
+    # Pass the node name into the docker image if it is set
+    if 'NODE_NAME' in environ:
+        docker_args.extend(['-e', 'NODE_NAME=%s' % environ['NODE_NAME']])
     # Ritual to make nginx run (even with -t) as the mapped user
     docker_args.extend(['--tmpfs', '/run/nginx',
                         '--tmpfs', '/var/log/nginx',

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -351,6 +351,21 @@ RSpec.describe 'building all books' do
     end
   end
 
+  context 'when there is a NODE_NAME in the environment' do
+    convert_before do |src, dest|
+      repo = src.repo_with_index 'repo', 'Some text.'
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      dest.prepare_convert_all(src.conf)
+          .node_name('my-node-name')
+          .convert
+    end
+    let(:commit_info) { @dest.commit_info }
+    it 'adds the NODE_NAME to the commit message' do
+      expect(commit_info).to include('my-node-name')
+    end
+  end
+
   context "when the index for the book isn't in the repo" do
     convert_before do |src, dest|
       repo = src.repo_with_index 'src', 'words'

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -124,7 +124,11 @@ sub commit {
     local $ENV{GIT_DIR} = $ENV{GIT_WORK_TREE} . '/.git';
 
     run qw(git add -A);
-    run qw(git commit -m), 'Updated docs';
+    my $commit_msg = 'Updated docs';
+    if ( $ENV{NODE_NAME} ) {
+        $commit_msg .= "\n\nBuilt on $ENV{NODE_NAME}";
+    }
+    run qw(git commit -m), $commit_msg;
 }
 
 #===================================


### PR DESCRIPTION
This will be useful for tracking down "rogue" builds outside of our
primary build.
