### PR TITLE
Speed up integration tests

### DIFF
--- a/integtest/.rubocop.yml
+++ b/integtest/.rubocop.yml
@@ -1,0 +1,6 @@
+inherit_from: ../.rubocop.yml
+
+
+Metrics/ClassLength:
+  Exclude:
+    - spec/helper/dest.rb

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'building all books' do
     end
   end
   context 'for a single book built by a single repo' do
-    convert_all_before_context do |src|
+    convert_all_before_context(init_from_shell: false) do |src|
       repo = src.repo_with_index 'repo', 'Some text.'
       book = src.book 'Test'
       book.source repo, 'index.asciidoc'

--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -8,9 +8,11 @@ module Dsl
     # uses it to:
     # 1. Create source repositories and write them
     # 2. Configure the books that should be built
-    def convert_all_before_context(relative_conf: false, target_branch: nil)
+    def convert_all_before_context(relative_conf: false, target_branch: nil,
+                                   init_from_shell: true)
       convert_before do |src, dest|
         yield src
+        dest.init_from_shell = init_from_shell
         dest.convert_all src.conf(relative_path: relative_conf),
                          target_branch: target_branch
         dest.checkout_conversion branch: target_branch

--- a/integtest/spec/helper/shell_repo.rb
+++ b/integtest/spec/helper/shell_repo.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+
+require_relative 'sh'
+
+##
+# Creates a repository with fonts in it so we don't have to add them over and
+# over and over and over again.
+module ShellRepo
+  extend Sh
+
+  def self.initalize
+    @built_shell_repo = false
+  end
+
+  ##
+  # Builds a "shell" repository that contains large resources that have to be
+  # added to every docs build. It is *much* more efficient to build it one
+  # time rather than add those resources to the build over and over again.
+  def self.build!
+    return if @built_shell_repo
+
+    sh 'git init /tmp/shell'
+    copy_fonts
+    build_readme
+    Dir.chdir '/tmp/shell' do
+      sh 'git add .'
+      sh 'git commit -m "add shell resources"'
+    end
+    @built_shell_repo = true
+  end
+
+  ##
+  # Copy the fonts that take so long to add to git.
+  def self.copy_fonts
+    prefix = '/docs_build/resources/web/lib'
+    %w[raw html].each do |dest|
+      FileUtils.mkdir_p "/tmp/shell/#{dest}/static"
+      %w[inter noto-sans-japanese].each do |font|
+        sh "cp -r #{prefix}/#{font}/*.woff* /tmp/shell/#{dest}/static"
+      end
+    end
+  end
+
+  ##
+  # Build the readme for the repo. This is mostly there to make the docs build's
+  # sparse checkout code happy.
+  def self.build_readme
+    File.open('/tmp/shell/README', 'w:UTF-8') do |f|
+      f.write 'Shell repository with fonts.'
+    end
+  end
+end


### PR DESCRIPTION
```
Before: 10m47.920s
After:   6m1.201s
```

The integration tests have felt slower to me so I did a little digging.
`top` told me that git was pretty busy during the integration tests and
it dawned on me that we put the fonts in the built-docs repo now and
they are pretty big.

This speeds up the tests by creating a "shell" repository before most
tests that already has the fonts in it and then clonging the "target"
repository from that shell before every test. That way we only have to
pay the cost of `git add`ing the font files one time.
