### PR TITLE
Add APM Node.js 3.x documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1110,7 +1110,7 @@ contents:
                     title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    2.x
-                    branches:   [ master, 2.x, 1.x, 0.x ]
+                    branches:   [ master, 3.x, 2.x, 1.x, 0.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Adds the `3.x` branch of the APM Node.js Agent to the documentation build.

When the branch is ready, we'll need to run the ci/docs test again with:
```
@elasticmachine, run elasticsearch-ci/docs rebuild
``` 