### PR TITLE
Add attribute for ecs-version to shared version files

### DIFF
--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.0
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.0
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.1
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.0
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.2
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.0
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.3
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.0
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.4
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.1
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 7.x
 :major-version:          7.x
 :prev-major-version:     6.x
+:ecs_version:            1.1
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -5,6 +5,7 @@
 :branch:                 master
 :major-version:          8.x
 :prev-major-version:     7.x
+:ecs_version:            1.1
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
We need a way to link ECS versions to stack versions.  This PR adds an `ecs-version` attribute to our shared version files. 

Issue:
#804

Related PRs:
#1147 
#1148