### PR TITLE
Switch Korean translation of kibana to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1478,6 +1478,7 @@ contents:
               lang:       ko
               tags:       Kibana/Reference
               subject:    Kibana
+              asciidoctor: true
               sources:
                 -
                   repo: kibana


### PR DESCRIPTION
It is time to retire AsciiDoc. It hasn't been maintained in a long time.
