### PR TITLE
Template on the fly in preview

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,6 @@
 !lib
 !package.json
 !preview
+!template
 !resources/web
 !yarn.lock

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -266,8 +266,7 @@ sub build_all {
         say "Writing main TOC";
         $toc->write( $raw_build_dir, $build_dir, $temp_dir, 0 );
 
-        my $static_dir = $build_dir->subdir( 'static' );
-        build_web_resources( $static_dir );
+        build_web_resources( $target_repo->destination );
 
         say "Writing extra HTML redirects";
         for ( @{ $Conf->{redirects} } ) {
@@ -983,14 +982,13 @@ sub check_opts {
         die('--push only compatible with --all') if $Opts->{push};
         die('--announce_preview only compatible with --all') if $Opts->{announce_preview};
         die('--rebuild only compatible with --all') if $Opts->{rebuild};
-        die('--reference only compatible with --all') if $Opts->{reference};
         die('--reposcache only compatible with --all') if $Opts->{reposcache};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
         die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
         die('--user only compatible with --all') if $Opts->{user};
     }
     if ( !$Opts->{all} && !$Opts->{preview} ) {
-        die('--target_branch only compatible with --all or --preview') if $Opts->{target_branch};
+        die('--reference only compatible with --all') if $Opts->{reference};
         die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
     }
 }

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -112,10 +112,12 @@ RSpec.describe 'building all books' do
       book.source repo, 'resources'
     end
     include_examples 'book basics', 'Test', 'test'
-    context 'raw/test/current' do
-      it "doesn't exist" do
-        # Because "current" doesn't exist at all in "raw"
-        expect(dest_file('raw/test/current')).not_to file_exist
+    page_context "the current version's raw chapter page",
+                 'raw/test/current/chapter.html' do
+      it 'has a link to the image' do
+        expect(body).to include(<<~HTML.strip)
+          <img src="resources/readme/cat.jpg" alt="A cat" />
+        HTML
       end
     end
     page_context "the current version's chapter page",
@@ -143,6 +145,7 @@ RSpec.describe 'building all books' do
       end
     end
     file_context 'html/test/current/resources/readme/cat.jpg'
+    file_context 'raw/test/current/resources/readme/cat.jpg'
     file_context 'html/test/master/resources/readme/cat.jpg'
     file_context 'raw/test/master/resources/readme/cat.jpg'
   end

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -24,6 +24,10 @@ class Book
   # Should this book allow overriding :edit_url:? Defaults to false.
   attr_accessor :respect_edit_url_overrides
 
+  ##
+  # The language of the book. Defaults to `en`.
+  attr_accessor :lang
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -33,6 +37,7 @@ class Book
     @branches = ['master']
     @current_branch = 'master'
     @respect_edit_url_overrides = false
+    @lang = 'en'
   end
 
   ##
@@ -81,6 +86,7 @@ class Book
       tags:       test tag
       subject:    Test
       asciidoctor: #{@asciidoctor}
+      lang:       #{@lang}
     YAML
   end
 

--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -87,14 +87,16 @@ RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
     end
     context 'the initial js state' do
       it 'contains the available alternatives' do
-        expect(initial_js_state).to include(
-          alternatives: {
-            console: {
-              js: { hasAny: true },
-              csharp: { hasAny: true },
-              java: { hasAny: false },
-            },
-          }
+        expect(contents).to initial_js_state(
+          include(
+            alternatives: {
+              console: {
+                js: { hasAny: true },
+                csharp: { hasAny: true },
+                java: { hasAny: false },
+              },
+            }
+          )
         )
       end
     end

--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -78,7 +78,7 @@ module Dsl
         m[1]
       end
       let(:initial_js_state) do
-        initial_js_state contents
+        extract_initial_js_state contents
       end
     end
   end

--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -77,9 +77,6 @@ module Dsl
 
         m[1]
       end
-      let(:initial_js_state) do
-        extract_initial_js_state contents
-      end
     end
   end
 end

--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -78,16 +78,7 @@ module Dsl
         m[1]
       end
       let(:initial_js_state) do
-        start_boundry = 'window.initial_state = '
-        start = contents.index start_boundry
-        return unless start
-
-        start += start_boundry.length
-        stop = contents.index '</script>', start
-        return unless stop
-
-        txt = contents[start, stop - start]
-        JSON.parse txt, symbolize_names: true
+        initial_js_state contents
       end
     end
   end

--- a/integtest/spec/helper/matcher/initial_js_state.rb
+++ b/integtest/spec/helper/matcher/initial_js_state.rb
@@ -2,6 +2,7 @@
 
 ##
 # Matches extracts the "initial javascript state" of a templated html page.
+# If the page doesn't contain the initial js state it'll be `nil`.
 RSpec::Matchers.define :initial_js_state do |expected|
   match do |actual|
     expected.matches? extract(actual)

--- a/integtest/spec/helper/matcher/initial_js_state.rb
+++ b/integtest/spec/helper/matcher/initial_js_state.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+##
+# Matches extracts the "initial javascript state" of a templated html page.
+RSpec::Matchers.define :initial_js_state do |expected|
+  match do |actual|
+    expected.matches? extract(actual)
+  end
+  failure_message do
+    "doc_body didn't match: #{expected.failure_message}"
+  end
+
+  def extract(contents)
+    start_boundry = 'window.initial_state = '
+    start = contents.index start_boundry
+    return unless start
+
+    start += start_boundry.length
+    stop = contents.index '</script>', start
+    return unless stop
+
+    txt = contents[start, stop - start]
+    JSON.parse txt, symbolize_names: true
+  end
+end

--- a/integtest/spec/helper/repo.rb
+++ b/integtest/spec/helper/repo.rb
@@ -42,6 +42,11 @@ class Repo
     File.open realpath, 'r:UTF-8', &:read
   end
 
+  def delete(source_relative_path)
+    realpath = path source_relative_path
+    File.delete realpath
+  end
+
   ##
   # Copy a file into the source path, returning the destination path.
   def cp(source_file, dest_relative_path)
@@ -77,10 +82,42 @@ class Repo
   end
 
   ##
+  # Checks out a branch.
+  def switch_to_branch(branch)
+    Dir.chdir @root do
+      sh "git checkout #{branch}"
+    end
+  end
+
+  ##
+  # The hash of the last commit.
+  def short_hash
+    Dir.chdir @root do
+      hash = sh 'git rev-parse --short HEAD'
+      hash.strip
+    end
+  end
+
+  ##
   # Create a worktree at `dest` for the branch `branch`.
   def create_worktree(dest, branch)
     Dir.chdir @root do
       sh "git worktree add #{dest} #{branch}"
+    end
+  end
+
+  ##
+  # Clone this repo from some directory on disk
+  def clone_from(src)
+    @initialized = true
+    sh "git clone #{src} #{@root}"
+  end
+
+  ##
+  # Push commits in this repo to some remote, maybe a directory on disk.
+  def push_to(dest)
+    Dir.chdir @root do
+      sh "git push #{dest}"
     end
   end
 

--- a/integtest/spec/helper/repo.rb
+++ b/integtest/spec/helper/repo.rb
@@ -42,6 +42,8 @@ class Repo
     File.open realpath, 'r:UTF-8', &:read
   end
 
+  ##
+  # Delete a file in the repo.
   def delete(source_relative_path)
     realpath = path source_relative_path
     File.delete realpath

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
   end
 
-  let(:expected_initial_js_state) { {} }
+  let(:expected_js_state) { {} }
   let(:expected_language) { 'en' }
 
   it 'logs that the built docs are ready' do
@@ -109,10 +109,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
     context 'the current index' do
       it 'has the correct initial_js_state' do
-        expect(current_index.code).to eq('200')
-        expect(extract_initial_js_state(current_index.body)).to eq(
-          expected_initial_js_state
-        )
+        expect(current_index).to serve(initial_js_state(eq(expected_js_state)))
       end
       it 'has the correct language' do
         expect(current_index).to serve(include(<<~HTML.strip))
@@ -412,7 +409,7 @@ RSpec.describe 'previewing built docs', order: :defined do
       LOGS
     end
     let(:branch) { 'alternative_examples' }
-    let(:expected_initial_js_state) do
+    let(:expected_js_state) do
       {
         alternatives: {
           console: {
@@ -442,7 +439,7 @@ RSpec.describe 'previewing built docs', order: :defined do
       LOGS
     end
     let(:branch) { 'foolang' }
-    let(:expected_initial_js_state) do
+    let(:expected_js_state) do
       {
         alternatives: {
           console: {

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     context 'the current index' do
       it 'has the correct initial_js_state' do
         expect(current_index.code).to eq('200')
-        expect(initial_js_state(current_index.body)).to eq(
+        expect(extract_initial_js_state(current_index.body)).to eq(
           expected_initial_js_state
         )
       end

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     @preview = @dest.start_preview
   end
   after(:context) do
-    @preview.exit
+    @preview&.exit
   end
   let(:repo) { @dest.bare_repo.sub '.git', '' }
   let(:preview) { @preview }
@@ -62,7 +62,9 @@ RSpec.describe 'previewing built docs', order: :defined do
 
     req['X-Opaque-Id'] = watermark
     req['Host'] = branch
-    Net::HTTP.start(uri.hostname, uri.port) { |http| http.request(req) }
+    Net::HTTP.start(uri.hostname, uri.port, read_timeout: 20) do |http|
+      http.request(req)
+    end
   end
 
   shared_context 'docs for branch' do
@@ -72,6 +74,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     let(:diff) { get watermark, branch, 'diff' }
     let(:robots_txt) { get watermark, branch, 'robots.txt' }
     let(:root) { get watermark, branch, 'guide/index.html' }
+    let(:current_index) { get watermark, branch, "#{current_url}/index.html" }
     let(:cat_image) do
       get watermark, branch, "#{current_url}/resources/readme/cat.jpg"
     end
@@ -83,21 +86,39 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
   end
 
+  let(:expected_initial_js_state) { {} }
+  let(:expected_language) { 'en' }
+
   it 'logs that the built docs are ready' do
     wait_for_logs(/Built docs are ready/)
   end
 
-  shared_examples 'serves the docs root' do
-    it 'serves the docs root' do
-      expect(root).to serve(doc_body(include(<<~HTML.strip)))
-        <a class="ulink" href="test/current/index.html" target="_top">Test</a>
-      HTML
+  shared_examples 'serves some docs' do
+    context 'the docs root' do
+      it 'contains a link to the current index' do
+        expect(root).to serve(doc_body(include(<<~HTML.strip)))
+          <a class="ulink" href="test/current/index.html" target="_top">Test</a>
+        HTML
+      end
+      it 'logs the access to the docs root' do
+        wait_for_access watermark, branch, '/guide/index.html'
+        expect(logs).to include(<<~LOGS)
+          #{watermark} #{branch} GET /guide/index.html HTTP/1.1 200
+        LOGS
+      end
     end
-    it 'logs the access to the docs root' do
-      wait_for_access watermark, branch, '/guide/index.html'
-      expect(logs).to include(<<~LOGS)
-        #{watermark} #{branch} GET /guide/index.html HTTP/1.1 200
-      LOGS
+    context 'the current index' do
+      it 'has the correct initial_js_state' do
+        expect(current_index.code).to eq('200')
+        expect(initial_js_state(current_index.body)).to eq(
+          expected_initial_js_state
+        )
+      end
+      it 'has the correct language' do
+        expect(current_index).to serve(include(<<~HTML.strip))
+          <section id="guide" lang="#{expected_language}">
+        HTML
+      end
     end
     it 'serves a "go away" robots.txt' do
       expect(robots_txt).to serve(eq(<<~TXT))
@@ -157,12 +178,12 @@ RSpec.describe 'previewing built docs', order: :defined do
   describe 'for the master branch' do
     let(:branch) { 'master' }
     include_context 'docs for branch'
-    include_examples 'serves the docs root'
+    include_examples 'serves some docs'
     it 'serves an image' do
       bytes = File.open("#{repo_root}/resources/readme/cat.jpg", 'rb', &:read)
       expect(cat_image).to serve(eq(bytes))
     end
-    it 'serves a very large file' do
+    it 'serves a very large image' do
       expect(very_large).to serve(eq(very_large_text))
     end
     context 'when you request a directory' do
@@ -203,7 +224,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     describe 'for the test branch' do
       let(:branch) { 'test' }
       include_context 'docs for branch'
-      include_examples 'serves the docs root'
+      include_examples 'serves some docs'
       context 'the diff' do
         include_examples 'valid diff'
         it 'contains a link to the index which has changed' do
@@ -220,6 +241,85 @@ RSpec.describe 'previewing built docs', order: :defined do
           expect(diff).not_to serve(include(<<~HTML))
             <p>There aren't any differences!</p>
           HTML
+        end
+      end
+      shared_examples 'logs the fetch' do
+        it 'logs the fetch' do
+          wait_for_logs(/#{@before_hash}\.\.#{@after_hash}\s+test\s+->\s+test/)
+          # The leading space in the second line is important because it causes
+          # filebeat to group the two log lines.
+          expect(logs).to include("\n" + <<~LOGS)
+            From #{repo}
+               #{@before_hash}..#{@after_hash}  test       -> test
+          LOGS
+        end
+      end
+      describe 'when we modify the template' do
+        before(:context) do
+          # This simulates modifying the template in the docs repo and running
+          # build_docs --all
+          work = @src.repo 'work'
+          work.clone_from @dest.bare_repo
+          work.switch_to_branch 'test'
+          @before_hash = work.short_hash
+          old_template = work.read 'template.html'
+          work.write 'template.html', old_template + 'trailing garbage'
+          work.commit 'add garbage to template'
+          work.push_to @dest.bare_repo
+          @after_hash = work.short_hash
+        end
+        include_examples 'logs the fetch'
+        it 'is immediately reflected in the root' do
+          expect(root).to serve(include(<<~HTML.strip))
+            </html>\ntrailing garbage
+          HTML
+        end
+      end
+      describe 'for a very very large html page' do
+        before(:context) do
+          # This simulates adding a very large html page without having to
+          # render it through asciidoc and docbook which would be very slow
+          work = @src.repo 'work'
+          @before_hash = work.short_hash
+          work.write 'raw/very_large.html', <<~HTML
+            <!DOCTYPE html>
+            <html>
+              <head><title>very large</title></head>
+              <body>#{very_large_text}</body>
+            </html>
+          HTML
+          work.commit 'add huge page'
+          work.push_to @dest.bare_repo
+          @after_hash = work.short_hash
+        end
+        let(:very_large_html) do
+          get watermark, branch, 'guide/very_large.html'
+        end
+        include_examples 'logs the fetch'
+        it 'serves the very large page without crashing' do
+          expect(very_large_html).to serve(include(very_large_text))
+        end
+        it 'logs the access to the very large page' do
+          wait_for_access watermark, branch, '/guide/very_large.html'
+          expect(logs).to include(<<~LOGS)
+            #{watermark} #{branch} GET /guide/very_large.html HTTP/1.1 200
+          LOGS
+        end
+      end
+      describe 'when we remove the template' do
+        before(:context) do
+          # This simulates what preview branches looked like before committing
+          # the template.
+          work = @src.repo 'work'
+          @before_hash = work.short_hash
+          work.delete 'template.html'
+          work.commit 'remove template'
+          work.push_to @dest.bare_repo
+          @after_hash = work.short_hash
+        end
+        include_examples 'logs the fetch'
+        describe 'everything still works because we fall back' do
+          include_examples 'serves some docs'
         end
       end
     end
@@ -271,7 +371,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     describe 'for the test branch' do
       let(:branch) { 'test_noop' }
       include_context 'docs for branch'
-      include_examples 'serves the docs root'
+      include_examples 'serves some docs'
       context 'the diff' do
         include_examples 'valid diff'
         it 'is empty' do
@@ -282,5 +382,77 @@ RSpec.describe 'previewing built docs', order: :defined do
         end
       end
     end
+  end
+  describe 'when there are alternative examples' do
+    before(:context) do
+      # We don't have any examples in our source document so we'll just make a
+      # dummy file so the checkout works. This is good enough to make a
+      # distinct initial_js_state
+      csharp_repo = @src.repo 'csharp'
+      csharp_repo.write 'examples/dummy', 'dummy'
+      csharp_repo.commit 'add example'
+
+      book = @src.book 'Test'
+      book.source(
+        csharp_repo,
+        'examples',
+        alternatives: { source_lang: 'console', alternative_lang: 'csharp' }
+      )
+      @dest.convert_all @src.conf, target_branch: 'alternative_examples'
+    end
+    it 'logs the fetch' do
+      wait_for_logs(
+        /\[new branch\]\s+alternative_examples\s+->\s+alternative_examples/
+      )
+      # The leading space in the second line is important because it causes
+      # filebeat to group the two log lines.
+      expect(logs).to include("\n" + <<~LOGS)
+        From #{repo}
+         * [new branch]      alternative_examples -> alternative_examples
+      LOGS
+    end
+    let(:branch) { 'alternative_examples' }
+    let(:expected_initial_js_state) do
+      {
+        alternatives: {
+          console: {
+            csharp: { hasAny: false },
+          },
+        },
+      }
+    end
+    include_context 'docs for branch'
+    include_examples 'serves some docs'
+  end
+  describe 'when the language is something other than `en`' do
+    before(:context) do
+      book = @src.book 'Test'
+      book.lang = 'foo'
+      @dest.convert_all @src.conf, target_branch: 'foolang'
+    end
+    it 'logs the fetch' do
+      wait_for_logs(
+        /\[new branch\]\s+foolang\s+->\s+foolang/
+      )
+      # The leading space in the second line is important because it causes
+      # filebeat to group the two log lines.
+      expect(logs).to include("\n" + <<~LOGS)
+        From #{repo}
+         * [new branch]      foolang    -> foolang
+      LOGS
+    end
+    let(:branch) { 'foolang' }
+    let(:expected_initial_js_state) do
+      {
+        alternatives: {
+          console: {
+            csharp: { hasAny: false },
+          },
+        },
+      }
+    end
+    let(:expected_language) { 'foo' }
+    include_context 'docs for branch'
+    include_examples 'serves some docs'
   end
 end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -45,13 +45,13 @@ RSpec.describe 'building a single book' do
           expect(language).to eq('en')
         end
         it 'has an empty initial js state' do
-          expect(initial_js_state).to be_empty
+          expect(contents).to initial_js_state(be_empty)
         end
       end
       page_context 'toc.html' do
-        it "doesn't have the initail js state" do
+        it "doesn't have the initial js state" do
           # because we didn't apply the template
-          expect(initial_js_state).to be_nil
+          expect(contents).to initial_js_state(be_nil)
         end
       end
       page_context 'raw/index.html' do
@@ -81,7 +81,7 @@ RSpec.describe 'building a single book' do
         end
         it "doesn't have the initial js state" do
           # because we don't apply the template which is how that gets in there
-          expect(initial_js_state).to be_nil
+          expect(contents).to initial_js_state(be_nil)
         end
       end
       page_context 'chapter.html' do

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -64,7 +64,7 @@ RSpec::Matchers.define :file_exist do
   end
 end
 
-def initial_js_state(contents)
+def extract_initial_js_state(contents)
   start_boundry = 'window.initial_state = '
   start = contents.index start_boundry
   return unless start

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -63,3 +63,16 @@ RSpec::Matchers.define :file_exist do
     msg + " but only #{parent}/#{entries.sort} exist"
   end
 end
+
+def initial_js_state(contents)
+  start_boundry = 'window.initial_state = '
+  start = contents.index start_boundry
+  return unless start
+
+  start += start_boundry.length
+  stop = contents.index '</script>', start
+  return unless stop
+
+  txt = contents[start, stop - start]
+  JSON.parse txt, symbolize_names: true
+end

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require_relative 'helper/matcher/doc_body'
 require_relative 'helper/matcher/have_same_keys'
+require_relative 'helper/matcher/initial_js_state'
 require_relative 'helper/matcher/serve'
 require_relative 'helper/console_alternative_examples'
 require_relative 'helper/dest'
@@ -62,17 +63,4 @@ RSpec::Matchers.define :file_exist do
     entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
     msg + " but only #{parent}/#{entries.sort} exist"
   end
-end
-
-def extract_initial_js_state(contents)
-  start_boundry = 'window.initial_state = '
-  start = contents.index start_boundry
-  return unless start
-
-  start += start_boundry.length
-  stop = contents.index '</script>', start
-  return unless stop
-
-  txt = contents[start, stop - start]
-  JSON.parse txt, symbolize_names: true
 end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -361,12 +361,17 @@ sub _copy_branch_to_current {
 #===================================
     my ( $self ) = @_;
 
-    my $branch_dir  = $self->dir->subdir( $self->current );
-    my $current_dir = $self->dir->subdir('current');
+    my $branch_dir  = $self->{dir}->subdir( $self->current );
+    my $current_dir = $self->{dir}->subdir('current');
+    my $raw_branch_dir  = $self->{raw_dir}->subdir( $self->current );
+    my $raw_current_dir = $self->{raw_dir}->subdir('current');
 
     $current_dir->rmtree;
     rcopy( $branch_dir, $current_dir )
         or die "Couldn't copy <$branch_dir> to <$current_dir>: $!";
+    $raw_current_dir->rmtree;
+    rcopy( $raw_branch_dir, $raw_current_dir )
+        or die "Couldn't copy <$raw_branch_dir> to <$raw_current_dir>: $!";
 }
 
 #===================================

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -899,7 +899,8 @@ sub build_web_resources {
     my $css = $static_dir->file( 'styles.css' );
     my $js_licenses = file( 'resources/web/docs.js.licenses' );
     my $css_licenses = file( 'resources/web/styles.css.licenses' );
-    $js->spew( iomode => '>:utf8',
+    $js->spew(
+        iomode => '>:utf8',
         $js_licenses->slurp( iomode => '<:encoding(UTF-8)' ) . $compiled_js->slurp( iomode => '<:encoding(UTF-8)' )
     );
     $css->spew(

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -11,5 +11,4 @@ COPY template /docs_build/template
 COPY resources /docs_build/resources
 
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--reference", "/tmp/repos", \
-     "--target_repo", "https://github.com/elastic/built-docs.git"]
+     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -7,7 +7,9 @@ COPY build_docs.pl /docs_build/
 COPY conf.yaml /docs_build/
 COPY lib /docs_build/lib
 COPY preview /docs_build/preview
+COPY template /docs_build/template
 COPY resources /docs_build/resources
 
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]
+     "--preview", "--reference", "/tmp/repos", \
+     "--target_repo", "https://github.com/elastic/built-docs.git"]

--- a/preview/Makefile
+++ b/preview/Makefile
@@ -9,4 +9,4 @@ check: jest
 
 .PHONY: jest
 jest:
-	/node_modules/jest/bin/jest.js preview
+	/node_modules/jest/bin/jest.js ./__test__/**

--- a/preview/__test__/git.test.js
+++ b/preview/__test__/git.test.js
@@ -1,0 +1,325 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+const {promisify} = require("util");
+
+const fs = require("fs");
+const child_process = require("child_process");
+const Git = require("../git");
+const rmfr = require("rmfr");
+const { Readable } = require("stream");
+
+const execFile = promisify(child_process.execFile);
+const mkdir = promisify(fs.mkdir);
+const unlink = promisify(fs.unlink);
+const writeFile = promisify(fs.writeFile);
+
+const collect = async stream => {
+  let all = '';
+  for await (const c of stream) {
+    all += c;
+  }
+  return all;
+}
+
+describe("git", () => {
+  const git = Git("/docs_build");
+
+  describe("objectType", () =>{
+    describe("when pointed at a blob", () => {
+      test("resolves to `blob`", () => {
+        return expect(git.objectType("HEAD:preview/git.js"))
+          .resolves.toBe("blob");
+      });
+    });
+    describe("when pointed at a commit", () => {
+      test("resolves to `commit`", () => {
+        return expect(git.objectType("HEAD"))
+          .resolves.toBe("commit");
+      });
+    });
+    // We don't have any tags worth checking so we'll just have to believe.
+    describe("when pointed at a tree", () => {
+      test("resolves to `tree`", () => {
+        return expect(git.objectType("HEAD:preview"))
+          .resolves.toBe("tree");
+      });
+    });
+    describe("when pointed at a missing file", () => {
+      test("resolves to `missing`", () => {
+        return expect(git.objectType("HEAD:totally_not_there"))
+          .resolves.toBe("missing");
+      });
+    });
+    describe("when pointed at a missing branch", () => {
+      test("resolves to `missing`", () => {
+        return expect(git.objectType("totally_missing_branch:template.html"))
+          .resolves.toBe("missing");
+      });
+    });
+  });
+
+  describe("_streamChild", () => {
+    describe("when running a successful child", () => {
+      describe("without output", () => {
+        test("returns an empty stream", () => {
+          return expect(collect(git._streamChild(child_process.spawn("true"))))
+            .resolves.toBe("");
+        });
+      });
+      describe("with output", () => {
+        test("returns the output", () => {
+          return expect(collect(git._streamChild(child_process.spawn("echo", ["words"]))))
+            .resolves.toBe("words\n");
+        });
+      });
+    });
+    describe("when the child says that an object is not valid", () => {
+      test("emits `missing`", () => {
+        return expect(collect(git._streamChild(child_process.spawn(
+          "echo Not a valid object name 1>&2 && false", [], {shell: true})
+        ))).rejects.toBe("missing");
+      });
+    });
+    describe("when the child says that revision is invalid", () => {
+      test("emits `missing`", () => {
+        return expect(collect(git._streamChild(child_process.spawn(
+          "echo fatal: bad revision 1>&2 && false", [], {shell: true})
+        ))).rejects.toBe("missing");
+      });
+    });
+    describe("when running a failing child", () => {
+      test("emits an error", () => {
+        return expect(collect(git._streamChild(child_process.spawn("false"))))
+          .rejects.toBe("Child failed with code 1");
+      });
+    });
+    describe("when the child is killed", () => {
+      test("emits an error", () => {
+        const child = child_process.spawn("sleep", ["1000"]);
+        process.nextTick(() => child.kill());
+        expect(collect(git._streamChild(child)))
+          .rejects.toBe("Child died with signal SIGTERM");
+      });
+    });
+  });
+
+  describe("catBlobToString", () => {
+    describe("when pointed at a blob", () => {
+      test("returns the blob", () => {
+        return expect(git.catBlobToString("HEAD:preview/git.js", 1024 * 1024))
+          .resolves.toMatch(/catBlobToString:/);
+      });
+    });
+    describe("when pointed at a missing file", () => {
+      test("rejectes to `missing`", () => {
+        return expect(git.catBlobToString("HEAD:totally_not_there", 1024))
+          .rejects.toBe("missing");
+      });
+    });
+    describe("when pointed at a missing branch", () => {
+      test("rejects to `missing`", () => {
+        return expect(git.catBlobToString("totally_missing_branch:template.html", 1024))
+          .rejects.toBe("missing");
+      });
+    });
+  });
+
+  describe("catBlob", () => {
+    describe("when the object is a blob", () => {
+      test("it contains the body of the blob", () => {
+        return expect(collect(git.catBlob("HEAD:preview/git.js")))
+          .resolves.toMatch(/catBlob:/);
+      });
+    });
+    describe("when the object is missing", () => {
+      test("the stream contains an error", () => {
+        return expect(collect(git.catBlob("HEAD:totally_not_here")))
+          .rejects.toBe("missing");
+      });
+    });
+    describe("when the branch is missing", () => {
+      test("the stream contains an error", () => {
+        return expect(collect(git.catBlob("totally_missing_branch:template.html")))
+          .rejects.toBe("missing");
+      });
+    });
+  });
+
+  describe("diffLastCommit", () => {
+    const tmp = "/tmp/preview_test_repo";
+    const gitOpts = {
+      cwd: tmp,
+      env: {
+        GIT_AUTHOR_NAME: "test",
+        GIT_AUTHOR_EMAIL: "test@example.com",
+        GIT_COMMITTER_NAME: "test",
+        GIT_COMMITTER_EMAIL: "test@example.com",
+      },
+    };
+    const collectDiff = async itr => {
+      const result = [];
+      for await (const change of itr) {
+        result.push(change);
+      }
+      return result;
+    };
+
+    let diff;
+    beforeAll(async () => {
+      await rmfr(tmp);
+      await mkdir(tmp);
+      await execFile("git", ["init"], gitOpts);
+      await writeFile(`${tmp}/removed`, "remove me");
+      await writeFile(`${tmp}/renamed_from`, "rename me");
+      await execFile("git", ["add", "."], gitOpts);
+      await execFile("git", ["commit", "-m", "init"], gitOpts);
+      await writeFile(`${tmp}/added`, "add me");
+      await writeFile(`${tmp}/renamed_to`, "rename me");
+      await unlink(`${tmp}/removed`);
+      await unlink(`${tmp}/renamed_from`);
+      await execFile("git", ["add", "."], gitOpts);
+      await execFile("git", ["commit", "-m", "diff me"], gitOpts);
+      diff = await collectDiff(Git(tmp).diffLastCommit("master"));
+    });
+
+    describe("when a file is added", () => {
+      test("it shows the right diff", () => {
+        expect(diff).toContainEqual({path: "added", added: "1", removed: "0"});
+      });
+    });
+    describe("when a file is removed", () => {
+      test("it shows the right diff", () => {
+        expect(diff).toContainEqual({path: "removed", added: "0", removed: "1"});
+      });
+    });
+    describe("when a file is moved", () => {
+      test("it shows the right diff", () => {
+        expect(diff).toContainEqual({
+          path: "renamed_from",
+          movedToPath: "renamed_to",
+          added: "0",
+          removed: "0"
+        });
+      });
+    });
+    describe("on a non-master branch", () => {
+      let nonMasterDiff;
+      beforeAll(async () => {
+        await execFile("git", ["checkout", "-b", "testbranch"], gitOpts);
+        await execFile("git", ["rm", "-f", "added"], gitOpts);
+        await execFile("git", ["add", "."], gitOpts);
+        await execFile("git", ["commit", "-m", "diff me too"], gitOpts);
+        nonMasterDiff = await collectDiff(Git(tmp).diffLastCommit("testbranch"));
+      });
+      test("shows the correct branch", () => {
+        expect(nonMasterDiff).toStrictEqual([{path: "added", added: "0", removed: "1"}]);
+      });
+    });
+    describe("when the branch is missing", () => {
+      test("the iterator yields an error", () => {
+        return expect(collectDiff(git.diffLastCommit("totally_missing_branch")))
+          .rejects.toBe("missing");
+      });
+    });
+    describe("when the branch is missing", () => {
+      test("the iterator yields an error", () => {
+        return expect(collectDiff(git.diffLastCommit("totally_missing_branch")))
+          .rejects.toBe("missing");
+      });
+    });
+  });
+  describe("_parseDiffTreeZ", () => {
+    const parse = async (itr, destroy = () => {}) => {
+      const result = [];
+      for await (const change of git._parseDiffTreeZ(itr, destroy)) {
+        result.push(change);
+      }
+      return result;
+    };
+    const smear = function* (str) {
+      for (const c of [...str]) {
+        yield Buffer.from(c);
+      }
+    };
+
+    describe("when sent an empty iterator", () => {
+      test("returns an empty diff", () => {
+        return expect(parse((function*() {
+          // Intentionally yield nothing
+        })())).resolves.toStrictEqual([]);
+      });
+    });
+    describe("when sent an iterator with just a commit hash", () => {
+      test("returns an empty diff", () => {
+        return expect(parse((function*() {
+          yield Buffer.from("ba07ac2cbbeea5f68bef9188249fbf0ff7953e37\0");
+        })())).resolves.toStrictEqual([]);
+      });
+    });
+    describe("when sent an iterator containing a file that wasn't moved", () => {
+      test("returns the file", () => {
+        return expect(parse((function*() {
+          yield Buffer.from("123\t334\tdon't move\0");
+        })())).resolves.toStrictEqual([{path: "don't move", added: "123", removed: "334"}]);
+      });
+    });
+    describe("when sent an iterator containing a file that was moved", () => {
+      test("returns the file including it's destination", () => {
+        return expect(parse((function*() {
+          yield Buffer.from("123\t334\t\0src\0dest\0");
+        })())).resolves.toStrictEqual([{path: "src", movedToPath: "dest", added: "123", removed: "334"}]);
+      });
+    });
+    describe("when a commit hash line is in many chunks", () => {
+      test("returns an empty diff", () => {
+        return expect(parse(smear("ba07ac2cbbeea5f68bef9188249fbf0ff7953e37\0")))
+          .resolves.toStrictEqual([]);
+      });
+    });
+    describe("when a normal line is in many chunks", () => {
+      test("returns the file", () => {
+        return expect(parse(smear("123\t334\tdon't move\0")))
+          .resolves.toStrictEqual([{path: "don't move", added: "123", removed: "334"}]);
+      });
+    });
+    describe("when chunk has a weird number of tabs", () => {
+      test("throws an error", () => {
+        return expect(parse(smear("what\tis\tthis\tmadness\0")))
+          .rejects.toThrow(/Strange entry fom git: what\tis\tthis\tmadness/);
+      });
+    });
+    describe("when chunk has stuff after the last nul", () => {
+      test("throws an error", () => {
+        return expect(parse(smear("\0undeserving")))
+          .rejects.toThrow(/Trailing garbage after diff: undeserving/);
+      });
+    });
+    describe("when the generator throws an error", () => {
+      test("throws an error", () => {
+        return expect(parse((async function*() {
+          throw new Error("testerr");
+        })())).rejects.toThrow(/testerr/);
+      });
+    });
+  });
+});

--- a/preview/git.js
+++ b/preview/git.js
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+const child_process = require("child_process");
+const { Transform } = require("stream");
+
+/**
+ * Git operations used by the preview. We'd love to use NodeGit but it doesn't
+ * looks like it is asynchronous and/or streaming in the places where we need
+ * it to be.
+ */
+module.exports = dir => {return {
+  /**
+   * Returns a promise that will contain the type of the object. Will be one of
+   * `blob`, `commit`, `tag`, `tree`, or `missing`. The first four are defined
+   * [here]{@link http://shafiul.github.io/gitbook/1_the_git_object_model.html}.
+   * `missing` is for missing objects.
+   */
+  objectType: object => {
+    return new Promise((resolve, reject) => {
+      const opts = {
+        cwd: dir,
+        max_buffer: 64,
+      };
+      child_process.execFile(
+        "git", ["cat-file", "-t", object], opts, toStringHandler(resolve, reject, resolve)
+      );
+    });
+  },
+  /**
+   * Returns a promise containing the contents of an object.
+   * @param {int} sizeLimit maximum size of the buffer for the object
+   */
+  catBlobToString: (object, sizeLimit) => {
+    return new Promise((resolve, reject) => {
+      const opts = {
+        cwd: dir,
+        max_buffer: sizeLimit,
+      };
+      child_process.execFile(
+        "git", ["cat-file", "blob", object], opts, toStringHandler(resolve, reject, reject)
+      );
+    });
+  },
+  /**
+   * Returns a stream containing the contents of the object.
+   */
+  catBlob: object => {
+    return streamChild(child_process.spawn(
+      "git", ["cat-file", "blob", object], {cwd: dir}
+    ));
+  },
+  diffLastCommit: branch => {
+    const stream = streamChild(child_process.spawn(
+      "git",
+      ["diff-tree", "-z", "--find-renames", "--numstat", branch, "--"],
+      {
+        cwd: dir,
+        /*
+         * We use the magic 'buffer' encoding so we don't have to build a
+         * a string out of the whole thing at once. We have convenient nuls
+         * in the parsing process that we can use to "chunk" this.
+         */
+        encoding: 'buffer',
+      }
+    ));
+    return parseDiffTreeZ(stream[Symbol.asyncIterator]());
+  },
+  /**
+   * Turn a spawned child process into a stream containing its stdout and
+   * emitting an error if it fails. Exported for testing only.
+   */
+  _streamChild: streamChild,
+  /**
+   * Parse the output of `git diff-tree -z --find-renames --numstat` as an
+   * async generator. Exported for testing only.
+   */
+  _parseDiffTreeZ: parseDiffTreeZ,
+}};
+
+const streamChild = (child) => {
+  // Error should be fairly short so we can safely spool them into a variable.
+  let stderrBuffer = '';
+  child.stderr.setEncoding('utf8');
+  child.stderr.addListener('data', chunk => {
+    stderrBuffer += chunk;
+  });
+
+  let flushCallback;
+  const out = child.stdout.pipe(new Transform({
+    transform(chunk, _encoding, callback) {
+      callback(null, chunk);
+    },
+    flush(callback) {
+      // Wait to emit the end until the process closes.
+      flushCallback = callback;
+    }
+  }));
+
+  let closed = false;
+  child.addListener('close', (code, signal) => {
+    /*
+     * We can get this call multiple times for some reason. Lets just ignore
+     * the second one.....
+     */
+    if (closed) {
+      return;
+    }
+    closed = true;
+    /*
+     * Since we've closed stdout we can be sure that our transform stream has
+     * received its `flush` callback. So we delegate to that now to close
+     * the transform stream with the results of the subprocess.
+     */
+    if (code) {
+      /*
+       * Normalize some "not found" style errors from git so the caller can
+       * 404 on them.
+       */
+      let missing = stderrBuffer.includes("Not a valid object name");
+      missing |= stderrBuffer.includes("fatal: bad revision");
+      if (missing) {
+        flushCallback("missing");
+      } else {
+        flushCallback(failureMessage(`Child failed with code ${code}`, stderrBuffer));
+      }
+    } else if (signal) {
+      flushCallback(failureMessage(`Child died with signal ${signal}`, stderrBuffer));
+    } else {
+      flushCallback();
+    }
+  });
+
+  return out;
+}
+
+const failureMessage = (firstPart, stderr) => {
+  if (stderr) {
+    return `${firstPart} and stderr:\n${stderr}`;
+  }
+  return firstPart;
+}
+
+const parseDiffTreeZ = async function* (itr) {
+  const loadFirstChunk = await itr.next();
+  if (loadFirstChunk.done) {
+    // Empty diff!
+    return;
+  }
+  let chunk = loadFirstChunk.value;
+  const sliceOffNul = async from => {
+    while (true) {
+      const nextNul = chunk.indexOf("\0", from);
+      if (nextNul === -1) {
+        const load = await itr.next();
+        if (load.done) {
+          if (chunk.length === 0) {
+            return null;
+          }
+          // The iterator is done here so we don't call itr.throw.
+          throw new Error(`Trailing garbage after diff: ${chunk}`);
+        } else {
+          /*
+           * Concat *is* a copying operations which is important because this
+           * is the operation that releases the memory from the last chunk.
+           */
+          chunk = Buffer.concat([chunk, load.value]);
+        }
+      } else {
+        const result = chunk.toString('utf8', from, nextNul);
+        /*
+         * Slice off the chunk working part that we're returning. Buffer
+         * slicing in nodejs is a non-copying operation so this is quick.
+         */
+        chunk = chunk.slice(nextNul + 1);
+        return result;
+      }
+    }
+  };
+  /*
+   * Parses output from `git diff-tree -z` which is in
+   * one of two formats:
+   * * added lines<tab>removed lines<tab>path<nul>
+   * * added lines<tab>removed lines<nul>source path<nul>destination path<nul>
+   * The second one is only used when git detects a rename.
+   */
+  while (true) {
+    let work = await sliceOffNul();
+    if (work === null) {
+      // Done!
+      return;
+    }
+    if (work[work.length - 1] === '\t') {
+      work = work.slice(work, -1);
+    }
+    const parts = work.split('\t');
+    if (parts.length === 3) {
+      const [added, removed, path] = parts;
+      yield {
+        path: path,
+        added: added,
+        removed: removed,
+      };
+    } else if (parts.length === 2) {
+      const [added, removed] = parts;
+      const path = await sliceOffNul();
+      const movedToPath = await sliceOffNul();
+      yield {
+        path: path,
+        movedToPath: movedToPath,
+        added: added,
+        removed: removed,
+      };
+    } else if (parts.length === 1) {
+      // The commit hash. Ignore it.
+    } else {
+      // Prematurely end the iterator because we've encountered a parsing error.
+      itr.throw(new Error(`Strange entry fom git: ${work}`));
+    }
+  }
+}
+
+const toStringHandler = (resolve, reject, onMissing) => (err, stdout) => {
+  if (err) {
+    if (err.message.includes("Not a valid object name")) {
+      onMissing("missing");
+    } else {
+      reject(err);
+    }
+  } else {
+    resolve(stdout.trim());
+  }
+};

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -185,7 +185,7 @@ const applyTemplate = async (branch, requestedObject, out) => {
 
 const loadLang = async requestedObject => {
   const langPath = path.dirname(requestedObject) + "/lang";
-  return await git.catBlobToString(langPath).trim();
+  return (await git.catBlobToString(langPath)).trim();
 };
 
 const loadInitialJsState = async requestedObject => {

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -185,7 +185,7 @@ const applyTemplate = async (branch, requestedObject, out) => {
 
 const loadLang = async requestedObject => {
   const langPath = path.dirname(requestedObject) + "/lang";
-  return await git.catBlobToString(langPath);
+  return await git.catBlobToString(langPath).trim();
 };
 
 const loadInitialJsState = async requestedObject => {

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -8,11 +8,16 @@
 set -e
 
 cd $(git rev-parse --show-toplevel)
+../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh built-docs.git
 docker build -t docker.elastic.co/docs/preview:4 -f preview/Dockerfile .
 id=$(docker run --rm \
-           --publish 8000:8000/tcp \
-           -d \
-           docker.elastic.co/docs/preview:4)
+          --publish 8000:8000/tcp \
+          -v $HOME/.git-references:/root/.git-references \
+          -d \
+          docker.elastic.co/docs/preview:4 \
+          /docs_build/build_docs.pl --in_standard_docker \
+              --preview --reference /root/.git-references \
+              --target_repo https://github.com/elastic/built-docs.git)
 echo "Started the preview. Some useful commands:"
 echo "   docker kill $id"
 echo "   docker logs -tf $id"

--- a/template/__test__/template.test.js
+++ b/template/__test__/template.test.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const Template = require('../template');
 
 describe(Template, () => {
@@ -65,7 +66,12 @@ describe(Template, () => {
     });
   });
   describe("apply", () => {
-    let template = Template("../resources/web/template.html")
+    let template = Template(() =>
+      fs.createReadStream("../resources/web/template.html", {
+        encoding: 'UTF-8',
+        autoDestroy: true,
+      })
+    );
     template.applyToString = async (raw, lang, initialJsState) => {
       const rawItr = (function* () {
         yield raw;

--- a/template/cli.js
+++ b/template/cli.js
@@ -34,10 +34,8 @@ const argv = yargs
   .option("template", {describe: "Path to the template"}).string("template")
   .option("source", {describe: "Path to the source files"}).string("source")
   .option("dest", {describe: "Path to write the templated files"}).string("dest")
-  .option("altsummary", {describe: "Path alternatives summary file if one exists"}).string("dest")
-  .option("lang", {describe: "Language of the book"}).string("lang")
   .option("tocmode", {describe: "Are we building a table of contents?"}).boolean("tocmode")
-  .demandOption(["template", "source", "dest", "lang"])
+  .demandOption(["template", "source", "dest"])
   .help()
   .argv;
 
@@ -46,5 +44,5 @@ const argv = yargs
     encoding: 'UTF-8',
     autoDestroy: true,
   }));
-  await template.applyToDir(argv.source, argv.dest, argv.lang, argv.altsummary, argv.tocmode);
+  await template.applyToDir(argv.source, argv.dest, argv.tocmode);
 })();

--- a/template/cli.js
+++ b/template/cli.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const Template = require('./template');
 const yargs = require('yargs');
 
@@ -41,6 +42,9 @@ const argv = yargs
   .argv;
 
 (async () => {
-  const template = await Template(argv.template);
-  template.applyToDir(argv.source, argv.dest, argv.lang, argv.altsummary, argv.tocmode);
+  const template = await Template(() => fs.createReadStream(argv.template, {
+    encoding: 'UTF-8',
+    autoDestroy: true,
+  }));
+  await template.applyToDir(argv.source, argv.dest, argv.lang, argv.altsummary, argv.tocmode);
 })();


### PR DESCRIPTION
This makes the preview service template html pages on the fly.

A few things had to happen to make this go:
1. Start writing everything that we need to render the tempelate on the
fly into built-docs, specifically the template and the language.
2. Only use the template if it is in the built-docs branch we're trying
to render. Branches without the template serve from the "html" directory
like we do in production.
3. Rework error handling for the git operations.
4. Move the git operations into their own file and unit test them.
5. Rework some other error handling after I found out the `.pipe`
doesn't propagate errors in node.

The performance cost of apply the template on the fly is something like
20 milliseconds which doesn't feel to bad because we're running six git
operations instead of two.