### PR TITLE
Obs docs box

### DIFF
--- a/resources/web/style/rtpcontainer.pcss
+++ b/resources/web/style/rtpcontainer.pcss
@@ -6,8 +6,8 @@
 #rtpcontainer {
   .mktg-promo {
     border-radius: 5px;
-    margin-bottom: 40px;
-    padding: 20px;
+    margin-bottom: 20px;
+    padding: 0px 20px;
     border: 1px solid #ccc;
   }
   ul.icons {
@@ -15,7 +15,7 @@
     li {
       align-items: center;
       list-style: none;
-      min-height: 60px;
+      min-height: 35px;
       padding-left: 0.6em;
       display: flex;
       :global(a.link) {
@@ -40,8 +40,8 @@
         background-size: 55%;
         background-position: center center;
         content: '';
-        height: 2.5em;
-        width: 2.5em;
+        height: 1.5em;
+        width: 1.5em;
         display: block;
         float: left;
         margin-left: -2.5em;
@@ -56,6 +56,36 @@
       &.icon-elasticsearch-white {
         &:before {
           background-image: inline(img/rtpcontainer/logo-elasticsearch-32-white.svg);
+        }
+      }
+      &.icon-apm-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-apm-32-white.svg);
+        }
+      }
+      &.icon-logging-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-logging-32-white.svg);
+        }
+      }
+      &.icon-uptime-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-uptime-32-white.svg);
+        }
+      }
+      &.icon-metrics-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-metrics-32-white.svg);
+        }
+      }
+      &.icon-code-search-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-code-search-32-white.svg);
+        }
+      }
+      &.icon-stack-white {
+        &:before {
+          background-image: inline(img/rtpcontainer/logo-stack-32-white.svg);
         }
       }
       &.logo-kibana-white {

--- a/resources/web/style/toc.pcss
+++ b/resources/web/style/toc.pcss
@@ -55,7 +55,108 @@
       > span {
         background-color: #efefef;
         border-bottom: 1px solid #ddd;
+        border-left: 1px solid #ddd;
         font-size: 1em;
+        background-position: 0 11px;
+        padding-left: 20px;
+      }
+      > ul > li {
+        > span {
+          padding-left: 40px;
+          background-position: 20px 8px;
+        }
+        > ul > li {
+          > span {
+            padding-left: 60px;
+            background-position: 40px 8px;
+          }
+          > ul > li {
+            > span {
+              padding-left: 80px;
+              background-position: 60px 8px;
+            }
+            ul > li > span {
+              padding-left: 80px;
+              background-image: none;
+            }
+          }
+        }
+      }
+    }
+
+    .experimental,
+    .beta,
+    .coming,
+    .added,
+    .deprecated {
+        display: none;
+    }
+  }
+  .toc2 {
+    ul {
+      margin: 0 0 1em 0;
+      padding: 0;
+      border: 1px solid #ddd;
+      ul {
+        /* Hide all sub-toc elements by default. See rules with `.show` that
+         * show specific sub-toc elements. */
+        display: none;
+      }
+    }
+    li {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      ul {
+        border: none;
+      }
+    }
+    span {
+      display: block;
+      padding: 0.5em 0;
+      font-size: 0.85em;
+      line-height: 1.3em;
+    }
+
+    .current_page {
+      font-weight: bold;
+    }
+
+    .collapsible.show {
+      > ul {
+        display: block;
+      }
+      > span {
+        background-image: inline("img/minus.png");
+        background-color: white;
+        border-bottom: 1px solid white;
+      }
+    }
+    .collapsible {
+      > span {
+        background-repeat: no-repeat;
+        background-image: inline("img/plus.png");
+        &:hover {
+          background-color: #fafafa;
+          cursor: pointer;
+        }
+      }
+    }
+
+    /* Customize each level of the TOC, mostly so it looks "indented". */
+    > li {
+      > span {
+        background-color: #efefef;
+        border-bottom: 1px solid #ddd;
+        border-left: 1px solid #ddd;
+        font-size: 1em;
+        background-position: 0 11px;
+        padding-left: 20px;
+      }
+      .related-title {
+        background-color: #ffffff;
+        font-size: 1em;
+        font-weight: bold !important;
         background-position: 0 11px;
         padding-left: 20px;
       }
@@ -96,6 +197,13 @@
   .article,
   .book {
       .toc {
+          float: none;
+          clear: none;
+          width:  auto;
+          margin: 0 0 2em 0;
+          padding: 0;
+      }
+      .toc2 {
           float: none;
           clear: none;
           width:  auto;

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -93,16 +93,31 @@
                         <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
                         <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
                       </ul>
-                      <h3>Observability Docs</h3>
-                      <ul class="icons">
-                        <li class="icon-stack-white"><a href="#">Observability Overview</a></li>
-                        <li class="icon-apm-white"><a href="#">Application Performance Monitoring</a></li>
-                        <li class="icon-logging-white"><a href="#">Log Management</a></li>
-                        <li class="icon-metrics-white"><a href="#">Metrics Guide</a></li>
-                        <li class="icon-uptime-white"><a href="#">Uptime Monitoring</a></li>
-                      </ul>
                     </div>
                   </div>
+                
+                  <!-- Related docs -->
+                  <div class="toc2">
+                    <ul class="toc2">
+                      <li>
+                        <span class="related-title">Related documentation</span>
+                        <span class="chapter">
+                          <a href="https://www.elastic.co/guide/en/apm/index.html">Application Performance Monitoring</a>
+                        </span>
+                        <span class="chapter">
+                          <a href="https://www.elastic.co/guide/en/logs/guide/current/index.html">Log Guide</a>
+                        </span>
+                        <span class="chapter">
+                          <a href="https://www.elastic.co/guide/en/metrics/guide/current/index.html">Metrics Guide</a>
+                        </span>
+                        <span class="chapter">
+                          <a href="https://www.elastic.co/guide/en/uptime/current/index.html">Uptime Monitoring</a>
+                        </span>
+                      </li>
+                    </ul>
+                  </div>
+                  <!-- End related docs -->
+
                 </div>
               </div>
             </div>

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -93,14 +93,13 @@
                         <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
                         <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
                       </ul>
-                      <h3>Observability</h3>
+                      <h3>Observability Docs</h3>
                       <ul class="icons">
-                        <li class="icon-stack-white"><a href="#">Overview</a></li>
-                        <li class="icon-apm-white"><a href="#">APM</a></li>
-                        <li class="icon-code-search-white"><a href="#">Code</a></li>
-                        <li class="icon-logging-white"><a href="#">Logs</a></li>
-                        <li class="icon-metrics-white"><a href="#">Metrics</a></li>
-                        <li class="icon-uptime-white"><a href="#">Uptime</a></li>
+                        <li class="icon-stack-white"><a href="#">Observability Overview</a></li>
+                        <li class="icon-apm-white"><a href="#">Application Performance Monitoring</a></li>
+                        <li class="icon-logging-white"><a href="#">Log Management</a></li>
+                        <li class="icon-metrics-white"><a href="#">Metrics Guide</a></li>
+                        <li class="icon-uptime-white"><a href="#">Uptime Monitoring</a></li>
                       </ul>
                     </div>
                   </div>

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -84,18 +84,7 @@
                   <!-- DOCS BODY -->
                   <!-- end body -->
                 </div>
-                <div class="col-xs-12 col-sm-4 col-md-4" id="right_col">
-                  <div id="rtpcontainer" style="display: block;">
-                    <div class="mktg-promo">
-                      <h3>Most Popular</h3>
-                      <ul class="icons">
-                        <li class="icon-elasticsearch-white"><a href="https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=default&elektra=docs&storm=top-video">Elasticsearch Service: Free Trial</a></li>
-                        <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
-                        <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
-                      </ul>
-                    </div>
-                  </div>
-                
+                <div class="col-xs-12 col-sm-4 col-md-4" id="right_col">                
                   <!-- Related docs -->
                   <div class="toc2">
                     <ul class="toc2">
@@ -117,6 +106,17 @@
                     </ul>
                   </div>
                   <!-- End related docs -->
+
+                  <div id="rtpcontainer" style="display: block;">
+                      <div class="mktg-promo">
+                        <h3>Most Popular</h3>
+                        <ul class="icons">
+                          <li class="icon-elasticsearch-white"><a href="https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=default&elektra=docs&storm=top-video">Elasticsearch Service: Free Trial</a></li>
+                          <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
+                          <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
+                        </ul>
+                      </div>
+                    </div>
 
                 </div>
               </div>

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -93,6 +93,15 @@
                         <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
                         <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
                       </ul>
+                      <h3>Observability</h3>
+                      <ul class="icons">
+                        <li class="icon-stack-white"><a href="#">Overview</a></li>
+                        <li class="icon-apm-white"><a href="#">APM</a></li>
+                        <li class="icon-code-search-white"><a href="#">Code</a></li>
+                        <li class="icon-logging-white"><a href="#">Logs</a></li>
+                        <li class="icon-metrics-white"><a href="#">Metrics</a></li>
+                        <li class="icon-uptime-white"><a href="#">Uptime</a></li>
+                      </ul>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
### DO NOT MERGE THIS PR

TLDR: **[CLICK HERE FOR A PREVIEW](http://docs_1277.docs-preview.app.elstc.co/guide/en/apm/get-started/current/index.html)** that mostly works (ish)

--- 
Over in https://github.com/elastic/observability-dev/issues/14, we've been trying to figure out how best to structure our Observability documentation. A general plan was eventually formed: Each solution's docs would live in its own documentation book, and we would explore ways to connect this content via the doc build. This could mean a [related docs widget](https://github.com/elastic/observability-dev/issues/14#issuecomment-534637225), an [aware navigation](https://github.com/elastic/observability-dev/issues/14#issuecomment-535991212),  [dynamic documentation](https://docs.google.com/document/d/1Ty0m-N4FTWN6zCODGxVk90KLj4RNODY48v0yPwm880U/edit#heading=h.4ob4rpg4dw57) based on a user's needs, or a host of other options discussed in weekly doc huddles.

The problem with most of these solutions is that they're not quick fixes. And although effort is already underway for a long-term solution in https://github.com/elastic/Design/issues/1650#issuecomment-540981241, we could still do with an  easier, short-term solution.

I decided to run with @dedemorton's mockup in [this comment](https://github.com/elastic/observability-dev/issues/14#issuecomment-534637225), also shown below.
![dedesmockup](https://user-images.githubusercontent.com/5618806/66527177-fd381c00-eaaf-11e9-8179-088fcdc7e057.png)

For this PR, I tried to simplify the idea even more. It is my understanding that we can't remove the "Getting Started Videos" widget that displays in the documentation, but what about adding to it? So, I came up with this:
<img width="448" alt="Screen Shot 2019-10-09 at 4 01 50 PM" src="https://user-images.githubusercontent.com/5618806/66527317-8e0ef780-eab0-11e9-95b7-1f94ff7face7.png">

---

But Brandon, won't that just push the TOC even _further_ down the page? A little, yes. But here's a side-by-side comparison -- with a few CSS adjustments, it's not as bad as you'd think.

<img width="699" alt="Screen Shot 2019-10-09 at 4 00 16 PM" src="https://user-images.githubusercontent.com/5618806/66527355-bdbdff80-eab0-11e9-9b40-fdf3898e0ecb.png">

---

But Brandon, doesn't that just add more links to our documentation? Yes it does, but it's so painfully hard to navigate between these solutions right now. I think this could be a good short-term fix.

---

But Brandon, isn't this only specific to Observability? Yes, but it wouldn't necessarily have to be. Each documentation book could define their own "related docs" content as needed.

---

At the end of the day, editing our doc build is not my wheelhouse. In fact, this PR won't work as-is. I'm not sure:
1. If it's possible to only apply a template to certain documentation books -- as this would only need to be applied to Observability content.
2. Just how flexible my CSS changes are across different devices 🤷‍♂
3. How to version links in this widget to point to the correct version of the documentation.

The idea here was mostly to provide the simplest thing I could think of as a **short-term** solution. 

---

If anyone has thoughts, or more importantly, criticism, I'd love to hear it. cc @dedemorton, @debadair, @lcawl, @nik9000, @Titch990 @tbragin 