### PR TITLE
Explicitly depend on shared docs in logstash

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -695,7 +695,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
           -
             title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins

--- a/conf.yaml
+++ b/conf.yaml
@@ -688,6 +688,14 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
@@ -704,6 +712,9 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/versioned-plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
     -
         title:      Beats: Collect, Parse, and Ship


### PR DESCRIPTION
Add explicit dependencies on the files in the docs repo that logstash
uses so that when they change we automatically rebuild the docs.
