### PR TITLE
Add python's pretty name to alternatives drop down

### DIFF
--- a/resources/web/docs_js/components/alternative_picker.jsx
+++ b/resources/web/docs_js/components/alternative_picker.jsx
@@ -10,10 +10,11 @@ import {saveSettings} from "../actions/settings";
 
 const alternativePrettyName = rawName => {
   switch(rawName) {
-    case 'console': return 'Console';
-    case 'csharp': return 'C#';
-    case 'js': return 'JavaScript';
-    case 'php': return 'PHP';
+    case "console": return "Console";
+    case "csharp": return "C#";
+    case "js": return "JavaScript";
+    case "php": return "PHP";
+    case "python": return "Python";
     default: return rawName;
   }
 };


### PR DESCRIPTION
We should probably be using the language string but we'll get there
eventually. For now, lets just make Python look a little nicer, shal we?
