### PR TITLE
[DOCS] Split Infrastructure Monitoring guide into separate Logs and Metrics docs.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1214,7 +1214,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
     -
-        title:      Observability: APM, Infrastructure, Logs, and Uptime
+        title:      Observability: APM, Logs, Metrics, and Uptime
         sections:
           -
             title:      Application Performance Monitoring (APM)

--- a/conf.yaml
+++ b/conf.yaml
@@ -1678,7 +1678,7 @@ contents:
             title:      Infrastructure Monitoring Guide for 6.5-7.4
             prefix:     en/infrastructure/guide
             current:    7.4
-            branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
             tags:       Infrastructure/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1369,7 +1369,27 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   docs
           -
-            title:      Infrastructure Monitoring Guide
+            title:      Logs Monitoring Guide
+            prefix:     en/logs/guide
+            current:    7.4
+            branches:   [ master, 7.x, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            index:      docs/en/logs/index.asciidoc
+            chunk:      1
+            tags:       Logs/Guide
+            subject:    Logs
+            asciidoctor: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          -
+            title:      Metrics Monitoring Guide
             prefix:     en/infrastructure/guide
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -1383,7 +1383,7 @@ contents:
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    master
-            branches:   [ master ]
+            branches:   [ master, 7.x, 7.5 ]
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1403,7 +1403,7 @@ contents:
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
             current:    master
-            branches:   [ master ]
+            branches:   [ master, 7.x, 7.5 ]
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide
@@ -1419,38 +1419,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Log Monitoring Guide
-            prefix:     en/logs/guide
-            current:    master
-            branches:   [ master, 7.x, 7.5 ]
-            index:      docs/index.asciidoc
-            chunk:      1
-            tags:       Logs/Guide
-            subject:    Logs
-            asciidoctor: true
-            sources:
-              -
-                # The perl client is a placeholder. We'll switch to the real docs once we're ready.
-                repo:   elasticsearch-perl
-                path:   docs/
-                map_branches: { 7.x: master, 7.5: master}
-          -
-            title:      Metrics Monitoring Guide
-            prefix:     en/metrics/guide
-            current:    master
-            branches:   [ master, 7.x, 7.5 ]
-            index:      docs/index.asciidoc
-            chunk:      1
-            tags:       Metrics/Guide
-            subject:    Metrics
-            asciidoctor: true
-            sources:
-              -
-                # The perl client is a placeholder. We'll switch to the real docs once we're ready.
-                repo:   elasticsearch-perl
-                path:   docs/
-                map_branches: { 7.x: master, 7.5: master}
           -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime

--- a/conf.yaml
+++ b/conf.yaml
@@ -1392,7 +1392,7 @@ contents:
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    master
-            branches:   [ master, 7.x, 7.5 ]
+            branches:   [ master ]
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1412,7 +1412,7 @@ contents:
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
             current:    master
-            branches:   [ master, 7.x, 7.5 ]
+            branches:   [ master ]
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1369,26 +1369,6 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   docs
           -
-            title:      Infrastructure Monitoring Guide
-            prefix:     en/infrastructure/guide
-            current:    7.4
-            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            index:      docs/en/infraops/index.asciidoc
-            chunk:      1
-            tags:       Infrastructure/Guide
-            subject:    Infrastructure
-            asciidoctor: true
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    master
@@ -1651,6 +1631,26 @@ contents:
     -
         title:      Legacy Documentation
         sections:
+          -
+            title:      Infrastructure Monitoring Guide for 6.5-7.4
+            prefix:     en/infrastructure/guide
+            current:    7.4
+            branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            index:      docs/en/infraops/index.asciidoc
+            chunk:      1
+            tags:       Infrastructure/Guide
+            subject:    Infrastructure
+            asciidoctor: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack

--- a/conf.yaml
+++ b/conf.yaml
@@ -1369,10 +1369,30 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   docs
           -
+            title:      Infrastructure Monitoring Guide
+            prefix:     en/infrastructure/guide
+            current:    7.4
+            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            index:      docs/en/infraops/index.asciidoc
+            chunk:      1
+            tags:       Infrastructure/Guide
+            subject:    Infrastructure
+            asciidoctor: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    7.4
-            branches:   [ master, 7.x, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            current:    master
+            branches:   [ master, 7.x, 7.5 ]
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1390,13 +1410,13 @@ contents:
                 path:   shared/attributes.asciidoc
           -
             title:      Metrics Monitoring Guide
-            prefix:     en/infrastructure/guide
-            current:    7.4
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            index:      docs/en/infraops/index.asciidoc
+            prefix:     en/metrics/guide
+            current:    master
+            branches:   [ master, 7.x, 7.5 ]
+            index:      docs/en/metrics/index.asciidoc
             chunk:      1
-            tags:       Infrastructure/Guide
-            subject:    Infrastructure
+            tags:       Metrics/Guide
+            subject:    Metrics
             asciidoctor: true
             sources:
               -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -61,7 +61,9 @@ alias docbldsoold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack
 alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldinf='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/infraops/index.asciidoc --chunk 1'
+alias docbldmet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/metrics/index.asciidoc --chunk 1'
+
+alias docbldlog='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/logs/index.asciidoc --chunk 1'
 
 alias docbldup='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -173,5 +173,6 @@ alias docbldall='$GIT_HOME/docs/build_docs --all --target_repo git@github.com:el
 # NOTE: To build all books and pick up un-merged changes from your local repos,
 # use one or more --sub_dir options. Specify the repo and branch you want to
 # override and the directory that contains your changes.
+# Do not include the docs repo in this list. The build always uses your local files.
 # For example:
 # --sub_dir elasticsearch:master:./elasticsearch

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,3 +1,4 @@
+
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
@@ -59,6 +60,7 @@
 :blog-ref:             https://www.elastic.co/blog/
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
+:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
 :metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
 :metrics-guide:        https://www.elastic.co/guide/en/metrics/guide/{branch}
 :logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
@@ -77,8 +79,9 @@
 :graph-forum:          https://discuss.elastic.co/c/x-pack/graph
 :apm-forum:            https://discuss.elastic.co/c/apm
 
+
 //////////
-Commonly referenced paths in commonly referenced repositories.
+Commonly referneced paths in commonly referenced repositories.
 //////////
 ifdef::elasticsearch-root[]
 :es-ref-dir: {elasticsearch-root}/docs/reference
@@ -232,8 +235,3 @@ Common words and phrases
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
 
-//////////
-Legacy definitions
-//////////
-// Superseded in 7.5
-:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -58,7 +58,6 @@
 :blog-ref:             https://www.elastic.co/blog/
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
-:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
 :metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
 :metrics-guide:        https://www.elastic.co/guide/en/metrics/guide/{branch}
 :logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
@@ -77,9 +76,8 @@
 :graph-forum:          https://discuss.elastic.co/c/x-pack/graph
 :apm-forum:            https://discuss.elastic.co/c/apm
 
-
 //////////
-Commonly referneced paths in commonly referenced repositories.
+Commonly referenced paths in commonly referenced repositories.
 //////////
 ifdef::elasticsearch-root[]
 :es-ref-dir: {elasticsearch-root}/docs/reference
@@ -229,3 +227,8 @@ Common words and phrases
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
 
+//////////
+Legacy definitions
+//////////
+// Superseded in 7.5
+:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,4 +1,3 @@
-
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
@@ -61,7 +60,9 @@
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
 :metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
+:metrics-guide:        https://www.elastic.co/guide/en/metrics/guide/{branch}
 :logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
+:logs-guide:           https://www.elastic.co/guide/en/logs/guide/{branch}
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -60,6 +60,8 @@
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
+:metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
+:logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}


### PR DESCRIPTION
Changes required as a result of splitting Infrastructure Monitoring Guide into separate Logs and Metrics guides.

This is part of a multi-repo change (see elastic/observability-dev#98). DO NOT PUSH UNTIL EVERYTHING IS READY.