### PR TITLE
Fix warning

### DIFF
--- a/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
@@ -60,7 +60,7 @@ module AlternativeLanguageLookup
         if @listing_index
           # While we're here check if there is a callout list.
           colist = parent.blocks[@listing_index + 1]
-          @colist = colist if colist&.context == :colist
+          @colist = colist&.context == :colist ? colist : nil
         else
           message = "Invalid document: parent doesn't include child!"
           logger.error(message_with_context(message, @block.source_location))


### PR DESCRIPTION
Fix a warning emitted when including alternative snippet. It isn't
causing any failure but it is making debugging failures more difficult.
