### PR TITLE
Add Elasticsearch repo to Stack Glossary for content reuse

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -113,6 +113,9 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
+              -
+                repo:   elasticsearch
+                path:   docs
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -46,7 +46,7 @@ alias docbldstkold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stac
 
 
 # Glossary
-alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
+alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs'
 
 # Getting started
 alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'


### PR DESCRIPTION
Updates the Stack Glossary build to include the Elasticsearch repo as a dependency.

This allows the Elasticsearch docs team to reuse definitions from the [Elasticsearch Reference Guide's glossary](https://www.elastic.co/guide/en/elasticsearch/reference/master/glossary.html).