### PR TITLE
Fix console widget style on mobile

### DIFF
--- a/resources/web/docs_js/components/alternative_switcher.js
+++ b/resources/web/docs_js/components/alternative_switcher.js
@@ -32,8 +32,8 @@ export default store => {
     sheet.insertRule(`#guide .default.has-${newValue} { display: none; }`);
     sheet.insertRule(`#guide .alternative.lang-${newValue} { display: block; }`);
     // Setup rules to show the warning unless the snippet has that alternative
-    sheet.insertRule(`#guide .AlternativePicker-warning { display: block; }`);
-    sheet.insertRule(`#guide .has-${newValue} .AlternativePicker-warning { display: none; }`);
+    sheet.insertRule(`#guide .AlternativePicker-warning { visibility: visible; }`);
+    sheet.insertRule(`#guide .has-${newValue} .AlternativePicker-warning { visibility: hidden; }`);
   };
   updateSheet();
   store.subscribe(updateSheet);

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -75,7 +75,7 @@ export const ConsoleWidget = props => {
   const modalAction = () => props.openModal(ConsoleForm, {setting: props.setting, url_label: props.url_label});
   return <div className="u-space-between">
     <AlternativePicker />
-    <div>
+    <div className="u-space-between">
       <a className="sense_widget copy_as_curl"
         onClick={e => props.copyAsCurl({isKibana: props.isKibana, consoleText: props.consoleText, setting: props.setting})}>
         {props.langStrings('Copy as cURL')}

--- a/resources/web/style/alternative_picker.pcss
+++ b/resources/web/style/alternative_picker.pcss
@@ -3,7 +3,7 @@
     margin-left: 20px;
 
     &-warning {
-      display: none; /* Unhidden if there isn't a matching alternative. */
+      visibility: hidden; /* Unhidden if there isn't a matching alternative. */
       margin: 5px 20px;
       $bg: "img/alert.svg";
       width: width($bg);
@@ -11,6 +11,10 @@
       background-image: inline($bg);
       background-repeat: no-repeat;
       background-position: 0 0;
+      align-self: center;
+      @media screen and (max-width: 500px) {
+        margin: 5px 10px;
+      }
     }
   }
 }

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -354,10 +354,14 @@ p.remark {
     cursor: pointer;
     font-weight: 500;
     text-decoration: underline;
-}
-
-#guide a.view_in_link {
-    margin-left: 20px;
+    margin-right: 20px;
+    @media screen and (max-width: 800px) {
+      font-size: 13px;
+    }
+    @media screen and (max-width: 500px) {
+      font-size: 12px;
+      margin-right: 5px;
+    }
 }
 
 #guide a.console_settings {
@@ -365,8 +369,10 @@ p.remark {
   display: inline-block;
   width: 16px;
   height: 16px;
+  min-width: 16px;
+  min-height: 16px;
   vertical-align: text-bottom;
-  margin-left: 1em;
+  align-self: center;
   &:hover {
     text-decoration: none !important;
     cursor: pointer;


### PR DESCRIPTION
This changes the console widget style so it looks better on mobile. It
1. Shrinks the link text slightly when the width shrinks. This is the
same shrinking that we have for the nav header and footer.
2. When there isn't enough space for the links they now wrap "inside"
themselves.
3. Switch the "bad language" warning from "not displayed" to "not
visible" to it takes up space all the time. This should prevent weird
stuff happening when it needs to be shown on mobile.
