### PR TITLE
Adds temporary redirects in out-dated shared version attribute files

### DIFF
--- a/shared/versions.asciidoc
+++ b/shared/versions.asciidoc
@@ -1,13 +1,1 @@
-:version:                8.0.0-alpha1
-:logstash_version:       8.0.0-alpha1
-:elasticsearch_version:  8.0.0-alpha1
-:kibana_version:         8.0.0-alpha1
-:branch:                 master
-:major-version:          8.x
-:prev-major-version:     7.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   prerelease
+include::versions/stack/master.asciidoc[]

--- a/shared/versions.asciidoc
+++ b/shared/versions.asciidoc
@@ -1,0 +1,13 @@
+:version:                8.0.0-alpha1
+:logstash_version:       8.0.0-alpha1
+:elasticsearch_version:  8.0.0-alpha1
+:kibana_version:         8.0.0-alpha1
+:branch:                 master
+:major-version:          8.x
+:prev-major-version:     7.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   prerelease

--- a/shared/versions55.asciidoc
+++ b/shared/versions55.asciidoc
@@ -1,13 +1,1 @@
-:version:                5.5.3
-:logstash_version:       5.5.3
-:elasticsearch_version:  5.5.3
-:kibana_version:         5.5.3
-:branch:                 5.5
-:major-version:          5.x
-:prev-major-version:     2.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
+include::versions/stack/5.5.asciidoc[]

--- a/shared/versions55.asciidoc
+++ b/shared/versions55.asciidoc
@@ -1,0 +1,13 @@
+:version:                5.5.3
+:logstash_version:       5.5.3
+:elasticsearch_version:  5.5.3
+:kibana_version:         5.5.3
+:branch:                 5.5
+:major-version:          5.x
+:prev-major-version:     2.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,0 +1,13 @@
+:version:                5.6.16
+:logstash_version:       5.6.16
+:elasticsearch_version:  5.6.16
+:kibana_version:         5.6.16
+:branch:                 5.6
+:major-version:          5.x
+:prev-major-version:     2.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:         released

--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,13 +1,1 @@
-:version:                5.6.16
-:logstash_version:       5.6.16
-:elasticsearch_version:  5.6.16
-:kibana_version:         5.6.16
-:branch:                 5.6
-:major-version:          5.x
-:prev-major-version:     2.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:         released
+include::versions/stack/5.6.asciidoc[]

--- a/shared/versions60.asciidoc
+++ b/shared/versions60.asciidoc
@@ -1,12 +1,1 @@
-:version:                6.0.1
-:logstash_version:       6.0.1
-:elasticsearch_version:  6.0.1
-:kibana_version:         6.0.1
-:branch:                 6.0
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-:release-state:          released
+include::versions/stack/6.0.asciidoc[]

--- a/shared/versions60.asciidoc
+++ b/shared/versions60.asciidoc
@@ -1,0 +1,12 @@
+:version:                6.0.1
+:logstash_version:       6.0.1
+:elasticsearch_version:  6.0.1
+:kibana_version:         6.0.1
+:branch:                 6.0
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          released

--- a/shared/versions61.asciidoc
+++ b/shared/versions61.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.1.4
+:logstash_version:       6.1.4
+:elasticsearch_version:  6.1.4
+:kibana_version:         6.1.4
+:branch:                 6.1
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions61.asciidoc
+++ b/shared/versions61.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.1.4
-:logstash_version:       6.1.4
-:elasticsearch_version:  6.1.4
-:kibana_version:         6.1.4
-:branch:                 6.1
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.1.asciidoc[]

--- a/shared/versions62.asciidoc
+++ b/shared/versions62.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.2.4
-:logstash_version:       6.2.4
-:elasticsearch_version:  6.2.4
-:kibana_version:         6.2.4
-:branch:                 6.2
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.2.asciidoc[]

--- a/shared/versions62.asciidoc
+++ b/shared/versions62.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.2.4
+:logstash_version:       6.2.4
+:elasticsearch_version:  6.2.4
+:kibana_version:         6.2.4
+:branch:                 6.2
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions63.asciidoc
+++ b/shared/versions63.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.3.2
-:logstash_version:       6.3.2
-:elasticsearch_version:  6.3.2
-:kibana_version:         6.3.2
-:branch:                 6.3
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.3.asciidoc[]

--- a/shared/versions63.asciidoc
+++ b/shared/versions63.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.3.2
+:logstash_version:       6.3.2
+:elasticsearch_version:  6.3.2
+:kibana_version:         6.3.2
+:branch:                 6.3
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.4.3
+:logstash_version:       6.4.3
+:elasticsearch_version:  6.4.3
+:kibana_version:         6.4.3
+:branch:                 6.4
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.4.3
-:logstash_version:       6.4.3
-:elasticsearch_version:  6.4.3
-:kibana_version:         6.4.3
-:branch:                 6.4
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.4.asciidoc[]

--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.5.4
+:logstash_version:       6.5.4
+:elasticsearch_version:  6.5.4
+:kibana_version:         6.5.4
+:branch:                 6.5
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.5.4
-:logstash_version:       6.5.4
-:elasticsearch_version:  6.5.4
-:kibana_version:         6.5.4
-:branch:                 6.5
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.5.asciidoc[]

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.6.2
+:logstash_version:       6.6.2
+:elasticsearch_version:  6.6.2
+:kibana_version:         6.6.2
+:branch:                 6.6
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.6.2
-:logstash_version:       6.6.2
-:elasticsearch_version:  6.6.2
-:kibana_version:         6.6.2
-:branch:                 6.6
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.6.asciidoc[]

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.7.2
-:logstash_version:       6.7.2
-:elasticsearch_version:  6.7.2
-:kibana_version:         6.7.2
-:branch:                 6.7
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.7.asciidoc[]

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.7.2
+:logstash_version:       6.7.2
+:elasticsearch_version:  6.7.2
+:kibana_version:         6.7.2
+:branch:                 6.7
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions68.asciidoc
+++ b/shared/versions68.asciidoc
@@ -1,13 +1,1 @@
-:version:                6.8.3
-:logstash_version:       6.8.3
-:elasticsearch_version:  6.8.3
-:kibana_version:         6.8.3
-:branch:                 6.8
-:major-version:          6.x
-:prev-major-version:     5.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:          released
+include::versions/stack/6.8.asciidoc[]

--- a/shared/versions68.asciidoc
+++ b/shared/versions68.asciidoc
@@ -1,0 +1,13 @@
+:version:                6.8.3
+:logstash_version:       6.8.3
+:elasticsearch_version:  6.8.3
+:kibana_version:         6.8.3
+:branch:                 6.8
+:major-version:          6.x
+:prev-major-version:     5.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:          released

--- a/shared/versions70.asciidoc
+++ b/shared/versions70.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.0.1
+:logstash_version:       7.0.1
+:elasticsearch_version:  7.0.1
+:kibana_version:         7.0.1
+:branch:                 7.0
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions70.asciidoc
+++ b/shared/versions70.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.0.1
-:logstash_version:       7.0.1
-:elasticsearch_version:  7.0.1
-:kibana_version:         7.0.1
-:branch:                 7.0
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
+include::versions/stack/7.0.asciidoc[]

--- a/shared/versions71.asciidoc
+++ b/shared/versions71.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.1.1
-:logstash_version:       7.1.1
-:elasticsearch_version:  7.1.1
-:kibana_version:         7.1.1
-:branch:                 7.1
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
+include::versions/stack/7.1.asciidoc[]

--- a/shared/versions71.asciidoc
+++ b/shared/versions71.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.1.1
+:logstash_version:       7.1.1
+:elasticsearch_version:  7.1.1
+:kibana_version:         7.1.1
+:branch:                 7.1
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions72.asciidoc
+++ b/shared/versions72.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.2.1
-:logstash_version:       7.2.1
-:elasticsearch_version:  7.2.1
-:kibana_version:         7.2.1
-:branch:                 7.2
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
+include::versions/stack/7.2.asciidoc[]

--- a/shared/versions72.asciidoc
+++ b/shared/versions72.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.2.1
+:logstash_version:       7.2.1
+:elasticsearch_version:  7.2.1
+:kibana_version:         7.2.1
+:branch:                 7.2
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions73.asciidoc
+++ b/shared/versions73.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.3.1
+:logstash_version:       7.3.1
+:elasticsearch_version:  7.3.1
+:kibana_version:         7.3.1
+:branch:                 7.3
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   released

--- a/shared/versions73.asciidoc
+++ b/shared/versions73.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.3.1
-:logstash_version:       7.3.1
-:elasticsearch_version:  7.3.1
-:kibana_version:         7.3.1
-:branch:                 7.3
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   released
+include::versions/stack/7.3.asciidoc[]

--- a/shared/versions74.asciidoc
+++ b/shared/versions74.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.4.0
+:logstash_version:       7.4.0
+:elasticsearch_version:  7.4.0
+:kibana_version:         7.4.0
+:branch:                 7.4
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   unreleased

--- a/shared/versions74.asciidoc
+++ b/shared/versions74.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.4.0
-:logstash_version:       7.4.0
-:elasticsearch_version:  7.4.0
-:kibana_version:         7.4.0
-:branch:                 7.4
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   unreleased
+include::versions/stack/7.4.asciidoc[]

--- a/shared/versions75.asciidoc
+++ b/shared/versions75.asciidoc
@@ -1,0 +1,13 @@
+:version:                7.5.0
+:logstash_version:       7.5.0
+:elasticsearch_version:  7.5.0
+:kibana_version:         7.5.0
+:branch:                 7.x
+:major-version:          7.x
+:prev-major-version:     6.x
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+
+:release-state:   unreleased

--- a/shared/versions75.asciidoc
+++ b/shared/versions75.asciidoc
@@ -1,13 +1,1 @@
-:version:                7.5.0
-:logstash_version:       7.5.0
-:elasticsearch_version:  7.5.0
-:kibana_version:         7.5.0
-:branch:                 7.x
-:major-version:          7.x
-:prev-major-version:     6.x
-
-//////////
-release-state can be: released | prerelease | unreleased
-//////////
-
-:release-state:   unreleased
+include::versions/stack/7.x.asciidoc[]


### PR DESCRIPTION
This PR reverts https://github.com/elastic/docs/pull/1172 and updates them to point to the new shared version files until all the Cloud references can be fixed.