### PR TITLE
Add explicit dependency on docs repo for some books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,6 +79,12 @@ contents:
                 repo:   logstash
                 path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
@@ -93,6 +99,12 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Glossary
             prefix:     en/elastic-stack-glossary
@@ -111,10 +123,10 @@ contents:
                 path:   docs/reference
               -
                 repo:   docs
-                path:   shared/attributes.asciidoc
+                path:   shared/versions/stack/{version}.asciidoc
               -
                 repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
+                path:   shared/attributes.asciidoc
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
@@ -142,6 +154,15 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
                 exclude_branches:   [ 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
           -
             title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
@@ -184,6 +205,12 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en/gke-on-prem
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
     -
         title:      Elasticsearch: Store, Search, and Analyze
         sections:
@@ -1020,7 +1047,12 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
-
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
     -
         title:      Observability: APM, Infrastructure, Logs, and Uptime
         sections:
@@ -1182,6 +1214,12 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime

--- a/conf.yaml
+++ b/conf.yaml
@@ -82,11 +82,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-             exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started

--- a/conf.yaml
+++ b/conf.yaml
@@ -82,9 +82,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+             exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started


### PR DESCRIPTION
This adds an explicit dependency on the docs repo for all books build
from `stack-docs`. This will expose the `docs-root` attribute to those
books and automatically rebuild the books if any of those file change.
