### PR TITLE
We have the autoprefixer

### DIFF
--- a/resources/web/style/conum.pcss
+++ b/resources/web/style/conum.pcss
@@ -6,7 +6,6 @@
     line-height: 16px;
     color: #f5f7fa;
     background-color: #0080d5;
-    -webkit-border-radius: 100px;
     border-radius: 100px;
     text-align: center;
     font-size: 10pt;

--- a/resources/web/style/link.pcss
+++ b/resources/web/style/link.pcss
@@ -2,12 +2,10 @@
   a {
     color: #00a9e5;
     font-weight: normal;
-    -webkit-text-decoration: none;
     text-decoration: none;
     outline: none;
     outline-offset: 0;
     &:hover, &:focus {
-      -webkit-text-decoration: underline !important;
       text-decoration: underline !important;
     }
   }

--- a/resources/web/style/util.pcss
+++ b/resources/web/style/util.pcss
@@ -6,11 +6,6 @@
     text-decoration: line-through;
   }
   .u-space-between {
-    /* TODO autoprefixer */
-    display: -webkit-box;
-    display: -moz-box;
-    display: -ms-flexbox;
-    display: -webkit-flex;
     display: flex;
     justify-content: space-between;
   }


### PR DESCRIPTION
Enabling pcss enabled the autoprefixer plugin so we really don't need to
be defining any of the funny prefixed styles. This drops all of them.
