### PR TITLE
ECS 1.1.0 docs for release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -142,8 +142,8 @@ contents:
           -
             title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    1.0
-            branches:   [ master, 1.0 ]
+            current:    1.1
+            branches:   [ master, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
Long time fan, first pull request to docs :-)

I'm in the process of releasing ECS 1.1.0, which has a live `1.1` branch, for docs adjustments.