### PR TITLE
Add optional Github creds to built-docs

### DIFF
--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/docs/preview:9
+FROM docker.elastic.co/docs/preview:10
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -19,6 +19,6 @@ GIT_DIR=air_gapped/work/target_repo.git git fetch
 
 # Build the images
 ./build_docs --just-build-image
-docker build -t docker.elastic.co/docs/preview:9 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:10 -f preview/Dockerfile .
 # Use buildkit here to pick up the customized dockerignore file
 DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs-private/air_gapped:latest -f air_gapped/Dockerfile .

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -26,4 +26,4 @@ COPY template /docs_build/template
 COPY resources /docs_build/resources
 
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]
+     "--preview", "--target_repo", "https://${GITHUB_USER}${GITHUB_USER:+:}${GITHUB_PASS}${GITHUB_USER:+@}github.com/elastic/built-docs.git"]

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -8,7 +8,7 @@
 set -e
 
 cd $(git rev-parse --show-toplevel)
-../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh built-docs.git
+../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh git@github.com:elastic/built-docs.git
 docker build -t docker.elastic.co/docs/preview:9 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh git@github.com:elastic/built-docs.git
-docker build -t docker.elastic.co/docs/preview:9 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:10 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:9 \
+          docker.elastic.co/docs/preview:10 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:9
+export PREVIEW=docker.elastic.co/docs/preview:10
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
Adds optional credentials to Github repo URL if they exist. If they don't exist, the URL should be properly formatted without credentials.