### PR TITLE
Add shared URL for Elasticsearch Node.js client book

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -47,6 +47,7 @@
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
+:jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}


### PR DESCRIPTION
This PR adds an attribute for the following book in the list of shared URLs: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master/index.html