### PR TITLE
Move CSS for code and callouts into its own file

### DIFF
--- a/resources/web/style/calloutlist.pcss
+++ b/resources/web/style/calloutlist.pcss
@@ -1,0 +1,23 @@
+#guide .calloutlist {
+  background: #343642;
+  color: #ffffff;
+  margin: -15px 0 15px auto;
+  border-top: 1px solid #52576a;
+  padding: 15px 0 0 15px;
+  p {
+    color: #ffffff;
+  }
+  code {
+    background: #343642;
+    color: #ffffff;
+  }
+  td {
+    padding: 0;
+    border: none;
+  }
+  a {
+    color: #ffffff;
+    cursor: pointer;
+    text-decoration: underline;
+  }
+}

--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -1,0 +1,71 @@
+#guide {
+  %code-common {
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
+  }
+
+  /* Inline code examples */
+  code {
+    @extend %code-common;
+    background: #f8f8f8;
+    padding: 0 3px;
+    font-size: 0.9em;
+    display:inline;
+  }
+
+  a code {
+    color: #00a9e5;
+  }
+
+  /* Block code examples */
+  .pre_wrapper {
+    overflow-x: auto;
+    position: relative;
+    width: 100%;
+    margin: 0 0 15px 0;
+    background-color:#343741;
+    display: inline-flex;
+    pre {
+      margin: 0;
+    }
+  }
+
+  /* Code blocks with and without prettyprint. */
+  pre {
+    @extend %code-common;
+    color: #888;
+    font-size: 16px;
+  }
+
+  /* Code prettified blocks. */
+  .prettyprint {
+    /* Extension to pre style above only applied to pretty printed code. Most
+     * code is pretty printed. */
+    margin: 0 0 15px 0;
+    padding: 20px;
+    border: none;
+    line-height: 1.5em;
+    overflow: auto;
+    white-space: pre;
+    background-color:#343741;
+    width: auto;
+    max-width: 10000px;
+  }
+
+  /* Code prettify styles. */
+  .str { color: #7de2d1; }
+  .kwd { color: #1ba9F5; }
+  .com { color: #66747B; }
+  .typ { color: #f5f7fa; }
+  .lit { color: #ff977a; }
+  .pun { color: #f5f7fa; }
+  .pln { color: #f5f7fa; }
+  .tag { color: #1ba9F5; }
+  .atn { color: #1ba9F5; }
+  .atv { color: #ff977a; }
+  .dec { color: #66747B; }
+
+  /* Alternative language examples. */
+  .alternative {
+    display: none;
+  }
+}

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -1,3 +1,5 @@
+@import './style/calloutlist.pcss';
+@import './style/code.pcss';
 @import './style/xpack.pcss';
 
 /* test comment used to detect unminified source */
@@ -315,66 +317,6 @@ h1, h2, h3, h4, h5, h6 {
     border:none;
 }
 
-/* Code */
-#guide code {
-    background: #f8f8f8;
-    padding: 0 3px;
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
-    font-size: 0.9em;
-    display:inline;
-}
-#guide pre {
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
-    color: #888;
-}
-
-#guide .prettyprint {
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
-    font-size: 16px;
-    margin: 0 0 15px 0;
-    padding: 20px;
-    border: none;
-    line-height: 1.5em;
-    overflow: auto;
-    white-space: pre;
-    background-color:#343741;
-    width: auto;
-    max-width: 10000px;
-}
-
-#guide .str { color: #7de2d1; }
-#guide .kwd { color: #1ba9F5; }
-#guide .com { color: #66747B; }
-#guide .typ { color: #f5f7fa; }
-#guide .lit { color: #ff977a; }
-#guide .pun { color: #f5f7fa; }
-#guide .pln { color: #f5f7fa; }
-#guide .tag { color: #1ba9F5; }
-#guide .atn { color: #1ba9F5; }
-#guide .atv { color: #ff977a; }
-#guide .dec { color: #66747B; }
-
-#guide .pre_wrapper {
-    overflow-x: auto;
-    position: relative;
-    width: 100%;
-    margin: 0 0 15px 0;
-    background-color:#343741;
-    display: inline-flex;
-}
-
-#guide .pre_wrapper pre {
-    margin: 0;
-}
-
-#guide .alternative {
-    display: none;
-}
-
-#guide a code {
-    color: #00a9e5;
-}
-
 /* Admonitions */
 #guide .admon {
     background: #fbfbfb;
@@ -613,30 +555,6 @@ p.remark {
   height: 16px;
   vertical-align: text-bottom;
   margin-left: 1em;
-}
-
-#guide .calloutlist {
-    background: #343642;
-    color: #ffffff;
-    margin: -15px 0 15px auto;
-    border-top: 1px solid #52576a;
-    padding: 15px 0 0 15px;
-}
-#guide .calloutlist p {
-    color: #ffffff;
-}
-#guide .calloutlist code {
-    background: #343642;
-    color: #ffffff;
-}
-#guide .calloutlist td {
-    padding: 0;
-    border: none;
-}
-#guide .calloutlist a {
-    color: #ffffff;
-    cursor: pointer;
-    text-decoration: underline;
 }
 
 /* Sense URL form */


### PR DESCRIPTION
We're going to be hacking on this code a fair bit in the future. This
*just* moves it and makes very little effort to simplify it.
