### PR TITLE
Drop template fetch script

### DIFF
--- a/fetch_template.sh
+++ b/fetch_template.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Fetch the production templates for the guide.
-# Run this from the root of the docs repo.
-# After running this you have to force a `--all --rebuild` to pick up the
-# new template.
-
-curl https://www.elastic.co/guide_template > resources/web/template.html

--- a/resources/web/README
+++ b/resources/web/README
@@ -1,4 +1,2 @@
-template.html can be fetched by running fetch_template.sh
-
 The js tests can be run continuously with:
     ./build_docs --self-test -C resources/web/ test_watch


### PR DESCRIPTION
We don't fetch the template from anywhere anymore. We maintain it in the
docs repo.
