### PR TITLE
Automatically relativize links to elastic.co

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -24,4 +24,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec -e 'README'
+	rspec

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -24,4 +24,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec
+	rspec -e 'README'

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -47,6 +47,8 @@ def normalize_html(html):
                         '"programlisting prettyprint lang-console"')
     html = html.replace('"pre_wrapper lang-js"',
                         '"pre_wrapper lang-console"')
+    # Asciidoctor relativizes https://www.elatic.co/ into /.
+    html = html.replace('https://www.elastic.co/', '/')
     # The URL for the console snippets has changed
     html = re.sub(r'data-snippet="[^"]+"', 'data-snippet="snippet"', html)
     return html

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -121,6 +121,7 @@ sub build_chunked {
                     '-a' => "alternative_language_report=$raw_dest/alternatives_report.json",
                     '-a' => "alternative_language_summary=$alternatives_summary",
                 ) : (),
+                '-a' => 'relativize-link=https://www.elastic.co/',
                 '--destination-dir=' . $raw_dest,
                 docinfo($index),
                 $index
@@ -287,6 +288,7 @@ sub build_single {
                 # Disable warning on missing attributes because we have
                 # missing attributes!
                 # '-a' => 'attribute-missing=warn',
+                '-a' => 'relativize-link=https://www.elastic.co/',
                 '--destination-dir=' . $raw_dest,
                 docinfo($index),
                 $index

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -11,6 +11,7 @@ require_relative 'elastic_compat_preprocessor/extension'
 require_relative 'elastic_include_tagged/extension'
 require_relative 'lang_override/extension'
 require_relative 'open_in_widget/extension'
+require_relative 'relativize_link/extension'
 
 Asciidoctor::Extensions.register do
   # Enable storing the source locations so we can look at them. This is required
@@ -21,6 +22,7 @@ Asciidoctor::Extensions.register CareAdmonition
 Asciidoctor::Extensions.register ChangeAdmonition
 Asciidoctor::Extensions.register CopyImages
 Asciidoctor::Extensions.register EditMe
+Asciidoctor::Extensions.register RelativizeLink
 Asciidoctor::Extensions.register do
   block_macro LangOverride
   preprocessor CrampedInclude

--- a/resources/asciidoctor/lib/relativize_link/extension.rb
+++ b/resources/asciidoctor/lib/relativize_link/extension.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+require_relative '../delegating_converter'
+
+##
+# Converts absolute links to some url root into relative links.
+module RelativizeLink
+  def self.activate(registry)
+    DelegatingConverter.setup(registry.document) do |doc|
+      Converter.new doc
+    end
+  end
+
+  ##
+  # Converter implementation that does the conversion.
+  class Converter < DelegatingConverter
+    def inline_anchor(node)
+      modify node
+      yield
+    end
+
+    def modify(node)
+      return unless node.type == :link
+      return unless (root = node.attr 'relativize-link')
+      return unless node.target.start_with? root
+
+      node.target = '/' + node.target[root.length..node.target.length]
+    end
+  end
+end

--- a/resources/asciidoctor/spec/relativize_link_spec.rb
+++ b/resources/asciidoctor/spec/relativize_link_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'relativize_link/extension'
+
+RSpec.describe RelativizeLink do
+  before(:each) do
+    Asciidoctor::Extensions.register RelativizeLink
+  end
+
+  after(:each) do
+    Asciidoctor::Extensions.unregister_all
+  end
+
+  context 'when not configured' do
+    include_context 'convert without logs'
+    let(:input) { 'https://www.elastic.co/guide/foo[foo]' }
+    it "doesn't do anything" do
+      expect(converted).to include(<<~DOCBOOK.strip)
+        <ulink url="https://www.elastic.co/guide/foo">foo</ulink>
+      DOCBOOK
+    end
+  end
+  context 'when configured' do
+    include_context 'convert without logs'
+    let(:convert_attributes) do
+      { 'relativize-link' => 'https://www.elastic.co/' }
+    end
+    context 'when the url matches' do
+      let(:input) { 'https://www.elastic.co/guide/foo[foo]' }
+      it 'relativizes the link' do
+        expect(converted).to include(<<~DOCBOOK.strip)
+          <ulink url="/guide/foo">foo</ulink>
+        DOCBOOK
+      end
+    end
+    context "when the url doesn't match" do
+      let(:input) { 'https://not.elastic.co/guide/foo[foo]' }
+      it "doesn't do anything" do
+        expect(converted).to include(<<~DOCBOOK.strip)
+          <ulink url="https://not.elastic.co/guide/foo">foo</ulink>
+        DOCBOOK
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds an asciidoctor plugin to automatically relativize links with a
particular prefix and configures it with `https://www.elastic.co/

Closes #1029