### PR TITLE
Drop some meta

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe 'building a single book' do
         it "doesn't have any xmlns declarations" do
           expect(contents).not_to include('xmlns=')
         end
+        it "doesn't have a meta generator" do
+          expect(contents).not_to include('<meta name="generator"')
+        end
+        it "doesn't have a meta description" do
+          expect(contents).not_to include('<meta name="description"')
+        end
         it "doesn't have any xml:lang tags" do
           expect(contents).not_to include('xml:lang=')
         end

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -525,6 +525,9 @@ sub _html5ify {
     # Strip xml lang tag. We already have the lang tag other places.
     $contents =~ s/\s+xml:lang="[^"]*"//g;
 
+    # Strip the generator tag because we don't need it
+    $contents =~ s|<meta name="generator" content="[^"]+" />||g;
+
     # Add a trailing newline because good documents have trailing newlines
     $contents =~ s/\s*$/\n/;
 

--- a/resources/website-l10n.xsl
+++ b/resources/website-l10n.xsl
@@ -50,9 +50,6 @@
         <l:template name="edit-me-title" text="Edit this page on GitHub" />
         <l:template name="edit-me-text" text="edit" />
       </l:context>
-      <l:context name="meta">
-        <l:template name="meta-description" text="Get started with the documentation for Elasticsearch, Kibana, Logstash, Beats, X-Pack, Elastic Cloud, Elasticsearch for Apache Hadoop, and our language clients." />
-      </l:context>
       <l:context name="annotation">
         <l:template name="added" text="Added in " />
         <l:template name="beta" text="beta" />
@@ -111,9 +108,6 @@
       <l:context name="edit-me">
         <l:template name="edit-me-title" text="在 GitHub 上编辑本页" />
         <l:template name="edit-me-text" text="编辑" />
-      </l:context>
-      <l:context name="meta">
-        <l:template name="meta-description" text="有关如何使用 Elasticsearch、Kibana、Logstash、Beats、X-Pack、Elastic Cloud、Elasticsearch for Apache Hadoop 及我们各种语言的客户端的文档。" />
       </l:context>
       <l:context name="annotation">
         <l:template name="added" text="添加于" />
@@ -174,9 +168,6 @@
         <l:template name="edit-me-title" text="GitHub上で編集" />
         <l:template name="edit-me-text" text="編集" />
       </l:context>
-      <l:context name="meta">
-        <l:template name="meta-description" text="Elasticsearch、Kibana、Logstash、Beats、X-Pack、Elastic Cloud、Elasticsearch for Apache Hadoop そして、さまざまな言語のクライアントの使用方法に関するドキュメント。" />
-      </l:context>
       <l:context name="annotation">
         <l:template name="added" text="追加されたバージョン：" />
         <l:template name="beta" text="ベータ版：" />
@@ -235,9 +226,6 @@
       <l:context name="edit-me">
         <l:template name="edit-me-title" text="GitHub에서 편집" />
         <l:template name="edit-me-text" text="편집" />
-      </l:context>
-      <l:context name="meta">
-        <l:template name="meta-description" text="Elasticsearch、Kibana、Logstash、Beats、X-Pack、Elastic Cloud、Elasticsearch for Apache Hadoop, 그 밖에 다양한 언어용 클라이언트 소개" />
       </l:context>
       <l:context name="annotation">
         <l:template name="added" text="추가" />

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -39,14 +39,6 @@
 
   <!-- meta elements -->
   <xsl:template name="user.head.content">
-    <xsl:variable name="meta-description">
-      <xsl:call-template name="gentext.template">
-        <xsl:with-param name="context" select="'meta'"/>
-        <xsl:with-param name="name" select="'meta-description'"/>
-      </xsl:call-template>
-    </xsl:variable>
-
-    <meta name="description" content="{$meta-description}" />
     <meta name="DC.type">
       <xsl:attribute name="content">
         <xsl:value-of select="$local.book.section.title" />


### PR DESCRIPTION
Drops some meta tags from the header. One is hard coded which seems
wrong. The other one isn't all that helpful.
