### PR TITLE
Enable alternative examples from C#

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -250,21 +250,16 @@ contents:
                 repo:   elasticsearch-php
                 path:   examples/docs/src/Examples
                 exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              # Coming soon!
-              # -
-              #   alternatives: { source_lang: console, alternative_lang: csharp }
-              #   repo:   elasticsearch-net
-              #   path:   examples
-              #   exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              #   map_branches:
-              #     master: doc-examples
-              # -
-              #   # These are used by .NET's doc examples but they are not in the same subdirectory
-              #   repo:   elasticsearch-net
-              #   path:   src/Examples
-              #   exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              #   map_branches:
-              #     master: doc-examples
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   elasticsearch-net
+                path:   examples
+                exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                # These are used by .NET's doc examples but they are not in the same subdirectory
+                repo:   elasticsearch-net
+                path:   src/Examples
+                exclude_branches:   [ 7.x, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           -
             title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency


### PR DESCRIPTION
Starts pulling C# examples from the elasticsearch-net repo into the
Elasticsearch reference. They aren't visible by default but we'll be
able to switch to them eventually.
