### PR TITLE
Redirect slightly more

### DIFF
--- a/integtest/spec/air_gapped_spec.rb
+++ b/integtest/spec/air_gapped_spec.rb
@@ -23,6 +23,9 @@ RSpec.describe 'air gapped deploy', order: :defined do
 
   let(:host) { 'localhost' }
   let(:books_index) { air_gapped.get 'guide/index.html', host: host }
+  let(:outside_of_guide) do
+    air_gapped.get 'cloud/elasticsearch-service/signup', host: host
+  end
 
   context 'the logs' do
     it "don't contain anything git" do
@@ -31,6 +34,7 @@ RSpec.describe 'air gapped deploy', order: :defined do
       expect(air_gapped.logs).not_to include('git')
     end
   end
+  include_examples 'the favicon'
 
   context 'the books index' do
     it 'links to the book' do
@@ -48,6 +52,11 @@ RSpec.describe 'air gapped deploy', order: :defined do
       expect(books_index).not_to serve(include(<<~HTML.strip))
         https://www.googletagmanager.com/gtag/js
       HTML
+    end
+  end
+  context 'for a url outside of the docs' do
+    it '404s' do
+      expect(outside_of_guide.code).to eq('404')
     end
   end
   context "when the host isn't localhost" do

--- a/integtest/spec/helper/matcher/redirect_to.rb
+++ b/integtest/spec/helper/matcher/redirect_to.rb
@@ -2,19 +2,19 @@
 
 ##
 # Matches http responses.
-RSpec::Matchers.define :redirect_to do |expected|
+RSpec::Matchers.define :redirect_to do |expected, ecode = '301'|
   match do |actual|
-    return false unless actual.code == '301'
+    return false unless actual.code == ecode
 
     expected.matches? actual['Location']
   end
   failure_message do |actual|
-    unless actual.code == '301'
-      return "expected status [301] but was [#{actual.code}]. Body:\n" +
+    unless actual.code == ecode
+      return "expected status [#{ecode}] but was [#{actual.code}]. Body:\n" +
              actual.body
     end
 
     message = expected.failure_message
-    "status was [301] but the location didn't match: #{message}"
+    "status was [#{ecode}] but the location didn't match: #{message}"
   end
 end

--- a/preview/core.js
+++ b/preview/core.js
@@ -53,6 +53,12 @@ const GitCore = (defaultTemplate, ignoreHost, repoPath) => {
 
     return {
       diff: () => Readable.from(bufferItr(diffItr(git, branch), 16 * 1024)),
+      outsideOfGuide: path => {
+        if (templateName === "air_gapped_template.html") {
+          return null;
+        }
+        return "https://www.elastic.co" + path;
+      },
       redirects: () => git.catBlob(`${branch}:redirects.conf`),
       file: async requestedPath => {
         const templateExists = await hasTemplate(git, branch);
@@ -115,6 +121,7 @@ const FsCore = (defaultTemplate, ignoreHost, rootPath) => {
         r.push(null);
         return r;
       },
+      outsideOfGuide: _path => null,
       redirects: () => null,
       file: async requestedPath => {
         const realPath = `${rootPath}/${requestedPath}`;

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -34,8 +34,15 @@ const requestHandler = async (core, parsedUrl, response) => {
     });
   }
   if (!parsedUrl.pathname.startsWith('/guide')) {
-    response.statusCode = 404;
-    response.end();
+    const redirect = core.outsideOfGuide(parsedUrl.pathname);
+    if (redirect) {
+      response.statusCode = 302;
+      response.setHeader('Location', redirect);
+      response.end();
+    } else {
+      response.statusCode = 404;
+      response.end();
+    }
     return;
   }
 


### PR DESCRIPTION
When you make a request to a location outside of the `guide` we should
redirect to `www.elastic.co` *unless*:
1. We have the file (then we should just send it to you).
2. You made the request for air gapped docs (we should 404).

This implements that by adding a `try_files` block to the `/` arm of our
nginx config which forwards requests for missing files right into the
preview application. The preview application checks if you are asking
for the air gapped deploy or not and performs the redirect or not.

Relates to #1300
