### PR TITLE
Drop commented out APM from template

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -68,70 +68,6 @@
     </script>
     <!-- new ga for staging server -->
 
-    <!-- Elastic APM -->
-    <!--
-    <script src="https://www.elastic.co/static/js/elastic-apm-js-base.umd.min.2.2.0.js"></script>
-    <script type="text/javascript">
-      var elasticApm = init({
-        serviceName: 'elastic-co-frontend',
-        serverUrl: 'https://3ddd1ee09cc242c4b169d36f5a2b8b77.apm.us-west1.gcp.cloud.es.io:443',
-        stackTraceLimit: 5,
-        serviceVersion: '1.0.0'
-      })
-    
-      var pageLoadName
-      var pathname = window.location.pathname.replace(/\/es|\/pt|\/jp|\/pt|\/fr|\/kr|\/cn|\/de/g, '')
-      var parts = pathname.split('/');
-    
-      if (parts.length && parts[1] === 'blog') {
-        if (parts.length === 2) {
-          pageLoadName =  '/blog';
-        }
-        else if (parts[2] === 'category') {
-          pageLoadName =  '/blog/category';
-        }
-        else if (parts[2] === 'archive') {
-          pageLoadName =  '/blog/archive';
-        }
-        else {
-          pageLoadName =  '/blog/detail';
-        }
-      }
-      else if (parts.length && parts[1] === 'elasticon') {
-        if (parts.length === 2) {
-          pageLoadName =  '/elasticon';
-        }
-        else if (parts.length === 5 && (parts[2] === 'conf' || parts[2] === 'tour')) {
-          pageLoadName =  '/elasticon/overview';
-        }
-        else if (parts.length > 5 && (parts[2] === 'conf' || parts[2] === 'tour')) {
-          pageLoadName =  '/elasticon/video';
-        }
-      }
-      else if (parts.length && parts[1] === 'guide') {
-        pageLoadName =  '/guide';
-      }
-      else if (parts.length === 2 && parts[1] === 'videos') {
-        pageLoadName =  '/videos';
-      }
-      else if (parts.length > 2 && parts[1] === 'videos') {
-        pageLoadName =  '/videos/detail';
-      }
-      else if (parts.length > 2 && parts[1] === 'webinars') {
-        pageLoadName =  '/webinars/detail';
-      }
-      else {
-        pageLoadName =  window.location.pathname;
-      }
-    
-      console.log('apm pageLoadName:', pageLoadName, parts)
-      elasticApm.setTags({env:"production"});
-      elasticApm.setInitialPageLoadName(pageLoadName);
-    </script>
-    -->
-
-    <!-- Header Section -->
-    
     <div id='elastic-nav'></div>
 
     <!-- Subnav -->
@@ -186,7 +122,6 @@
       </section>
     </div>
 
-    
 <script type="text/javascript">
 	var suggestionsUrl = "https://search.elastic.co/suggest";
 	var localeUrl = '{"relative_url_prefix":"/","code":"en-us","display_code":"en-us","url":"/guide_template"}';


### PR DESCRIPTION
When we're ready to enable it we'll fold it into the main javascript
file probably. But until then let's get it out of the template so it
doesn't take up extra space.
