### PR TITLE
Drop main.css from elastic.co in favor of docs css

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -45,7 +45,6 @@
     <!-- For first- and second-generation iPad: -->
     <link rel="apple-touch-icon-precomposed" sizes="16x16" href="/favicon_16x16.png">
     <!-- css -->
-    <link href="/static/css/main.css" rel="stylesheet">
     <script src="/static/js/jquery.min.js"></script>
     <script src="/static/js/bootstrap.min.js"></script>
     <script src="/static/js/jquery.cookie.js"></script>


### PR DESCRIPTION
This drops main.css from the elastic.co requests. 

Testing to see if this is possible yet. 