### PR TITLE
Drop ie8 and social stuff from air gapped

### DIFF
--- a/resources/web/air_gapped_template.html
+++ b/resources/web/air_gapped_template.html
@@ -26,7 +26,6 @@
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
     <meta name="theme-color" content="#ffffff">
     <meta name="localized" content="true" />
-    <meta property="og:image" content="https://www.elastic.co/static/images/elastic-logo-200.png" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" sizes="64x64" href="/favicon_64x64_16bit.png">
@@ -34,11 +33,6 @@
     <link rel="apple-touch-icon-precomposed" sizes="16x16" href="/favicon_16x16.png">
     <script src="/static/js/jquery.min.js"></script>
     <script src="/static/js/bootstrap.min.js"></script>
-    <!-- Give IE8 a fighting chance -->
-    <!--[if lt IE 9]>
-    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
-    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
-    <![endif]-->
     <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 


### PR DESCRIPTION
Drops our "best effort" for IE8 from the air gapped network template
because it requires access to the external web. We *could* bundle it but
it doesn't seem worth it for IE8.

Drops our `og:image` because that is used by facebook when linking to
the page. The air gapped docs aren't going to be linked to facebook
anyway. And that link is the last reference to www.elastic.co on the
template.
