### PR TITLE
Switch kr X-Pack docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1476,6 +1476,7 @@ contents:
               lang:       ko
               tags:       X-Pack/Reference
               subject:    X-Pack
+              asciidoctor: true
               sources:
                 -
                   repo: x-pack


### PR DESCRIPTION
It is time to drop AsciiDoc support. It hasn't been maintained for a
long, long time.
