### PR TITLE
Fix toc in preview

### DIFF
--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     let(:robots_txt) { get watermark, branch, 'robots.txt' }
     let(:root) { get watermark, branch, 'guide/index.html' }
     let(:current_index) { get watermark, branch, "#{current_url}/index.html" }
+    let(:current_toc) { get watermark, branch, "#{current_url}/toc.html" }
     let(:cat_image) do
       get watermark, branch, "#{current_url}/resources/readme/cat.jpg"
     end
@@ -141,6 +142,11 @@ RSpec.describe 'previewing built docs', order: :defined do
         expect(current_index).to serve(include(<<~HTML.strip))
           <section id="guide" lang="#{expected_language}">
         HTML
+      end
+    end
+    context 'the current table of contents' do
+      it "isn't templated" do
+        expect(current_toc).to serve(start_with('<div class="toc">'))
       end
     end
     it 'serves a "go away" robots.txt' do

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe 'building a single book' do
           expect(contents).to initial_js_state(be_nil)
         end
       end
+      page_context 'raw/toc.html'
       page_context 'raw/index.html' do
         it "doesn't have the xml prolog" do
           expect(contents).not_to include('?xml')
@@ -571,6 +572,7 @@ RSpec.describe 'building a single book' do
         http.request(req)
       end
     end
+    let(:toc) { Net::HTTP.get_response(URI("#{root}/toc.html")) }
     let(:js) do
       Net::HTTP.get_response(URI("#{static}/docs.js"))
     end
@@ -602,6 +604,11 @@ RSpec.describe 'building a single book' do
             <a href="chapter.html">Chapter
           HTML
         end
+      end
+    end
+    context 'the table of contents' do
+      it "isn't templated" do
+        expect(toc).not_to serve(start_with('<div class="toc">'))
       end
     end
 

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -608,7 +608,7 @@ RSpec.describe 'building a single book' do
     end
     context 'the table of contents' do
       it "isn't templated" do
-        expect(toc).not_to serve(start_with('<div class="toc">'))
+        expect(toc).to serve(start_with('<div class="toc">'))
       end
     end
 

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -187,8 +187,8 @@ sub build_chunked {
         $child_dest->spew( iomode => '>:utf8', $contents );
         unlink $_ or die "Coudln't remove $_ $!";
     }
+    extract_toc_from_index( $raw_dest );
     finish_build( $index->parent, $raw_dest, $dest, $lang, 0 );
-    extract_toc_from_index( $dest );
     $chunk_dir->rmtree;
 }
 

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -56,7 +56,7 @@ const requestHandler = async (core, parsedUrl, response) => {
   }
 
   response.setHeader('Content-Type', type);
-  if (file.hasTemplate && type === "text/html; charset=utf-8") {
+  if (file.hasTemplate && !path.endsWith("toc.html") && type === "text/html; charset=utf-8") {
     const template = Template(file.template);
     const lang = await file.lang();
     const initialJsState = await buildInitialJsState(file.alternativesReport);

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh built-docs.git
-docker build -t docker.elastic.co/docs/preview:6 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:7 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:6 \
+          docker.elastic.co/docs/preview:7 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:6
+export PREVIEW=docker.elastic.co/docs/preview:7
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image

--- a/template/template.js
+++ b/template/template.js
@@ -141,6 +141,7 @@ module.exports = templateSource => {
     const langFile = `${sourcePath}/lang`;
     const alternativesSummaryFile = `${sourcePath}/alternatives_summary.json`;
     const alternativesReportFile = `${sourcePath}/alternatives_report.json`;
+    const tocFile = `${sourcePath}/toc.html`;
     const initialJsState = await buildInitialJsStateFromFile(alternativesSummaryFile);
     const lang = (await readFile(langFile, {
       encoding: "utf8",
@@ -178,7 +179,7 @@ module.exports = templateSource => {
         }
         continue;
       }
-      if (!basename.endsWith(".html")) {
+      if (source === tocFile || !basename.endsWith(".html")) {
         await recursiveCopy(source, dest);
         continue;
       }


### PR DESCRIPTION
Fix the table of contents in the preview and `--doc --open` modes.
Without this the table of contents just *doesn't* show up. With this we
continue to perform client side merging of the toc into the page.

Now that we're templating on the fly it is tempting to merge the toc at
template time, but that won't work in production because we're not
templating on the fly in production. Yet.
