### PR TITLE
Streaming templates

### DIFF
--- a/.docker/apt/sources.list.d/nodesource.list
+++ b/.docker/apt/sources.list.d/nodesource.list
@@ -1,1 +1,1 @@
-deb https://deb.nodesource.com/node_10.x stretch main
+deb https://deb.nodesource.com/node_12.x stretch main

--- a/template/__test__/template.test.js
+++ b/template/__test__/template.test.js
@@ -20,12 +20,12 @@
 
 'use strict';
 
-const template = require('../template');
+const Template = require('../template');
 
-describe(template, () => {
+describe(Template, () => {
   describe("buildInitialJsState", () => {
     describe("for empty alternatives summary", () => {
-      const state = template.buildInitialJsState({});
+      const state = Template.buildInitialJsState({});
       test("not to have any alternatives", () => {
         expect(state).toStrictEqual({
           alternatives: {}
@@ -33,7 +33,7 @@ describe(template, () => {
       });
     });
     describe("for a small alternatives summary", () => {
-      const state = template.buildInitialJsState({
+      const state = Template.buildInitialJsState({
         console: {
           total: 2,
           alternatives: {
@@ -65,14 +65,24 @@ describe(template, () => {
     });
   });
   describe("apply", () => {
-    let t;
-    beforeAll(async () => {
-      t = await template("../resources/web/template.html");
-    });
+    let template = Template("../resources/web/template.html")
+    template.applyToString = async (raw, lang, initialJsState) => {
+      const rawItr = (function* () {
+        yield raw;
+      })();
+      return template.applyToItr(rawItr, lang, initialJsState);
+    };
+    template.applyToItr = async (rawItr, lang, initialJsState) => {
+      let result = '';
+      for await (const chunk of template.apply(rawItr, lang, initialJsState)) {
+        result += chunk;
+      }
+      return result;
+    };
     describe("when applied to simple html", () => {
       let result;
-      beforeAll(() => {
-        result = t.apply(`
+      beforeAll(async () => {
+        result = await template.applyToString(`
           <!DOCTYPE html>
           <html>
             <head><title>foo</title></head>
@@ -96,16 +106,101 @@ describe(template, () => {
         );
       });
     });
+    describe("when the head and body are empty", () => {
+      let result;
+      beforeAll(async () => {
+        result = await template.applyToString(`
+          <!DOCTYPE html>
+          <html>
+            <head></head>
+            <body></body>
+          </html>`);
+      });
+      test("doesn't add anything to the head", () => {
+        expect(result).toMatch(
+          /<head>\s+<meta http-equiv="content-type"/
+        );
+      });
+      test("outputs an empty body", () => {
+        expect(result).toMatch(
+          /<!-- start body -->\s+<!-- end body -->/
+        );
+      });
+    });
     describe("when it gets a document without a head", () => {
-      test("throws an exception", () => {
-        expect(() => t.apply(`<html><body>words</body></html>`))
-          .toThrow(/Couldn't find head/);
+      test("throws an exception", async () => {
+        return expect(template.applyToString(`<html><body>words</body></html>`))
+          .rejects.toThrow(/Couldn't find <head> in raw/);
+      });
+    });
+    describe("when it gets a document with an unclosed head", () => {
+      test("throws an exception", async () => {
+        return expect(template.applyToString(`<html><head><body>words</body></html>`))
+          .rejects.toThrow(/Couldn't find <\/head> in raw/);
       });
     });
     describe("when it gets a document without a body", () => {
       test("throws an exception", () => {
-        expect(() => t.apply(`<html><head><script>foo</script></head></html>`))
-          .toThrow(/Couldn't find body/);
+        expect(template.applyToString(`<html><head><script>foo</script></head></html>`))
+          .rejects.toThrow(/Couldn't find <body> in raw/);
+      });
+    });
+    describe("when it gets a document with an unclosed body", () => {
+      test("throws an exception", () => {
+        expect(template.applyToString(`<html><head><script>foo</script></head><body></html>`))
+          .rejects.toThrow(/Couldn't find <\/body> in raw/);
+      });
+    });
+    describe("when the head start tag is in two chunks", () => {
+      let result;
+      beforeAll(async () => {
+        result = await template.applyToItr((function* () {
+          yield '<html><he';
+          yield 'ad>head stuff</head><body></body></html>';
+        })());
+      });
+      test("outputs the correct head anyway", () => {
+        expect(result).toMatch(/<head>\s+head stuff/);
+      });
+    });
+    describe("when the head e nd tag is in two chunks", () => {
+      let result;
+      beforeAll(async () => {
+        result = await template.applyToItr((function* () {
+          yield '<html><head>head stuff</he';
+          yield 'ad><body></body></html>';
+        })());
+      });
+      test("outputs the correct head anyway", () => {
+        expect(result).toMatch(/<head>\s+head stuff/);
+      });
+    });
+    describe("when the body start tag is in two chunks", () => {
+      let result;
+      beforeAll(async () => {
+        result = await template.applyToItr((function* () {
+          yield '<html><head></head><b';
+          yield 'ody>body stuff</body></html>';
+        })());
+      });
+      test("outputs the correct body anyway", () => {
+        expect(result).toMatch(
+          /<!-- start body -->\s+body stuff\s+<!-- end body -->/
+        );
+      });
+    });
+    describe("when the body end tag is in two chunks", () => {
+      let result;
+      beforeAll(async () => {
+        result = await template.applyToItr((function* () {
+          yield '<html><head></head><body>body stuff</';
+          yield 'body></html>';
+        })());
+      });
+      test("outputs the correct body anyway", () => {
+        expect(result).toMatch(
+          /<!-- start body -->\s+body stuff\s+<!-- end body -->/
+        );
       });
     });
   });

--- a/template/template.js
+++ b/template/template.js
@@ -22,6 +22,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const {Readable} = require('stream');
 const {promisify} = require('util');
 const recursiveCopy = promisify(require('recursive-copy'));
 
@@ -29,38 +30,83 @@ const mkdir = promisify(fs.mkdir);
 const readdir = promisify(fs.readdir);
 const readFile = promisify(fs.readFile);
 const stat = promisify(fs.stat);
-const writeFile = promisify(fs.writeFile);
 
-module.exports = async templatePath => {
-  const contents = await readFile(templatePath, {encoding: 'UTF-8'});
+module.exports = templatePath => {
+  const apply = (rawItr, lang, initialJsState) => {
+    /*
+     * We apply the template by walking a stream for the template and a stream
+     * for the raw page in parallel. We do this instead of pulling everything
+     * into memory and manipulating it to keep the memory usage small even when
+     * the template or raw page are very large. We expect the most memory this
+     * can use is 3x the sum of the sum of highWaterMark of both streams.
+     */
+    const Gatherer = async (name, itr) => {
+      let chunk = '';
+      const nextChunk = async preserve => {
+        const result = await itr.next();
+        if (preserve) {
+          chunk = chunk.slice(chunk.length - preserve) + result.value;
+        } else {
+          chunk = result.value;
+        }
+        return !result.done;
+      };
+      if (!await nextChunk()) {
+        // TODO handle totally empty stream?!
+      }
+      const gather = async function* (marker) {
+        let index;
+        while ((index = chunk.indexOf(marker)) < 0) {
+          yield chunk.slice(0, chunk.length - marker.length);
+          if (!await nextChunk(marker.length)) {
+            throw new Error(`Couldn't find ${marker} in ${name}`);
+          }
+        }
+        yield chunk.substring(0, index);
+        chunk = chunk.substring(index + marker.length);
+      };
+      const dump = async marker => {
+        let index;
+        while ((index = chunk.indexOf(marker)) < 0) {
+          if (!await nextChunk(marker.length)) {
+            throw new Error(`Couldn't find ${marker} in ${name}`);
+          }
+        }
+        chunk = chunk.substring(index + marker.length);
+      }
+      async function* remaining() {
+        yield chunk;
+        while (await nextChunk()) {
+          yield chunk;
+        }
+      }
+      return {
+        gather: gather,
+        dump: dump,
+        remaining: remaining,
+      };
+    };
 
-  const map = {};
-  const parts = contents.split(/<!-- (DOCS \w+) -->/).map((part, index) => {
-    const matcher = /DOCS (\w+)/.exec(part);
-    if (matcher) {
-      map[matcher[1]] = index;
-      return '';
-    }
-    return part;
-  });
-  const apply = (raw, lang, initialJsState) => {
-    const head = /<head>(.+?)<\/head>/s.exec(raw);
-    if (!head) {
-      throw new Error(`Couldn't find head in ${raw}`);
-    }
-    const body = /<body>(.+?)<\/body>/s.exec(raw);
-    if (!body) {
-      throw new Error(`Couldn't find body in ${raw}`);
-    }
-
-    const theseParts = parts.slice(0);
-    theseParts[map.PREHEAD] = head[1];
-    theseParts[map.LANG] = `lang="${lang}"`;
-    theseParts[map.BODY] = body[1];
-    theseParts[map.FINAL] = `
-<script type="text/javascript">
+    async function* asyncApply() {
+      const templateStream = fs.createReadStream(templatePath, {encoding: 'UTF-8'});
+      const template = await Gatherer('template', templateStream[Symbol.asyncIterator]());
+      yield* template.gather("<!-- DOCS PREHEAD -->");
+      const raw = await Gatherer('raw', rawItr);
+      await raw.dump("<head>");
+      yield* raw.gather("</head>");
+      yield* template.gather("<!-- DOCS LANG -->");
+      yield `lang="${lang}"`;
+      yield* template.gather("<!-- DOCS BODY -->");
+      await raw.dump("<body>");
+      yield* raw.gather("</body>");
+      yield* template.gather("<!-- DOCS FINAL -->");
+      yield `<script type="text/javascript">
 window.initial_state = ${initialJsState}</script>`;
-    return theseParts.join('');
+      yield* template.remaining();
+      // TODO close the templates
+    }
+    
+    return Readable.from(asyncApply());
   };
   const buildInitialJsStateFromFile = async alternativesSummary => {
     if (!alternativesSummary) {
@@ -102,9 +148,13 @@ window.initial_state = ${initialJsState}</script>`;
         await recursiveCopy(source, dest);
         continue;
       }
-      const contents = await readFile(source, {encoding: 'UTF-8'});
-      const result = apply(contents, lang, initialJsState);
-      await writeFile(dest, result, {encoding: 'UTF-8'});
+      const raw = fs.createReadStream(source, {encoding: 'UTF-8'});
+      const write = fs.createWriteStream(dest, {encoding: 'UTF-8'});
+      apply(raw[Symbol.asyncIterator](), lang, initialJsState).pipe(write);
+      await new Promise((resolve, reject) => {
+        write.on("finish", () => resolve());
+        write.on("error", reject);
+      });
     };
   };
   return {


### PR DESCRIPTION
Replaces the template implementation copied from perl with a work-alike
that uses async iterators and async generators. It has *slightly* higher
overhead but streams the template and raw html rather than pulling it
all into memory which protects it against very large html which should
make it embeddable into the preview application so we can template on
the fly.

Note: to get this I had to update Node to 12.x to support turning an
async generator into a readable stream. This is important because these
streams properly handle backpressure. I don't really expect any
backpressure when streaming to local files but I *do* expect it in the
preview app.
