### PR TITLE
Switch Kibana's CN book to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1339,6 +1339,7 @@ contents:
               chunk:      1
               tags:       Kibana/Reference
               subject:    Kibana
+              asciidoctor: true
               sources:
                 -
                   repo: kibana-cn


### PR DESCRIPTION
Asciidoc is unmaintained. It is time to get everything off of it.
