### PR TITLE
Clean integtest/Makefile

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -1,12 +1,5 @@
 SHELL = /bin/bash -eux -o pipefail
 MAKEFLAGS += --silent
-TMP = /tmp/docs_integtest/$@
-
-# Used by the test for --all
-export GIT_AUTHOR_NAME=Test
-export GIT_AUTHOR_EMAIL=test@example.com
-export GIT_COMMITTER_NAME=Test
-export GIT_COMMITTER_EMAIL=test@example.com
 
 .PHONY: check
 check: rspec style


### PR DESCRIPTION
It has some variables that are left over from when we were writing tests
in the Makefile directly. We don't need them any more.
