### PR TITLE
Shrink diffs for sitemap.xml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN cat /yarn.gpg | apt-key add - && rm yarn.gpg
 # * Used by the docs build
 #   * libjson-perl
 #   * libnss-wrapper
+#   * libxml-libxml-perl
 #   * libxml2-utils
 #   * nginx
 #   * openssh-client (used by git)
@@ -47,6 +48,7 @@ RUN install_packages \
   less \
   libjson-perl \
   libnss-wrapper \
+  libxml-libxml-perl \
   libxml2-dev \
   libxml2-utils \
   make \

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -431,7 +431,6 @@ sub build_sitemap {
     }
     for ( split /\0/, $changed ) {
         next unless s|^html/||;
-        say "ASDFADF $_";
         $dates{$_} = $now;
     }
 

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -17,6 +17,7 @@ our @Old_ARGV = @ARGV;
 use Cwd;
 use FindBin;
 use Data::Dumper;
+use XML::LibXML;
 
 BEGIN {
     $Old_Pwd = Cwd::cwd();
@@ -402,31 +403,41 @@ sub build_entries {
 #===================================
 sub build_sitemap {
 #===================================
-    my ($dir) = @_;
+    my ( $dir, $changed ) = @_;
+
+    # Build the sitemap by iterating over all of the toc and index files. Uses
+    # the old sitemap to populate the dates for files that haven't changed.
+    # Use "now" for files that have.
+
     my $sitemap = $dir->file('sitemap.xml');
+    my $now = timestamp();
+    my %dates;
 
-    say "Building sitemap: $sitemap";
-    open my $fh, '>', $sitemap or die "Couldn't create $sitemap: $!";
-    say $fh <<SITEMAP_START;
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-SITEMAP_START
+    if ( -e $sitemap ) {
+        my $doc = XML::LibXML->load_xml( location => $sitemap );
+        for ($doc->firstChild->childNodes) {
+            next unless $_->nodeName eq 'url';
+            my $loc;
+            my $lastmod;
+            for ($_->childNodes) {
+                $loc = $_->to_literal if $_->nodeName eq 'loc';
+                $lastmod = $_->to_literal if $_->nodeName eq 'lastmod';
+            }
+            die "Dind't find <loc> in $_" unless $loc;
+            die "Dind't find <lastmod> in $_" unless $lastmod;
+            $loc =~ s|https://www.elastic.co/guide/||;
+            $dates{$loc} = $lastmod;
+        }
+    }
+    for ( split /\0/, $changed ) {
+        next unless s|^html/||;
+        say "ASDFADF $_";
+        $dates{$_} = $now;
+    }
 
-    my $date     = timestamp();
-    my $add_link = sub {
-        my $file = shift;
-        my $url  = 'https://www.elastic.co/guide/' . $file->relative($dir);
-        say $fh <<ENTRY;
-<url>
-    <loc>$url</loc>
-    <lastmod>$date</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.5</priority>
-</url>
-ENTRY
-
-    };
-
+    # Build a list of the files we're going to index and sort it so entries in
+    # the sitemap don't "jump around".
+    my @files;
     $dir->recurse(
         callback => sub {
             my $item = shift;
@@ -435,15 +446,37 @@ ENTRY
             if ( -e $item->file('toc.html') ) {
                 my $content = $item->file('toc.html')
                     ->slurp( iomode => '<:encoding(UTF-8)' );
-                $add_link->( $item->file($_) )
+                push @files, $item->file($_)
                     for ( $content =~ /href="([^"]+)"/g );
             }
             elsif ( -e $item->file('index.html') ) {
-                $add_link->( $item->file('index.html') );
+                push @files, $item->file('index.html');
             }
             return $item->PRUNE;
         }
     );
+    @files = sort @files;
+
+    open my $fh, '>', $sitemap or die "Couldn't create $sitemap: $!";
+    say $fh <<SITEMAP_START;
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+SITEMAP_START
+
+    for ( @files ) {
+        my $loc  = $_->relative($dir);
+        my $url  = "https://www.elastic.co/guide/$loc";
+        my $date = $dates{$loc};
+        die "Couldn't find a modified time for $loc" unless $date;
+        say $fh <<ENTRY;
+<url>
+    <loc>$url</loc>
+    <lastmod>$date</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+</url>
+ENTRY
+    }
 
     say $fh "</urlset>";
     close $fh or die "Couldn't close $sitemap: $!"
@@ -619,10 +652,12 @@ sub push_changes {
 #===================================
     my ($build_dir, $target_repo, $tracker ) = @_;
 
-    if ( $tracker->has_non_local_changes || $target_repo->outstanding_changes ) {
+    my $outstanding = $target_repo->outstanding_changes;
+    if ( $tracker->has_non_local_changes || $outstanding ) {
+        say "Saving branch tracker";
         $tracker->write;
-        say 'Preparing commit';
-        build_sitemap($build_dir);
+        say "Building sitemap";
+        build_sitemap( $build_dir, $outstanding );
         say "Commiting changes";
         $target_repo->commit;
         say "Pushing changes";

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -86,6 +86,14 @@ class Dest
   end
 
   ##
+  # Executes `git show` for a single file.
+  def commit_info_for_file(file)
+    Dir.chdir bare_repo do
+      sh "git show -- #{file}"
+    end
+  end
+
+  ##
   # Start the preview service.
   def start_preview
     Preview.new(bare_repo)

--- a/lib/ES/TargetRepo.pm
+++ b/lib/ES/TargetRepo.pm
@@ -111,7 +111,9 @@ sub outstanding_changes {
     local $ENV{GIT_WORK_TREE} = $self->{destination};
     local $ENV{GIT_DIR} = $ENV{GIT_WORK_TREE} . '/.git';
 
-    return run qw(git status -s --);
+    # This command will list all modified files, including deleted files.
+    # Unlike `git status` it won't group new directories.
+    return run qw(git ls-files -zomd --);
 }
 
 #===================================


### PR DESCRIPTION
We generate `sitemap.xml` with an entry for every page in every
"current" book. Before this change we'd set the last modified time to
"now" for every single page, every time we rebuild the books. This
changes it so that we only change the last modified time when we modify
the file which is how you are supposed to use `sitemap.xml` anyway.

Beyond that, it sorts the entries in the sitemap before building it so
it doesn't "jump arround" on every commit.

These two combine to significantly shrink the size of small diffs which
should make working with the docs just a little bit faster.

Closes #684
