### PR TITLE
Rename attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -79,7 +79,7 @@
 Commonly referneced paths in commonly referenced repositories.
 //////////
 ifdef::elasticsearch-root[]
-:elasticsearch-reference: {elasticsearch-root}/docs/reference
+:es-ref-dir: {elasticsearch-root}/docs/reference
 endif::elasticsearch-root[]
 
 //////////


### PR DESCRIPTION
`es-ref-dir` is quite descriptive for us and *much* shorter.
