### PR TITLE
Switch Japanese Kibana docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1405,6 +1405,7 @@ contents:
               lang:       ja
               tags:       Kibana/Reference
               subject:    Kibana
+              asciidoctor: true
               sources:
                 -
                   repo: kibana


### PR DESCRIPTION
It is time to retire AsciiDoc because it is no longer maintained.
