### PR TITLE
Add basic request example to API Reference Template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -5,8 +5,9 @@
 ++++
 ////
 This section includes a brief, 1-2 sentence description
-followed by an optional basic request example.
-DO NOT include the response.
+followed by an optional request example. DO NOT include the response.
+
+While optional, we recommend including the example request when possible.
 ////
 
 Creates a cool thing.

--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -3,8 +3,23 @@
 ++++
 <titleabbrev>Sample</titleabbrev>
 ++++
+////
+This section includes a brief, 1-2 sentence description
+followed immediately by a basic request example.
+DO NOT include the response.
+////
 
 Creates a cool thing.
+
+[source,js]
+--------------------------------------------------
+PUT twitter
+--------------------------------------------------
+// CONSOLE
+
+////
+***********************************************************
+////
 
 ////
 Use the appropriate heading levels for your book.
@@ -132,8 +147,8 @@ Indicates one or more listed indices or index aliases **do not** exist.
 [[sample-api-example]]
 ==== {api-examples-title}
 ////
-Optional brief example.
-Use an 'Examples' heading if you include multiple examples.
+Optional additional examples.
+DO NOT repeat the basic example used earlier.
 
 
 [source,js]

--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -5,7 +5,7 @@
 ++++
 ////
 This section includes a brief, 1-2 sentence description
-followed immediately by a basic request example.
+followed by an optional basic request example.
 DO NOT include the response.
 ////
 


### PR DESCRIPTION
### Changes
- Adds a basic example to the intro section
- Adds additional guidelines for the intro and examples sections

### Context
We've heard from several folks that it's helpful to include a basic example at the top of API ref pages. This tries to address that feedback without adding new sections or headings.