### PR TITLE
Style: Fix up code blocks

### DIFF
--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -1,11 +1,7 @@
 #guide {
-  %code-common {
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
-  }
-
   /* Inline code examples */
   code {
-    @extend %code-common;
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
     background: #f8f8f8;
     padding: 0 3px;
     font-size: 0.9em;
@@ -31,7 +27,7 @@
 
   /* Code blocks with and without prettyprint. */
   pre {
-    @extend %code-common;
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
     color: #888;
     font-size: 16px;
   }
@@ -49,6 +45,12 @@
     background-color:#343741;
     width: auto;
     max-width: 10000px;
+
+    span {
+      /* We need to match the element name exactly or the * rule will
+       * override here. */
+      font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
+    }
   }
 
   /* Code prettify styles. */


### PR DESCRIPTION
We need to be pretty specific in order for code blocks to get the right
style because of the global `*` rule.
