### PR TITLE
Point to latest PHP client doc

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -444,8 +444,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    7.0
-                branches:   [ master, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
+                current:    7.2
+                branches:   [ master, 7.2, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients


### PR DESCRIPTION
This PR sets the current doc _pointer_ to the latest branch `7.2` of the client