### PR TITLE
Preview: Survive git fetch failures

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -658,8 +658,9 @@ sub preview {
         } else {
             while (1) {
                 sleep 1;
-                my $fetch_result = $target_repo->fetch;
-                say "$fetch_result" if ( $fetch_result );
+                my $fetch_result = eval { $target_repo->fetch };
+                say $fetch_result if $fetch_result;
+                say $@ if $@;
             }
         }
         exit;

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -119,7 +119,7 @@ class Dest
   end
 
   ##
-  # The location of the bare repository. the first time this is called in a
+  # The location of the bare repository. The first time this is called in a
   # given context the bare repository is initialized
   def bare_repo
     unless @initialized_bare_repo


### PR DESCRIPTION
If github is down or something, we really should just fail the pull, log
a message, and keep going. Before this PR we'd crash and k8s would
restart us. As nice as that is, we really ought to stay up.
