### PR TITLE
Switch Japanese XPack docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1277,6 +1277,7 @@ contents:
               lang:       ja
               tags:       X-Pack/Reference
               subject:    X-Pack
+              asciidoctor: true
               sources:
                 -
                   repo: x-pack


### PR DESCRIPTION
These are very, very old but we'd still like to be able to build
them with Asciidoctor so we can drop support for AsciiDoc all together.
