### PR TITLE
Adjust ECS version mapping for unreleased Elastic docs

### DIFF
--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -10,7 +10,7 @@ bare_version never includes -alpha or -beta
 :branch:                 7.x
 :major-version:          7.x
 :prev-major-version:     6.x
-:ecs_version:            1.1
+:ecs_version:            1.2
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -10,7 +10,7 @@ bare_version never includes -alpha or -beta
 :branch:                 master
 :major-version:          8.x
 :prev-major-version:     7.x
-:ecs_version:            1.1
+:ecs_version:            1.2
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
ECS 1.2 came out in advance of 7.5, and should be associated with ECS 1.2
when it comes out.

Until 7.5 is released however, 7.x and 'master' should be associated with ECS 1.2.

cc @karenzone @benskelker