### PR TITLE
Only relativize links build with --all

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -115,12 +115,14 @@ sub build_local {
         build_single( $index, $raw_dir, $dir, %$Opts,
                 latest       => $latest,
                 alternatives => \@alternatives,
+                relativize => 0,
         );
     }
     else {
         build_chunked( $index, $raw_dir, $dir, %$Opts,
                 latest       => $latest,
                 alternatives => \@alternatives,
+                relativize => 0,
         );
     }
 

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -292,6 +292,24 @@ RSpec.describe 'building all books' do
       end
     end
   end
+
+  context 'when there is a link to elastic.co' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'repo', <<~ASCIIDOC
+        https://www.elastic.co/cloud/[link]
+      ASCIIDOC
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+    end
+    page_context 'raw/test/master/chapter.html' do
+      it 'contains a relative link to www.elatic.co' do
+        expect(body).to include(<<~HTML.strip)
+          <a class="ulink" href="/cloud/" target="_top">link</a>
+        HTML
+      end
+    end
+  end
+
   context 'for a book that uses {source_branch}' do
     convert_all_before_context do |src|
       repo = src.repo_with_index 'repo', <<~ASCIIDOC

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -273,6 +273,24 @@ RSpec.describe 'building a single book' do
       end
     end
   end
+  context 'when there is a link to elastic.co' do
+    convert_single_before_context do |src|
+      src.write 'index.asciidoc', <<~ASCIIDOC
+        = Title
+
+        [[chapter]]
+        == Chapter
+        https://www.elastic.co/cloud/[link]
+      ASCIIDOC
+    end
+    page_context 'chapter.html' do
+      it 'contains an absolute link to www.elatic.co' do
+        expect(body).to include(<<~HTML.strip)
+          <a class="ulink" href="https://www.elastic.co/cloud/" target="_top">link</a>
+        HTML
+      end
+    end
+  end
 
   context 'regarding the xpack tag' do
     let(:edit_me) do

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -287,6 +287,7 @@ sub _build_book {
                 alternatives  => $alternatives,
                 branch => $branch,
                 roots => $roots,
+                relativize => 1,
             );
         }
         else {
@@ -312,6 +313,7 @@ sub _build_book {
                 alternatives  => $alternatives,
                 branch => $branch,
                 roots => $roots,
+                relativize => 1,
             );
         }
         $checkout->rmtree;

--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -42,7 +42,8 @@ sub write {
             root_dir    => '',  # Required but thrown on the floor with asciidoctor
             latest      => 1,   # Run all of our warnings
             private     => 1,   # Don't generate edit me urls
-            branch => '' # TOCs don't have a branch but it is a required arg
+            branch => '', # TOCs don't have a branch but it is a required arg
+            relativize => 1,
     );
     $adoc_file->remove;
 }

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -55,6 +55,7 @@ sub build_chunked {
     my $alternatives_summary = $raw_dest->file('alternatives_summary.json');
     my $branch = $opts{branch};
     my $roots = $opts{roots};
+    my $relativize = $opts{relativize};
 
     die "Can't find index [$index]" unless -f $index;
 
@@ -121,7 +122,7 @@ sub build_chunked {
                     '-a' => "alternative_language_report=$raw_dest/alternatives_report.json",
                     '-a' => "alternative_language_summary=$alternatives_summary",
                 ) : (),
-                '-a' => 'relativize-link=https://www.elastic.co/',
+                $relativize ? ('-a' => 'relativize-link=https://www.elastic.co/') : (),
                 roots_opts( $roots ),
                 '--destination-dir=' . $raw_dest,
                 docinfo($index),
@@ -230,6 +231,7 @@ sub build_single {
     my $alternatives_summary = $raw_dest->file('alternatives_summary.json');
     my $branch = $opts{branch};
     my $roots = $opts{roots};
+    my $relativize = $opts{relativize};
 
     die "Can't find index [$index]" unless -f $index;
 
@@ -300,7 +302,7 @@ sub build_single {
                 # Disable warning on missing attributes because we have
                 # missing attributes!
                 # '-a' => 'attribute-missing=warn',
-                '-a' => 'relativize-link=https://www.elastic.co/',
+                $relativize ? ('-a' => 'relativize-link=https://www.elastic.co/') : (),
                 roots_opts( $roots ),
                 '--destination-dir=' . $raw_dest,
                 docinfo($index),


### PR DESCRIPTION
I don't particularly like building different books with `--all` vs
`--doc`, but in this case it seems like it is the best solution....

We want to relativize links to `www.elastic.co` because it prevent
linking off into "nowhere" when you use the docs in a air gapped
network. And it makes it less likely that you'll accidentally get linked
to production when browsing the docs preview. On the other hand, when
you are building docs with `--doc` the URL space looks nothing like when
you build all the docs so links into the docs that aren't already part
of the book aren't going to resolve properly if we relativize them.

So, this does what I don't really want to do but think is probably the
right thing to do anyway: it only relativizes the links if you build
all of the books and skips it if you build with `--doc`.

Relates to #1300
