### PR TITLE
Make sure we don't rebuild at a bad time

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -643,7 +643,11 @@ sub init_repos {
 
     # Setup the docs repo
     # We support configuring the remote for the docs repo for testing
-    ES::DocsRepo->new( $tracker, $conf->{docs} || '/docs_build' );
+    ES::DocsRepo->new( 
+        tracker => $tracker,
+        dir => $conf->{docs} || '/docs_build',
+        keep_hash => $Opts->{keep_hash}
+    );
 
     return $tracker;
 }

--- a/lib/ES/DocsRepo.pm
+++ b/lib/ES/DocsRepo.pm
@@ -11,15 +11,17 @@ use parent qw( ES::Repo );
 #===================================
 sub new {
 #===================================
-    my ( $class, $tracker, $dir ) = @_;
+    my ( $class, %args ) = @_;
 
+    my $tracker = $args{tracker} or die 'Missing <tracker>';
+    my $dir = $args{dir} or die 'Missing <dir>';
     $dir = Path::Class::dir( $dir );
     my $self = $class->SUPER::new(
         name      => 'docs',
         git_dir   => $dir->subdir( '.git' ),
         tracker   => $tracker,
         url       => 'git@github.com:elastic/docs.git',
-        keep_hash => 0,
+        keep_hash => $args{keep_hash},
     );
     $self->{dir} = $dir;
     return $self;

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -88,8 +88,6 @@ sub has_changed {
     # new sources specially.
     return 'changed' if exists $self->{sub_dirs}->{$branch};
 
-    say "ASDFSADF $path $old_info $new_info";
-
     if ($self->{keep_hash}) {
         return $old_info ne $new_info ? 'changed' : 'not_changed';
     }

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -88,6 +88,8 @@ sub has_changed {
     # new sources specially.
     return 'changed' if exists $self->{sub_dirs}->{$branch};
 
+    say "ASDFSADF $path $old_info $new_info";
+
     if ($self->{keep_hash}) {
         return $old_info ne $new_info ? 'changed' : 'not_changed';
     }


### PR DESCRIPTION
It is important that changes to the docs repo don't trigger a rebuild
when `--keep_hash` is specified or else every time we change this
file we'll rebuild all books in every PR build. That is a waste of
time and a potential source of spurious errors.

This PR does exactly that: it adds tests that make sure we don't rebuild
and it makes a small change to the initialization fo the docs repo to
make the test pass.
