### PR TITLE
Restor code style from main.css

### DIFF
--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -2,10 +2,12 @@
   /* Inline code examples */
   code {
     font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
-    background: #f8f8f8;
     padding: 0 3px;
     font-size: 0.9em;
-    display:inline;
+    display: inline;
+    white-space: pre-wrap;
+    background: #f8f8f8;
+    color: #555;
   }
 
   a code {


### PR DESCRIPTION
We were getting a nice code style from main.css. This moves it into the
docs css.
