### PR TITLE
Adds 7.5 version attributes

### DIFF
--- a/shared/versions/stack/7.5.asciidoc
+++ b/shared/versions/stack/7.5.asciidoc
@@ -1,13 +1,13 @@
-:version:                7.6.0
+:version:                7.5.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.6.0
-:logstash_version:       7.6.0
-:elasticsearch_version:  7.6.0
-:kibana_version:         7.6.0
-:apm_server_version:     7.6.0
-:branch:                 7.x
+:bare_version:           7.5.0
+:logstash_version:       7.5.0
+:elasticsearch_version:  7.5.0
+:kibana_version:         7.5.0
+:apm_server_version:     7.5.0
+:branch:                 7.5
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.2


### PR DESCRIPTION
This PR adds a shared version attribute file for the 7.5 branch of the documentation.