### PR TITLE
Allow clients to specify alternative responses

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -144,6 +144,7 @@ book:
 build_docs --doc path/to/index.asciidoc --chunk 1
 ----------------------------
 
+[[alternative_languages]]
 === Alternative languages for examples
 
 The build supports finding "alternative languages" for examples that allows
@@ -1038,7 +1039,7 @@ the Elaticsearch repository because it can recognize it to make tests. The
 ==================================
 [source,asciidoc]
 --
-[source,js]
+[source,console]
 ----------------------------------
 GET /_search
 {
@@ -1096,6 +1097,39 @@ build_docs -d my_doc.asciidoc --open <1>
 The local web browser can be stopped with `Ctrl-C`.
 
 ================================
+
+==== Responses
+
+If `Console` requests are followed by a "response" then it should be written
+with the language set to `console-response`. That will allow
+<<alternative_languages, alternative examples>> to find the responses.
+Like this:
+
+[source,asciidoc]
+--
+[source,console-result]
+----------------------------------
+{
+    "hits": {
+        "total": { "value": 0, "relation": "eq" },
+        "hits": []
+    }
+}
+----------------------------------
+--
+
+Which should render as:
+
+[source,console-result]
+----------------------------------
+{
+    "hits": {
+        "total": { "value": 0, "relation": "eq" },
+        "hits": []
+    }
+}
+----------------------------------
+
 
 [[admon-blocks]]
 === Admonition blocks

--- a/integtest/readme_examples/js/9fa2da152878d1d5933d483a3c2af35e.adoc
+++ b/integtest/readme_examples/js/9fa2da152878d1d5933d483a3c2af35e.adoc
@@ -1,0 +1,12 @@
+[source,js-result]
+----
+{
+  "statusCode": 200,
+  "body": {
+    "hits": {
+      "total": { "value": 0, "relation": "eq" },
+      "hits": []
+    }
+  }
+}
+----

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -261,50 +261,30 @@ RSpec.describe 'building all books' do
   end
 
   context 'for a book with console alternatives' do
-    def self.index
-      <<~ASCIIDOC
-        [source,console]
-        ----------------------------------
-        GET /_search
-        {
-            "query": "foo bar" <1>
-        }
-        ----------------------------------
-        <1> Here's the explanation
-
-        [source,console]
-        ----------------------------------
-        GET /_search
-        {
-            "query": "missing"
-        }
-        ----------------------------------
-      ASCIIDOC
-    end
-
     def self.examples_dir
       "#{__dir__}/../readme_examples/"
     end
 
-    def self.setup_example(repo, lang)
+    def self.setup_example(repo, lang, hash)
       repo.cp(
-        "#{examples_dir}/#{lang}/8a7e0a79b1743d5fd94d79a7106ee930.adoc",
-        'examples/8a7e0a79b1743d5fd94d79a7106ee930.adoc'
+        "#{examples_dir}/#{lang}/#{hash}.adoc",
+        "examples/#{hash}.adoc"
       )
       repo.commit 'add example'
     end
 
     convert_all_before_context do |src|
-      repo = src.repo_with_index 'repo', index
+      repo = src.repo_with_index 'repo', ConsoleExamples::README_LIKE
 
       js_repo = src.repo 'js'
-      setup_example js_repo, 'js'
+      setup_example js_repo, 'js', '8a7e0a79b1743d5fd94d79a7106ee930'
+      setup_example js_repo, 'js', '9fa2da152878d1d5933d483a3c2af35e'
 
       csharp_repo = src.repo 'csharp'
       csharp_repo.write 'dummy', 'dummy'
       csharp_repo.commit 'init'
       csharp_repo.switch_to_new_branch 'mapped'
-      setup_example csharp_repo, 'csharp'
+      setup_example csharp_repo, 'csharp', '8a7e0a79b1743d5fd94d79a7106ee930'
 
       java_repo = src.repo 'java'
       java_repo.write 'examples/dummy', 'dummy'

--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -1,5 +1,39 @@
 # frozen_string_literal: true
 
+module ConsoleExamples
+  README_LIKE = <<~ASCIIDOC
+    When you execute this:
+    [source,console]
+    ----------------------------------
+    GET /_search
+    {
+        "query": "foo bar" <1>
+    }
+    ----------------------------------
+    <1> Here's the explanation
+
+    The result is this:
+    [source,console-result]
+    ----------------------------------
+    {
+        "hits": {
+            "total": { "value": 0, "relation": "eq" },
+            "hits": []
+        }
+    }
+    ----------------------------------
+
+    This one doesn't have an alternative:
+    [source,console]
+    ----------------------------------
+    GET /_search
+    {
+        "query": "missing"
+    }
+    ----------------------------------
+  ASCIIDOC
+end
+
 RSpec.shared_examples 'README-like console alternatives' do |path|
   page_context "#{path}/chapter.html" do
     let(:has_classes) { 'has-js has-csharp' }
@@ -10,7 +44,7 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
     end
     it 'contains the js listing followed by the csharp listing' do
       expect(body).to include(<<~HTML.strip)
-        </div><div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
+        <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
           body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
         })</pre></div><div class="pre_wrapper alternative lang-csharp">
       HTML
@@ -66,7 +100,7 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
   file_context "#{path}/alternatives_report.adoc" do
     it 'has a report on the example with all alternatives' do
       expect(contents).to include(<<~ASCIIDOC)
-        === index.asciidoc: line 6: 8a7e0a79b1743d5fd94d79a7106ee930.adoc
+        === index.asciidoc: line 7: 8a7e0a79b1743d5fd94d79a7106ee930.adoc
         [source,console]
         ----
         GET /_search
@@ -81,9 +115,28 @@ RSpec.shared_examples 'README-like console alternatives' do |path|
         |===
       ASCIIDOC
     end
+    it 'has a report on the example result' do
+      expect(contents).to include(<<~ASCIIDOC)
+        === index.asciidoc: line 17: 9fa2da152878d1d5933d483a3c2af35e.adoc
+        [source,console-result]
+        ----
+        {
+            "hits": {
+                "total": { "value": 0, "relation": "eq" },
+                "hits": []
+            }
+        }
+        ----
+        |===
+        | js-result | csharp-result | java-result
+
+        | &check; | &cross; | &cross;
+        |===
+      ASCIIDOC
+    end
     it 'has a report on the example without any alternatives' do
       expect(contents).to include(<<~ASCIIDOC)
-        === index.asciidoc: line 15: d21765565081685a36dfc4af89e7cece.adoc
+        === index.asciidoc: line 28: d21765565081685a36dfc4af89e7cece.adoc
         [source,console]
         ----
         GET /_search

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -397,22 +397,7 @@ RSpec.describe 'building a single book' do
 
         [[chapter]]
         == Chapter
-        [source,console]
-        ----------------------------------
-        GET /_search
-        {
-            "query": "foo bar" <1>
-        }
-        ----------------------------------
-        <1> Here's the explanation
-
-        [source,console]
-        ----------------------------------
-        GET /_search
-        {
-            "query": "missing"
-        }
-        ----------------------------------
+        #{ConsoleExamples::README_LIKE}
       ASCIIDOC
     end
     convert_before do |src, dest|

--- a/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
@@ -6,10 +6,17 @@ module AlternativeLanguageLookup
   ##
   # Information about a listing in the original document.
   class Listing
+    RESULT_SUFFIX = '-result'
+    RESULT_SUFFIX_LENGTH = RESULT_SUFFIX.length
+
     include Asciidoctor::Logging
 
     attr_reader :block
     attr_reader :lang
+    attr_reader :is_result
+    ##
+    # If `key_lang` normalises `lang` into the lookup key for alternatives.
+    attr_reader :key_lang
     attr_reader :alternatives
     attr_reader :source
     attr_reader :digest
@@ -17,8 +24,16 @@ module AlternativeLanguageLookup
     def initialize(block)
       @block = block
       @lang = block.attr 'language'
+      return unless @lang
+
+      @is_result = @lang.end_with? RESULT_SUFFIX
+      @key_lang = if @is_result
+                    @lang[0, @lang.length - RESULT_SUFFIX_LENGTH]
+                  else
+                    @lang
+                  end
       lookups = block.document.attr 'alternative_language_lookups'
-      @alternatives = lookups[@lang]
+      @alternatives = lookups[@key_lang]
     end
 
     def process
@@ -34,7 +49,9 @@ module AlternativeLanguageLookup
         next unless (found = a[:index][@digest])
 
         # TODO: we can probably cache this. There are lots of dupes.
-        alternative = Alternative.new document, a[:lang], found[:path]
+        alt_lang = a[:lang]
+        alt_lang += '-result' if @is_result
+        alternative = Alternative.new document, alt_lang, found[:path]
         alternative_listing = alternative.listing @block.parent
         next unless alternative_listing
 

--- a/resources/asciidoctor/lib/alternative_language_lookup/report.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/report.rb
@@ -34,7 +34,8 @@ module AlternativeLanguageLookup
     end
 
     def lang_header(listing)
-      listing.alternatives.map { |a| "| #{a[:lang]}" }.join ' '
+      suffix = listing.is_result ? '-result' : ''
+      listing.alternatives.map { |a| "| #{a[:lang]}#{suffix}" }.join ' '
     end
 
     def lang_line(listing, found_langs)

--- a/resources/asciidoctor/lib/alternative_language_lookup/summary.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/summary.rb
@@ -19,7 +19,7 @@ module AlternativeLanguageLookup
     end
 
     def on_listing(listing, found_langs)
-      sdata = @data[listing.lang]
+      sdata = @data[listing.key_lang]
       sdata[:total] += 1
       adata = sdata[:alternatives]
       found_langs.each { |alt| adata[alt][:found] += 1 }

--- a/resources/asciidoctor/spec/resources/alternative_language_lookup/js/c4f54085e4784ead2ef4a758d03edd16.adoc
+++ b/resources/asciidoctor/spec/resources/alternative_language_lookup/js/c4f54085e4784ead2ef4a758d03edd16.adoc
@@ -1,0 +1,4 @@
+[source,js-result]
+----
+'just js result'
+----

--- a/resources/web/docs_js/__tests__/components/alternative_switcher.test.js
+++ b/resources/web/docs_js/__tests__/components/alternative_switcher.test.js
@@ -28,6 +28,10 @@ describe(_AlternativeSwitcher, () => {
       <div id="csharp-colist"   class="alternative lang-csharp calloutlist"</div>
       <div id="js-colist"       class="alternative lang-js calloutlist"></div>
       <div id="console-colist"  class="default lang-console has-csharp has-js calloutlist"></div>
+
+      <div id="csharp-result"   class="alternative lang-csharp-result pre_wrapper"></div>
+      <div id="js-result"       class="alternative lang-js-result pre_wrapper"></div>
+      <div id="console-result"  class="default lang-console-result has-csharp has-js pre_wrapper"></div>
     </div>
   `;
 
@@ -58,6 +62,14 @@ describe(_AlternativeSwitcher, () => {
           isVisible(colist);
         } else {
           isHidden(colist);
+        }
+      });
+      describe(`the result for ${lang}`, () => {
+        const listing = document.getElementById(`${lang}-result`);
+        if (lang === selected) {
+          isVisible(listing);
+        } else {
+          isHidden(listing);
         }
       });
     }

--- a/resources/web/docs_js/components/alternative_switcher.js
+++ b/resources/web/docs_js/components/alternative_switcher.js
@@ -51,6 +51,8 @@ export const _AlternativeSwitcher = (preScrollToKeepOnScreen, store) => {
        * when there isn't an alternative. */
       sheet.insertRule(`#guide .default.has-${newValue} { display: none; }`);
       sheet.insertRule(`#guide .alternative.lang-${newValue} { display: block; }`);
+      sheet.insertRule(`#guide .default.has-${newValue}-result { display: none; }`);
+      sheet.insertRule(`#guide .alternative.lang-${newValue}-result { display: block; }`);
       // Setup rules to show the warning unless the snippet has that alternative
       sheet.insertRule(`#guide .AlternativePicker-warning { visibility: visible; }`);
       sheet.insertRule(`#guide .has-${newValue} .AlternativePicker-warning { visibility: hidden; }`);


### PR DESCRIPTION
This changes the "alternative language lookup" process to look for the
special suffix `-result` on the end of a language and look in the
non-`result` spot. For example, if a snippet has the langauge
`console-result` then we'll look up the snippet for all configured
alternatives for `console`.

This is useful because there are many, many "result" snippets in the
Elasticsearch reference and it looks funny today when you select, say,
"PHP" from the alternative language drop down and the *request* is in
PHP but the result of the request is in JSON. With this change all
clients, including the PHP client, will be able to provide stand ins for
all of these results snippets.

Well, all of the results snippets that are labeled explicitly as
results. Right now no snippets in the Elasticsearch reference are
labeled that way but we'll change that soon!
