### PR TITLE
Add APM to shared versioning

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -18,12 +18,8 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
-:apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
-:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
-:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
+:apm-overview-ref:     https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
@@ -42,7 +38,12 @@
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
+:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
+:apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
 // End deprecated APM attributes

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -25,26 +25,26 @@
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
+:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
+:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+// Begin outdated APM attributes
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
 :apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-// Begin outdated APM attributes
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
-:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
-:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
 :apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
-:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/current
-:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/current
-:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current
-:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
-:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
 // End outdated APM attributes
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -32,7 +32,7 @@
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
 :apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
 :apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-// Begin outdated APM attributes
+// Begin deprecated APM attributes
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
@@ -45,7 +45,7 @@
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
-// End outdated APM attributes
+// End deprecated APM attributes
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -28,7 +28,9 @@
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
 :apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
 :apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-// Begin deprecated APM attributes
+////
+Begin deprecated APM attributes
+////
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
@@ -46,7 +48,9 @@
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
-// End deprecated APM attributes
+////
+End deprecated APM attributes
+////
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -18,39 +18,16 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
-:apm-overview-ref:     https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
-:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-////
-Begin deprecated APM attributes
-////
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
-:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
-:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
-:apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
-////
-End deprecated APM attributes
-////
+:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
@@ -218,3 +195,27 @@ End deprecated APM attributes
 :api-example-title:        Example
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
+
+////
+Begin deprecated APM attributes
+////
+:apm-overview-ref:     https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
+:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
+:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
+:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/{branch}
+:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/{branch}
+:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/{branch}
+:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/{branch}
+:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
+:apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
+:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{branch}
+:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
+:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{branch}
+:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{branch}
+////
+End deprecated APM attributes
+////

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -18,25 +18,34 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
-:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
-:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
+:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
+// Begin outdated APM attributes
+:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
-:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
+:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
 :apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
 :apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/current
 :apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/current
 :apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
+// End outdated APM attributes
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
@@ -204,4 +213,3 @@
 :api-example-title:        Example
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
-   

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -204,3 +204,4 @@
 :api-example-title:        Example
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
+

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -18,16 +18,25 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
+:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
+:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
+:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
-:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
-:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
-:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
-:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
-:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
-:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
-:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
+:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
+:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
+:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
+:apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
+:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/current
+:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/current
+:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current
+:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
+:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
@@ -195,27 +204,3 @@
 :api-example-title:        Example
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
-
-////
-Begin deprecated APM attributes
-////
-:apm-overview-ref:     https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
-:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
-:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
-:apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/{branch}
-:apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/{branch}
-:apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/{branch}
-:apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/{branch}
-:apm-node-ref-index:   https://www.elastic.co/guide/en/apm/agent/nodejs
-:apm-node-ref-1x:      https://www.elastic.co/guide/en/apm/agent/nodejs/1.x
-:apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/{branch}
-:apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
-:apm-ruby-ref:         https://www.elastic.co/guide/en/apm/agent/ruby/{branch}
-:apm-rum-ref:          https://www.elastic.co/guide/en/apm/agent/rum-js/{branch}
-////
-End deprecated APM attributes
-////

--- a/shared/versions/stack/6.0.asciidoc
+++ b/shared/versions/stack/6.0.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.0.1
 :elasticsearch_version:  6.0.1
 :kibana_version:         6.0.1
+:apm_server_version:     6.0.1
 :branch:                 6.0
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.1.asciidoc
+++ b/shared/versions/stack/6.1.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.1.4
 :elasticsearch_version:  6.1.4
 :kibana_version:         6.1.4
+:apm_server_version:     6.1.4
 :branch:                 6.1
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.2.asciidoc
+++ b/shared/versions/stack/6.2.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.2.4
 :elasticsearch_version:  6.2.4
 :kibana_version:         6.2.4
+:apm_server_version:     6.2.4
 :branch:                 6.2
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.3.asciidoc
+++ b/shared/versions/stack/6.3.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.3.2
 :elasticsearch_version:  6.3.2
 :kibana_version:         6.3.2
+:apm_server_version:     6.3.2
 :branch:                 6.3
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.3.asciidoc
+++ b/shared/versions/stack/6.3.asciidoc
@@ -13,7 +13,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-rum-branch:        0.x
 :apm-node-branch:       1.x
 :apm-py-branch:         3.x

--- a/shared/versions/stack/6.3.asciidoc
+++ b/shared/versions/stack/6.3.asciidoc
@@ -11,3 +11,8 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-rum-branch:        0.x
+:apm-node-branch:       1.x
+:apm-py-branch:         3.x

--- a/shared/versions/stack/6.4.asciidoc
+++ b/shared/versions/stack/6.4.asciidoc
@@ -13,7 +13,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-rum-branch:        0.x
 :apm-node-branch:       1.x
 :apm-py-branch:         3.x

--- a/shared/versions/stack/6.4.asciidoc
+++ b/shared/versions/stack/6.4.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.4.3
 :elasticsearch_version:  6.4.3
 :kibana_version:         6.4.3
+:apm_server_version:     6.4.3
 :branch:                 6.4
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.4.asciidoc
+++ b/shared/versions/stack/6.4.asciidoc
@@ -11,3 +11,8 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-rum-branch:        0.x
+:apm-node-branch:       1.x
+:apm-py-branch:         3.x

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -13,7 +13,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        2.x

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.5.4
 :elasticsearch_version:  6.5.4
 :kibana_version:         6.5.4
+:apm_server_version:     6.5.4
 :branch:                 6.5
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -20,3 +20,4 @@ release-state can be: released | prerelease | unreleased
 :apm-node-branch:       2.x
 :apm-py-branch:         4.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -11,3 +11,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        2.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -18,5 +18,6 @@ release-state can be: released | prerelease | unreleased
 :apm-java-branch:       1.x
 :apm-rum-branch:        3.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.6.2
 :elasticsearch_version:  6.6.2
 :kibana_version:         6.6.2
+:apm_server_version:     6.6.2
 :branch:                 6.6
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -11,3 +11,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        3.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -13,7 +13,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        3.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -13,7 +13,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -2,6 +2,7 @@
 :logstash_version:       6.7.2
 :elasticsearch_version:  6.7.2
 :kibana_version:         6.7.2
+:apm_server_version:     6.7.2
 :branch:                 6.7
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -11,3 +11,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        3.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -16,7 +16,8 @@ release-state can be: released | prerelease | unreleased
 // APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        3.x
+:apm-rum-branch:        4.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -17,7 +17,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -15,3 +15,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        3.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -20,7 +20,8 @@ release-state can be: released | prerelease | unreleased
 // APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        3.x
+:apm-rum-branch:        4.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       6.8.3
 :elasticsearch_version:  6.8.3
 :kibana_version:         6.8.3
+:apm_server_version:     6.8.3
 :branch:                 6.8
 :major-version:          6.x
 :prev-major-version:     5.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.0.1
 :elasticsearch_version:  7.0.1
 :kibana_version:         7.0.1
+:apm_server_version:     7.0.1
 :branch:                 7.0
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -16,3 +16,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -23,5 +23,6 @@ release-state can be: released | prerelease | unreleased
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -16,3 +16,11 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.1.1
 :elasticsearch_version:  7.1.1
 :kibana_version:         7.1.1
+:apm_server_version:     7.1.1
 :branch:                 7.1
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -23,5 +23,6 @@ release-state can be: released | prerelease | unreleased
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -23,6 +23,6 @@ release-state can be: released | prerelease | unreleased
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
-:apm-py-branch:         4.x
+:apm-py-branch:         5.x
 :apm-ruby-branch:       2.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.2.1
 :elasticsearch_version:  7.2.1
 :kibana_version:         7.2.1
+:apm_server_version:     7.2.1
 :branch:                 7.2
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -16,3 +16,12 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         4.x
+:apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -15,4 +15,13 @@ bare_version never includes -alpha or -beta
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:   released
+:release-state:          released
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         5.x
+:apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          released
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.3.2
 :elasticsearch_version:  7.3.2
 :kibana_version:         7.3.2
+:apm_server_version:     7.3.2
 :branch:                 7.3
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -16,3 +16,12 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          unreleased
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         5.x
+:apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.4.0
 :elasticsearch_version:  7.4.0
 :kibana_version:         7.4.0
+:apm_server_version:     7.4.0
 :branch:                 7.4
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          unreleased
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       7.5.0
 :elasticsearch_version:  7.5.0
 :kibana_version:         7.5.0
+:apm_server_version:     7.5.0
 :branch:                 7.x
 :major-version:          7.x
 :prev-major-version:     6.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -16,3 +16,12 @@ release-state can be: released | prerelease | unreleased
 //////////
 
 :release-state:          unreleased
+
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         5.x
+:apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          unreleased
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -17,3 +17,11 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          unreleased
 
+// APM Agent versions
+:apm-go-branch:         1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        4.x
+:apm-node-branch:       2.x
+:apm-py-branch:         5.x
+:apm-ruby-branch:       2.x
+:apm-dotnet-branch:     1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -6,6 +6,7 @@ bare_version never includes -alpha or -beta
 :logstash_version:       8.0.0
 :elasticsearch_version:  8.0.0
 :kibana_version:         8.0.0
+:apm_server_version:     8.0.0
 :branch:                 master
 :major-version:          8.x
 :prev-major-version:     7.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -18,7 +18,9 @@ release-state can be: released | prerelease | unreleased
 
 :release-state:          unreleased
 
-// APM Agent versions
+////
+APM Agent versions
+////
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x


### PR DESCRIPTION
* Allows APM Server to take advantage of the new shared version file by adding `apm_server_version`
* ~Allows us to **finally** stop linking to `current` versions of all APM Agent documentation 🎉~ 
  * ~Moves APM Agent version attributes to the shared version files.~
  * Moves APM Agent attributes from the APM Server version file to the shared attributes file