### PR TITLE
Redirect from the root the `/guide`

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -430,7 +430,7 @@ RSpec.describe 'building all books' do
 
     let(:root) { 'http://localhost:8000/guide' }
     let(:book_root) { "#{root}/test/current" }
-    let(:root_index) { Net::HTTP.get_response(URI("#{root}/")) }
+    let(:guide_index) { Net::HTTP.get_response(URI("#{root}/")) }
     let(:legacy_redirect) do
       Net::HTTP.get_response(URI("#{root}/reference/setup/"))
     end
@@ -441,10 +441,10 @@ RSpec.describe 'building all books' do
       Net::HTTP.get_response(URI("#{book_root}/resources/readme/example.svg"))
     end
 
+    include_examples 'the root'
     include_examples 'the favicon'
-
-    it 'serves the root index' do
-      expect(root_index).to serve(doc_body(include(<<~HTML.strip)))
+    it 'serves the guide index' do
+      expect(guide_index).to serve(doc_body(include(<<~HTML.strip)))
         <a class="ulink" href="test/current/index.html" target="_top">Test
       HTML
     end

--- a/integtest/spec/helper/dsl.rb
+++ b/integtest/spec/helper/dsl.rb
@@ -43,6 +43,17 @@ module Dsl
     end
   end
 
+  RSpec.shared_examples 'the root' do
+    context 'the root' do
+      let(:root) do
+        Net::HTTP.get_response(URI('http://localhost:8000/'))
+      end
+      it 'redirects to the guide root' do
+        expect(root.code).to eq('301')
+        expect(root['Location']).to eq('http://localhost:8000/guide/index.html')
+      end
+    end
+  end
   RSpec.shared_examples 'the favicon' do
     context 'the favicon' do
       let(:favicon) do

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -583,6 +583,7 @@ RSpec.describe 'building a single book' do
       Net::HTTP.get_response(URI("#{static}/styles.css"))
     end
 
+    include_examples 'the root'
     include_examples 'the favicon'
 
     context 'the index' do

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -761,6 +761,9 @@ http {
 
   server {
     listen 8000;
+    location = / {
+      return 301 /guide/index.html;
+    }
 $web_conf
 $guide_conf
     location / {
@@ -819,6 +822,9 @@ http {
 
   server {
     listen 8000;
+    location = / {
+      return 301 /guide/index.html;
+    }
     location = /robots.txt {
       return 200 "User-agent: *\nDisallow: /\n";
     }


### PR DESCRIPTION
This should make it ever so slightly simpler to generate links to "the
docs".
