### PR TITLE
Serve air gapped template from preview

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -921,9 +921,11 @@ sub build_web_resources {
 
     # Copy the template to the root of the repo so we can apply it on the fly.
     # NOTE: We only apply it on the fly for preview right now.
-    my $template_source = file('resources/web/template.html');
-    my $template = $dest->file('template.html');
-    rcopy( $template_source, $template );
+    for ( qw(template air_gapped_template) ) {
+        my $template_source = file("resources/web/$_.html");
+        my $template = $dest->file("$_.html");
+        rcopy( $template_source, $template );
+    }
 }
 
 1

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -239,7 +239,6 @@ const branchInfo = host => {
   } else {
     template = "template.html";
   }
-  console.log("ASDF", template, prefix);
   return [template, prefix];
 }
 

--- a/resources/web/air_gapped_template.html
+++ b/resources/web/air_gapped_template.html
@@ -25,8 +25,6 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">
-    <meta name="naver-site-verification" content="936882c1853b701b3cef3721758d80535413dbfd" />
-    <meta name="yandex-verification" content="d8a47e95d0972434" />
     <meta name="localized" content="true" />
     <meta property="og:image" content="https://www.elastic.co/static/images/elastic-logo-200.png" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
@@ -45,23 +43,7 @@
   </head>
 
   <body>
-    <!-- Google Tag Manager -->
-    <script>dataLayer = [];</script><noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-58RLH5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-58RLH5');</script>
-    <!-- End Google Tag Manager -->
-    
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-12395217-16"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-      gtag('config', 'UA-12395217-16');
-    </script>
-
-    <div id='elastic-nav' style="display:none;"></div>
-    <script src='https://www.elastic.co/elastic-nav.js'></script>
-
+    <!-- TODO air gapped nav -->
     <!-- Subnav -->
     <div>
       <div>
@@ -88,36 +70,17 @@
                   <!-- end body -->
                 </div>
                 <div class="col-xs-12 col-sm-4 col-md-4" id="right_col">
-                  <div id="rtpcontainer" style="display: block;">
-                    <div class="mktg-promo">
-                      <h3>Getting Started Videos</h3>
-                      <ul class="icons">
-                        <li class="icon-elasticsearch-white"><a href="https://www.elastic.co/webinars/getting-started-elasticsearch?baymax=default&elektra=docs&storm=top-video">Starting Elasticsearch</a></li>
-                        <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Introduction to Kibana</a></li>
-                        <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/getting-started-logstash?baymax=default&elektra=docs&storm=top-video">Logstash Starter Guide</a></li>
-                      </ul>
-                    </div>
-                  </div>
                 </div>
               </div>
             </div>
           </section>
 
+          <!-- TODO air gapped footer -->
+
         </div>
-
-
-<div id='elastic-footer'></div>
-<script src='https://www.elastic.co/elastic-footer.js'></script>
-<!-- Footer Section end-->
-
       </section>
     </div>
 
-<script type="text/javascript">
-	var suggestionsUrl = "https://search.elastic.co/suggest";
-	var localeUrl = '{"relative_url_prefix":"/","code":"en-us","display_code":"en-us","url":"/guide_template"}';
-</script>
-<script src="/static/js/swiftype_app_search.umd.min.js"></script>
 <script type="text/javascript" src="/static/js/slick.min.js"></script>
 <script type="text/javascript" src="/guide/static/docs.js"></script>
 <!-- DOCS FINAL -->


### PR DESCRIPTION
This allows you to request the "air gapped" template from the preview
application by prefixing the branch name with `gapped_`. So you'd do
`http://gapped_master.docs-preview.app.elstc.co/guide` to see the master
branch with the air gapped template. It won't look good at all because
I've made no real effort to make it look right yet. That'll come in a
bit. For now, just seeing it is nice.

This also adds an air gapped template that drops some lines that
obviously aren't going to work properly when the docs are air gapped.
I've kept things like the favicon around because I believe we *should*
be able to make those work.

If you request the air gapped template from preview for a branch that
doesn't have a copy of the air gapped template then the request will
just 404.

Finally, I removed a few comments from the template because they don't
look like they really belong. I saw then when I was building the air
gapped template.
