### PR TITLE
[docs-preview] Switch Github creds to use SSH

### DIFF
--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/docs/preview:11
+FROM docker.elastic.co/docs/preview:13
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 

--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/docs/preview:12
+FROM docker.elastic.co/docs/preview:11
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -19,6 +19,6 @@ GIT_DIR=air_gapped/work/target_repo.git git fetch
 
 # Build the images
 ./build_docs --just-build-image
-docker build -t docker.elastic.co/docs/preview:11 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:13 -f preview/Dockerfile .
 # Use buildkit here to pick up the customized dockerignore file
 DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs-private/air_gapped:latest -f air_gapped/Dockerfile .

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -19,6 +19,6 @@ GIT_DIR=air_gapped/work/target_repo.git git fetch
 
 # Build the images
 ./build_docs --just-build-image
-docker build -t docker.elastic.co/docs/preview:12 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:11 -f preview/Dockerfile .
 # Use buildkit here to pick up the customized dockerignore file
 DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs-private/air_gapped:latest -f air_gapped/Dockerfile .

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -26,8 +26,6 @@ BEGIN {
 
 use lib 'lib';
 
-use URI();
-
 use ES::Util qw(
     run $Opts
     build_chunked build_single build_pdf
@@ -557,17 +555,9 @@ sub init_target_repo {
 #===================================
     my ( $repos_dir, $temp_dir, $reference_dir ) = @_;
 
-    my $git_repo = $Opts->{target_repo};
-    my $git_uri = URI->new($git_repo);
-
-    if ( ( $git_uri->scheme || "" ) eq "https" && defined $ENV{GITHUB_USER} && defined $ENV{GITHUB_PASS} ){
-        $git_uri->userinfo( $ENV{GITHUB_USER} . ":" . $ENV{GITHUB_PASS} );
-        $git_repo = $git_uri->as_string;
-    }
-
     my $target_repo = ES::TargetRepo->new(
         git_dir     => $repos_dir->subdir('target_repo.git'),
-        url         => $git_repo,
+        url         => $Opts->{target_repo},
         reference   => $reference_dir,
         destination => dir( "$temp_dir/target_repo" ),
         branch      => $Opts->{target_branch} || 'master',

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -26,4 +26,4 @@ COPY template /docs_build/template
 COPY resources /docs_build/resources
 
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--target_repo", "https://${GITHUB_USER}${GITHUB_USER:+:}${GITHUB_PASS}${GITHUB_USER:+@}github.com/elastic/built-docs.git"]
+     "--preview", "--target_repo", "git@github.com:elastic/built-docs.git"]

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -26,4 +26,4 @@ COPY template /docs_build/template
 COPY resources /docs_build/resources
 
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]
+     "--preview", "--target_repo", "https://${GITHUB_USER}${GITHUB_USER:+:}${GITHUB_PASS}${GITHUB_USER:+@}github.com/elastic/built-docs.git"]

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh git@github.com:elastic/built-docs.git
-docker build -t docker.elastic.co/docs/preview:12 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:11 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:12 \
+          docker.elastic.co/docs/preview:11 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh git@github.com:elastic/built-docs.git
-docker build -t docker.elastic.co/docs/preview:11 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:13 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:11 \
+          docker.elastic.co/docs/preview:13 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:11
+export PREVIEW=docker.elastic.co/docs/preview:13
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:12
+export PREVIEW=docker.elastic.co/docs/preview:11
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
Loading creds into the URI ends up making it way too easy to leak creds in logs and such. Switching to clone the repo via SSH, with the assumption that SSH creds will be available on the box.