### PR TITLE
Hide nav until styles are loaded

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -132,7 +132,8 @@
 
     <!-- Header Section -->
     
-    <div id='elastic-nav'></div>
+    <div id='elastic-nav' style="display:none;"></div>
+    <script src='https://www.elastic.co/elastic-nav.js'></script>
 
     <!-- Subnav -->
     <div>
@@ -179,10 +180,9 @@
 
 
 <div id='elastic-footer'></div>
+<script src='https://www.elastic.co/elastic-footer.js'></script>
 <!-- Footer Section end-->
 
-<script src='https://www.elastic.co/elastic-nav.js'></script>
-<script src='https://www.elastic.co/elastic-footer.js'></script>
       </section>
     </div>
 


### PR DESCRIPTION
This hides the nav until JS and styles are loaded to prevent the flash of unstyled content. 