### PR TITLE
Improve --sub_dir --keep_hash for /

### DIFF
--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -17,4 +17,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec
+	rspec -e '--sub_dir'

--- a/integtest/spec/all_books_sub_dir_spec.rb
+++ b/integtest/spec/all_books_sub_dir_spec.rb
@@ -153,6 +153,16 @@ RSpec.describe 'building all books' do
         include_examples 'log merge', 'docs'
         include_examples 'contains the new master and subbed changes'
       end
+      describe 'when the source path is the entire repo' do
+        def self.setup_book(src, repo)
+          book = src.book 'Test'
+          book.index = 'docs/index.adoc'
+          book.source repo, '/'
+        end
+        convert_with_sub
+        include_examples 'log merge', 'docs'
+        include_examples 'contains the new master and subbed changes'
+      end
       describe 'when the subbed dir has already been merged' do
         # This simulates what github will do if you ask it to build the "sha"
         # of the merged PR instead of the "head" of the branch.

--- a/integtest/spec/all_books_sub_dir_spec.rb
+++ b/integtest/spec/all_books_sub_dir_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'building all books' do
           book.source repo, '/'
         end
         convert_with_sub
-        include_examples 'log merge', 'docs'
+        include_examples 'log merge', '.'
         include_examples 'contains the new master and subbed changes'
       end
       describe 'when the subbed dir has already been merged' do

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -196,6 +196,7 @@ sub _prepare_sub_dir {
     delete local $ENV{GIT_DIR};
     my $merge_branch = "${resolved_branch}_${subbed_head}_$path";
     $merge_branch =~ s|/|_|g;
+    $merge_branch =~ s|\.$||g; # Fix funny shaped paths
 
     # Check if we've already merged this path by looking for the merged_branch
     # in the source repo. This is safe because:
@@ -225,8 +226,10 @@ sub _prepare_sub_dir {
         run qw(git remote add subbed_repo), $source_root;
         run qw(git fetch subbed_repo), $subbed_head;
         run qw(git remote remove subbed_repo);
-        run qw(git config core.sparseCheckout true);
-        $self->_write_sparse_config( $work, $path );
+        unless ($path eq '.') {
+            run qw(git config core.sparseCheckout true);
+            $self->_write_sparse_config( $work, $path );
+        }
         run qw(git checkout -b), $merge_branch, $resolved_branch;
         run qw(git merge -m merge), $subbed_head;
         run qw(git push origin -f), $merge_branch; # Origin here is just our clone.


### PR DESCRIPTION
When an entire repo is included by the docs we were failing to properly
perform the merge. This fixes that.
