### PR TITLE
Configure preview's git gc

### DIFF
--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/docs/preview:7
+FROM docker.elastic.co/docs/preview:8
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -19,6 +19,6 @@ GIT_DIR=air_gapped/work/target_repo.git git fetch
 
 # Build the images
 ./build_docs --just-build-image
-docker build -t docker.elastic.co/docs/preview:7 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:8 -f preview/Dockerfile .
 # Use buildkit here to pick up the customized dockerignore file
 DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs/air_gapped:latest -f air_gapped/Dockerfile .

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -7,6 +7,16 @@ RUN mkdir -p /run/nginx
 RUN git config --global pack.windowMemory 500m
 RUN git config --global pack.deltaCacheSize 10m
 RUN git config --global pack.threads 1
+# Prevent git auto-gc from warning about too many references by increasing the
+# threshold of unreachable objects that triggers a prune and more aggressively
+# pruning those unreachable objects. While we're at it we more aggressively
+# prune the reflog as well. It is important to prevent corruption that we do
+# leave *some* grace period in all of these (see the note in docs for git gc
+# for more about this).
+RUN git config --global gc.auto 20000
+RUN git config --global gc.pruneExpire 1.hour.ago
+RUN git config --global gc.reflogExpire 1.hour.ago
+RUN git config --global gc.reflogExpireUnreachable 1.hour.ago
 
 COPY build_docs.pl /docs_build/
 COPY conf.yaml /docs_build/

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh built-docs.git
-docker build -t docker.elastic.co/docs/preview:7 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:8 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:7 \
+          docker.elastic.co/docs/preview:8 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:7
+export PREVIEW=docker.elastic.co/docs/preview:8
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
This should help to prevent
```
warning: There are too many unreachable loose objects; run 'git prune' to remove them
```

Related to #1214
