### PR TITLE
Allow selecting headings

### DIFF
--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -62,7 +62,9 @@ module Dsl
       let(:title) do
         return unless body
 
-        m = body.match %r{<h1 class="title"><a id=".+"></a>([^<]+)(<a.+?)?</h1>}
+        m = body.match(
+          %r{<h1 class="title"><a id="[^\"]+">([^<]+)</a>(<a.+?)?</h1>}
+        )
         raise "Can't find title in #{body}" unless m
 
         m[1]

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe 'building a single book' do
         <a class="xpack_tag" href="/subscriptions"></a>
       HTML
     end
-    let(:rx) { %r{<#{h} class="title"><a id="#{id}"></a>(.+?)</#{h}>} }
+    let(:rx) { %r{<#{h} class="title"><a id="#{id}">(.+?)</a></#{h}>} }
     let(:title_tag) do
       return unless body
 

--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -5,15 +5,21 @@
     font-family: aktiv-grotesk, sans-serif;
     /* Override the "funny" line height from bootstrap. */
     line-height: normal;
-    &:hover a[id][href] {
+    a[id][href] {
+      font: inherit;
+      color: inherit;
+      &:hover, &:focus {
+        text-decoration: none !important;
+      }
+    }
+    &:hover a[id][href]::before {
+      content: '';
       display: block;
       position: absolute;
-      bottom: 3px;
-      margin: 0;
-      padding: 0;
       left: -20px;
-      width: 100%;
+      width: 20px;
       height: 1em;
+      bottom: 3px;
       background-repeat: no-repeat;
       background-position: 0% 50%;
       background-image: inline("img/link.png");

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -206,18 +206,20 @@
       <xsl:attribute name="class">title</xsl:attribute>
       <!-- Elastic changes start here -->
       <a>
-        <xsl:attribute name="name">
+        <xsl:attribute name="id">
           <xsl:call-template name="object.id">
             <xsl:with-param name="object" select="$node"/>
           </xsl:call-template>
         </xsl:attribute>
         <xsl:apply-templates select="$node" mode="object.title.markup">
-          <xsl:with-param name="allow-anchors" select="1"/>
+          <xsl:with-param name="allow-anchors" select="0"/>
         </xsl:apply-templates>
       </a>
       <xsl:if test="$node[@role='xpack']">
         <a class="xpack_tag" href="/subscriptions" />
       </xsl:if>
+      <!-- Grab the edit_me link if there is one. -->
+      <xsl:apply-templates select="*" />
       <!-- Elastic changes end here -->
     </xsl:element>
   </xsl:template>
@@ -227,17 +229,27 @@
     <xsl:param name="node" select="."/>
     <h1>
       <xsl:attribute name="class">title</xsl:attribute>
-      <xsl:call-template name="anchor">
-        <xsl:with-param name="node" select="$node"/>
-        <xsl:with-param name="conditional" select="0"/>
-      </xsl:call-template>
+      <!-- Elastic changes start here -->
+      <a>
+        <xsl:attribute name="id">
+          <xsl:call-template name="object.id">
+            <xsl:with-param name="object" select="$node"/>
+          </xsl:call-template>
+        </xsl:attribute>
+        <xsl:apply-templates select="$node" mode="object.title.markup">
+          <xsl:with-param name="allow-anchors" select="0"/>
+        </xsl:apply-templates>
+      </a>
       <xsl:apply-templates select="$node" mode="object.title.markup">
         <xsl:with-param name="allow-anchors" select="1"/>
       </xsl:apply-templates>
-      <!-- The Elastic addition -->
       <xsl:if test="$node[@role='xpack']">
         <a class="xpack_tag" href="/subscriptions" />
       </xsl:if>
+      foooo
+      <!-- Grab the edit_me link if there is one. -->
+      <xsl:apply-templates select="*" />
+      <!-- Elastic changes end here -->
     </h1>
   </xsl:template>
 

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -204,17 +204,21 @@
 
     <xsl:element name="h{$level+1}" namespace="http://www.w3.org/1999/xhtml">
       <xsl:attribute name="class">title</xsl:attribute>
-      <xsl:call-template name="anchor">
-        <xsl:with-param name="node" select="$node"/>
-        <xsl:with-param name="conditional" select="0"/>
-      </xsl:call-template>
-      <xsl:apply-templates select="$node" mode="object.title.markup">
-        <xsl:with-param name="allow-anchors" select="1"/>
-      </xsl:apply-templates>
-      <!-- The Elastic addition -->
+      <!-- Elastic changes start here -->
+      <a>
+        <xsl:attribute name="name">
+          <xsl:call-template name="object.id">
+            <xsl:with-param name="object" select="$node"/>
+          </xsl:call-template>
+        </xsl:attribute>
+        <xsl:apply-templates select="$node" mode="object.title.markup">
+          <xsl:with-param name="allow-anchors" select="1"/>
+        </xsl:apply-templates>
+      </a>
       <xsl:if test="$node[@role='xpack']">
         <a class="xpack_tag" href="/subscriptions" />
       </xsl:if>
+      <!-- Elastic changes end here -->
     </xsl:element>
   </xsl:template>
 


### PR DESCRIPTION
Previously our headings were "covered up" by a funny anchor tag that we
used to make it possible to link to portions of the page. This made them
impossible to select. This changes headings so they are *part of* the
anchor tag. Text inside an anchor tag isn't selectable on its own but
you *can* select it by dragging from outside of the tag inwards. This is
"how browsers work" so folks should be used to this. Hopefully making
the text part of the anchor tag will make it much more obvious what is
going on.

Closes #277
