### PR TITLE
Fixup error handling for new port

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -302,9 +302,9 @@ def run_build_docs(args):
         logger.info(line)
         if open_browser:
             open_browser.on_line(line)
-        if 'Bind for 0.0.0.0:8000 failed: port is already allocated.' in line:
-            logger.error('Another process has port 8000. Is there already a '
-                         'docs build running with --open?')
+        if 'failed: port is already allocated.' in line:
+            logger.error('Another process has a port we need. Is there '
+                         'already a docs build running with --open?')
         if should_forward_ssh_auth_into_container:
             match = re.match('Waiting for ssh auth to be forwarded to (.+)',
                              line)


### PR DESCRIPTION
Switching to two ports for `--open` broke our nice error message when
ports colide. This fixes it.
