### PR TITLE
Drop source maps from production web resources

### DIFF
--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -76,12 +76,18 @@ module Dsl
             {function ka(a){return a&&a.__esModule?{d:a.default}:{d:a}}
           JS
         end
+        it "doesn't include a source map" do
+          expect(contents).not_to include('sourceMappingURL=')
+        end
       end
       file_context 'html/static/styles.css' do
         it 'is minified' do
           expect(contents).to include(<<~CSS.strip)
             *{font-family:Inter,sans-serif}
           CSS
+        end
+        it "doesn't include a source map" do
+          expect(contents).not_to include('sourceMappingURL=')
         end
       end
     end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -457,6 +457,7 @@ RSpec.describe 'building a single book' do
         <a href="chapter.html">Chapter
       HTML
     end
+
     context 'the js' do
       it 'is unminified' do
         expect(js).to serve(include(<<~JS))
@@ -468,11 +469,19 @@ RSpec.describe 'building a single book' do
           // Setup hot module replacement for css if we're in dev mode.
         JS
       end
+      it 'includes a source map' do
+        expect(js).to serve(include('sourceMappingURL='))
+      end
     end
-    it 'serves the css unminified' do
-      expect(css).to serve(include(<<~CSS))
-        /* test comment used to detect unminified source */
-      CSS
+    context 'the css' do
+      it 'is unminified' do
+        expect(css).to serve(include(<<~CSS))
+          /* test comment used to detect unminified source */
+        CSS
+      end
+      it 'includes a source map' do
+        expect(css).to serve(include('sourceMappingURL='))
+      end
     end
   end
 

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -760,14 +760,16 @@ sub build_web_resources {
     my ( $dest ) = @_;
 
     run '/node_modules/parcel/bin/cli.js', 'build',
-        '-d', $dest, '-o', 'docs.js', '--experimental-scope-hoisting',
+        '--experimental-scope-hoisting', '--no-source-maps',
+        '-d', $dest, '-o', 'docs.js',
         'resources/web/docs_js/index.js', '/node_modules';
     my $docs = $dest->file('docs.js');
     my $licenses = file('resources/web/docs.js.licenses')->slurp;
-    my $minified = $docs->slurp;
-    $docs->spew($licenses . $minified);
+    my $built = $docs->slurp;
+    $docs->spew($licenses . $built);
 
     run '/node_modules/parcel/bin/cli.js', 'build',
+        '--no-source-maps',
         '-d', $dest, '-o', 'styles.css',
         'resources/web/styles.pcss';
 }


### PR DESCRIPTION
We don't ship the original files so the source map fails to load anyway.
