### PR TITLE
Allow explicit suppress of MIGRATION warnings

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1434,6 +1434,7 @@ contents:
             noindex:    1
             tags:       Legacy/Elasticsearch/Definitive Guide
             subject:    Elasticsearch
+            suppress_migration_warnings: true
             sources:
               -
                 repo:   guide

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -28,6 +28,11 @@ class Book
   # The language of the book. Defaults to `en`.
   attr_accessor :lang
 
+  ##
+  # Should this book suppress all migration warnings, even in the newest
+  # version? Defaults to false.
+  attr_accessor :suppress_migration_warnings
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -38,6 +43,7 @@ class Book
     @current_branch = 'master'
     @respect_edit_url_overrides = false
     @lang = 'en'
+    @suppress_migration_warnings = false
   end
 
   ##
@@ -69,6 +75,9 @@ class Book
     # only supports 1.0.....
     conf = standard_conf
     conf += "respect_edit_url_overrides: true\n" if @respect_edit_url_overrides
+    if @suppress_migration_warnings
+      conf += "suppress_migration_warnings: #{@suppress_migration_warnings}\n"
+    end
     conf += <<~YAML
       sources:
       #{sources_conf}

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -153,6 +153,7 @@ sub new {
         lang          => $lang,
         asciidoctor   => $asciidoctor,
         respect_edit_url_overrides => $respect_edit_url_overrides,
+        suppress_migration_warnings => $args{suppress_migration_warnings} || 0,
     }, $class;
 }
 
@@ -175,7 +176,7 @@ sub build {
         }
     );
 
-    my $latest = 1;
+    my $latest = !$self->{suppress_migration_warnings};
     my $update_version_toc = 0;
     my $rebuilding_current_branch = 0;
     for my $branch ( @{ $self->branches } ) {


### PR DESCRIPTION
MIGRATION warnings are problems that we should fix in newer versions of
a book but aren't worth fixing in old versions of a book. But some books
are old and aren't going to be updated, probably ever. Those books
should just suppress their MIGRATION warnings all together. This allows
you to configure that.
