### PR TITLE
Air gapped docs in a docker image

### DIFF
--- a/.ci/publish_air_gapped_docs.sh
+++ b/.ci/publish_air_gapped_docs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -eo pipefail
+
+./air_gapped/build.sh
+# TODO publish

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ bin
 metastore_db
 html_docs/
 vendor
+air_gapped/work
 
 # Compiled docs.js
 .cache/

--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.elastic.co/docs/preview:7
+
+COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
+
+CMD ["/docs_build/build_docs.pl", "--in_standard_docker", "--gapped", \
+     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]

--- a/air_gapped/Dockerfile.dockerignore
+++ b/air_gapped/Dockerfile.dockerignore
@@ -1,0 +1,2 @@
+*
+!air_gapped

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Build the docker image for the air gapped docs.
+
+set -eo pipefail
+
+if [[ ! -d ~/.git-references/built-docs.git ]]; then
+  echo "~/.git-references/built-docs.git must exist and contain a reference clone of the built-docs repo"
+  exit 1
+fi
+
+# Get an up to date copy of the repo
+rm -rf air_gapped/work
+mkdir air_gapped/work
+git clone --reference ~/.git-references/built-docs.git --dissociate \
+  --depth 2 --branch master --bare \
+  git@github.com:elastic/built-docs.git air_gapped/work/target_repo.git
+GIT_DIR=air_gapped/work/target_repo.git git fetch
+
+# Build the images
+./build_docs --just-build-image
+docker build -t docker.elastic.co/docs/preview:7 -f preview/Dockerfile .
+# Use buildkit here to pick up the customized dockerignore file
+DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs/air_gapped:latest -f air_gapped/Dockerfile .

--- a/air_gapped/test.sh
+++ b/air_gapped/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Performs a quick and dirty local test on the air gapped docs. Because this
+# runs as it would in k8s you'll need to `docker kill` it when you are done.
+# We do have integration tests for this in integtest/spec/air_gapped_spec.rb
+# which are much faster because they don't use real data but this is useful too.
+
+set -e
+
+cd $(git rev-parse --show-toplevel)
+
+./air_gapped/build.sh
+id=$(docker run --rm \
+          --publish 8000:8000/tcp \
+          -d \
+          docker.elastic.co/docs/air_gapped:latest)
+echo "Started the air gapped docs. Some useful commands:"
+echo "   docker kill $id"
+echo "   docker logs -tf $id"
+echo "You should eventually be able to access:"
+echo "   http://master.localhost:8000/guide/index.html"

--- a/integtest/spec/air_gapped_spec.rb
+++ b/integtest/spec/air_gapped_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'net/http'
+
+##
+# Test for the air gapped deploy of the docs. For the most part the air gapped
+# deploy is the same as a preview that doesn't attempt to update itself so we
+# don't test a ton of things here.
+RSpec.describe 'air gapped deploy', order: :defined do
+  convert_before do |src, dest|
+    repo = src.repo_with_index 'repo', <<~ASCIIDOC
+      Some text.
+    ASCIIDOC
+    book = src.book 'Test'
+    book.source repo, 'index.asciidoc'
+    dest.convert_all src.conf
+  end
+  before(:context) do
+    @air_gapped = @dest.start_air_gapped
+  end
+  after(:context) do
+    @air_gapped&.exit
+  end
+  let(:air_gapped) { @air_gapped }
+
+  let(:root) { 'http://localhost:8000/guide' }
+  let(:books_index) { Net::HTTP.get_response(URI("#{root}/index.html")) }
+
+  context 'the logs' do
+    it "don't contain anything git" do
+      air_gapped.wait_for_logs(/Built docs are ready/, 10)
+      expect(air_gapped.logs).not_to include('Cloning built docs')
+      expect(air_gapped.logs).not_to include('git')
+    end
+  end
+
+  context 'the books index' do
+    it 'links to the book' do
+      expect(books_index).to serve(doc_body(include(<<~HTML.strip)))
+        <a class="ulink" href="test/current/index.html" target="_top">Test</a>
+      HTML
+    end
+    it 'logs the access to the docs root' do
+      air_gapped.wait_for_logs %r{localhost:8000 GET /guide/index.html}, 10
+      expect(air_gapped.logs).to include(<<~LOGS)
+        localhost:8000 GET /guide/index.html HTTP/1.1 200
+      LOGS
+    end
+    it 'uses the air gapped template' do
+      expect(books_index).not_to serve(include(<<~HTML.strip))
+        https://www.googletagmanager.com/gtag/js
+      HTML
+    end
+  end
+end

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'fileutils'
 require 'open3'
 
 require_relative 'opened_docs'
@@ -98,6 +99,17 @@ class Dest
   # Start the preview service.
   def start_preview
     Preview.new(bare_repo)
+  end
+
+  ##
+  # Start the preview service in air gapped mode.
+  def start_air_gapped
+    # The air gapped build expects the built docs to be *exactly* where the
+    # Dockerfile puts them. So we put them there too.
+    FileUtils.rm_rf '/docs_build/.repos/target_repo.git'
+    FileUtils.mkdir_p '/docs_build/.repos'
+    FileUtils.cp_r bare_repo, '/docs_build/.repos/target_repo.git'
+    Preview.new(bare_repo, air_gapped: true)
   end
 
   def remove_target_brach(branch_name)

--- a/integtest/spec/helper/preview.rb
+++ b/integtest/spec/helper/preview.rb
@@ -9,11 +9,11 @@ class Preview < ServingDocs
   # Reads the logs of the preview without updating them from the subprocess.
   attr_reader :logs
 
-  def initialize(bare_repo)
+  def initialize(bare_repo, air_gapped: false)
     super [
       '/docs_build/build_docs.pl', '--in_standard_docker',
       '--preview', '--target_repo', bare_repo
-    ]
+    ].concat(air_gapped ? ['--gapped'] : [])
 
     wait_for_logs(/^preview server is listening on 3000$/, 60)
   end

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -4,11 +4,11 @@ require 'net/http'
 require 'securerandom'
 
 ##
-# Test for the `--preview` functionality that is usually deployed in
-# Elastic Apps. It previews all branches of the `--target_repo`. The test runs
-# everything in the defined order because starting the preview is fairly heavy
-# and the preview is designed to update itself as its target repo changes so
-# we start it once and play with the target repo during the tests.
+# Test for a preview that is usually deployed in Elastic Apps. It previews all
+# branches of the `--target_repo`. The test runs everything in the defined
+# order because starting the preview is fairly heavy and the preview is
+# designed to update itself as its target repo changes so we start it once and
+# play with the target repo during the tests.
 RSpec.describe 'previewing built docs', order: :defined do
   very_large_text = 'muchtext' * 1024 * 1024 * 5 # 40mb
   repo_root = File.expand_path '../../', __dir__

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -896,7 +896,7 @@ sub start_web_resources_watcher {
 #===================================
 sub start_preview {
 #===================================
-    my ( $command, $root ) = @_;
+    my ( $command, $root, $default_template ) = @_;
 
     my $preview_pid = fork;
     return $preview_pid if $preview_pid;
@@ -904,7 +904,7 @@ sub start_preview {
     close STDIN;
     open( STDIN, "</dev/null" );
     exec( qw(node --max-old-space-size=128 /docs_build/preview/cli.js),
-          $command, $root );
+          $command, $root, '--default-template', $default_template );
 }
 
 #===================================

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -1,4 +1,4 @@
-from docker.elastic.co/docs/build:1
+FROM docker.elastic.co/docs/build:1
 
 RUN mkdir /var/log/nginx
 RUN mkdir -p /run/nginx

--- a/preview/cli.js
+++ b/preview/cli.js
@@ -30,18 +30,21 @@ process.on('unhandledRejection', error => {
 });
 
 yargs
+  .option("default-template", {
+    default: "template.html"
+  })
   .command({
     command: "git <repo>",
     desc: "Serve a repo",
     handler: argv => {
-      preview(core.Git(argv.repo));
+      preview(core.Git(argv["default-template"], argv.repo));
     },
   })
   .command({
     command: "fs <path>",
     desc: "Serve some files from disk",
     handler: argv => {
-      preview(core.Fs(argv.path));
+      preview(core.Fs(argv["default-template"], argv.path));
     },
   })
   .version(false)

--- a/preview/core.js
+++ b/preview/core.js
@@ -30,10 +30,10 @@ const { promisify } = require('util');
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 
-const GitCore = repoPath => {
+const GitCore = (defaultTemplate, repoPath) => {
   const hostInfo = hostPrefix => {
     if (!hostPrefix) {
-      return ["template.html", "master"];
+      return [defaultTemplate, "master"];
     }
     let prefix = hostPrefix;
     let template;
@@ -87,9 +87,15 @@ const GitCore = repoPath => {
   };
 };
 
-const FsCore = rootPath => {
+const FsCore = (defaultTemplate, rootPath) => {
+  const hostInfo = hostPrefix => {
+    if (!hostPrefix) {
+      return defaultTemplate;
+    }
+    return "gapped" === hostPrefix ? "air_gapped_template.html" : "template.html";
+  };
   return hostPrefix => {
-    const template = "gapped" === hostPrefix ? "air_gapped_template.html" : "template.html";
+    const template = hostInfo(hostPrefix);
     const readAlternativesReport = async dir => {
       try {
         return await readFile(`${dir}alternatives_summary.json`, { encoding: "utf8" });

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -3,7 +3,7 @@
 # Performs a quick and dirty local test on the preview. Because this runs as
 # it would in k8s you'll need to `docker kill` it when you are done. We do
 # have integration tests for this in integtest/spec/preview_spec.rb which are
-# much faster because they don't use real data.
+# much faster because they don't use real data but this is useful too.
 
 set -e
 


### PR DESCRIPTION
Adds scripts to build a docker image with the air gapped docs. This
required a ton of changes that came before this, but this commits adds
the following features:

1. Adds a `--default-template` option to `preview/cli.js` which is used
when you don't specify a branch or the `gapped_` prefix.
2. Adds the `--gapped` option to the perl code handling previews which,
when specified, skips the initial fetch of the built docs, specifies the
`--default-template` to the preview, and skips the periodic fetches.
3. Adds a Dockerfile and scripts to build the docker image.

This project still isn't done because:
1. We need to add the infrastructure to publish the docker image.
2. We need to remove all external dependencies from the air gapped
template.

Probably more stuff I haven't thought of yet.
