### PR TITLE
Add Elastic Cloud Control to conf.yaml and build aliases

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -10,7 +10,9 @@ repos:
     azure-marketplace:    https://github.com/elastic/azure-marketplace.git
     beats:                https://github.com/elastic/beats.git
     cloud:                https://github.com/elastic/cloud.git
+    cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
     curator:              https://github.com/elastic/curator.git
+    ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -34,7 +36,6 @@ repos:
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
-    cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
 
 contents_title:     Elastic Stack and Product Documentation
 
@@ -637,6 +638,20 @@ contents:
             sources:
               -
                 repo:   cloud-on-k8s
+                path:   docs/
+          -
+            title:      Elastic Cloud Control
+            prefix:     en/ecctl
+            tags:       CloudControl/Reference
+            subject:    ECCTL
+            current:    master
+            branches:   [ master ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            asciidoctor: true
+            sources:
+              -
+                repo:   ecctl
                 path:   docs/
 
     -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -70,14 +70,19 @@ alias docbldsec='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-d
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
-# Cloud
+# Cloud - Elasticsearch Service
 alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
+# Cloud - Elastic Cloud Enterprise
 alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
-# Cloud
+# Cloud - Elasticsearch Add-on for Heroku
 alias docbldech='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/heroku/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud/docs/saas --chunk 1'
 
+# Cloud - Elastic Cloud Control
+alias docbldecctl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecctl/docs/index.asciidoc --chunk 1'
+
+# Cloud - Elastic Cloud for K8s
 alias docbldk8s='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
 # Beats


### PR DESCRIPTION
This PR adds Elastic Cloud Control and includes:

* doc_build_aliases.sh: A new `ecctl` build script alias
* conf.yaml: A new entry for Elastic Cloud Control (and moved the cloud-on-k8s repo to be in alphabetical order)

