### PR TITLE
Limit git gc's memory usage

### DIFF
--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -3,6 +3,11 @@ from docker.elastic.co/docs/build:1
 RUN mkdir /var/log/nginx
 RUN mkdir -p /run/nginx
 
+# Limit the memory used by git gc so we can be good k8s citizens.
+RUN git config --global pack.windowMemory 500m
+RUN git config --global pack.deltaCacheSize 10m
+RUN git config --global pack.threads 1
+
 COPY build_docs.pl /docs_build/
 COPY conf.yaml /docs_build/
 COPY lib /docs_build/lib

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh built-docs.git
-docker build -t docker.elastic.co/docs/preview:5 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:6 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:5 \
+          docker.elastic.co/docs/preview:6 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:5
+export PREVIEW=docker.elastic.co/docs/preview:6
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
This limits `git gc`'s memory usage. I chose a single thread because all
of the memory is per thread. I chose a small window size because I
[heard][so] that it isn't particularly useful. Even if it were, it'd make
the compressed result smaller which isn't currently super important to
us. I went with 500mb as the limit for the window because this seemed
more useful.

[so]: https://stackoverflow.com/a/27839473
