### PR TITLE
Move the repos dir config to parameter

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -452,9 +452,7 @@ ENTRY
 #===================================
 sub init_dirs {
 #===================================
-    my $repos_dir = $Conf->{paths}{repos}
-        or die "Missing <paths.repos> in config";
-
+    my $repos_dir = $Opts->{reposcache};
     $repos_dir = dir($repos_dir)->absolute;
     $repos_dir->mkpath;
 
@@ -813,6 +811,7 @@ sub command_line_opts {
         'push',
         'rebuild',
         'reference=s',
+        'reposcache=s',
         'skiplinkcheck',
         'sub_dir=s@',
         'user=s',
@@ -871,6 +870,8 @@ sub usage {
                             what has changed
           --reference       Directory of `--mirror` clones to use as a
                             local cache
+          --repos_cache     Directory to which working repositories are cloned.
+                            Defaults to `<script_dir>/.repos`.
           --skiplinkcheck   Omit the step that checks for broken links
           --sub_dir         Use a directory as a branch of some repo
                             (eg --sub_dir elasticsearch:master:~/Code/elasticsearch)
@@ -931,6 +932,7 @@ sub check_opts {
         die('--announce_preview only compatible with --all') if $Opts->{announce_preview};
         die('--rebuild only compatible with --all') if $Opts->{rebuild};
         die('--reference only compatible with --all') if $Opts->{reference};
+        die('--reposcache only compatible with --all') if $Opts->{reposcache};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
         die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
         die('--user only compatible with --all') if $Opts->{user};

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -452,7 +452,7 @@ ENTRY
 #===================================
 sub init_dirs {
 #===================================
-    my $repos_dir = $Opts->{reposcache};
+    my $repos_dir = $Opts->{reposcache} || '.repos';
     $repos_dir = dir($repos_dir)->absolute;
     $repos_dir->mkpath;
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,6 +1,5 @@
 paths:
     build:          html/
-    repos:          .repos/
     branch_tracker: html/branches.yaml
 
 docs_repo:

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -23,6 +23,7 @@ class Dest
   attr_reader :convert_statuses
 
   def initialize(tmp)
+    @repos_cache = File.expand_path 'repos', tmp
     @bare_dest = File.expand_path 'dest.git', tmp
     @dest = File.expand_path 'dest', tmp
     Dir.mkdir @dest
@@ -57,7 +58,7 @@ class Dest
   end
 
   def prepare_convert_all(conf)
-    ConvertAll.new conf, bare_repo, self
+    ConvertAll.new conf, @repos_cache, bare_repo, self
   end
 
   ##
@@ -177,11 +178,12 @@ class Dest
   end
 
   class ConvertAll < CmdBuilder
-    def initialize(conf, target_repo, dest)
+    def initialize(conf, repos_cache, target_repo, dest)
       super()
       @cmd = %W[
         --all
         --push
+        --reposcache #{repos_cache}
         --target_repo #{target_repo}
         --conf #{conf}
       ]

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -65,7 +65,7 @@ class Dest
   # Convert a conf file worth of books and check it out.
   def convert_all(conf, expect_failure: false, target_branch: nil)
     # TODO: remove this in favor of prepare_convert_all
-    convert = ConvertAll.new conf, bare_repo, self
+    convert = prepare_convert_all conf
     convert.target_branch target_branch if target_branch
     convert.convert expect_failure: expect_failure
   end

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -112,7 +112,6 @@ class Source
   private
 
   def common_conf
-    repos_path = path '../repos'
     <<~YAML
       template:
         defaults:
@@ -123,7 +122,6 @@ class Source
       paths:
         build:          html/
         branch_tracker: html/branches.yaml
-        repos:          #{repos_path}
       contents_title: Test
     YAML
   end

--- a/lib/ES/BaseRepo.pm
+++ b/lib/ES/BaseRepo.pm
@@ -100,7 +100,8 @@ sub _try_to_fetch {
     my $name = $self->name;
     my $url  = $self->url;
     if ( $origin ne $url ) {
-        printf(" - %20s: Upstream has changed to <%s>. Deleting\n", $self->name, $url);
+        printf(" - %20s: Upstream has changed from <%s> to <%s>. Deleting\n",
+                $self->name, $origin, $url);
         $git_dir->rmtree;
         return;
     }

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -28,7 +28,11 @@ our @EXPORT_OK = qw(
     build_web_resources
 );
 
-our $Opts = { procs => 3, lang => 'en' };
+our $Opts = {
+    procs => 3,
+    lang => 'en',
+    reposcache => '.repos',
+};
 
 #===================================
 sub build_chunked {

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -28,11 +28,7 @@ our @EXPORT_OK = qw(
     build_web_resources
 );
 
-our $Opts = {
-    procs => 3,
-    lang => 'en',
-    reposcache => '.repos',
-};
+our $Opts = { procs => 3, lang => 'en' };
 
 #===================================
 sub build_chunked {


### PR DESCRIPTION
Removes the `paths.repos` config entry from the conf file because we
rarely want to change it outside of tests. Adds a command line parameter
to change the path (`--reposcache`) and uses it in the tests.

This sort of accidentally fixes a problem where running `--self-test`
will trash the contents of `.repos/target_repo.git`, forcing subsequent
`--all` builds on the same machine to fetch it.
