### PR TITLE
Copies shared version attributes to new location

### DIFF
--- a/shared/versions/stack/5.5.asciidoc
+++ b/shared/versions/stack/5.5.asciidoc
@@ -1,0 +1,13 @@
+:version:                5.5.3
+:logstash_version:       5.5.3
+:elasticsearch_version:  5.5.3
+:kibana_version:         5.5.3
+:branch:                 5.5
+:major-version:          5.x
+:prev-major-version:     2.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions/stack/5.6.asciidoc
+++ b/shared/versions/stack/5.6.asciidoc
@@ -1,0 +1,13 @@
+:version:                5.6.16
+:logstash_version:       5.6.16
+:elasticsearch_version:  5.6.16
+:kibana_version:         5.6.16
+:branch:                 5.6
+:major-version:          5.x
+:prev-major-version:     2.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:         released

--- a/shared/versions/stack/6.0.asciidoc
+++ b/shared/versions/stack/6.0.asciidoc
@@ -1,0 +1,12 @@
+:version:                6.0.1
+:logstash_version:       6.0.1
+:elasticsearch_version:  6.0.1
+:kibana_version:         6.0.1
+:branch:                 6.0
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          released

--- a/shared/versions/stack/6.1.asciidoc
+++ b/shared/versions/stack/6.1.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.1.4
+:logstash_version:       6.1.4
+:elasticsearch_version:  6.1.4
+:kibana_version:         6.1.4
+:branch:                 6.1
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.2.asciidoc
+++ b/shared/versions/stack/6.2.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.2.4
+:logstash_version:       6.2.4
+:elasticsearch_version:  6.2.4
+:kibana_version:         6.2.4
+:branch:                 6.2
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.3.asciidoc
+++ b/shared/versions/stack/6.3.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.3.2
+:logstash_version:       6.3.2
+:elasticsearch_version:  6.3.2
+:kibana_version:         6.3.2
+:branch:                 6.3
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.4.asciidoc
+++ b/shared/versions/stack/6.4.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.4.3
+:logstash_version:       6.4.3
+:elasticsearch_version:  6.4.3
+:kibana_version:         6.4.3
+:branch:                 6.4
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.5.4
+:logstash_version:       6.5.4
+:elasticsearch_version:  6.5.4
+:kibana_version:         6.5.4
+:branch:                 6.5
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.6.2
+:logstash_version:       6.6.2
+:elasticsearch_version:  6.6.2
+:kibana_version:         6.6.2
+:branch:                 6.6
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.7.2
+:logstash_version:       6.7.2
+:elasticsearch_version:  6.7.2
+:kibana_version:         6.7.2
+:branch:                 6.7
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.8.3
+:logstash_version:       6.8.3
+:elasticsearch_version:  6.8.3
+:kibana_version:         6.8.3
+:branch:                 6.8
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.0.1
+:logstash_version:       7.0.1
+:elasticsearch_version:  7.0.1
+:kibana_version:         7.0.1
+:branch:                 7.0
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.1.1
+:logstash_version:       7.1.1
+:elasticsearch_version:  7.1.1
+:kibana_version:         7.1.1
+:branch:                 7.1
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.2.1
+:logstash_version:       7.2.1
+:elasticsearch_version:  7.2.1
+:kibana_version:         7.2.1
+:branch:                 7.2
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.3.1
+:logstash_version:       7.3.1
+:elasticsearch_version:  7.3.1
+:kibana_version:         7.3.1
+:branch:                 7.3
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.4.0
+:logstash_version:       7.4.0
+:elasticsearch_version:  7.4.0
+:kibana_version:         7.4.0
+:branch:                 7.4
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.5.0
+:logstash_version:       7.5.0
+:elasticsearch_version:  7.5.0
+:kibana_version:         7.5.0
+:branch:                 7.x
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,0 +1,13 @@
+:version:                8.0.0-alpha1
+:logstash_version:       8.0.0-alpha1
+:elasticsearch_version:  8.0.0-alpha1
+:kibana_version:         8.0.0-alpha1
+:branch:                 master
+:major-version:          8.x
+:prev-major-version:     7.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   prerelease


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/issues/804

This PR copies the version attribute files to a new folder and names them based on branch names. 
This will potentially enable us to pull the right filename using attributes provided by the build (see https://github.com/elastic/docs/pull/1147).

If we go ahead with the use of these files, the older copies of the version attribute files are redundant and can be removed after all books that use them have been updated to use the new files.
