### PR TITLE
Fix some duplication problems in buffer itr

### DIFF
--- a/preview/__test__/buffer_itr.test.js
+++ b/preview/__test__/buffer_itr.test.js
@@ -24,6 +24,7 @@ const bufferItr = require("../buffer_itr.js");
 
 const bufferedCollect = async itrGen => {
   const all = [];
+  // Use 20 chunking point to make it easy to write test strings.
   for await (const c of bufferItr(itrGen(), 20)) {
     all.push(c);
   }

--- a/preview/__test__/buffer_itr.test.js
+++ b/preview/__test__/buffer_itr.test.js
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+const bufferItr = require("../buffer_itr.js");
+
+const bufferedCollect = async itrGen => {
+  const all = [];
+  for await (const c of bufferItr(itrGen(), 20)) {
+    all.push(c);
+  }
+  return all;
+}
+
+describe(bufferItr, () => {
+  describe("when there aren't any entries",  () => {
+    it("emits no entries", async () => {
+      expect(await bufferedCollect(function* () {
+      })).toStrictEqual([]);
+    });
+  });
+  describe("when there is a single string", () => {
+    it("emits a single result", async () => {
+      expect(await bufferedCollect(function* () {
+        yield "foo";
+      })).toStrictEqual(["foo"]);
+    });
+  });
+  describe("when there are a few longs strings", () => {
+    it("emits each one", async () => {
+      expect(await bufferedCollect(function* () {
+        yield "string that is more than twenty characters. ";
+        yield "another string";
+      })).toStrictEqual([
+        "string that is more than twenty characters. ",
+        "another string"
+      ]);
+    });
+  });
+  describe("when there are a few short strings", () => {
+    it("they are all bundled", async () => {
+      expect(await bufferedCollect(function* () {
+        yield "a";
+        yield "b";
+        yield "c";
+        yield "d";
+      })).toStrictEqual(["abcd"]);
+    });
+  });
+});

--- a/preview/__test__/git.test.js
+++ b/preview/__test__/git.test.js
@@ -26,7 +26,6 @@ const fs = require("fs");
 const child_process = require("child_process");
 const Git = require("../git");
 const rmfr = require("rmfr");
-const { Readable } = require("stream");
 
 const execFile = promisify(child_process.execFile);
 const mkdir = promisify(fs.mkdir);

--- a/preview/buffer_itr.js
+++ b/preview/buffer_itr.js
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+'use strict';
+
+/**
+ * Buffers an async iterator until its output is at least min characters
+ * @param {Generator} itr async iterator that returns a string to buffer 
+ */
+module.exports = async function* (itr, min) {
+  let buffer = "";
+  for await (const chunk of itr) {
+    buffer += chunk;
+    if (buffer.length > min) {
+      yield buffer;
+      buffer = "";
+    }
+  }
+  if (buffer !== "") {
+    yield buffer;
+  }
+};

--- a/preview/core.js
+++ b/preview/core.js
@@ -20,6 +20,7 @@
 
 'use strict';
 
+const bufferItr = require("./buffer_itr");
 const fs = require("fs");
 const dedent = require("dedent");
 const Git = require("./git");
@@ -158,21 +159,6 @@ const hasTemplate = async (git, branch) => {
       throw new Error(`The template is a strange object type: ${type}`);
   }
 }
-
-/**
- * Buffers an async iterator until its output is at least min characters
- * @param {Generator} itr async iterator that returns a string to buffer 
- */
-const bufferItr = async function* (itr, min) {
-  let buffer = '';
-  for await (const chunk of itr) {
-    buffer += chunk;
-    if (buffer.length > min) {
-      yield buffer;
-    }
-  }
-  yield buffer;
-};
 
 /**
  * Creates an async iterator describing the diff. The iterator is very "chatty"


### PR DESCRIPTION
The code that emits the `html` for our `diff` endpoint if pretty chatty
and we wrap it in a "buffering iterator" to save up chunks until they
are worth sending. It had a bug where it'd duplicate stuff. This fixes
that bug and adds tests.
