### PR TITLE
Fixes 8.0 release-state attribute

### DIFF
--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -1,4 +1,8 @@
 :version:                6.8.3
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           6.8.3
 :logstash_version:       6.8.3
 :elasticsearch_version:  6.8.3
 :kibana_version:         6.8.3

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.0.1
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.0.1
 :logstash_version:       7.0.1
 :elasticsearch_version:  7.0.1
 :kibana_version:         7.0.1
@@ -11,4 +15,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   released
+:release-state:          released

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.1.1
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.1.1
 :logstash_version:       7.1.1
 :elasticsearch_version:  7.1.1
 :kibana_version:         7.1.1
@@ -11,4 +15,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   released
+:release-state:          released

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.2.1
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.2.1
 :logstash_version:       7.2.1
 :elasticsearch_version:  7.2.1
 :kibana_version:         7.2.1
@@ -11,4 +15,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   released
+:release-state:          released

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.3.2
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.3.2
 :logstash_version:       7.3.2
 :elasticsearch_version:  7.3.2
 :kibana_version:         7.3.2

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.4.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.4.0
 :logstash_version:       7.4.0
 :elasticsearch_version:  7.4.0
 :kibana_version:         7.4.0
@@ -11,4 +15,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   unreleased
+:release-state:          unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -1,4 +1,8 @@
 :version:                7.5.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.5.0
 :logstash_version:       7.5.0
 :elasticsearch_version:  7.5.0
 :kibana_version:         7.5.0
@@ -11,4 +15,4 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   unreleased
+:release-state:          unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,7 +1,11 @@
-:version:                8.0.0-alpha1
-:logstash_version:       8.0.0-alpha1
-:elasticsearch_version:  8.0.0-alpha1
-:kibana_version:         8.0.0-alpha1
+:version:                8.0.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           8.0.0
+:logstash_version:       8.0.0
+:elasticsearch_version:  8.0.0
+:kibana_version:         8.0.0
 :branch:                 master
 :major-version:          8.x
 :prev-major-version:     7.x
@@ -11,4 +15,5 @@
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   prerelease
+:release-state:          unreleased
+


### PR DESCRIPTION
This PR fixes the version and release-state for documentation in the master branch, since the current values are providing incorrect download details.

It also adds the "bare_version" attribute, which is used in the elasticsearch repo (https://raw.githubusercontent.com/elastic/elasticsearch/master/docs/Versions.asciidoc) and might be useful in the broader library.