### PR TITLE
Change Kibana Reference to Kibana Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -610,7 +610,7 @@ contents:
         title:      Kibana: Explore, Visualize, and Share
         sections:
           -
-            title:      Kibana Reference
+            title:      Kibana Guide
             prefix:     en/kibana
             current:    7.3
             branches:   [ master, 7.x, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]


### PR DESCRIPTION
This PR alters the name of the "Kibana Reference" in the conf.yaml file.

This affects the title that appears in the following locations:

- https://www.elastic.co/guide/index.html
- https://www.elastic.co/guide/en/kibana/current/index.html

For example:
![image](https://user-images.githubusercontent.com/26471269/64371544-a71a1980-cfd5-11e9-84a2-39538bc4210a.png)

![image](https://user-images.githubusercontent.com/26471269/64371591-c618ab80-cfd5-11e9-8ac7-383bfd1033b9.png)

