### PR TITLE
Remove marketo code from docs template

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -460,51 +460,11 @@
 	
 </style>
 
-<script src="//app-lon02.marketo.com/js/forms2/js/forms2.min.js"></script>
-<script>
-$(document).ready(function(){
-
-    var ipSuccess = function(data) {
-        country = data.country_code;
-        if (data.in_eu){
-                        
-            marketo_id = "6196";
-            
-        }else{ 
-            marketo_id = "1398";
-
-        }
-
-        $('.subscribe-form form.sb-form').attr('id', 'mktoForm_' + marketo_id);
-        if(window.MktoForms2){
-            MktoForms2.loadForm("//app-lon02.marketo.com", "813-MAM-392", marketo_id,function(form){
-                form.onSuccess(function(form){
-                    $('#mktoForm_'+marketo_id).css('display','none');
-                    $('.subscribe-wrapper .subscribe-form-container').hide();
-                    $('.subscribe-wrapper').find('.form_thanks').removeClass('hide')
-                    dataLayer.push({'event': 'mktoFormSubmit'});
-                    return false;
-                });
-            });  
-        }
-    }
-
-    var marketo_id;
-
-    $.ajax({
-        url: "/gdpr-data"
-    }).success(function(data) {
-        ipSuccess(data);
-    });
-
-})
-</script>
-
       </section>
     </div>
 
     
-     <script type="text/javascript">
+<script type="text/javascript">
 	var suggestionsUrl = "https://search.elastic.co/suggest";
 	var localeUrl = '{"relative_url_prefix":"/","code":"en-us","display_code":"en-us","url":"/guide_template"}';
 </script>


### PR DESCRIPTION
This removes the marketo code from the docs template. This form's code will come in with the footer javascript, so we don't need it in the template anymore. 