### PR TITLE
Switch all attribute links to https

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -5,7 +5,7 @@
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
 :xpack-ref:            https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
-:logstash-ref:         http://www.elastic.co/guide/en/logstash/{branch}
+:logstash-ref:         https://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}
 :beats-ref:            https://www.elastic.co/guide/en/beats/libbeat/{branch}
 :beats-ref-60:         https://www.elastic.co/guide/en/beats/libbeat/6.0
@@ -39,10 +39,10 @@
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
-:stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
-:stack-ref-67:         http://www.elastic.co/guide/en/elastic-stack/6.7
-:stack-ref-68:         http://www.elastic.co/guide/en/elastic-stack/6.8
-:stack-ref-70:         http://www.elastic.co/guide/en/elastic-stack/7.0
+:stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
+:stack-ref-67:         https://www.elastic.co/guide/en/elastic-stack/6.7
+:stack-ref-68:         https://www.elastic.co/guide/en/elastic-stack/6.8
+:stack-ref-70:         https://www.elastic.co/guide/en/elastic-stack/7.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
@@ -54,7 +54,7 @@
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :cloud:                https://www.elastic.co/guide/en/cloud/current
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
-:glossary:             http://www.elastic.co/guide/en/elastic-stack-glossary/current
+:glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 :blog-ref:             https://www.elastic.co/blog/
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}

--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -2,7 +2,7 @@
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
 :xpack-ref:            https://www.elastic.co/guide/en/x-pack/{branch}
-:logstash-ref:         http://www.elastic.co/guide/en/logstash/{branch}
+:logstash-ref:         https://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}
 :beats-ref:            https://www.elastic.co/guide/en/beats/libbeat/{branch}
 :auditbeat-ref:        https://www.elastic.co/guide/en/beats/auditbeat/{branch}
@@ -17,7 +17,7 @@
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-node-ref:         https://www.elastic.co/guide/en/apm/agent/nodejs/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
-:stack-ref:            http://www.elastic.co/guide/en/elastic-stack/{branch}
+:stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
 :jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}
@@ -27,7 +27,7 @@
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :cloud:                https://www.elastic.co/guide/en/cloud/current
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
-:glossary:             http://www.elastic.co/guide/en/elastic-stack-glossary/current
+:glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 :blog-ref:             https://www.elastic.co/blog/
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}


### PR DESCRIPTION
We should prefer https for the security and because our link relativizer
only does the job for https.
