### PR TITLE
More attributes for the Elasticsearch node.js client documentation

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -48,6 +48,7 @@
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
 :jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}
+:jsclient-current:     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}

--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -20,6 +20,8 @@
 :stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
+:jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}
+:jsclient-current:     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/master
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}


### PR DESCRIPTION
This PR backports the new attributes that were added in https://github.com/elastic/docs/pull/1301 and adds a URL that points to the "current" version.