### PR TITLE
Add an attribute for the root of the ES reference

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -72,6 +72,17 @@
 :graph-forum:          https://discuss.elastic.co/c/x-pack/graph
 :apm-forum:            https://discuss.elastic.co/c/apm
 
+
+//////////
+Commonly referneced paths in commonly referenced repositories.
+//////////
+ifdef::elasticsearch-root[]
+:elasticsearch-reference: {elasticsearch-root}/docs/reference
+endif::elasticsearch-root[]
+
+//////////
+Common words and phrases
+//////////
 :stack:           Elastic Stack
 :xpack:           X-Pack
 :es:              Elasticsearch


### PR DESCRIPTION
We include files from the Elasticsearch reference in a bunch of
different books and it is big to type
`{elasticsearch-root}/docs/reference`. That takes up half of a line!
This adds an attribute, `{elasticsearch-reference}` to the root of the
reference. It is slightly shorter and hopefully a little less breakable.
