### PR TITLE
Remove broken link from a deleted topic

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -14,7 +14,7 @@ settings dynamically with the
 |Logs UI                   |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]           |No
 |Machine learning          |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]                |No
 |Management                |No                                    |No                                                   |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
-|Monitoring                |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes]        |{logstash-ref}/configuring-logstash.html#monitoring-settings[Yes]
+|Monitoring                |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes]        |Yes
 |Reporting                 |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]         |No
 .2+|Security
 


### PR DESCRIPTION
Restructuring Monitoring content for Logstash (https://github.com/elastic/logstash/pull/11033) resulted in a broken link in a deprecated topic. This PR removes the link. 