### PR TITLE
Air gapped docs always serve master

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -125,7 +125,7 @@ sub build_local {
     say "Done";
 
     if ( $Opts->{open} ) {
-        my $preview_pid = start_preview( 'fs', $raw_dir, 'template.html' );
+        my $preview_pid = start_preview( 'fs', $raw_dir, 'template.html', 0 );
         serve_local_preview( $dir, 0, $web_resources_pid, $preview_pid );
     }
 }
@@ -637,7 +637,7 @@ sub preview {
 
         my $default_template = $Opts->{gapped} ? "air_gapped_template.html" : "template.html";
         my $preview_pid = start_preview(
-            'git', '/docs_build/.repos/target_repo.git', $default_template
+            'git', '/docs_build/.repos/target_repo.git', $default_template, $Opts->{gapped}
         );
         $SIG{TERM} = sub {
             # We should be a good citizen and shut down the subprocesses.

--- a/integtest/spec/air_gapped_spec.rb
+++ b/integtest/spec/air_gapped_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'net/http'
-
 ##
 # Test for the air gapped deploy of the docs. For the most part the air gapped
 # deploy is the same as a preview that doesn't attempt to update itself so we
@@ -23,8 +21,8 @@ RSpec.describe 'air gapped deploy', order: :defined do
   end
   let(:air_gapped) { @air_gapped }
 
-  let(:root) { 'http://localhost:8000/guide' }
-  let(:books_index) { Net::HTTP.get_response(URI("#{root}/index.html")) }
+  let(:host) { 'localhost' }
+  let(:books_index) { air_gapped.get 'guide/index.html', host: host }
 
   context 'the logs' do
     it "don't contain anything git" do
@@ -41,15 +39,29 @@ RSpec.describe 'air gapped deploy', order: :defined do
       HTML
     end
     it 'logs the access to the docs root' do
-      air_gapped.wait_for_logs %r{localhost:8000 GET /guide/index.html}, 10
+      air_gapped.wait_for_logs %r{localhost GET /guide/index.html}, 10
       expect(air_gapped.logs).to include(<<~LOGS)
-        localhost:8000 GET /guide/index.html HTTP/1.1 200
+        localhost GET /guide/index.html HTTP/1.1 200
       LOGS
     end
     it 'uses the air gapped template' do
       expect(books_index).not_to serve(include(<<~HTML.strip))
         https://www.googletagmanager.com/gtag/js
       HTML
+    end
+  end
+  context "when the host isn't localhost" do
+    let(:host) { 'dot.dot.localhost' }
+    it 'we can still serve the books index' do
+      expect(books_index).to serve(doc_body(include(<<~HTML.strip)))
+        <a class="ulink" href="test/current/index.html" target="_top">Test</a>
+      HTML
+    end
+    it 'logs the access to the funny host' do
+      air_gapped.wait_for_logs %r{dot.dot.localhost GET /guide/index.html}, 10
+      expect(air_gapped.logs).to include(<<~LOGS)
+        dot.dot.localhost GET /guide/index.html HTTP/1.1 200
+      LOGS
     end
   end
 end

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -106,7 +106,6 @@ RSpec.describe 'building all books' do
       end
       include_examples 'all links are ok'
     end
-    shared_examples ''
     describe 'when there is a broken absolute link in the docs' do
       include_context 'there is a broken absolute link in the docs', true
       include_examples 'there are broken links in the docs'

--- a/integtest/spec/helper/serving_docs.rb
+++ b/integtest/spec/helper/serving_docs.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'net/http'
 require 'open3'
 
 ##
@@ -35,6 +36,19 @@ class ServingDocs
     Process.kill 'TERM', @wait_thr.pid
     @wait_thr.exit
     wait_for_logs(/^Terminated preview services$/, 10)
+  end
+
+  ##
+  # Perform an HTTP GET.
+  def get(path, host: 'localhost', watermark: false, timeout: 20)
+    uri = URI("http://localhost:8000/#{path}")
+    req = Net::HTTP::Get.new(uri)
+
+    req['X-Opaque-Id'] = watermark if watermark
+    req['Host'] = host
+    Net::HTTP.start(uri.hostname, uri.port, read_timeout: timeout) do |http|
+      http.request(req)
+    end
   end
 
   private

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -912,7 +912,7 @@ sub start_web_resources_watcher {
 #===================================
 sub start_preview {
 #===================================
-    my ( $command, $root, $default_template ) = @_;
+    my ( $command, $root, $default_template, $ignore_host ) = @_;
 
     my $preview_pid = fork;
     return $preview_pid if $preview_pid;
@@ -920,7 +920,10 @@ sub start_preview {
     close STDIN;
     open( STDIN, "</dev/null" );
     exec( qw(node --max-old-space-size=128 /docs_build/preview/cli.js),
-          $command, $root, '--default-template', $default_template );
+          $command, $root,
+          '--default-template', $default_template,
+          ( $ignore_host ? ('--ignore-host') : () )
+    );
 }
 
 #===================================

--- a/preview/cli.js
+++ b/preview/cli.js
@@ -33,18 +33,22 @@ yargs
   .option("default-template", {
     default: "template.html"
   })
+  .option("ignore-host", {
+    default: false
+  })
+  .boolean("ignore-host")
   .command({
     command: "git <repo>",
     desc: "Serve a repo",
     handler: argv => {
-      preview(core.Git(argv["default-template"], argv.repo));
+      preview(core.Git(argv["default-template"], argv["ignore-host"], argv.repo));
     },
   })
   .command({
     command: "fs <path>",
     desc: "Serve some files from disk",
     handler: argv => {
-      preview(core.Fs(argv["default-template"], argv.path));
+      preview(core.Fs(argv["default-template"], argv["ignore-host"], argv.path));
     },
   })
   .version(false)

--- a/preview/core.js
+++ b/preview/core.js
@@ -30,9 +30,9 @@ const { promisify } = require('util');
 const stat = promisify(fs.stat);
 const readFile = promisify(fs.readFile);
 
-const GitCore = (defaultTemplate, repoPath) => {
+const GitCore = (defaultTemplate, ignoreHost, repoPath) => {
   const hostInfo = hostPrefix => {
-    if (!hostPrefix) {
+    if (ignoreHost || !hostPrefix) {
       return [defaultTemplate, "master"];
     }
     let prefix = hostPrefix;
@@ -87,9 +87,9 @@ const GitCore = (defaultTemplate, repoPath) => {
   };
 };
 
-const FsCore = (defaultTemplate, rootPath) => {
+const FsCore = (defaultTemplate, ignoreHost, rootPath) => {
   const hostInfo = hostPrefix => {
-    if (!hostPrefix) {
+    if (ignoreHost || !hostPrefix) {
       return defaultTemplate;
     }
     return "gapped" === hostPrefix ? "air_gapped_template.html" : "template.html";


### PR DESCRIPTION
I'd configured the air gapped docs so if you access them as
`localhost/blah` they'd always give you the master branch. But I still
allowed you to grab other branches with `foo.localhost/blah`. The
trouble with that is that folks will tend to want to have `.`s in the
hostname when they deploy it.

This locks the branch to always be `master` regardless of the host
header.
