### PR TITLE
Switch callouts from images to css

### DIFF
--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -10,7 +10,7 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
       expect(body).to include(<<~HTML.strip)
         <div class="pre_wrapper default #{has_roles} lang-console"><pre class="default #{has_roles} programlisting prettyprint lang-console">GET /_search
         {
-            "query": "foo bar" <a id="CO1-1"></a><span><img src="images/icons/callouts/1.png" alt="" /></span>
+            "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
         }</pre></div>#{console_widget}<div class="default #{has_roles} lang-console calloutlist">
       HTML
       # The last line is important: we need the snippet to be followed
@@ -20,7 +20,7 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
     it 'contains the js example' do
       expect(body).to include(<<~HTML.strip)
         <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
-          body: { query: 'foo bar' } <a id="A0-CO1-1"></a><span><img src="images/icons/callouts/1.png" alt="" /></span>
+          body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
         })</pre></div><div class="alternative lang-js calloutlist">
       HTML
       # The last line is important: we need the snippet to be followed
@@ -31,7 +31,7 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
         <div class="pre_wrapper alternative lang-csharp"><pre class="alternative programlisting prettyprint lang-csharp">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
             .Query(q =&gt; q
                 .QueryString(m =&gt; m
-                    .Query("foo bar") <a id="A1-CO1-1"></a><span><img src="images/icons/callouts/1.png" alt="" /></span>
+                    .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
                 )
             )
         );</pre></div><div class="alternative lang-csharp calloutlist">

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -385,8 +385,6 @@ RSpec.describe 'building a single book' do
     file_context 'images/icons/important.png'
     file_context 'images/icons/note.png'
     file_context 'images/icons/warning.png'
-    file_context 'images/icons/callouts/1.png'
-    file_context 'images/icons/callouts/2.png'
   end
 
   context 'for a book with console alternatives' do

--- a/lib/ES/Template.pm
+++ b/lib/ES/Template.pm
@@ -81,7 +81,7 @@ sub _autosense_snippets {
 
         # Remove callouts from snippet
         my $snippet = $2;
-        $snippet =~ s{<a.+?</span>}{}gs;
+        $snippet =~ s{<a.+?</i>}{}gs;
 
         # Unescape HTML entities
         $snippet =~ s/&lt;/</g;

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -77,7 +77,6 @@ sub build_chunked {
         $dest_xml = $dest->file($dest_xml);
 
         %xsltopts = (%xsltopts,
-                'callout.graphics' => 1,
                 'navig.graphics'   => 1,
                 'admon.textlabel'  => 0,
                 'admon.graphics'   => 1,
@@ -87,8 +86,8 @@ sub build_chunked {
         # Emulate asciidoc_dir because we use it to find shared asciidoc files
         # but asciidoctor doesn't support it.
         my $asciidoc_dir = dir('resources/asciidoc-8.6.8/')->absolute;
-        # We use the callouts from asciidoc so add it as a resource so we
-        # can find them
+        # We use the admonishment images from asciidoc so add it as a resource
+        # so we can find them
         push @$resources, $asciidoc_dir;
         eval {
             $output = run(
@@ -108,7 +107,6 @@ sub build_chunked {
                 # '-a' => 'attribute-missing=warn',
                 '-a' => 'asciidoc-dir=' . $asciidoc_dir,
                 '-a' => 'resources=' . join(',', @$resources),
-                '-a' => 'copy-callout-images=png',
                 '-a' => 'copy-admonition-images=png',
                 $latest ? () : ('-a' => "migration-warnings=false"),
                 $respect_edit_url_overrides ? ('-a' => "respect_edit_url_overrides=true") : (),
@@ -220,7 +218,6 @@ sub build_single {
         $dest_xml = $dest->file($dest_xml);
 
         %xsltopts = (%xsltopts,
-                'callout.graphics' => 1,
                 'navig.graphics'   => 1,
                 'admon.textlabel'  => 0,
                 'admon.graphics'   => 1,
@@ -231,8 +228,8 @@ sub build_single {
         # Emulate asciidoc_dir because we use it to find shared asciidoc files
         # but asciidoctor doesn't support it.
         my $asciidoc_dir = dir('resources/asciidoc-8.6.8/')->absolute;
-        # We use the callouts from asciidoc so add it as a resource so we
-        # can find them
+        # We use the admonishment images from asciidoc so add it as a resource
+        # so we can find them
         push @$resources, $asciidoc_dir;
         eval {
             $output = run(
@@ -246,7 +243,6 @@ sub build_single {
                     edit_urls_for_asciidoctor($edit_urls) ),
                 '-a' => 'asciidoc-dir=' . $asciidoc_dir,
                 '-a' => 'resources=' . join(',', @$resources),
-                '-a' => 'copy-callout-images=png',
                 '-a' => 'copy-admonition-images=png',
                 $latest ? () : ('-a' => "migration-warnings=false"),
                 $respect_edit_url_overrides ? ('-a' => "respect_edit_url_overrides=true") : (),

--- a/resources/web/style/conum.pcss
+++ b/resources/web/style/conum.pcss
@@ -1,0 +1,20 @@
+#guide {
+  .conum {
+    display: inline-block;
+    width: 16px;
+    height: 16px;
+    line-height: 16px;
+    color: #f5f7fa;
+    background-color: #0080d5;
+    -webkit-border-radius: 100px;
+    border-radius: 100px;
+    text-align: center;
+    font-size: 10pt;
+    font-weight: bold;
+    font-family: Inter, sans-serif;
+    font-style: normal;
+    &::after {
+      content: attr(data-value);
+    }
+  }
+}

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -1,5 +1,6 @@
 @import './style/admonishment.pcss';
 @import './style/calloutlist.pcss';
+@import './style/conum.pcss';
 @import './style/code.pcss';
 @import './style/util.pcss';
 @import './style/xpack.pcss';

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -329,10 +329,11 @@
     <!-- Throw away the link by not copying it. -->
   </xsl:template>
 
-  <!-- Make callouts non-selectable -->
+  <!-- Use asciidoctor style callouts -->
   <xsl:template name="callout-bug">
     <xsl:param name="conum" select="1"/>
-    <span><img src="{$callout.graphics.path}{$conum}{$callout.graphics.extension}" alt="" /></span>
+    <!-- <i> is a hack here to avoid all of the styling that comes in with a <span>....-->
+    <i class="conum" data-value="{$conum}"></i>
   </xsl:template>
 
   <!-- added and deprecated markup -->


### PR DESCRIPTION
This switches the callout numbers from images to css-managed text. It is
still copy-and-paste safe.
