### PR TITLE
Upgrade some dependencies

### DIFF
--- a/.docker/apt/sources.list.d/nodesource.list
+++ b/.docker/apt/sources.list.d/nodesource.list
@@ -1,1 +1,1 @@
-deb https://deb.nodesource.com/node_10.x stretch main
+deb https://deb.nodesource.com/node_12.x buster main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Debian builds the docs about 20% faster than alpine. The image is larger
 # and takes longer to build but that is worth it.
-FROM bitnami/minideb:stretch
+FROM bitnami/minideb:buster
 
 LABEL MAINTAINERS="Nik Everett <nik@elastic.co>"
 
@@ -26,6 +26,7 @@ RUN cat /yarn.gpg | apt-key add - && rm yarn.gpg
 #   * python (is python2)
 #   * xsltproc
 # * To install rubygems for asciidoctor
+#   * bundler
 #   * build-essential
 #   * cmake
 #   * libxml2-dev
@@ -41,6 +42,7 @@ RUN cat /yarn.gpg | apt-key add - && rm yarn.gpg
 RUN install_packages \
   bash \
   build-essential \
+  bundler \
   curl \
   cmake \
   git \
@@ -79,7 +81,6 @@ RUN pip3 install \
   pycodestyle==2.5.0
 
 # Install ruby deps with bundler to make things more standard for Ruby folks.
-RUN gem install bundler:2.0.1
 RUN bundle config --global silence_root_warning 1
 COPY Gemfile* /
 RUN bundle install --binstubs --system --frozen

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # regenerate Gemfile.lock or building the docker image will fail.
 source "https://rubygems.org"
 
-ruby "~> 2.3"
+ruby "~> 2.5"
 
 # We commit Gemfile.lock so we're not going to have "unexpected" version bumps
 # of our gems. This file specifies what we think *should* work. Gemfile.lock

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,4 +55,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Upgrades us from a rather old version of debian and all that brings
along which includes at least ruby 2.5. Upgrades nodejs to 12.x which'll
be nicer to work with on the server side. Switches to installing bundler
with apt to save a little time.
