### PR TITLE
Update Azure Marketplace docs to 7.4

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -159,9 +159,9 @@ contents:
           -
             title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    7.3
+            current:    7.4
             index:      docs/index.asciidoc
-            branches:   [ master, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This PR adds version 7.4  to the Azure Marketplace docs and sets 7.4 as the current version

