### PR TITLE
Disable signup form and mobile nav while fixing

### DIFF
--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -387,3 +387,10 @@ p.remark {
 .guide-section {
   margin-bottom: 30px;
 }
+
+.navbar-toggler, 
+#locale-selector,
+#footer-subscribe {
+  display: none;
+}
+


### PR DESCRIPTION
This disables forms in the footer and mobile nav until they are fixed from the main site.