### PR TITLE
Vastly speed up integration testing

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -247,7 +247,6 @@ sub build_all {
         say "Writing main TOC";
         $toc->write( $build_dir, 0 );
 
-        say "Writing web resources";
         my $static_dir = $build_dir->subdir( 'static' );
         build_web_resources( $static_dir );
 

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -766,6 +766,11 @@ sub build_web_resources {
     my $css = $dest->file('styles.css');
 
     unless ( -e $compiled_js && -e $compiled_css ) {
+        # We write the compiled js and css to /tmp so we can use them on
+        # subsequent runs in the same container. This doesn't come up when you
+        # build docs either with --doc or --all *but* it comes up all the time
+        # when you run the integration tests and saves about 1.5 seconds on
+        # every docs build.
         say "Compiling web resources";
         run '/node_modules/parcel/bin/cli.js', 'build',
             '--experimental-scope-hoisting', '--no-source-maps',


### PR DESCRIPTION
Before: 5m50.802s
 After: 2m46.185s

Works by only building the web resources one time in the docker
container. In normal operation that means it'll build it every time
because we only use the docker container once. But we reuse the same
container over and over again for integration tests so this saves quite
a bit of time there. Parcel *does* have a cache that works well for us,
but it cuts the web resource compile time from 5 seconds to 1.5 seconds
milliseconds. Great, but 1.5 seconds can add up.

This also merges two parcel runs into one and lets parcel parallelize
the builds. This saves a few hundred milliseconds on the compile which
is nice. Less nice now that we only do it once for all the integration
tests, but still nice.
