### PR TITLE
Remove locale bouncer from template

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -47,38 +47,12 @@
     <!-- css -->
     <script src="/static/js/jquery.min.js"></script>
     <script src="/static/js/bootstrap.min.js"></script>
-    <script src="/static/js/jquery.cookie.js"></script>
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
     <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <script type="text/javascript">
-      // -------------------- set language based on browser language --------------------
-      var lang = '/'+(navigator.language || navigator.userLanguage).slice(0,2)+'/',
-      locales = {
-        '/en':'/',
-        '/de/': '/de/',
-        '/fr/': '/fr/',
-        '/ja/':'/jp/',
-        '/ko/':'/kr/',
-        '/zh/':'/cn/',
-        '/es/': '/es/'
-      },
-      localeUrl = '{"relative_url_prefix":"/","code":"en-us","display_code":"en-us","url":"/guide_template"}',
-      currentlocale = JSON.parse(localeUrl).relative_url_prefix;
-
-      if($.cookie("is_lang_detected") == undefined){
-        if(locales[lang] != undefined && locales[lang] != currentlocale){
-          locale_lang_url = locales[lang] + window.location.pathname.slice(1,window.location.pathname.length);
-          $.cookie("is_lang_detected",true ,{ path: '/'});
-          window.location = locale_lang_url;
-        }
-      }
-            
-      // --------------------- end of set language based on browser language -----------------
-    </script>
     <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 


### PR DESCRIPTION
I don't think it has worked for a while and no one is complaining. We
always ended up with `currentlocale` as `undefined` because `/en` was
missing a trailing `/`.

With that picker gone we can also remove `jquery.cookie` because it was
the last thing to use it.
