### PR TITLE
Apply template on the fly with --doc

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -84,6 +84,7 @@ class OpenBrowserState:
     def __init__(self):
         self.need_nginx = True
         self.need_parcel = False
+        self.need_preview = False
         self.opened = False
 
     def building_single_book(self):
@@ -94,6 +95,7 @@ class OpenBrowserState:
         of the build before starting nginx so we don't have to wait for it.
         """
         self.need_parcel = True
+        self.need_preview = True
 
     def handle_line(self, line):
         if self.opened:
@@ -107,7 +109,12 @@ class OpenBrowserState:
             # server might not yet be up and nginx will fail to proxy to it.
             self.need_parcel = False
             show = False
-        if not self.need_nginx and not self.need_parcel:
+        if 'preview server is listening on 3000' in line:
+            self.need_preview = False
+            show = False
+        if not self.need_nginx and \
+                not self.need_parcel and \
+                not self.need_preview:
             if platform == "darwin" and 'BROWSER' not in environ:
                 # On mac webbrowser seeem to want to default to safari which
                 # is weird. If we tell it that the browser's name is `open`

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -125,7 +125,6 @@ sub build_local {
     say "Done";
 
     if ( $Opts->{open} ) {
-        # TODO wait for this to start before opening browser
         my $preview_pid = start_preview( 'fs', $raw_dir );
         serve_local_preview( $dir, 0, $web_resources_pid, $preview_pid );
     }

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -36,6 +36,7 @@ use ES::Util qw(
     write_nginx_test_config
     write_nginx_preview_config
     start_web_resources_watcher
+    start_preview
     build_web_resources
 );
 
@@ -123,7 +124,11 @@ sub build_local {
 
     say "Done";
 
-    serve_and_open_browser( $dir, 0, $web_resources_pid ) if $Opts->{open};
+    if ( $Opts->{open} ) {
+        # TODO wait for this to start before opening browser
+        my $preview_pid = start_preview( 'fs', $raw_dir );
+        serve_local_preview( $dir, 0, $web_resources_pid, $preview_pid );
+    }
 }
 
 #===================================
@@ -286,7 +291,7 @@ sub build_all {
     }
     $tracker->prune_out_of_date( @$contents );
     push_changes( $build_dir, $target_repo, $tracker ) if $Opts->{push};
-    serve_and_open_browser( $build_dir, $redirects, 0 ) if $Opts->{open};
+    serve_local_preview( $build_dir, $redirects, 0, 0 ) if $Opts->{open};
 
     $temp_dir->rmtree;
 }
@@ -621,39 +626,34 @@ sub preview {
     my $nginx_config = file('/tmp/nginx.conf');
     write_nginx_preview_config( $nginx_config );
 
-    if ( my $node_pid = fork ) {
+    if ( my $nginx_pid = fork ) {
         my ( $repos_dir, $temp_dir, $reference_dir ) = init_dirs();
 
         say "Cloning built docs";
         my $target_repo = init_target_repo( $repos_dir, $temp_dir, $reference_dir );
         say "Built docs are ready";
 
-        if ( my $nginx_pid = fork ) {
-            $SIG{TERM} = sub {
-                # We should be a good citizen and shut down the subprocesses.
-                # This isn't so important in k8s or docker because we shoot
-                # the entire container when we're done, but it is nice when
-                # testing.
-                say 'Terminating preview services...nginx';
-                kill 'TERM', $nginx_pid;
-                wait;
-                say 'Terminating preview services...node';
-                kill 'TERM', $node_pid;
-                wait;
-                say 'Terminated preview services';
-                exit 0;
-            };
-            while (1) {
-                sleep 1;
-                my $fetch_result = $target_repo->fetch;
-                say "$fetch_result" if ( $fetch_result );
-            }
-            exit;
-        } else {
-            close STDIN;
-            open( STDIN, "</dev/null" );
-            exec( qw(node --max-old-space-size=128 /docs_build/preview/preview.js) );
+        my $preview_pid = start_preview( 'git', '/docs_build/.repos/target_repo.git' );
+        $SIG{TERM} = sub {
+            # We should be a good citizen and shut down the subprocesses.
+            # This isn't so important in k8s or docker because we shoot
+            # the entire container when we're done, but it is nice when
+            # testing.
+            say 'Terminating preview services...nginx';
+            kill 'TERM', $nginx_pid;
+            wait;
+            say 'Terminating preview services...preview';
+            kill 'TERM', $preview_pid;
+            wait;
+            say 'Terminated preview services';
+            exit 0;
+        };
+        while (1) {
+            sleep 1;
+            my $fetch_result = $target_repo->fetch;
+            say "$fetch_result" if ( $fetch_result );
         }
+        exit;
     } else {
         close STDIN;
         open( STDIN, "</dev/null" );
@@ -801,32 +801,46 @@ sub pick_conf {
 }
 
 #===================================
-# Serve the documentation that we just built and open a browser to look at it.
+# Serve the documentation that we just built.
 #
 # docs_dir        - directory containing generated docs : Path::Class::dir
 # redirects_file  - file containing redirects or 0 if there aren't
 #                 - any redirects : Path::Class::file||0
+# web_resources_pid - pid of a subprocess that rebuilds the web resources on
+#                     the fly if we're running one or 0
+# preview_pid     - pid of the preview application or 0 if we're not running it
 #===================================
-sub serve_and_open_browser {
+sub serve_local_preview {
 #===================================
-    my ( $docs_dir, $redirects_file, $web_resources_pid ) = @_;
+    my ( $docs_dir, $redirects_file, $web_resources_pid, $preview_pid ) = @_;
 
-    if ( my $pid = fork ) {
+    if ( my $nginx_pid = fork ) {
         # parent
         $SIG{INT} = sub {
-            kill 'TERM', $pid;
-            kill 'TERM', $web_resources_pid if $web_resources_pid;
+            say 'Terminating preview services...nginx';
+            kill 'TERM', $nginx_pid;
+            wait;
+            if ( $preview_pid ) {
+                say 'Terminating preview services...preview';
+                kill 'TERM', $preview_pid;
+                wait;
+            }
+            if ( $web_resources_pid ) {
+                say 'Terminating preview services...parcel';
+                kill 'TERM', $web_resources_pid;
+                wait;
+            }
         };
         $SIG{TERM} = $SIG{INT};
 
         wait;
         say 'Terminated preview services';
         exit;
-    }
-    else {
+    } else {
         my $nginx_config = file('/tmp/nginx.conf');
         write_nginx_test_config(
-            $nginx_config, $docs_dir, $redirects_file, $web_resources_pid
+            $nginx_config, $docs_dir, $redirects_file,
+            $web_resources_pid, $preview_pid
         );
         close STDIN;
         open( STDIN, "</dev/null" );

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -24,4 +24,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec -e 'preview'
+	rspec

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -24,4 +24,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec
+	rspec -e 'preview'

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -133,10 +133,10 @@ class Dest
     @convert_statuses << status.exitstatus
   end
 
-  def run_convert_and_open(cmd)
+  def run_convert_and_open(cmd, uses_preview)
     cmd.unshift '/docs_build/build_docs.pl', '--in_standard_docker'
     cmd += ['--open']
-    OpenedDocs.new cmd
+    OpenedDocs.new cmd, uses_preview
   end
 
   class CmdBuilder
@@ -147,7 +147,7 @@ class Dest
     def open
       raise 'env unsupported' unless @env.empty?
 
-      @dest.run_convert_and_open @cmd
+      @dest.run_convert_and_open @cmd, uses_preview
     end
 
     def node_name(node_name)
@@ -183,6 +183,10 @@ class Dest
     def alternatives(source_lang, dest_lang, dir)
       @cmd += ['--alternatives', "#{source_lang}:#{dest_lang}:#{dir}"]
       self
+    end
+
+    def uses_preview
+      true
     end
   end
 
@@ -222,6 +226,10 @@ class Dest
     def sub_dir(repo, branch)
       @cmd += ['--sub_dir', "#{repo.name}:#{branch}:#{repo.root}"]
       self
+    end
+
+    def uses_preview
+      false
     end
   end
 end

--- a/integtest/spec/helper/opened_docs.rb
+++ b/integtest/spec/helper/opened_docs.rb
@@ -9,9 +9,11 @@ class OpenedDocs < ServingDocs
   # Reads the logs of the preview without updating them from the subprocess.
   attr_reader :logs
 
-  def initialize(cmd)
+  def initialize(cmd, uses_preview)
     super cmd
 
     wait_for_logs(/start worker processes$/, 60)
+    wait_for_logs(/^preview server is listening on 3000$/, 60) if uses_preview
+    puts "waited for preview #{uses_preview}"
   end
 end

--- a/preview/cli.js
+++ b/preview/cli.js
@@ -20,30 +20,31 @@
 
 'use strict';
 
-const fs = require('fs');
-const Template = require('./template');
-const yargs = require('yargs');
+const core = require("./core");
+const preview = require("./preview");
+const yargs = require("yargs");
 
 process.on('unhandledRejection', error => {
   console.error("unhandled rejection", error);
   process.exit(1);
 });
 
-const argv = yargs
-  .usage('./$0 - follow ye instructions true')
-  .option("template", {describe: "Path to the template"}).string("template")
-  .option("source", {describe: "Path to the source files"}).string("source")
-  .option("dest", {describe: "Path to write the templated files"}).string("dest")
-  .option("tocmode", {describe: "Are we building a table of contents?"}).boolean("tocmode")
-  .demandOption(["template", "source", "dest"])
+yargs
+  .command({
+    command: "git <repo>",
+    desc: "Serve a repo",
+    handler: argv => {
+      preview(core.Git(argv.repo));
+    },
+  })
+  .command({
+    command: "fs <path>",
+    desc: "Serve some files from disk",
+    handler: argv => {
+      preview(core.Fs(argv.path));
+    },
+  })
   .version(false)
+  .demandCommand()
   .help()
   .argv;
-
-(async () => {
-  const template = await Template(() => fs.createReadStream(argv.template, {
-    encoding: 'UTF-8',
-    autoDestroy: true,
-  }));
-  await template.applyToDir(argv.source, argv.dest, argv.tocmode);
-})();

--- a/preview/core.js
+++ b/preview/core.js
@@ -35,7 +35,7 @@ const GitCore = repoPath => {
     if (!hostPrefix) {
       return ["template.html", "master"];
     }
-    let prefix = host.substring(0, dot);
+    let prefix = hostPrefix;
     let template;
     if (prefix.startsWith("gapped_")) {
       template = "air_gapped_template.html";
@@ -74,9 +74,9 @@ const GitCore = repoPath => {
               hasTemplate: templateExists,
               stream: git.catBlob(requestedObject),
               template: () => git.catBlob(`${branch}:${templateName}`),
-              lang: () => git.catBlobToString(`${dir}lang`),
+              lang: () => git.catBlobToString(`${dir}/lang`),
               alternativesReport: () => git.catBlobToString(
-                `${dir}alternatives_summary.json`, 10 * 1024
+                `${dir}/alternatives_summary.json`, 10 * 1024
               ),
             };
           default:

--- a/preview/core.js
+++ b/preview/core.js
@@ -1,0 +1,208 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+const fs = require("fs");
+const dedent = require("dedent");
+const Git = require("./git");
+const path = require("path");
+const { Readable } = require("stream");
+const { promisify } = require('util');
+
+const stat = promisify(fs.stat);
+const readFile = promisify(fs.readFile);
+
+const GitCore = repoPath => {
+  const hostInfo = hostPrefix => {
+    if (!hostPrefix) {
+      return ["template.html", "master"];
+    }
+    let prefix = host.substring(0, dot);
+    let template;
+    if (prefix.startsWith("gapped_")) {
+      template = "air_gapped_template.html";
+      prefix = prefix.substring("gapped_".length);
+    } else {
+      template = "template.html";
+    }
+    return [template, prefix];
+  };
+
+  const git = Git(repoPath);
+  return hostPrefix => {
+    const [templateName, branch] = hostInfo(hostPrefix);
+
+    return {
+      diff: () => Readable.from(bufferItr(diffItr(git, branch), 16 * 1024)),
+      file: async requestedPath => {
+        const templateExists = await hasTemplate(git, branch);
+        /*
+         * We're using the existence of the template to check if the branch is
+         * "ready" for templating on the fly. There are a few changes that came in
+         * with that preparation, like making sure all of the required js is written
+         * to the `raw` directory as well.
+         */
+        const pathPrefix = templateExists ? "raw" : "html";
+        const requestedObject = `${branch}:${pathPrefix}${requestedPath}`;
+        const objectType = await git.objectType(requestedObject);
+        switch (objectType) {
+          case "missing":
+            return "missing";
+          case "tree":
+            return "dir";
+          case 'blob':
+            const dir = path.dirname(requestedObject);
+            return {
+              hasTemplate: templateExists,
+              stream: git.catBlob(requestedObject),
+              template: () => git.catBlob(`${branch}:${templateName}`),
+              lang: () => git.catBlobToString(`${dir}lang`),
+              alternativesReport: () => git.catBlobToString(
+                `${dir}alternatives_summary.json`, 10 * 1024
+              ),
+            };
+          default:
+            throw new Error(`Don't know how to return ${objecType}`);
+        }
+      },
+    };
+  };
+};
+
+const FsCore = rootPath => {
+  return hostPrefix => {
+    const template = "gapped" === hostPrefix ? "air_gapped_template.html" : "template.html";
+    const readAlternativesReport = async dir => {
+      try {
+        return await readFile(`${dir}alternatives_summary.json`, { encoding: "utf8" });
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          throw "missing";
+        }
+        throw err;
+      }
+    };
+    return {
+      diff: () => {
+        const r = new Readable;
+        r.push("diff not supported");
+        r.push(null);
+        return r;
+      },
+      file: async requestedPath => {
+        const realPath = `${rootPath}/${requestedPath}`;
+        let pathStat;
+        try {
+          pathStat = await stat(realPath);
+        } catch (err) {
+          if (err.code === "ENOENT") {
+            return "missing";
+          }
+          throw err;
+        }
+        if (pathStat.isDirectory()) {
+          return "dir";
+        }
+        const dir = path.dirname(realPath);
+        return {
+          hasTemplate: true,
+          stream: fs.createReadStream(realPath),
+          template: () => fs.createReadStream(`/docs_build/resources/web/${template}`),
+          lang: () => readFile(`${dir}lang`, { encoding: "utf8" }),
+          alternativesReport: () => readAlternativesReport(dir),
+        };
+      }
+    };
+  };
+};
+
+module.exports = {
+  Git: GitCore,
+  Fs: FsCore,
+};
+
+const hasTemplate = async (git, branch) => {
+  const type = await git.objectType(`${branch}:template.html`);
+  switch (type) {
+    case 'blob':
+      return true;
+    case 'missing':
+      return false;
+    default:
+      throw new Error(`The template is a strange object type: ${type}`);
+  }
+}
+
+/**
+ * Buffers an async iterator until its output is at least min characters
+ * @param {Generator} itr async iterator that returns a string to buffer 
+ */
+const bufferItr = async function* (itr, min) {
+  let buffer = '';
+  for await (const chunk of itr) {
+    buffer += chunk;
+    if (buffer.length > min) {
+      yield buffer;
+    }
+  }
+  yield buffer;
+};
+
+/**
+ * Creates an async iterator describing the diff. The iterator is very "chatty"
+ * so is probably best wrapped in bufferItr.
+ * @param {string} branch branch to describe
+ */
+const diffItr = async function* (git, branch) {
+  yield dedent `
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <title>Diff for ${branch}</title>
+    </head>
+    <body><ul>\n`;
+
+  let sawAny = false;
+  for await (const change of git.diffLastCommit(branch)) {
+    // Skip boring files
+    if (!change.path.startsWith("raw/")) {
+      continue;
+    }
+    // Strip the prefixes from the paths
+    change.path = change.path.substring("raw/".length);
+    if (change.movedToPath) {
+      change.movedToPath = change.movedToPath.substring("raw/".length);
+    }
+
+    // Build the output html
+    yield `  <li>+${change.added} -${change.removed}`;
+    const linkTarget = change.movedToPath ? change.movedToPath : change.path;
+    yield ` <a href="/guide/${linkTarget}">`;
+    yield change.movedToPath ? `${change.path} -> ${change.movedToPath}` : change.path;
+    yield `</a>\n`;
+    sawAny = true;
+  }
+  yield `</ul>`;
+  if (!sawAny) {
+    yield `<p>There aren't any differences!</p>`;
+  }
+  yield `</html>\n`;
+};

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -20,84 +20,59 @@
 
 'use strict';
 
-/*
- * Little server that listens for requests in the form of
- * `${branch}.host/guide/${doc}`, looks up the doc from git and streams
- * it back over the response.
- */
-
-const dedent = require("dedent");
-const Git = require("./git");
 const http = require("http");
 const path = require("path");
-const { Readable } = require("stream");
-const Template = require("../template/template");
 const url = require("url");
+const Template = require("../template/template");
 
 const port = 3000;
-const git = Git("/docs_build/.repos/target_repo.git");
 
-const requestHandler = async (request, response) => {
-  const parsedUrl = url.parse(request.url);
-  const [templateName, branch] = branchInfo(request.headers['host']);
+const requestHandler = async (core, parsedUrl, response) => {
   if (parsedUrl.pathname === '/diff') {
-    return serveDiff(branch, response);
+    return new Promise((resolve, reject) => {
+      pipeToResponse(core.diff(), response, resolve, reject);
+    });
   }
   if (!parsedUrl.pathname.startsWith('/guide')) {
     response.statusCode = 404;
     response.end();
     return;
   }
-  const templateExists = await checkIfTemplateExists(branch);
-  /*
-   * We're using the existence of the template to check if the branch is
-   * "ready" for templating on the fly. There are a few changes that came in
-   * with that preparation, like making sure all of the required js is written
-   * to the `raw` directory as well.
-   */
-  const pathPrefix = templateExists ? "raw" : "html";
-  const path = pathPrefix + parsedUrl.pathname.substring("/guide".length);
-  const requestedObject = `${branch}:${path}`;
 
-  const objectType = await git.objectType(requestedObject);
-  switch (objectType) {
-    case 'missing':
-      response.statusCode = 404;
-      response.end(`Can't find ${requestedObject}\n`);
-      return;
-    case 'tree':
-      response.statusCode = 301;
-      const sep = requestedObject.endsWith('/') ? '' : '/';
-      response.setHeader('Location', `${parsedUrl.pathname}${sep}index.html`);
-      response.end();
-      return;
-    case 'blob':
-      return serveBlob(response, templateName, branch, templateExists, requestedObject);
-    default:
-      throw new Error(`Don't know how to return ${objecType}`);
+  const path = parsedUrl.pathname.substring("/guide".length);
+  const type = contentType(path);
+  const file = await core.file(path, type);
+  if (file === "dir") {
+    response.statusCode = 301;
+    const sep = parsedUrl.pathname.endsWith('/') ? '' : '/';
+    response.setHeader('Location', `${parsedUrl.pathname}${sep}index.html`);
+    response.end();
+    return;
+  }
+  if (file === "missing") {
+    response.statusCode = 404;
+    response.end(`Can't find ${parsedUrl.pathname}\n`);
+    return;
+  }
+
+  response.setHeader('Content-Type', type);
+  if (file.hasTemplate && type === "text/html; charset=utf-8") {
+    const template = Template(file.template);
+    const lang = await file.lang();
+    const initialJsState = await buildInitialJsState(file.alternativesReport);
+    const templated = template.apply(
+      file.stream[Symbol.asyncIterator](), lang.trim(), initialJsState
+    );
+    return new Promise((resolve, reject) => {
+      file.stream.on("error", reject);
+      pipeToResponse(templated, response, resolve, reject);
+    });
+  } else {
+    return new Promise((resolve, reject) => {
+      pipeToResponse(file.stream, response, resolve, reject);
+    });
   }
 }
-
-const checkIfTemplateExists = async branch => {
-  const type = await git.objectType(`${branch}:template.html`);
-  switch (type) {
-    case 'blob':
-      return true;
-    case 'missing':
-      return false;
-    default:
-      throw new Error(`The template is a strange object type: ${type}`);
-  }
-};
-
-const serveDiff = (branch, response) => {
-  return new Promise((resolve, reject) => {
-    pipeToResponse(
-      Readable.from(bufferItr(diffItr(branch), 16 * 1024)),
-      response, resolve, reject
-    );
-  });
-};
 
 const pipeToResponse = (out, response, resolve, reject) => {
   response.on("close", resolve);
@@ -106,80 +81,8 @@ const pipeToResponse = (out, response, resolve, reject) => {
   out.pipe(response);
 }
 
-/**
- * Buffers an async iterator until its output is at least min characters
- * @param {Generator} itr async iterator that returns a string to buffer 
- */
-const bufferItr = async function* (itr, min) {
-  let buffer = '';
-  for await (const chunk of itr) {
-    buffer += chunk;
-    if (buffer.length > min) {
-      yield buffer;
-    }
-  }
-  yield buffer;
-}
-
-/**
- * Creates an async iterator describing the diff. The iterator is very "chatty"
- * so is probably best wrapped in bufferItr.
- * @param {string} branch branch to describe
- */
-const diffItr = async function* (branch) {
-  yield dedent `
-    <!DOCTYPE html>
-    <html>
-    <head>
-      <title>Diff for ${branch}</title>
-    </head>
-    <body><ul>\n`;
-
-  let sawAny = false;
-  for await (const change of git.diffLastCommit(branch)) {
-    // Skip boring files
-    if (!change.path.startsWith("raw/")) {
-      continue;
-    }
-    // Strip the prefixes from the paths
-    change.path = change.path.substring("raw/".length);
-    if (change.movedToPath) {
-      change.movedToPath = change.movedToPath.substring("raw/".length);
-    }
-
-    // Build the output html
-    yield `  <li>+${change.added} -${change.removed}`;
-    const linkTarget = change.movedToPath ? change.movedToPath : change.path;
-    yield ` <a href="/guide/${linkTarget}">`;
-    yield change.movedToPath ? `${change.path} -> ${change.movedToPath}` : change.path;
-    yield `</a>\n`;
-    sawAny = true;
-  }
-  yield `</ul>`;
-  if (!sawAny) {
-    yield `<p>There aren't any differences!</p>`;
-  }
-  yield `</html>\n`;
-};
-
-const serveBlob = (response, templateName, branch, templateExists, requestedObject) => {
-  return new Promise((resolve, reject) => {
-    let raw = git.catBlob(requestedObject);
-    const type = contentType(requestedObject);
-    response.setHeader('Content-Type', type);
-    if (templateExists && type === "text/html; charset=utf-8") {
-      raw.on("error", reject);
-      applyTemplate(branch, templateName, requestedObject, raw)
-        .then(out => pipeToResponse(out, response, resolve, reject))
-        .catch(reject);
-    } else {
-      pipeToResponse(raw, response, resolve, reject);
-    }
-  });
-};
-
-const contentType = requestedObject => {
-  const ext = path.extname(requestedObject);
+const contentType = rawPath => {
+  const ext = path.extname(rawPath);
   switch (ext) {
     case ".css":
       return "text/css";
@@ -200,79 +103,65 @@ const contentType = requestedObject => {
   }
 };
 
-const applyTemplate = async (branch, templateName, requestedObject, raw) => {
-  const template = Template(() => git.catBlob(`${branch}:${templateName}`));
-  const lang = await loadLang(requestedObject);
-  const initialJsState = await loadInitialJsState(requestedObject);
-  return template.apply(raw[Symbol.asyncIterator](), lang, initialJsState);
-};
-
-const loadLang = async requestedObject => {
-  const langPath = path.dirname(requestedObject) + "/lang";
-  return (await git.catBlobToString(langPath)).trim();
-};
-
-const loadInitialJsState = async requestedObject => {
+const buildInitialJsState = async alternativesReportSource => {
   try {
-    const reportPath = path.dirname(requestedObject) + "/alternatives_summary.json";
-    const summary = JSON.parse(await git.catBlobToString(reportPath, 10 * 1024));
-    return JSON.stringify(Template.buildInitialJsState(summary));
+    const parsed = JSON.parse(await alternativesReportSource());
+    return JSON.stringify(Template.buildInitialJsState(parsed));
   } catch (err) {
     if (err === "missing") {
       return "{}";
-    } else {
-      throw err;
     }
+    throw err;
   }
 };
 
-const branchInfo = host => {
+const hostPrefix = host => {
+  if (!host) {
+    return null;
+  }
   const dot = host.indexOf(".");
   if (dot === -1) {
-    return ["template.html", "master"];
+    return null;
   }
-  let prefix = host.substring(0, dot);
-  let template;
-  if (prefix.startsWith("gapped_")) {
-    template = "air_gapped_template.html";
-    prefix = prefix.substring("gapped_".length);
-  } else {
-    template = "template.html";
-  }
-  return [template, prefix];
-}
+  return host.substring(0, dot);
+};
 
-const server = http.createServer((request, response) => {
-  requestHandler(request, response)
-    .catch(err => {
-      if (err === "missing") {
-        response.statusCode = 404;
-        response.end("404!");
-      } else {
-        console.warn('unhandled error for', request, err);
-        /*
-         * *try* to set the status code to 500. This might not be possible
-         * because we might be in the middle of a chunked transfer. In that
-         * case this'll look funny.
-         */
-        response.statusCode = 500;
-        response.end(err.message);
-      }
-    });
-});
-
-server.listen(port, err => {
-  if (err) {
-    console.error("preview server couldn't listen", err);
-    process.exit(1);
-  }
-
-  console.info(`preview server is listening on ${port}`);
-});
-
-process.on('SIGTERM', () => {
-  console.info('preview server shutting down');
-  server.close(() => {
-    process.exit();
+module.exports = Core => {
+  const server = http.createServer((request, response) => {
+    const parsedUrl = url.parse(request.url);
+    const prefix = hostPrefix(request.headers['host']);
+    const core = Core(prefix);
+    requestHandler(core, parsedUrl, response)
+      .catch(err => {
+        if (err === "missing") {
+          response.statusCode = 404;
+          response.end("404!");
+        } else {
+          console.warn('unhandled error for', prefix, parsedUrl, err);
+          /*
+           * *try* to set the status code to 500. This might not be possible
+           * because we might be in the middle of a chunked transfer. In that
+           * case this'll look funny.
+           */
+          response.statusCode = 500;
+          response.end(err.message);
+        }
+      });
   });
-});
+
+  server.listen(port, err => {
+    if (err) {
+      console.error("preview server couldn't listen", err);
+      process.exit(1);
+    }
+
+    console.info(`preview server is listening on ${port}`);
+  });
+
+  process.on('SIGTERM', () => {
+    console.info('preview server shutting down');
+    server.close(() => {
+      process.exit();
+    });
+  });
+};

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -58,8 +58,11 @@ const requestHandler = async (core, parsedUrl, response) => {
   response.setHeader('Content-Type', type);
   if (file.hasTemplate && type === "text/html; charset=utf-8") {
     const template = Template(file.template);
+    console.log("asdfadsf1");
     const lang = await file.lang();
+    console.log("asdfadsf2");
     const initialJsState = await buildInitialJsState(file.alternativesReport);
+    console.log("asdfadsf3");
     const templated = template.apply(
       file.stream[Symbol.asyncIterator](), lang.trim(), initialJsState
     );
@@ -105,7 +108,9 @@ const contentType = rawPath => {
 
 const buildInitialJsState = async alternativesReportSource => {
   try {
+    console.log("checking alternatives");
     const parsed = JSON.parse(await alternativesReportSource());
+    console.log("building initial js");
     return JSON.stringify(Template.buildInitialJsState(parsed));
   } catch (err) {
     if (err === "missing") {


### PR DESCRIPTION
This applies the template on the fly when building docs locally. This is
useful for quickly iterating on the template. It also allows you to get
the air gapped template for the doc by requesting
`gapped.localhost:8000/guide`.

I implemented this by extracting the git logic for the preview service
into a "git core" and adding a new "fs core" which can serve documents
from the local filesystem. I like this particular implementation because
it gives us fewer things to test because almost everything is going
through the preview application.

It doesn't apply the template on the fly to `--all --open` because
*that* is supposed to be a more "production like" test. And, at least
for now, production uses nginx to serve static files locally.
