### PR TITLE
Check warnings from asciidoctor before next steps

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -738,4 +738,22 @@ RSpec.describe 'building a single book' do
       LOG
     end
   end
+  context 'when a referenced id is missing' do
+    convert_before do |src, dest|
+      repo = src.repo_with_index 'src', <<~ASCIIDOC
+        <<missing-ref>>
+      ASCIIDOC
+      dest.prepare_convert_single("#{repo.root}/index.asciidoc", '.')
+          .asciidoctor
+          .convert(expect_failure: true)
+    end
+    it 'fails with an appropriate error status' do
+      expect(statuses[0]).to eq(255)
+    end
+    it 'logs the missing file' do
+      expect(outputs[0]).to include(<<~LOG.strip)
+        asciidoctor: WARNING: invalid reference: missing-ref
+      LOG
+    end
+  end
 end

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -131,13 +131,13 @@ sub build_chunked {
 
         if ( !$lenient ) {
             eval {
-                $output .= _xml_lint($dest_xml);
+                $output = _xml_lint($dest_xml);
                 1;
             } or do { $output = $@; $died = 1; };
             _check_build_error( $output, $died, $lenient );
         }
         eval {
-            $output .= run(
+            $output = run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
                 '--stringparam', 'base.dir', $chunks_path->absolute . '/',
@@ -306,13 +306,13 @@ sub build_single {
 
         if ( !$lenient ) {
             eval {
-                $output .= _xml_lint($dest_xml);
+                $output = _xml_lint($dest_xml);
                 1;
             } or do { $output = $@; $died = 1; };
             _check_build_error( $output, $died, $lenient );
         }
         eval {
-            $output .= run(
+            $output = run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
                 '--output' => "$raw_dest/index.html",

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -125,9 +125,18 @@ sub build_chunked {
                 docinfo($index),
                 $index
             );
-            if ( !$lenient ) {
+            1;
+        } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
+
+        if ( !$lenient ) {
+            eval {
                 $output .= _xml_lint($dest_xml);
-            }
+                1;
+            } or do { $output = $@; $died = 1; };
+            _check_build_error( $output, $died, $lenient );
+        }
+        eval {
             $output .= run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
@@ -135,9 +144,10 @@ sub build_chunked {
                 file('resources/website_chunked.xsl')->absolute,
                 $dest_xml
             );
-            unlink $dest_xml;
             1;
         } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
+        unlink $dest_xml;
     }
     else {
         my $edit_url = $edit_urls->{$root_dir};
@@ -167,9 +177,8 @@ sub build_chunked {
             );
             1;
         } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
     }
-
-    _check_build_error( $output, $died, $lenient );
 
     my ($chunk_dir) = grep { -d and /\.chunked$/ } $raw_dest->children
         or die "Couldn't find chunk dir in <$raw_dest>";
@@ -291,9 +300,18 @@ sub build_single {
                 docinfo($index),
                 $index
             );
-            if ( !$lenient ) {
+            1;
+        } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
+
+        if ( !$lenient ) {
+            eval {
                 $output .= _xml_lint($dest_xml);
-            }
+                1;
+            } or do { $output = $@; $died = 1; };
+            _check_build_error( $output, $died, $lenient );
+        }
+        eval {
             $output .= run(
                 'xsltproc',
                 rawxsltopts(%xsltopts),
@@ -301,9 +319,10 @@ sub build_single {
                 file('resources/website.xsl')->absolute,
                 $dest_xml
             );
-            unlink $dest_xml;
             1;
         } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
+        unlink $dest_xml;
     }
     else {
         my $edit_url = $edit_urls->{$root_dir};
@@ -330,9 +349,8 @@ sub build_single {
             );
             1;
         } or do { $output = $@; $died = 1; };
+        _check_build_error( $output, $died, $lenient );
     }
-
-    _check_build_error( $output, $died, $lenient );
 
     my $base_name = $index->basename;
     $base_name =~ s/\.[^.]+$/.html/;


### PR DESCRIPTION
Before this commit we bundled executing `asciidoctor`, `xmllint`, and
`xsltproc` together, checking warnings after the whole process
succeedes. If any step in the process fails we'd log the errors for
*that* *step* and exit non-0. The trouble with this behavior is that
we'd throw out the warnings from the previous steps. This is especially
bad because the warnings from `asciidoctor` are *much* easier to debug
that errors from `xmllint`.

This commit causes us to check the warnings after each step. If there
are any warnings we log them and exit non-0. This is will effectively
prefer warnings from asciidoctor if there are any which should make
debugging problems like bad links *much* simpler.
