### PR TITLE
Add APM app attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -21,6 +21,7 @@
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
+:apm-app-ref:          https://www.elastic.co/guide/en/kibana/{branch}
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2


### PR DESCRIPTION
This PR adds a new attribute for the APM app documentation: `apm-app-ref`. Right now, this reference points to the Kibana docs. Over the next few weeks I'll slowly be moving APM Agent/Server links to this new attribute. Then, when the APM app documentation moves out of Kibana, I'll simply need to adjust this attribute to point to the right location.

FYI @gchaps @KOTungseth
