### PR TITLE
Slightly clean up raw output

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -55,6 +55,21 @@ RSpec.describe 'building a single book' do
         end
       end
       page_context 'raw/index.html' do
+        it "doesn't have the xml prolog" do
+          expect(contents).not_to include('?xml')
+        end
+        it 'has the html5 doctype' do
+          expect(contents).to include("<!DOCTYPE html>\n")
+        end
+        it "doesn't have any xmlns declarations" do
+          expect(contents).not_to include('xmlns=')
+        end
+        it "doesn't have any xml:lang tags" do
+          expect(contents).not_to include('xml:lang=')
+        end
+        it 'has a trailing newline' do
+          expect(contents).to end_with("\n")
+        end
         it 'has the right title' do
           expect(title).to eq('Title')
         end

--- a/lib/ES/Template.pm
+++ b/lib/ES/Template.pm
@@ -50,12 +50,6 @@ sub apply {
 
         my $contents = $source->slurp( iomode => '<:encoding(UTF-8)' );
 
-        # Strip XML guff
-        $contents =~ s/\s+xmlns="[^"]*"//g;
-        $contents =~ s/\s+xml:lang="[^"]*"//g;
-        $contents =~ s/^<\?xml[^>]+>\n//;
-        $contents =~ s/\s*$/\n/;
-
         # Extract AUTOSENSE snippets
         $contents = $self->_autosense_snippets( $source, $contents ) unless $asciidoctor;
 


### PR DESCRIPTION
This'd make it simpler for *anything* else to use the raw output by
normalizing docbooks quirks away.
