### PR TITLE
Stop the tracker from lying about changes

### DIFF
--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -43,6 +43,7 @@ sub set_sha_for_branch {
 #===================================
     my ( $self, $repo, $branch, $sha ) = @_;
 
+    return if $self->shas->{$repo}{$branch} eq $sha;
     $self->{has_non_local_changes} = 1 unless $sha =~ /^local/;
     $self->shas->{$repo}{$branch} = $sha;
 }


### PR DESCRIPTION
We set a flag on the branch tracker whenever there are changes to one of
the branches that we use to build the docs. When we're done building the
docs we commit them if *either* the flag is set or the built resulted in
any changed files. We do this because we want to commit the branch
changes even if there aren't changed files so we know were to start from
on the next build.

This fixes a problem where the tracker would lie about there being
changes when there weren't any. In particular, the kibana link checking
would set the branch even if it hadn't changed and that triggered the
tracker to *think* that it had changes. That caused us to try and
`git commit` when there aren't actually any changes. This fixes that.

Previously this wasn't causing trouble because we would rebuild the
entire sitemap if the tracker changed, causing a commit with just the
sitemap. We fixed that in #1110. With this change we can entirely skip
the commit.
