### PR TITLE
Move the swiftype placeholder to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -985,6 +985,7 @@ contents:
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
+            asciidoctor: true
             sources:
               -
                 repo:   swiftype
@@ -999,6 +1000,7 @@ contents:
             single:     1
             tags:       App Search/Reference
             subject:    Swiftype
+            asciidoctor: true
             sources:
               -
                 repo:   swiftype


### PR DESCRIPTION
Another step in our effort to remove the unmaintained AsciiDoc in favor
of the actively maintained Asciidoctor.
