### PR TITLE
Style: Duplicate styles from next.js

### DIFF
--- a/resources/web/style/layout.pcss
+++ b/resources/web/style/layout.pcss
@@ -1,0 +1,7 @@
+#guide {
+  .container, .row {
+    &:before, &:after {
+      content: normal;
+    }
+  }
+}

--- a/resources/web/style/link.pcss
+++ b/resources/web/style/link.pcss
@@ -1,0 +1,14 @@
+#guide {
+  a {
+    color: #00a9e5;
+    font-weight: normal;
+    -webkit-text-decoration: none;
+    text-decoration: none;
+    outline: none;
+    outline-offset: 0;
+    &:hover, &:focus {
+      -webkit-text-decoration: underline !important;
+      text-decoration: underline !important;
+    }
+  }
+}

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -4,6 +4,8 @@
 @import './style/conum.pcss';
 @import './style/code.pcss';
 @import './style/heading.pcss';
+@import './style/layout.pcss';
+@import './style/link.pcss';
 @import './style/list.pcss';
 @import './style/nav.pcss';
 @import './style/rtpcontainer.pcss';
@@ -121,6 +123,9 @@
 }
 
 /* Tables */
+#guide .informaltable table .literal{white-space:initial;}
+#guide .informaltable table td:first-child .literal{white-space:nowrap;}
+
 #guide table{
     margin-bottom:1em;
     border: none;
@@ -156,6 +161,9 @@
 
 /* Admonitions */
 #guide .admon {
+    text-transform: unset;
+    color: #343741 !important;
+    font-weight: normal;
     background: #fbfbfb;
     padding: 10px;
     min-height: 80px;


### PR DESCRIPTION
The header and footer and delivering a bunch of `#guide` specific styles
that we'd prefer to have control over ourselves. We keep up with the
public site for the most part, but we'd like to do it on our schedule.
This duplicates the `#guide` styles from the public site on our side so
it can safely drop them.
