### PR TITLE
Replace ecs version with attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -60,7 +60,7 @@
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
-:ecs-ref:              https://www.elastic.co/guide/en/ecs/1.0
+:ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs-version}
 :subscriptions:        https://www.elastic.co/subscriptions
 
 :forum:                https://discuss.elastic.co/

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -60,7 +60,7 @@
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
-:ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs-version}
+:ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :subscriptions:        https://www.elastic.co/subscriptions
 
 :forum:                https://discuss.elastic.co/


### PR DESCRIPTION
Related to #1169 
This PR replaces the hard-coded ECS version number with an attribute that supports versioning.

DO NOT MERGE until all books using the hard-coded ECS attribute have been updated to include `//shared/versions/stack/{source_branch}.asciidoc` (or handled in product repo versioning)
- [x] Logstash Reference
- [x] Beats (libbeat and winlogbeat)
- [x] Kibana Reference (https://github.com/elastic/kibana/pull/45051)
    * SIEM
    *  ML
    - [ ] Logs. Note to self: This reference is weird. Check it out to verify or correct before merge. 
- [x] SIEM Guide (stack-docs) (https://github.com/elastic/stack-docs/pull/497)



