### PR TITLE
[docs] Update current for APM Node.js Agent

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1129,7 +1129,7 @@ contents:
                       -
                         repo:   apm-agent-nodejs
                         path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 3.x, 1.x, 0.x ]
+                        exclude_branches:   [ 1.x, 0.x ]
                   -
                     title:      APM Python Agent
                     prefix:     python

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -19,7 +19,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        3.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -19,7 +19,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -23,7 +23,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -24,7 +24,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       2.x
+:apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x


### PR DESCRIPTION
Updates `current` links for the APM Node.js Agent.