### PR TITLE
Copy images from unordeed lists

### DIFF
--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -80,7 +80,7 @@ module CopyImages
     # with this.
     def process_inline_image_from_converted(block)
       return unless block.context == :list_item &&
-                    block.parent.context == :olist
+                    %i[olist ulist].include?(block.parent.context)
 
       block.text.scan(DOCBOOK_IMAGE_RX) do |(target)|
         # We have to resolve attributes inside the target. But there is a

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -275,11 +275,21 @@ RSpec.describe CopyImages do
         expect(logs).to eq(expected_logs.strip)
       end
     end
-    context 'when the inline image is inside a list' do
+    context 'when the inline image is inside an ordered list' do
       let(:input) do
         <<~ASCIIDOC
           == Example
           . words image:example1.png[] words
+        ASCIIDOC
+      end
+      let(:resolved) { 'example1.png' }
+      include_examples 'copies example1'
+    end
+    context 'when the inline image is inside an unordered list' do
+      let(:input) do
+        <<~ASCIIDOC
+          == Example
+          * words image:example1.png[] words
         ASCIIDOC
       end
       let(:resolved) { 'example1.png' }


### PR DESCRIPTION
We had support for copying images within ordered lists but not within
*un*ordered lists. This fixes that.
