### PR TITLE
Move table styles into their own file

### DIFF
--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -1,0 +1,41 @@
+#guide {
+  table {
+    margin-bottom:1em;
+    border: none;
+    width: 100%;
+
+    /* Allow wrapping in some code and pre tags inside tables. */
+    .literal {
+      white-space: initial;
+    }
+    /* But *not* those in the first column. Those are usually the names of
+     * variables and things and they don't make a lot of sense to wrap. */
+    td:first-child .literal {
+      white-space: nowrap;
+    }
+  }
+  thead, tbody {
+    text-align:left;
+    vertical-align:top;
+  }
+  th {
+    font-weight: 700;
+    padding: .5em 0.2em;
+  }
+  td {
+    vertical-align: top;
+    padding: .75em 0.2em 0;
+  }
+  th, td {
+    border: none;
+    border-bottom: 1px solid #e5eae4;
+    &:last-child {
+      padding-right: 0;
+    }
+  }
+  tr:last-child {
+    th, td {
+      border: none;
+    }
+  }
+}

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -10,6 +10,7 @@
 @import './style/nav.pcss';
 @import './style/rtpcontainer.pcss';
 @import './style/settings_modal.pcss';
+@import './style/table.pcss';
 @import './style/this_page.pcss';
 @import './style/toc.pcss';
 @import './style/util.pcss';
@@ -81,10 +82,6 @@
     padding: 0;
 }
 
-#guide table p {
-    margin-top: 0
-}
-
 #guide p.simpara+div.orderedlist,
 #guide p.simpara+div.itemizedlist {
     margin-top: -0.9em;
@@ -100,43 +97,6 @@
 
 #guide dd {
     margin: 0 0 0.5em 2em;
-}
-
-/* Tables */
-#guide .informaltable table .literal{white-space:initial;}
-#guide .informaltable table td:first-child .literal{white-space:nowrap;}
-
-#guide table{
-    margin-bottom:1em;
-    border: none;
-    width: 100%;
-}
-
-#guide table thead,#guide table tbody{
-    text-align:left;
-    vertical-align:top;
-}
-
-#guide table td:last-child{
-    padding-right:0;
-}
-
-#guide table th{
-    font-weight:700;
-    padding:.5em 0.2em;
-    border:none;
-    border-bottom:2px solid #e5eae4;
-}
-
-#guide table td{
-    vertical-align:top;
-    padding:.75em 0.2em 0;
-    border:none;
-    border-bottom:1px solid #e5eae4;
-}
-
-#guide table tr:last-child td {
-    border:none;
 }
 
 /* Admonitions */


### PR DESCRIPTION
Moves the styles for tables into their own file so it is a bit easier to
manage. Drops the stype for paragraphs inside tables because it isn't
being used.
