### PR TITLE
Create "current" stack version file

### DIFF
--- a/shared/versions/stack/README
+++ b/shared/versions/stack/README
@@ -11,14 +11,10 @@ branch.
 
 NOTE: `current.asciidoc` is never automatically used.
 
-Books outside of the stack have three choices:
+Books outside of the stack have two choices:
 
-1. Don't use these versions files at all.
-2. Use the `current.asciidoc` file.
-3. "Pin" theselves to some version of the stack.
-
-Not using these files is perfectly appopriate for books that don't link to the
-stack.
+1. Use the `current.asciidoc` file.
+2. "Pin" theselves to some version of the stack.
 
 Using `current.asciidoc` is useful because we'll update on whenever we release
 a new version of the stack so the doc will automatically update on release.

--- a/shared/versions/stack/README
+++ b/shared/versions/stack/README
@@ -24,6 +24,6 @@ Using `current.asciidoc` is useful because we'll update on whenever we release
 a new version of the stack so the doc will automatically update on release.
 
 "Pinning" the version of the stack that a book refers to is quite useful for
-old versions of books for which consistently see broken links when we release
+old versions of books for which we consistently see broken links when we release
 new versions of the docs. It could also be useful for books that need special
 care when bumping the stack version.

--- a/shared/versions/stack/README
+++ b/shared/versions/stack/README
@@ -16,7 +16,7 @@ Books outside of the stack have two choices:
 1. Use the `current.asciidoc` file.
 2. "Pin" theselves to some version of the stack.
 
-Using `current.asciidoc` is useful because we'll update on whenever we release
+Using `current.asciidoc` is useful because we'll update it whenever we release
 a new version of the stack so the doc will automatically update on release.
 
 "Pinning" the version of the stack that a book refers to is quite useful for

--- a/shared/versions/stack/README
+++ b/shared/versions/stack/README
@@ -1,0 +1,29 @@
+Books that are "part of the stack" include these files by looking at their
+branch. So the docs for Elasticsearch can use this:
+
+```
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
+```
+
+Which will resolve to the `6.3.asciidoc` file for he 6.3 branch. Or the
+`7.2.asciidoc` file for the 7.2 branch. Or `master.asciidoc` for the master
+branch.
+
+NOTE: `current.asciidoc` is never automatically used.
+
+Books outside of the stack have three choices:
+
+1. Don't use these versions files at all.
+2. Use the `current.asciidoc` file.
+3. "Pin" theselves to some version of the stack.
+
+Not using these files is perfectly appopriate for books that don't link to the
+stack.
+
+Using `current.asciidoc` is useful because we'll update on whenever we release
+a new version of the stack so the doc will automatically update on release.
+
+"Pinning" the version of the stack that a book refers to is quite useful for
+old versions of books for which consistently see broken links when we release
+new versions of the docs. It could also be useful for books that need special
+care when bumping the stack version.

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,0 +1,1 @@
+include::versions/stack/7.4.asciidoc[]


### PR DESCRIPTION
This file will be useful for books that *generally* want to point the
current release of the stack. We'll update it when we release a new
version of the stack.
