### PR TITLE
Load Perl Client docs from the repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -27,6 +27,7 @@ repos:
     elasticsearch-php:    https://github.com/elastic/elasticsearch-php
     elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
     elasticsearch-py:     https://github.com/elastic/elasticsearch-py
+    elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl
     elasticsearch:        https://github.com/elastic/elasticsearch.git
     guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
     guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
@@ -469,15 +470,15 @@ contents:
                 prefix:     perl-api
                 current:    master
                 branches:   [ master ]
-                index:      docs/perl/index.asciidoc
+                index:      docs/index.asciidoc
                 single:     1
                 tags:       Clients/Perl
                 subject:    Clients
                 asciidoctor: true
                 sources:
                   -
-                    repo:   elasticsearch
-                    path:   docs/perl
+                    repo:   elasticsearch-perl
+                    path:   docs/
 
               -
                 title:      Python API


### PR DESCRIPTION
Moved the docs folder from the elasticsearch repo to the perl client's repo.

Ref: https://github.com/elastic/elasticsearch-perl/pull/173