### PR TITLE
Merge template customization into template

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1541,7 +1541,3 @@ redirects:
 
 template:
     defaults:
-        POSTHEAD: |
-            <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
-        FINAL: |
-            <script type="text/javascript" src="/guide/static/docs.js"></script>

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -116,10 +116,6 @@ class Source
     <<~YAML
       template:
         defaults:
-          POSTHEAD: |
-            <link rel="stylesheet" type="text/css" href="styles.css" />
-          FINAL: |
-            <script type="text/javascript" src="/guide/static/docs.js"></script>
       paths:
         build:          html/
         branch_tracker: html/branches.yaml

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -80,6 +80,7 @@
             
       // --------------------- end of set language based on browser language -----------------
     </script>
+    <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 
   <body>
@@ -512,6 +513,6 @@ $(document).ready(function(){
 <script type="text/javascript" src="/static/js/slick.min.js"></script>
 <script src="/static/js/nav-v5.js"></script>
 <script src="/static/js/script.js"></script>
-
+<script type="text/javascript" src="/guide/static/docs.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Now that the web and docs teams are collaborating more closely we
don't really *need* to patch the template on startup. Instead we can put
all of our patches into the template file directly and everything is
just a little bit clearer.
