### PR TITLE
Adds transform redirects

### DIFF
--- a/resources/legacy_redirects.conf
+++ b/resources/legacy_redirects.conf
@@ -1157,3 +1157,15 @@ rewrite (?i)^/guide/en/elasticsearch/reference/current/preview-data-frame-transf
 rewrite (?i)^/guide/en/elasticsearch/reference/current/start-data-frame-transform.html /guide/en/elasticsearch/reference/current/start-transform.html permanent;
 rewrite (?i)^/guide/en/elasticsearch/reference/current/stop-data-frame-transform.html /guide/en/elasticsearch/reference/current/stop-transform.html permanent;
 rewrite (?i)^/guide/en/elasticsearch/reference/current/data-frame-transform-resource.html /guide/en/elasticsearch/reference/current/transform-resource.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/ml-dataframes.html /guide/en/elasticsearch/reference/master/transforms.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/ml-transform-overview.html /guide/en/elasticsearch/reference/master/transform-overview.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/ml-transforms-usage.html /guide/en/elasticsearch/reference/master/transform-usage.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/ml-transform-checkpoints.html /guide/en/elasticsearch/reference/master/transform-checkpoints.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/df-api-quickref.html /guide/en/elasticsearch/reference/master/transform-api-quickref.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/dataframe-examples.html /guide/en/elasticsearch/reference/master/transform-examples.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/ecommerce-dataframes.html /guide/en/elasticsearch/reference/master/ecommerce-transforms.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/example-best-customers.html /guide/en/elasticsearch/reference/master/transform-examples.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/example-airline.html /guide/en/elasticsearch/reference/master/transform-examples.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/example-clientips.html /guide/en/elasticsearch/reference/master/transform-examples.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/dataframe-troubleshooting.html /guide/en/elasticsearch/reference/master/transform-troubleshooting.html permanent;
+rewrite (?i)^/guide/en/elastic-stack-overview/master/dataframe-limitations.html /guide/en/elasticsearch/reference/master/transform-limitations.html permanent;

--- a/resources/legacy_redirects.conf
+++ b/resources/legacy_redirects.conf
@@ -1169,3 +1169,6 @@ rewrite (?i)^/guide/en/elastic-stack-overview/master/example-airline.html /guide
 rewrite (?i)^/guide/en/elastic-stack-overview/master/example-clientips.html /guide/en/elasticsearch/reference/master/transform-examples.html permanent;
 rewrite (?i)^/guide/en/elastic-stack-overview/master/dataframe-troubleshooting.html /guide/en/elasticsearch/reference/master/transform-troubleshooting.html permanent;
 rewrite (?i)^/guide/en/elastic-stack-overview/master/dataframe-limitations.html /guide/en/elasticsearch/reference/master/transform-limitations.html permanent;
+rewrite (?i)^/guide/en/kibana/master/creating-df-kib.html /guide/en/elasticsearch/reference/master/ecommerce-transforms.html permanent;
+rewrite (?i)^/guide/en/kibana/master/ml-jobs.html /guide/en/elastic-stack-overview/master/create-jobs.html permanent;
+rewrite (?i)^/guide/en/kibana/master/job-tips.html /guide/en/elastic-stack-overview/master/job-tips.html permanent;


### PR DESCRIPTION
This PR adds redirects for transform content that was moved from the Stack Overview to the Elasticsearch Guide.  It also adds redirects for machine learning content that was moved from the Kibana Guide to the Stack Overview.

These redirects enable us to remove the matching "deleted pages" from the end of the books.