### PR TITLE
Make Curator 5.8 the current release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -516,7 +516,7 @@ contents:
           -
             title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
-            current:    5.7
+            current:    5.8
             branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator


### PR DESCRIPTION
Just changed 5.7 to 5.8 here. The 5.8 branch has been building stably for some time, so I don't think there should be any issues.