### PR TITLE
Skip new --sub_dirs unless all sources are present

### DIFF
--- a/lib/ES/BranchTracker.pm
+++ b/lib/ES/BranchTracker.pm
@@ -43,7 +43,7 @@ sub set_sha_for_branch {
 #===================================
     my ( $self, $repo, $branch, $sha ) = @_;
 
-    return if $self->shas->{$repo}{$branch} eq $sha;
+    return if defined $self->shas->{$repo}{$branch} && $self->shas->{$repo}{$branch} eq $sha;
     $self->{has_non_local_changes} = 1 unless $sha =~ /^local/;
     $self->shas->{$repo}{$branch} = $sha;
 }

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -135,7 +135,7 @@ sub extract {
 
     if ( exists $self->{sub_dirs}->{$branch} ) {
         # Copies the $path from the subsitution directory. It is tempting to
-        # just symlink the substitution directoriy into the destionation and
+        # just symlink the substitution directory into the destination and
         # call it a day and that *almost* works! The trouble is that we often
         # use relative paths to include asciidoc files from other repositories
         # and those relative paths don't work at all with symlinks.

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -44,12 +44,13 @@ sub add_sub_dir {
 }
 
 #===================================
+# Returns 0 if the repo hasn't changed since we last built it, 1 if it has, and
+# 'new_sub_dir' if this is a sub_dir for a new source.
+#===================================
 sub has_changed {
 #===================================
     my $self = shift;
     my ( $title, $branch, $path, $asciidoctor ) = @_;
-
-    return 1 if exists $self->{sub_dirs}->{$branch};
 
     local $ENV{GIT_DIR} = $self->git_dir;
     my $old_info = $self->_last_commit_info(@_);
@@ -60,7 +61,12 @@ sub has_changed {
         # hash that means that the branch wasn't used the last time we built
         # this book. That means we'll skip it entirely when building the book
         # anyway so we should consider the book not to have changed.
-        return 0 unless $old_info;
+        unless ($old_info) {
+            # New sub_dirs *might* build, but only if the entire book is built
+            # out of new sub_dirs.
+            return 'new_sub_dir' if exists $self->{sub_dirs}->{$branch};
+            return 0;
+        }
 
         $new = $self->_last_commit(@_);
     } else {
@@ -74,6 +80,10 @@ sub has_changed {
     }
     my $new_info = $new;
     $new_info .= '|asciidoctor' if $asciidoctor;
+
+    # We check sub_dirs *after* the checks above so we can handle sub_dir for
+    # new sources specially.
+    return 1 if exists $self->{sub_dirs}->{$branch};
 
     return $old_info ne $new_info if $self->{keep_hash};
     return if $old_info eq $new_info;
@@ -124,7 +134,7 @@ sub extract {
     my ( $title, $branch, $path, $dest ) = @_;
 
     if ( exists $self->{sub_dirs}->{$branch} ) {
-        # Copies the $path from the subsitution diretory. It is tempting to
+        # Copies the $path from the subsitution directory. It is tempting to
         # just symlink the substitution directoriy into the destionation and
         # call it a day and that *almost* works! The trouble is that we often
         # use relative paths to include asciidoc files from other repositories
@@ -140,9 +150,10 @@ sub extract {
         return;
     }
 
-    $branch = $self->_resolve_branch( @_ );
-    unless ( $branch ) {
-        printf(" - %40.40s: %s is new. Skipping\n", $title, $self->{name});
+    my $resolved_branch = $self->_resolve_branch( @_ );
+    unless ( $resolved_branch ) {
+        printf(" - %40.40s: Skipping new repo %s for branch %s.\n",
+               $title, $self->{name}, $branch);
         return;
     }
 
@@ -151,7 +162,7 @@ sub extract {
     $dest->mkpath;
     my $tar = $dest->file('.temp_git_archive.tar');
     die "File <$tar> already exists" if -e $tar;
-    run qw(git archive --format=tar -o ), $tar, $branch, $path;
+    run qw(git archive --format=tar -o ), $tar, $resolved_branch, $path;
 
     run "tar", "-x", "-C", $dest, "-f", $tar;
     $tar->remove;

--- a/lib/ES/Source.pm
+++ b/lib/ES/Source.pm
@@ -51,12 +51,29 @@ sub has_changed {
     my $title  = shift;
     my $branch = shift;
     my $asciidoctor = shift;
+    # If any of the repos have changed then we'll return 1. 
+    my $all_new_sub_dir = 1;
     for my $source ( $self->_sources_for_branch($branch) ) {
         my $repo_branch = $source->{map_branches}->{$branch} || $branch;
-        return 1
-            if $source->{repo}->has_changed( $title, $repo_branch, $source->{path}, $asciidoctor );
+        my $has_changed = $source->{repo}->has_changed(
+            $title, $repo_branch, $source->{path}, $asciidoctor
+        );
+        if ( $has_changed eq 'new_sub_dir' ) {
+            # sub_dirs for new sources are special: They don't count as
+            # "changed" most of the time. The idea is that if the book built
+            # properly without them last time it was built with these hashes
+            # then it won't need them *this* time. On the other hand, if the
+            # *entire* book is new sub_dirs we'll build it because we have
+            # entirely new sources. This has the advantage of rebuilding books
+            # like the Kibana reference in PR builds against a new branch
+            # because it is a single source book. This is nice because it gets
+            # us *some* test coverage.
+            next;
+        }
+        return 1 if $has_changed;
+        $all_new_sub_dir = 0;
     }
-    return;
+    return $all_new_sub_dir;
 }
 
 #===================================


### PR DESCRIPTION
When we added a new branch to the list of books last week we broke the
docs PR tests for books that were involved in more than one repo. The
build saw `--sub_dir` for *that* repo and no other history so it tried
to build those multi-source books with just the `--sub_dir`ed repo. This
didn't work because we were missing a ton of files.

This detects when `--sub_dir` is used for a new source and skips
building the book *unless* all of the sources are new *and*
`--sub_dir`ed. This means we'll still build, say, the Elasticsearch
reference on Elasticsearch PRs even if the book is new but we won't
build, say, the stack overview. So we lose test coverage here but in
exchange we don't fail builds.

The more paranoid option would be to "fail closed" and log a more
helpful message but fail the build until the "global" docs build has
run. This doesn't seem like the right option because, frankly, we'd
prefer to keep merging a little smoother on release day at the cost of
failing the global docs build a little more. We are used to some trouble
with the global docs build on release day.
