### PR TITLE
docs: update APM ruby current to 3.x

### DIFF
--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -21,5 +21,5 @@ APM Agent versions
 :apm-rum-branch:        2.x
 :apm-node-branch:       2.x
 :apm-py-branch:         4.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -21,5 +21,5 @@ APM Agent versions
 :apm-rum-branch:        3.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -21,5 +21,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -25,5 +25,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -26,5 +26,5 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       2.x
+:apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x


### PR DESCRIPTION
Couple more changes per [this](https://github.com/elastic/observability-dev/blob/master/docs/apm/apm-documentation.md#updating-an-apm-agent-to-a-new-version).

This PR updates `3.x` to the current version of the APM Ruby Agent back to `6.5`.