### PR TITLE
Prevent jumping when you pick an alternative lang

### DIFF
--- a/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
+++ b/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
@@ -86,13 +86,10 @@ describe(_AlternativePicker, () => {
       * have to do it ourselves. Like an animal. */
     select.dispatchEvent(new Event("change"));
     test("saves the config", () => {
+      // We can't use toMatchObject here because tagName is busted.
+      expect(updates).toHaveLength(1);
+      expect(updates[0].consoleAlternative).toBe("js");
       expect(updates[0].alternativeChangeSource.tagName).toBe("SELECT");
-      expect(updates).toMatchObject([{
-        consoleAlternative: "js",
-        alternativeChangeSource: {
-          className: "SELECT",
-        }
-      }]);
     })
   });
 });

--- a/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
+++ b/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
@@ -86,7 +86,13 @@ describe(_AlternativePicker, () => {
       * have to do it ourselves. Like an animal. */
     select.dispatchEvent(new Event("change"));
     test("saves the config", () => {
-      expect(updates).toStrictEqual([{consoleAlternative: 'js'}]);
+      expect(updates[0].alternativeChangeSource.tagName).toBe("SELECT");
+      expect(updates).toMatchObject([{
+        consoleAlternative: "js",
+        alternativeChangeSource: {
+          className: "SELECT",
+        }
+      }]);
     })
   });
 });

--- a/resources/web/docs_js/__tests__/components/alternative_switcher.test.js
+++ b/resources/web/docs_js/__tests__/components/alternative_switcher.test.js
@@ -1,31 +1,33 @@
 import {newStore} from "../../store";
 import {saveSettings} from "../../actions/settings";
-import AlternativeSwitcher from "../../components/alternative_switcher";
+import {_AlternativeSwitcher} from "../../components/alternative_switcher";
 
-describe(AlternativeSwitcher, () => {
+describe(_AlternativeSwitcher, () => {
   let db;
-  // This is what the example snippets sort of look like:
   document.head.innerHTML = `
     <style>
+      /* Mimic the main css so the tests detect "display" correctly. */
       .alternative {
         display: none;
       }
       .AlternativePicker-warning {
         display: none;
       }
-    </style>
+      </style>
   `;
+  // This is what the example snippets sort of look like:
   document.body.innerHTML = `
     <div id="guide">
-      <div id="csharp-listing"  class="alternative lang-csharp pre_wrapper" />
-      <div id="js-listing"      class="alternative lang-js pre_wrapper" />
-      <div id="console-listing" class="default lang-console has-csharp has-js pre_wrapper" />
+      <div id="csharp-listing"  class="alternative lang-csharp pre_wrapper"></div>
+      <div id="js-listing"      class="alternative lang-js pre_wrapper"></div>
+      <div id="console-listing" class="default lang-console has-csharp has-js pre_wrapper"></div>
       <div id="widget"          class="has-csharp has-js console_widget">
-        <div id="warning"       class="AlternativePicker-warning" />
+        <div id="picker"></div>
+        <div id="warning"       class="AlternativePicker-warning"></div>
       </div>
-      <div id="csharp-colist"   class="alternative lang-csharp calloutlist" />
-      <div id="js-colist"       class="alternative lang-js calloutlist" />
-      <div id="console-colist"  class="default lang-console has-csharp has-js calloutlist" />
+      <div id="csharp-colist"   class="alternative lang-csharp calloutlist"</div>
+      <div id="js-colist"       class="alternative lang-js calloutlist"></div>
+      <div id="console-colist"  class="default lang-console has-csharp has-js calloutlist"></div>
     </div>
   `;
 
@@ -74,32 +76,115 @@ describe(AlternativeSwitcher, () => {
     // });
   };
 
+  const noScrolling = (element) => {
+    expect(element).toBeUndefined();
+    return () => {};
+  }
+
   describe("when initialized with console", () => {
+    const picker = document.getElementById("picker");
+    const scrolls = [];
+    const scrollChecker = (element) => {
+      scrolls.push("before");
+      scrolls.push(element);
+      return () => {
+        scrolls.push("after");
+      };
+    }
     beforeAll(() => {
       db = newStore({settings: {consoleAlternative: "console"}});
-      AlternativeSwitcher(db);
+      _AlternativeSwitcher(scrollChecker, db);
     });
     afterAll(() => {
       document.getElementById('console-alternative').remove();
     });
 
     showsLanguage("console", false);
+    test("hasn't scrolled", () => {
+      expect(scrolls).toEqual(["before", undefined, "after"]);
+    });
 
     describe("changed to csharp", () => {
       beforeAll(() => {
-        db.dispatch(saveSettings({consoleAlternative: "csharp"}));
+        db.dispatch(saveSettings({
+          consoleAlternative: "csharp",
+          alternativeChangeSource: picker,
+        }));
       });
       showsLanguage("csharp", false);
+      test("scrolls after selecting", () => {
+        expect(scrolls).toEqual([
+          "before", undefined, "after",
+          "before", picker, "after",
+        ]);
+      });
       describe("then changed to js", () => {
         beforeAll(() => {
-          db.dispatch(saveSettings({consoleAlternative: "js"}));
+          db.dispatch(saveSettings({
+            consoleAlternative: "js",
+            alternativeChangeSource: picker,
+          }));
         });
         showsLanguage("js", false);
+        test("scrolls after selecting", () => {
+          expect(scrolls).toEqual([
+            "before", undefined, "after",
+            "before", picker, "after",
+            "before", picker, "after",
+          ]);
+        });  
         describe("then changed to bogus", () => {
           beforeAll(() => {
-            db.dispatch(saveSettings({consoleAlternative: "bogus"}));
+            db.dispatch(saveSettings({
+              consoleAlternative: "bogus",
+              alternativeChangeSource: picker,
+            }));
           });
           showsLanguage("console", true);
+          test("scrolls after selecting", () => {
+            expect(scrolls).toEqual([
+              "before", undefined, "after",
+              "before", picker, "after",
+              "before", picker, "after",
+              "before", picker, "after",
+            ]);
+          });
+          describe("then changed to console", () => {
+            beforeAll(() => {
+              db.dispatch(saveSettings({
+                consoleAlternative: "console",
+                alternativeChangeSource: picker,
+              }));
+            });
+            showsLanguage("console", false);
+            test("scrolls after selecting", () => {
+              expect(scrolls).toEqual([
+                "before", undefined, "after",
+                "before", picker, "after",
+                "before", picker, "after",
+                "before", picker, "after",
+                "before", picker, "after",
+              ]);
+            });
+            describe("then kept at console but still firing a change event", () => {
+              beforeAll(() => {
+                db.dispatch(saveSettings({
+                  consoleAlternative: "console",
+                  alternativeChangeSource: picker,
+                }));
+              });
+              showsLanguage("console", false);
+              test("doesn't scroll", () => {
+                expect(scrolls).toEqual([
+                  "before", undefined, "after",
+                  "before", picker, "after",
+                  "before", picker, "after",
+                  "before", picker, "after",
+                  "before", picker, "after",
+                ]);
+              });
+            });
+          });
         });
       });
     });
@@ -108,7 +193,7 @@ describe(AlternativeSwitcher, () => {
   describe("when initialized with csharp", () => {
     beforeAll(() => {
       db = newStore({settings: {consoleAlternative: "csharp"}});
-      AlternativeSwitcher(db);
+      _AlternativeSwitcher(noScrolling, db);
     });
     afterAll(() => {
       document.getElementById('console-alternative').remove();
@@ -120,7 +205,7 @@ describe(AlternativeSwitcher, () => {
   describe("when initialized with bogus", () => {
     beforeAll(() => {
       db = newStore({settings: {consoleAlternative: "bogus"}});
-      AlternativeSwitcher(db);
+      _AlternativeSwitcher(noScrolling, db);
     });
     afterAll(() => {
       document.getElementById('console-alternative').remove();

--- a/resources/web/docs_js/actions/settings.js
+++ b/resources/web/docs_js/actions/settings.js
@@ -10,7 +10,7 @@ export const setCookies = forEach(([k, v]) => Cookies.set(k, v));
 // the function used in the app is setup below
 export const _saveSettings = setCookies =>
   m => dispatch => {
-    const values = omit(["console_curl_password", "kibana_curl_password", "sense_curl_password"], m);
+    const values = omit(["console_curl_password", "kibana_curl_password", "sense_curl_password", "alternativeChangeSource"], m);
     setCookies(toPairs(values));
     dispatch(closeModal());
     return dispatch({

--- a/resources/web/docs_js/components/alternative_picker.jsx
+++ b/resources/web/docs_js/components/alternative_picker.jsx
@@ -52,11 +52,15 @@ export const _AlternativePicker = ({
   // TODO we shouldn't change these drop downs after the first time they are rendered. The extra choice should stay while you stay on the page. Maybe we can get away with rendering this once on page load and never subscribing again?
 
   // TODO add the "message" bubble to the warning.
-  // TODO prevent "jumping" when the size of the snippets isn't the same
   return <div className="AlternativePicker u-space-between">
     <select className="AlternativePicker-select"
             value={consoleAlternative}
-            onChange={(e) => saveSettings({consoleAlternative: e.target.value})}>
+            onChange={(e) => {
+              saveSettings({
+                consoleAlternative: e.target.value,
+                alternativeChangeSource: e.target,
+              });
+            }}>
       {items}
     </select>
     <div className="AlternativePicker-warning" />

--- a/resources/web/docs_js/components/alternative_switcher.js
+++ b/resources/web/docs_js/components/alternative_switcher.js
@@ -18,8 +18,11 @@ export default store => {
     }
     oldValue = newValue;
 
-    /* Updating the consoleAlternative propery */
-
+    /* Since this swaps a lot of `display: none` with `display: block` we can
+     * expect it to force a reflow which feels like a "jump" when you are
+     * looking at the page. We attempt to prevent the "jump" by keeping the
+     * element that initiated the state change in the same position on
+     * the page. */
     const changeSource = store.getState().settings.alternativeChangeSource;
     const beforeTop = changeSource ? changeSource.getBoundingClientRect().top : 0;
     // Clear all the rules because they were for showing a different alternative

--- a/resources/web/docs_js/components/alternative_switcher.js
+++ b/resources/web/docs_js/components/alternative_switcher.js
@@ -18,22 +18,27 @@ export default store => {
     }
     oldValue = newValue;
 
+    /* Updating the consoleAlternative propery */
+
+    const changeSource = store.getState().settings.alternativeChangeSource;
+    const beforeTop = changeSource ? changeSource.getBoundingClientRect().top : 0;
     // Clear all the rules because they were for showing a different alternative
     for (let i = sheet.cssRules.length - 1; i >= 0; i--) {
       sheet.deleteRule(i);
     }
     // The default doesn't need any rules.
-    if (newValue === "console") {
-      return;
+    if (newValue !== "console") {
+      /* Setup rules to show alternatives when they exist and keep the default
+      * when there isn't an alternative. */
+      sheet.insertRule(`#guide .default.has-${newValue} { display: none; }`);
+      sheet.insertRule(`#guide .alternative.lang-${newValue} { display: block; }`);
+      // Setup rules to show the warning unless the snippet has that alternative
+      sheet.insertRule(`#guide .AlternativePicker-warning { display: block; }`);
+      sheet.insertRule(`#guide .has-${newValue} .AlternativePicker-warning { display: none; }`);
+      // TODO check if it is faster to remove the sheet, add the rules, and re-add the sheet.
     }
-
-    /* Setup rules to show alternatives when they exist and keep the default
-     * when there isn't an alternative. */
-    sheet.insertRule(`#guide .default.has-${newValue} { display: none; }`);
-    sheet.insertRule(`#guide .alternative.lang-${newValue} { display: block; }`);
-    // Setup rules to show the warning unless the snippet has that alternative
-    sheet.insertRule(`#guide .AlternativePicker-warning { display: block; }`);
-    sheet.insertRule(`#guide .has-${newValue} .AlternativePicker-warning { display: none; }`);
+    const afterTop = changeSource ? changeSource.getBoundingClientRect().top : 0;
+    window.scrollBy(0, afterTop - beforeTop);
   };
   updateSheet();
   store.subscribe(updateSheet);


### PR DESCRIPTION
When you pick an alternative language the page has to reflow because the
alternatives have different vertical size. This reflow looks like a big
"jump", especially when you pick the language lower down on the page.
This prevents the "jump" by storing the location of the picker before
the reflow, updating the styles to cause the reflow, grabbing the new
location, and then scrolling the window the difference between the new
and old location. This keeps the picker, which is usually right under
your mouse when you change the language, from jumping. This "feels"
smooth!

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
