### PR TITLE
Fix the ordering of alternative examples

### DIFF
--- a/integtest/readme_examples/csharp/8a7e0a79b1743d5fd94d79a7106ee930.adoc
+++ b/integtest/readme_examples/csharp/8a7e0a79b1743d5fd94d79a7106ee930.adoc
@@ -8,4 +8,4 @@ var searchResponse = _client.Search<Project>(s => s
     )
 );
 ----
-<1> Here's the explanation
+<1> Here's the explanation for csharp

--- a/integtest/readme_examples/js/8a7e0a79b1743d5fd94d79a7106ee930.adoc
+++ b/integtest/readme_examples/js/8a7e0a79b1743d5fd94d79a7106ee930.adoc
@@ -4,4 +4,4 @@ const result = await client.search({
   body: { query: 'foo bar' } <1>
 })
 ----
-<1> Here's the explanation
+<1> Here's the explanation for js

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe 'building all books' do
             "query": "foo bar" <1>
         }
         ----------------------------------
-        <1> Example
+        <1> Here's the explanation
 
         [source,console]
         ----------------------------------

--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -2,31 +2,20 @@
 
 RSpec.shared_examples 'README-like console alternatives' do |path|
   page_context "#{path}/chapter.html" do
-    it 'contains the default example' do
-      has_roles = 'has-js has-csharp'
-      console_widget = <<~HTML.strip
-        <div class="console_widget default #{has_roles}" data-snippet="snippets/1.console"></div>
+    let(:has_classes) { 'has-js has-csharp' }
+    let(:console_widget) do
+      <<~HTML.strip
+        <div class="console_widget #{has_classes}" data-snippet="snippets/1.console"></div>
       HTML
-      expect(body).to include(<<~HTML.strip)
-        <div class="pre_wrapper default #{has_roles} lang-console"><pre class="default #{has_roles} programlisting prettyprint lang-console">GET /_search
-        {
-            "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
-        }</pre></div>#{console_widget}<div class="default #{has_roles} lang-console calloutlist">
-      HTML
-      # The last line is important: we need the snippet to be followed
-      # immediately by the console widget and then immediately by the callout
-      # list.
     end
-    it 'contains the js example' do
+    it 'contains the js listing followed by the csharp listing' do
       expect(body).to include(<<~HTML.strip)
-        <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
+        </div><div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
           body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
-        })</pre></div><div class="alternative lang-js calloutlist">
+        })</pre></div><div class="pre_wrapper alternative lang-csharp">
       HTML
-      # The last line is important: we need the snippet to be followed
-      # immediately by the callout list.
     end
-    it 'contains the csharp example' do
+    it 'contains the csharp listing followed by the default listing' do
       expect(body).to include(<<~HTML.strip)
         <div class="pre_wrapper alternative lang-csharp"><pre class="alternative programlisting prettyprint lang-csharp">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
             .Query(q =&gt; q
@@ -34,7 +23,30 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
                     .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
                 )
             )
-        );</pre></div><div class="alternative lang-csharp calloutlist">
+        );</pre></div><div class="pre_wrapper default #{has_classes} lang-console">
+      HTML
+    end
+    it 'contains the default listing followed by the console widget' do
+      expect(body).to include(<<~HTML.strip)
+        <div class="pre_wrapper default #{has_classes} lang-console"><pre class="default #{has_classes} programlisting prettyprint lang-console">GET /_search
+        {
+            "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+        }</pre></div>#{console_widget}
+      HTML
+    end
+    it 'contains the console widget followed by the js calloutlist' do
+      expect(body).to include(<<~HTML.strip)
+        #{console_widget}<div class="alternative lang-js calloutlist">
+      HTML
+    end
+    it 'contains the js calloutlist followed by the csharp calloutlist' do
+      expect(body).to include(<<~HTML.strip)
+        js</p></td></tr></table></div><div class="alternative lang-csharp calloutlist">
+      HTML
+    end
+    it 'contains the csharp calloutlist followed by the default calloutlist' do
+      expect(body).to include(<<~HTML.strip)
+        csharp</p></td></tr></table></div><div class="default #{has_classes} lang-console calloutlist">
       HTML
     end
   end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -401,7 +401,7 @@ RSpec.describe 'building a single book' do
             "query": "foo bar" <1>
         }
         ----------------------------------
-        <1> Example
+        <1> Here's the explanation
 
         [source,console]
         ----------------------------------

--- a/resources/asciidoctor/lib/alternative_language_lookup/alternative.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/alternative.rb
@@ -18,22 +18,35 @@ module AlternativeLanguageLookup
       @lang = lang
       @path = path
       @counter = @document.attr 'alternative_language_counter', 0
-      @text = nil
+      @listing_text = nil
+      @colist_text = nil
       load
       return unless validate
 
       munge
       @document.attributes['alternative_language_counter'] = @counter + 1
-      @text = @child.convert
+      @listing_text = @listing.convert
+      @colist_text = @colist&.convert
     end
 
     ##
-    # A block that can be inserted into the main document if we've successfully
-    # loaded, validated, and munged the alternative. nil otherwise.
-    def block(parent)
-      return unless @text
+    # A block for the alternative listing that can be inserted into the main
+    # document if we've successfully loaded, validated, and munged the
+    # alternative. nil otherwise.
+    def listing(parent)
+      return unless @listing_text
 
-      Asciidoctor::Block.new parent, :pass, source: @text
+      Asciidoctor::Block.new parent, :pass, source: @listing_text
+    end
+
+    ##
+    # A block for the alternative callout list that can be inserted into the
+    # main document if the alternative contains a callout list and we've
+    # successfully loaded, validated, and munged the alternative. nil otherwise.
+    def colist(parent)
+      return unless @colist_text
+
+      Asciidoctor::Block.new parent, :pass, source: @colist_text
     end
 
     def load

--- a/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
@@ -26,7 +26,7 @@ module AlternativeLanguageLookup
 
       @source = @block.source
       @digest = Digest::MurmurHash3_x64_128.hexdigest @source
-      @next_index = nil # We'll look it up when we need it
+      @listing_index = nil # We'll look it up when we need it
 
       found_langs = []
 
@@ -35,10 +35,11 @@ module AlternativeLanguageLookup
 
         # TODO: we can probably cache this. There are lots of dupes.
         alternative = Alternative.new document, a[:lang], found[:path]
-        alternative_block = alternative.block @block
-        next unless alternative_block
+        alternative_listing = alternative.listing @block.parent
+        next unless alternative_listing
 
-        insert alternative_block
+        alternative_colist = alternative.colist @block.parent
+        insert alternative_listing, alternative_colist
         found_langs << a[:lang]
       end
       report = document.attr 'alternative_language_report'
@@ -47,29 +48,33 @@ module AlternativeLanguageLookup
       cleanup_original_after_add found_langs unless found_langs.empty?
     end
 
-    def insert(alternative)
-      unless @next_index
+    def insert(alternative_listing, alternative_colist)
+      unless @listing_index
         # Find the right spot in the parent's blocks to add any alternatives:
         # right after this block's callouts if it has any, otherwise just after
         # this block.
-        @next_index = parent.blocks.find_index(@block) + 1
-        unless @next_index
+        @listing_index = parent.blocks.find_index(@block)
+        @colist_offset = 1
+        if @listing_index
+          # While we're here check if there is a callout list.
+          colist = parent.blocks[@listing_index + 1]
+          @colist = colist if colist&.context == :colist
+        else
           message = "Invalid document: parent doesn't include child!"
           logger.error(message_with_context(message, @block.source_location))
           # In grand Asciidoctor tradition we'll *try* to make some
           # output though
-          @next_index = 0
-        end
-        if (colist = parent.blocks[@next_index])&.context == :colist
-          @next_index += 1
-          @colist = colist
-        else
+          @listing_index = 0
           @colist = nil
         end
       end
 
-      parent.blocks.insert @next_index, alternative
-      @next_index += 1
+      parent.blocks.insert @listing_index, alternative_listing
+      @listing_index += 1
+      return unless alternative_colist
+
+      parent.blocks.insert @listing_index + @colist_offset, alternative_colist
+      @colist_offset += 1
     end
 
     def cleanup_original_after_add(found_langs)

--- a/resources/asciidoctor/lib/scaffold.rb
+++ b/resources/asciidoctor/lib/scaffold.rb
@@ -18,7 +18,13 @@ class TreeProcessorScaffold < Asciidoctor::Extensions::TreeProcessor
 
   def process_blocks(block)
     process_block block
-    sub_blocks = block.context == :dlist ? block.blocks.flatten : block.blocks
+    sub_blocks =
+      if block.context == :dlist
+        block.blocks.flatten
+      else
+        # Dup so modifications to the list don't cause us to reprocess
+        block.blocks.dup
+      end
     sub_blocks.each do |sub_block|
       # subblock can be nil for definition lists without a definition.
       # this is weird, but it is safe to skip nil here because subclasses

--- a/resources/asciidoctor/spec/alternative_language_lookup_spec.rb
+++ b/resources/asciidoctor/spec/alternative_language_lookup_spec.rb
@@ -140,8 +140,8 @@ RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
         expect(converted).to eq(<<~DOCBOOK.strip)
           <preface>
           <title></title>
-          <programlisting role="default has-js" language="console" linenumbering="unnumbered">#{snippet_contents}</programlisting>
           <programlisting role="alternative" language="js" linenumbering="unnumbered">console.info('just js alternative');</programlisting>
+          <programlisting role="default has-js" language="console" linenumbering="unnumbered">#{snippet_contents}</programlisting>
           </preface>
         DOCBOOK
       end
@@ -163,10 +163,10 @@ RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
         expect(converted).to eq(<<~DOCBOOK.strip)
           <preface>
           <title></title>
-          <programlisting role="default has-js has-csharp has-java" language="console" linenumbering="unnumbered">#{snippet_contents}</programlisting>
           <programlisting role="alternative" language="js" linenumbering="unnumbered">console.info('all alternatives');</programlisting>
           <programlisting role="alternative" language="csharp" linenumbering="unnumbered">Console.WriteLine("all alternatives");</programlisting>
           <programlisting role="alternative" language="java" linenumbering="unnumbered">System.out.println("all alternatives");</programlisting>
+          <programlisting role="default has-js has-csharp has-java" language="console" linenumbering="unnumbered">#{snippet_contents}</programlisting>
           </preface>
         DOCBOOK
       end
@@ -228,28 +228,27 @@ RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
           <2> b
         ASCIIDOC
       end
-      it 'inserts the alternatives below the callouts' do
+      it 'inserts the alternative code above the default code' do
         expect(converted).to include(<<~DOCBOOK.strip)
+          <programlisting role="alternative" language="csharp" linenumbering="unnumbered">Console.WriteLine("there are callouts"); <co id="A0-CO1-1"/> <co id="A0-CO1-2"/></programlisting>
           <programlisting role="default has-csharp" language="console" linenumbering="unnumbered">GET /there_are_callouts <co id="CO1-1"/> <co id="CO1-2"/></programlisting>
+        DOCBOOK
+      end
+      it 'inserts the alternative callouts above the default callouts' do
+        expect(converted).to include(<<~DOCBOOK.strip)
+          <calloutlist role="alternative lang-csharp">
+          <callout arearefs="A0-CO1-1">
+          <para>csharp a</para>
+          </callout>
+          <callout arearefs="A0-CO1-2">
+          <para>csharp b</para>
+          </callout>
+          </calloutlist>
           <calloutlist role="default has-csharp lang-console">
           <callout arearefs="CO1-1">
           <para>a</para>
           </callout>
           <callout arearefs="CO1-2">
-          <para>b</para>
-          </callout>
-          </calloutlist>
-          <programlisting role="alternative" language="csharp"
-        DOCBOOK
-      end
-      it 'adds the alternative including its callouts' do
-        expect(converted).to include(<<~DOCBOOK.strip)
-          <programlisting role="alternative" language="csharp" linenumbering="unnumbered">Console.WriteLine("matching callouts"); <co id="A0-CO1-1"/> <co id="A0-CO1-2"/></programlisting>
-          <calloutlist role="alternative lang-csharp">
-          <callout arearefs="A0-CO1-1">
-          <para>a</para>
-          </callout>
-          <callout arearefs="A0-CO1-2">
           <para>b</para>
           </callout>
           </calloutlist>

--- a/resources/asciidoctor/spec/resources/alternative_language_lookup/csharp/9e01493a85c06a5100ff712f6b3eead4.adoc
+++ b/resources/asciidoctor/spec/resources/alternative_language_lookup/csharp/9e01493a85c06a5100ff712f6b3eead4.adoc
@@ -1,6 +1,6 @@
 [source,csharp]
 ----
-Console.WriteLine("matching callouts"); <1> <2>
+Console.WriteLine("there are callouts"); <1> <2>
 ----
-<1> a
-<2> b
+<1> csharp a
+<2> csharp b

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -317,6 +317,7 @@
     <xsl:if test="@language = 'console' or @language = 'sense' or @language = 'kibana'">
       <xsl:variable name="widget_class">
         <xsl:value-of select="@language"/>_widget
+        <xsl:value-of select="substring-after(@role, 'default')"/>
       </xsl:variable>
       <div
         class="{normalize-space($widget_class)}"

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -316,7 +316,7 @@
     <!-- Asciidoctor's CONSOLE widget -->
     <xsl:if test="@language = 'console' or @language = 'sense' or @language = 'kibana'">
       <xsl:variable name="widget_class">
-        <xsl:value-of select="@language"/>_widget <xsl:value-of select="@role"/>
+        <xsl:value-of select="@language"/>_widget
       </xsl:variable>
       <div
         class="{normalize-space($widget_class)}"


### PR DESCRIPTION
This changes the order of the html generated by alternative examples so
it is simpler to switch to different alternatives. Instead of the html
looking like:

```
default example
console widget
default callout list
alternative 1 example
alternative 1 callout list
alternative 2 example
alternative 2 callout list
```

It now looks like:

```
alternative 1 example
alternative 2 example
default example
console widget
alternative 1 callout list
alternative 2 callout list
default callout list
```

The advantage of this order is that it works with how we want to display
these examples: we always hide all but one of the examples and all but
one of the callout list and we want the order of shown things to always
be:

```
example
console widget
callout list
```
