### PR TITLE
Support redirects in preview

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -449,9 +449,10 @@ RSpec.describe 'building all books' do
       HTML
     end
     it 'serves a legacy redirect' do
-      expect(legacy_redirect.code).to eq('301')
-      expect(legacy_redirect['location']).to eq(
-        "#{root}/en/elasticsearch/reference/current/setup.html"
+      expect(legacy_redirect).to redirect_to(
+        eq(
+          "#{root}/en/elasticsearch/reference/current/setup.html"
+        )
       )
     end
     context 'for a JPG' do

--- a/integtest/spec/helper/dsl.rb
+++ b/integtest/spec/helper/dsl.rb
@@ -46,7 +46,7 @@ module Dsl
 
   RSpec.shared_examples 'the root' do
     context 'the root' do
-      let(:root_uri) { 'http://localhost:8000/' }
+      let(:root_uri) { 'http://localhost:8000' }
       let(:root) { Net::HTTP.get_response(URI(root_uri)) }
       it 'redirects to the guide root' do
         expect(root).to redirect_to(eq("#{root_uri}/guide/index.html"))

--- a/integtest/spec/helper/dsl.rb
+++ b/integtest/spec/helper/dsl.rb
@@ -46,12 +46,10 @@ module Dsl
 
   RSpec.shared_examples 'the root' do
     context 'the root' do
-      let(:root) do
-        Net::HTTP.get_response(URI('http://localhost:8000/'))
-      end
+      let(:root_uri) { 'http://localhost:8000/' }
+      let(:root) { Net::HTTP.get_response(URI(root_uri)) }
       it 'redirects to the guide root' do
-        expect(root.code).to eq('301')
-        expect(root['Location']).to eq('http://localhost:8000/guide/index.html')
+        expect(root).to redirect_to(eq("#{root_uri}/guide/index.html"))
       end
     end
   end

--- a/integtest/spec/helper/matcher/redirect_to.rb
+++ b/integtest/spec/helper/matcher/redirect_to.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+##
+# Matches http responses.
+RSpec::Matchers.define :redirect_to do |expected|
+  match do |actual|
+    return false unless actual.code == '301'
+
+    expected.matches? actual['Location']
+  end
+  failure_message do |actual|
+    unless actual.code == '301'
+      return "expected status [301] but was [#{actual.code}]. Body:\n" +
+             actual.body
+    end
+
+    message = expected.failure_message
+    "status was [301] but the location didn't match: #{message}"
+  end
+end

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require_relative 'helper/matcher/doc_body'
 require_relative 'helper/matcher/have_same_keys'
 require_relative 'helper/matcher/initial_js_state'
+require_relative 'helper/matcher/redirect_to'
 require_relative 'helper/matcher/serve'
 require_relative 'helper/console_alternative_examples'
 require_relative 'helper/dest'

--- a/preview/core.js
+++ b/preview/core.js
@@ -52,6 +52,7 @@ const GitCore = (defaultTemplate, ignoreHost, repoPath) => {
 
     return {
       diff: () => Readable.from(bufferItr(diffItr(git, branch), 16 * 1024)),
+      redirects: () => git.catBlob(`${branch}:redirects.conf`),
       file: async requestedPath => {
         const templateExists = await hasTemplate(git, branch);
         /*
@@ -113,6 +114,7 @@ const FsCore = (defaultTemplate, ignoreHost, rootPath) => {
         r.push(null);
         return r;
       },
+      redirects: () => null,
       file: async requestedPath => {
         const realPath = `${rootPath}/${requestedPath}`;
         let pathStat;


### PR DESCRIPTION
This add support for parsing the redirects.conf file that we've been
including in every do build for a while. It is *technically* an nginx
config file but it is safe to treat it as a list of regex substitutions.
