### PR TITLE
Commit less

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -268,8 +268,7 @@ sub build_all {
         check_links($build_dir);
     }
     $tracker->prune_out_of_date( @$contents );
-    $tracker->write;
-    push_changes( $build_dir, $target_repo ) if $Opts->{push};
+    push_changes( $build_dir, $target_repo, $tracker ) if $Opts->{push};
     serve_and_open_browser( $build_dir, $redirects, 0 ) if $Opts->{open};
 
     $temp_dir->rmtree;
@@ -618,13 +617,13 @@ sub preview {
 #===================================
 sub push_changes {
 #===================================
-    my ($build_dir, $target_repo ) = @_;
+    my ($build_dir, $target_repo, $tracker ) = @_;
 
-    say 'Building revision.txt';
-    $build_dir->file('revision.txt')
-        ->spew( iomode => '>:utf8', ES::Repo->all_repo_branches );
-
-    if ( $target_repo->outstanding_changes ) {
+    if ( $tracker->has_non_local_changes || $target_repo->outstanding_changes ) {
+        $tracker->write;
+        say 'Building revision.txt';
+        $build_dir->file('revision.txt')
+            ->spew( iomode => '>:utf8', ES::Repo->all_repo_branches );
         say 'Preparing commit';
         build_sitemap($build_dir);
         say "Commiting changes";

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe 'building all books' do
           end
           include_examples 'all links are ok'
         end
-        describe 'when the broken link is in an *new* unbuilt branch' do
+        describe 'when the broken link is in a *new* unbuilt branch' do
           convert_before do |src, dest|
             setup src, dest
             kibana = src.repo('kibana')

--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -25,6 +25,7 @@ sub new {
     my $self = bless {
         file => $file,
         shas => \%shas,
+        has_non_local_changes => 0,
     }, $class;
 
     return $self;
@@ -49,6 +50,7 @@ sub set_sha_for_branch {
 #===================================
     my ( $self, $repo, $branch, $sha ) = @_;
 
+    $self->{has_non_local_changes} = 1 unless $sha =~ /^local/;
     $self->shas->{$repo}{$branch} = $sha;
 }
 
@@ -74,6 +76,7 @@ sub prune_out_of_date {
             # right now.
             unless ($allowed_for_repo->{$branch} || $branch =~ /^link-check/) {
                 delete $branches->{$branch};
+                $self->{has_non_local_changes} = 1;
             }
         }
         # Empty can show up because there is a new book that were not
@@ -111,6 +114,14 @@ sub write {
     my $self = shift;
     $self->file->parent->mkpath;
     $self->file->spew( iomode => '>:utf8', Dump( $self->{shas} ) );
+}
+
+#===================================
+sub has_non_local_changes {
+#===================================
+# Truthy if any book was rebuilt with non-local changes.
+#===================================
+    shift->{has_non_local_changes};
 }
 
 #===================================


### PR DESCRIPTION
Adds a new mechanism to detect when it is time to commit changes.
Previously, we only used `git status` to look for changes. This first
consults the branch tracker to see if any books were rebuilt with
non-`--sub_dir` based changes. If any were then we can skip the
`git status` entirely!

This allows us to wait until *after* we've decided to commit before
writing the branch tracker and the revisions helper file. This'll save
some time, especially on PR builds that are noops. It should also allow
us to consider many more PR builds to be noops then we could before! It
used to be that we're write information about the "--sub-dir"-ness of
the build to the branch tracker file and that'd *always* cause us to
think that PR builds changed docs even if they didn't. Now PR builds
won't trigger a commit unless they actually change rendered html.
:party:
