### PR TITLE
[DOCS] Add attributes for SLM

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -120,6 +120,9 @@
 :ilm:                     index lifecycle management
 :ilm-cap:                 Index lifecycle management
 :ilm-init:                ILM
+:slm:                     snapshot lifecycle management
+:slm-cap:                 Snapshot lifecycle management
+:slm-init:                SLM
 :rollup-features:         data rollup features
 
 :rollup:                     rollup


### PR DESCRIPTION
Adds Asciidoc attributes for various uses of 'snapshot lifecycle management.'

The idea is to keep the docs DRY, reduce the likelihood of error, and make future updates easier if we decide to rename SLM to something else.

I largely followed the pattern used for ILM, but let me know if you'd like to see anything else.

This should also fix the current attribute in use in the SLM docs:
https://github.com/elastic/elasticsearch/blame/master/docs/reference/ilm/apis/slm-api.asciidoc#L44