### PR TITLE
Fix Copy as cURL's default port for kibana

### DIFF
--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -152,7 +152,7 @@ $(function() {
       langStrings: LangStrings,
       baseUrl: base_url,
       kibana_url: Cookies.get("kibana_url") || default_kibana_url,
-      kibana_curl_host: Cookies.get("kibana_curl_host") || "localhost:9200",
+      kibana_curl_host: Cookies.get("kibana_curl_host") || "localhost:5601",
       kibana_curl_user: Cookies.get("kibana_curl_user"),
       kibana_curl_password: "$KIBANAPASS",
       console_url: Cookies.get("console_url") || default_console_url,


### PR DESCRIPTION
It was starting with Elasticsearch's port.
