### PR TITLE
Include jquery in built-docs

### DIFF
--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -69,6 +69,16 @@ module Dsl
           expect(contents).not_to include('sourceMappingURL=')
         end
       end
+      file_context 'html/static/jquery.js' do
+        it 'is minified' do
+          expect(contents).to include(<<~JS.strip)
+            /*! jQuery v1.12.4 | (c) jQuery Foundation | jquery.org/license */
+          JS
+        end
+        it "doesn't include a source map" do
+          expect(contents).not_to include('sourceMappingURL=')
+        end
+      end
       file_context 'html/static/styles.css' do
         it 'is minified' do
           expect(contents).to include(<<~CSS.strip)

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -576,6 +576,9 @@ RSpec.describe 'building a single book' do
     let(:js) do
       Net::HTTP.get_response(URI("#{static}/docs.js"))
     end
+    let(:jquery) do
+      Net::HTTP.get_response(URI("#{static}/jquery.js"))
+    end
     let(:css) do
       Net::HTTP.get_response(URI("#{static}/styles.css"))
     end
@@ -625,6 +628,18 @@ RSpec.describe 'building a single book' do
       end
       it 'includes a source map' do
         expect(js).to serve(include('sourceMappingURL='))
+      end
+    end
+    context 'jquery' do
+      it 'is unminified' do
+        # This comment is a little brittle to detect but I don't expect us to
+        # rely on jquery forever.
+        expect(jquery).to serve(include(<<~JS))
+          Includes Sizzle.js
+        JS
+      end
+      it "doesn't include a source map" do
+        expect(jquery).not_to serve(include('sourceMappingURL='))
       end
     end
     context 'the css' do

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -701,6 +701,12 @@ sub write_nginx_test_config {
     if ( $watching_web ) {
         $web_conf = <<"CONF"
     rewrite ^/guide/static/docs\\.js(.*)\$ /guide/static/docs_js/index.js\$1 last;
+    location ^~ /guide/static/jquery.js {
+      alias /node_modules/jquery/dist/jquery.js;
+      types {
+        application/javascript js;
+      }
+    }
     location ^~ /guide/static/ {
       proxy_pass http://0.0.0.0:1234;
     }
@@ -951,6 +957,8 @@ sub build_web_resources {
         next unless /.+\.woff2?/;
         rcopy( $_, $static_dir );
     }
+
+    rcopy( '/node_modules/jquery/dist/jquery.min.js', $static_dir->file( 'jquery.js' ) );
 
     # The public site can't ready anything from the raw directory so we have to
     # copy the static files to html as well.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "license": "SEE LICENSE IN README.asciidoc",
   "devDependencies": {
     "jest": "^24.8.0",
-    "jquery": "^1.11.3",
     "nock": "^10.0.6",
     "parcel": "^1.12.3",
     "rmfr": "^2.0.0"
@@ -18,6 +17,7 @@
   "dependencies": {
     "dedent": "^0.7.0",
     "js-cookie": "^2.1.0",
+    "jquery": "^1.11.3",
     "linkstate": "^1.1.1",
     "postcss-assets": "^5.0.0",
     "preact": "^8.4.2",

--- a/resources/web/air_gapped_template.html
+++ b/resources/web/air_gapped_template.html
@@ -31,7 +31,6 @@
     <link rel="apple-touch-icon-precomposed" sizes="64x64" href="/favicon_64x64_16bit.png">
     <link rel="apple-touch-icon-precomposed" sizes="32x32" href="/favicon_32x32.png">
     <link rel="apple-touch-icon-precomposed" sizes="16x16" href="/favicon_16x16.png">
-    <script src="/static/js/jquery.min.js"></script>
     <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 
@@ -74,6 +73,7 @@
       </section>
     </div>
 
+<script src="/guide/static/jquery.js"></script>
 <script type="text/javascript" src="/guide/static/docs.js"></script>
 <!-- DOCS FINAL -->
   </body>

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -34,7 +34,6 @@
     <link rel="apple-touch-icon-precomposed" sizes="64x64" href="/favicon_64x64_16bit.png">
     <link rel="apple-touch-icon-precomposed" sizes="32x32" href="/favicon_32x32.png">
     <link rel="apple-touch-icon-precomposed" sizes="16x16" href="/favicon_16x16.png">
-    <script src="/static/js/jquery.min.js"></script>
     <!-- Give IE8 a fighting chance -->
     <!--[if lt IE 9]>
     <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
@@ -117,6 +116,7 @@
 	var localeUrl = '{"relative_url_prefix":"/","code":"en-us","display_code":"en-us","url":"/guide_template"}';
 </script>
 <script src="/static/js/swiftype_app_search.umd.min.js"></script>
+<script src="/guide/static/jquery.js"></script>
 <script type="text/javascript" src="/guide/static/docs.js"></script>
 <!-- DOCS FINAL -->
   </body>


### PR DESCRIPTION
Switches the template from serving the jquery from the public site to
serving it from the `/guide/static` which is served from the
`built-docs` repo. Also copies jquery.min.js into the `built-docs` repo.

I tried bundling `jquery` into `docs.js` but it made it much, much
bigger. That didn't seem worth it.
