### PR TITLE
Switch the edit_me link implementation

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -4,13 +4,11 @@ inherit_from: ../../.rubocop.yml
 
 Metrics/AbcSize:
   Exclude:
-    - lib/edit_me/extension.rb
     - lib/open_in_widget/extension.rb
     - lib/elastic_compat_tree_processor/extension.rb
 
 Metrics/MethodLength:
   Exclude:
-    - lib/edit_me/extension.rb
     - lib/open_in_widget/extension.rb
     - lib/elastic_compat_preprocessor/extension.rb
     - lib/elastic_include_tagged/extension.rb

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require_relative '../log_util'
+require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
+require_relative '../log_util'
 require_relative 'copier'
 
 ##

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -1,110 +1,126 @@
 # frozen_string_literal: true
 
+require 'asciidoctor/extensions'
 require 'csv'
-require_relative '../scaffold'
+require_relative '../delegating_converter'
 require_relative '../log_util'
 
 ##
-# TreeProcessor extension to automatically add "Edit Me" links to appropriate
-# spots in the documentation.
-#
-class EditMe < TreeProcessorScaffold
-  include LogUtil
+# Automatically adds "Edit Me" links to appropriate spots in the documentation.
+module EditMe
+  extend LogUtil
 
-  def process(document)
-    error message: 'sourcemap is required' unless document.sourcemap
+  def self.activate(registry)
+    error message: 'sourcemap is required' unless registry.document.sourcemap
+    return unless configure registry.document
+
+    DelegatingConverter.setup(registry.document) do |doc|
+      Converter.new doc
+    end
+  end
+
+  def self.configure(document)
     edit_urls_string = document.attributes['edit_urls']
     return unless edit_urls_string
 
     if edit_urls_string.is_a? String
       document.attributes['edit_urls'] = parse_edit_urls edit_urls_string
+      return unless document.attributes['edit_urls']
     end
-    super
+
+    true
   end
 
-  def parse_edit_urls(edit_urls_string)
+  def self.parse_edit_urls(edit_urls_string)
     edit_urls = []
     CSV.parse edit_urls_string do |toplevel, url|
-      unless toplevel
-        error message: 'invalid edit_urls, no toplevel'
-        next
-      end
-      unless url
-        error message: 'invalid edit_urls, no url'
-        next
-      end
-      url = url[0..-2] if url.end_with? '/'
-      edit_urls << { toplevel: toplevel, url: url }
+      handle_link edit_urls, toplevel, url
     end
     # Prefer the longest matching edit url
     edit_urls.sort_by { |e| [-e[:toplevel].length, e[:toplevel]] }
   end
 
-  def process_block(block)
-    return unless %i[preamble section floating_title].include? block.context
-
-    block.extend WithEditLink
-    if block.context == :preamble
-      def block.source_path
-        # source_location.path doesn't work for relative includes outside of
-        # the base_dir which we use when we build books from many repos.
-        document.source_location.file
-      end
-    else
-      def block.source_path
-        # source_location.path doesn't work for relative includes outside of
-        # the base_dir which we use when we build books from many repos.
-        source_location.file
-      end
+  def self.handle_link(edit_urls, toplevel, url)
+    unless toplevel
+      error message: 'invalid edit_urls, no toplevel'
+      return
     end
+    unless url
+      error message: 'invalid edit_urls, no url'
+      return
+    end
+    url = url[0..-2] if url.end_with? '/'
+    edit_urls << { toplevel: toplevel, url: url }
   end
 
   ##
-  # Extension to blocks that need an "edit me" link.
-  module WithEditLink
-    def title
-      if (url = edit_url)
-        "#{super}<ulink role=\"edit_me\" url=\"#{url}\">Edit me</ulink>"
-      else
-        super
+  # Converter implementation that decorates docbook with edit me links.
+  class Converter < DelegatingConverter
+    include LogUtil
+
+    RESPECT_OVERRIDES = 'respect_edit_url_overrides'
+
+    def preamble(block)
+      yield.sub '</title>' do
+        "#{link_for block}</title>"
       end
     end
 
-    def edit_url
-      if @document.attributes['respect_edit_url_overrides']
-        url = @document.attributes['edit_url']
-        if url == ''
-          false
-        elsif url
-          url
-        else
-          edit_url_by_path
-        end
-      else
-        edit_url_by_path
+    def section(block)
+      yield.sub '</title>' do
+        "#{link_for block}</title>"
       end
     end
 
-    def edit_url_by_path
+    def floating_title(block)
+      yield.sub '</bridgehead>' do
+        "#{link_for block}</bridgehead>"
+      end
+    end
+
+    def link_for(block)
+      url = edit_url block
+      if url
+        %(<ulink role="edit_me" url="#{url}">Edit me</ulink>)
+      else
+        ''
+      end
+    end
+
+    def edit_url(block)
+      return edit_url_by_path block unless block.attr RESPECT_OVERRIDES
+
+      url = block.attr 'edit_url'
+      return false if url == ''
+      return url if url
+
+      edit_url_by_path block
+    end
+
+    def edit_url_by_path(block)
+      # source_location.path doesn't work for relative includes outside of
+      # the base_dir which we use when we build books from many repos.
       # || '<stdin>' allows us to not blow up when translating strings that
       # aren't associated with any particular file. '<stdin>' is asciidoctor's
       # standard name for such strings.
-      path = source_path || '<stdin>'
+      path = block.source_location&.file || '<stdin>'
 
-      edit_urls = @document.attributes['edit_urls']
+      edit_urls = block.attr 'edit_urls'
       entry = edit_urls.find { |e| path.start_with? e[:toplevel] }
-      if entry
-        url = entry[:url]
-        if url == '<disable>'
-          false
-        else
-          url + path[entry[:toplevel].length..-1]
-        end
-      else
-        warn location: source_location, message: <<~WARN.strip
-          couldn't find edit url for #{path}
-        WARN
+      return url_for_path path, entry if entry
+
+      warn block: block, message: <<~WARN.strip
+        couldn't find edit url for #{path}
+      WARN
+      false
+    end
+
+    def url_for_path(path, entry)
+      url = entry[:url]
+      if url == '<disable>'
         false
+      else
+        url + path[entry[:toplevel].length..-1]
       end
     end
   end

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -12,17 +12,19 @@ require_relative 'elastic_include_tagged/extension'
 require_relative 'lang_override/extension'
 require_relative 'open_in_widget/extension'
 
-Asciidoctor::Extensions.register CareAdmonition
-Asciidoctor::Extensions.register ChangeAdmonition
-Asciidoctor::Extensions.register CopyImages
 Asciidoctor::Extensions.register do
   # Enable storing the source locations so we can look at them. This is required
   # for EditMe to get a nice location.
   document.sourcemap = true
+end
+Asciidoctor::Extensions.register CareAdmonition
+Asciidoctor::Extensions.register ChangeAdmonition
+Asciidoctor::Extensions.register CopyImages
+Asciidoctor::Extensions.register EditMe
+Asciidoctor::Extensions.register do
   block_macro LangOverride
   preprocessor CrampedInclude
   preprocessor ElasticCompatPreprocessor
-  treeprocessor EditMe
   treeprocessor ElasticCompatTreeProcessor
   # The tree processors after this must come after ElasticComptTreeProcessor
   # or they won't see the right tree.

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -5,9 +5,7 @@ require 'edit_me/extension'
 
 RSpec.describe EditMe do
   before(:each) do
-    Asciidoctor::Extensions.register do
-      tree_processor EditMe
-    end
+    Asciidoctor::Extensions.register EditMe
   end
 
   after(:each) do


### PR DESCRIPTION
Switches the edit_me link implementation from a TreeProcessor to a
DelegatingConverter. This is nice because, eventually, we'll want to
generate the edit_me links differently if we're converting to html
instead of docbook. Converters are the place where we can make that
call.

Also I can remove some rubocop suppressions which is nice.
