### PR TITLE
Add APM .NET Agent docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1070,8 +1070,8 @@ contents:
                   -
                     title:      APM .NET Agent
                     prefix:     dotnet
-                    current:    master
-                    branches:   [ master ]
+                    current:    1.0.0
+                    branches:   [ master, 1.0.0 ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Adds the APM .NET Agent `1.0.0` documentation and copies it to `current`. This documentation is built from a [tag](https://github.com/elastic/apm-agent-dotnet/tags) in the repo (not a branch).