### PR TITLE
Improve error message if port 8000 taken

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -259,6 +259,9 @@ def run_build_docs(args):
                 environ['BROWSER'] = 'open'
             webbrowser.open('http://localhost:8000/guide',
                             new=1, autoraise=False)
+        if 'Bind for 0.0.0.0:8000 failed: port is already allocated.' in line:
+            logger.error('Another process has port 8000. Is there already a '
+                         'docs build running with --open?')
         if should_forward_ssh_auth_into_container:
             match = re.match('Waiting for ssh auth to be forwarded to (.+)',
                              line)


### PR DESCRIPTION
Catches the docker error message if port 8000 is already in use and adds
a more user friendly one below it.

Closes #739
