### PR TITLE
Remove .NET client src/Examples directory

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -250,11 +250,6 @@ contents:
                 path:   examples
                 exclude_branches:   [ 7.x, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
-                # These are used by .NET's doc examples but they are not in the same subdirectory
-                repo:   elasticsearch-net
-                path:   src/Examples
-                exclude_branches:   [ 7.x, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   elasticsearch-py
                 path:   example/docs/asciidoc


### PR DESCRIPTION
With the change in https://github.com/elastic/elasticsearch-net/pull/4043 to write C# examples directly to asciidoc, rather than use an include:: element, the src/Examples directory in elastic/elasticsearch-net no longer needs to be referenced. This commit removes the reference.
