### PR TITLE
Adds shared attributes for Watcher transforms

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -144,6 +144,10 @@
 :dataframes:                 data frames
 :dataframe-cap:              Data frame
 :dataframes-cap:             Data frames
+:watcher-transform:          payload transform
+:watcher-transforms:         payload transforms
+:watcher-transform-cap:      Payload transform
+:watcher-transforms-cap:     Payload transforms
 :transform:                  transform
 :transforms:                 transforms
 :transform-cap:              Transform


### PR DESCRIPTION
This PR adds attributes to make it easier to differentiate between Watcher transforms (https://www.elastic.co/guide/en/elasticsearch/reference/master/transform.html) and data transforms (https://www.elastic.co/guide/en/elasticsearch/reference/master/transforms.html).