### PR TITLE
Add tooltip when hovering over alt picker warning icon

### DIFF
--- a/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
+++ b/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
@@ -8,6 +8,7 @@ describe(_AlternativePicker, () => {
       expect(picker).toStrictEqual(render(<div/>));
     });
   });
+
   describe("when there aren't any alternatives", () => {
     const picker = render(<_AlternativePicker alternatives={{
       bash: {
@@ -16,10 +17,12 @@ describe(_AlternativePicker, () => {
         powershell: {},
       }
     }}/>);
+
     test("is just an empty div", () => {
       expect(picker).toStrictEqual(render(<div/>));
     });
   });
+
   describe("when there are console alternatives", () => {
     const picker = render(<_AlternativePicker
       consoleAlternative="console"
@@ -30,6 +33,7 @@ describe(_AlternativePicker, () => {
         }
       }}/>);
     const select = picker.childNodes[0];
+
     test("renders all configured options", () => {
       expect(picker).toStrictEqual(render(
         <div class="AlternativePicker u-space-between">
@@ -39,14 +43,17 @@ describe(_AlternativePicker, () => {
             <option value="csharp">C#</option>
           </select>
           <div class="AlternativePicker-warning" />
+          {null}
         </div>
       ));
     });
+
     test("selects the consoleAlternative from the props", () => {
       expect(select.value).toBe("console");
     });
   });
-  describe("when the the console alternative isn't in the options", () => {
+
+  describe("when the console alternative isn't in the options", () => {
     const picker = render(<_AlternativePicker
       consoleAlternative="bort"
       alternatives={{
@@ -55,6 +62,7 @@ describe(_AlternativePicker, () => {
           csharp: {},
         }
       }}/>);
+
     test("includes an option for the current alternative", () => {
       expect(picker).toStrictEqual(render(
         <div class="AlternativePicker u-space-between">
@@ -65,10 +73,12 @@ describe(_AlternativePicker, () => {
             <option value="bort">Bort</option>
           </select>
           <div class="AlternativePicker-warning" />
+          {null}
         </div>
       ));
     });
   });
+
   describe("when the value changes", () => {
     const updates = [];
     const picker = render(<_AlternativePicker
@@ -85,6 +95,7 @@ describe(_AlternativePicker, () => {
     /* Browsers don't dispatch a change even when you change the value so we
       * have to do it ourselves. Like an animal. */
     select.dispatchEvent(new Event("change"));
+
     test("saves the config", () => {
       // We can't use toMatchObject here because tagName is busted.
       expect(updates).toHaveLength(1);

--- a/resources/web/docs_js/components/alternative_picker.jsx
+++ b/resources/web/docs_js/components/alternative_picker.jsx
@@ -21,7 +21,7 @@ const AlternativeChoice = ({name: name}) => {
   return <option value={name}>{alternativePrettyName(name)}</option>;
 };
 
-class _AlternativePicker extends Component {
+export class _AlternativePicker extends Component {
   constructor(props) {
     super(props);
     this.state = { tooltipVisible: false };

--- a/resources/web/docs_js/components/alternative_picker.jsx
+++ b/resources/web/docs_js/components/alternative_picker.jsx
@@ -3,7 +3,7 @@
  * instead of "Console".
  */
 
-import {h} from "../../../../../../node_modules/preact";
+import {h, Component} from "../../../../../../node_modules/preact";
 import {pick, merge} from "../../../../../node_modules/ramda";
 import {connect} from "../../../../../node_modules/preact-redux";
 import {saveSettings} from "../actions/settings";
@@ -21,50 +21,73 @@ const AlternativeChoice = ({name: name}) => {
   return <option value={name}>{alternativePrettyName(name)}</option>;
 };
 
-export const _AlternativePicker = ({
-  alternatives: alternatives,
-  consoleAlternative: consoleAlternative,
-  saveSettings: saveSettings,
-}) => {
-  if (!alternatives) {
-    return <div/>; // Empty div to preserve the spacing
-  }
-  const consoleAlternatives = alternatives.console;
-  if (!consoleAlternatives) {
-    return <div/>;
+class _AlternativePicker extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { tooltipVisible: false };
+    this.toggleWarning = this.toggleWarning.bind(this);
   }
 
-  const items = [];
-  let sawChoice = 'console' === consoleAlternative;
-  items.push(<AlternativeChoice name='console'/>);
-  for (const name of Object.keys(consoleAlternatives)) {
-    sawChoice |= name === consoleAlternative;
-    items.push(<AlternativeChoice name={name} />);
+  toggleWarning(show) {
+    this.setState({ tooltipVisible: show });
   }
 
-  /* If value isn't in the list then *make* it and we'll render our standard
-   * "there no example for this language" option. This prevents us from
-   * squashing preferences that users set. */
-  if (!sawChoice) {
-    items.push(<AlternativeChoice name={consoleAlternative} />);
-  }
-  // TODO we shouldn't change these drop downs after the first time they are rendered. The extra choice should stay while you stay on the page. Maybe we can get away with rendering this once on page load and never subscribing again?
+  render() {
+    const { alternatives, consoleAlternative, saveSettings } = this.props;
 
-  // TODO add the "message" bubble to the warning.
-  return <div className="AlternativePicker u-space-between">
-    <select className="AlternativePicker-select"
-            value={consoleAlternative}
-            onChange={(e) => {
-              saveSettings({
-                consoleAlternative: e.target.value,
-                alternativeChangeSource: e.target,
-              });
-            }}>
-      {items}
-    </select>
-    <div className="AlternativePicker-warning" />
-  </div>;
-};
+    if (!alternatives) {
+      return <div />;
+    }
+
+    const consoleAlternatives = alternatives.console;
+    if (!consoleAlternatives) {
+      return <div/>;
+    }
+
+    const items = [];
+    let sawChoice = 'console' === consoleAlternative;
+    items.push(<AlternativeChoice name='console'/>);
+    for (const name of Object.keys(consoleAlternatives)) {
+      sawChoice |= name === consoleAlternative;
+      items.push(<AlternativeChoice name={name} />);
+    }
+
+    /* If value isn't in the list then *make* it and we'll render our standard
+     * "there no example for this language" option. This prevents us from
+     * squashing preferences that users set. */
+    if (!sawChoice) {
+      items.push(<AlternativeChoice name={consoleAlternative} />);
+    }
+    // TODO we shouldn't change these drop downs after the first time they are rendered. The extra choice should stay while you stay on the page. Maybe we can get away with rendering this once on page load and never subscribing again?
+
+    return <div className="AlternativePicker u-space-between">
+      <select className="AlternativePicker-select"
+              value={consoleAlternative}
+              onChange={(e) => {
+                saveSettings({
+                  consoleAlternative: e.target.value,
+                  alternativeChangeSource: e.target,
+                });
+              }}>
+        {items}
+      </select>
+      <div
+        className="AlternativePicker-warning"
+        onMouseOver={() => this.toggleWarning(true)}
+        onMouseOut={() => this.toggleWarning(false)} />
+
+      { this.state.tooltipVisible
+          ? (
+            <div className="AlternativePicker-tooltip-wrapper">
+              <div className="AlternativePicker-tooltip" role="tooltip">
+                <div className="arrow"></div>
+                <div>No {alternativePrettyName(consoleAlternative)} version available for this example</div>
+              </div>
+            </div>
+          ) : null }
+    </div>;
+  }
+}
 
 export default connect(
   state => merge(

--- a/resources/web/style/alternative_picker.pcss
+++ b/resources/web/style/alternative_picker.pcss
@@ -1,3 +1,15 @@
+@keyframes tooltip {
+  0% {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 #guide {
   .AlternativePicker {
     margin-left: 20px;
@@ -14,6 +26,43 @@
       align-self: center;
       @media screen and (max-width: 500px) {
         margin: 5px 10px;
+      }
+    }
+
+    &-tooltip-wrapper {
+      position: relative;
+      top: 40px;
+      left: -155px;
+    }
+
+    &-tooltip {
+      animation: tooltip 350ms ease-out 250ms forwards;
+      animation-name: tooltip;
+      background-color: #404040;
+      border-radius: 4px;
+      box-shadow: 0 12px 24px 0 rgba(0, 0, 0, 0.1), 0 6px 12px 0 rgba(0, 0, 0, 0.1), 0 4px 4px 0 rgba(0, 0, 0, 0.1), 0 2px 2px 0 rgba(0, 0, 0, 0.1);
+      color: #FFF;
+      font-size: 0.875rem;
+      font-size: 14px;
+      line-height: 1.5;
+      width: 256px;
+      padding: 12px;
+      position: absolute;
+      text-align: center;
+      z-index: 9000;
+      opacity: 0;
+
+      .arrow {
+        content: '';
+        position: absolute;
+        top: 2px;
+        left: 120px;
+        transform-origin: center;
+        border-radius: 2px;
+        background-color: #404040;
+        width: 12px;
+        height: 12px;
+        transform: translateY(-5px) rotateZ(45deg);
       }
     }
   }

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -311,4 +311,3 @@ p.remark {
 .guide-section {
   margin-bottom: 30px;
 }
-


### PR DESCRIPTION
![tooltip](https://user-images.githubusercontent.com/160161/64878753-dd7d1780-d619-11e9-9251-d87621274fdb.gif)

Just what it says on the tin.

I adjusted the `_AlternativePicker` component to be written as a class instead of a stateless component, in order to keep track of the hover state of a tooltip.

The rest was just CSS styling and animations that I borrowed from EUI, then adapted and tweaked to meet our specific use case.

Fixes #1113.