### PR TITLE
Switch the Chinese Definitive Guide to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1419,6 +1419,7 @@ contents:
               tags:       Elasticsearch/Definitive Guide
               subject:    Elasticsearch
               asciidoctor: true
+              suppress_migration_warnings: true
               sources:
                 -
                   repo: guide-cn

--- a/conf.yaml
+++ b/conf.yaml
@@ -1326,6 +1326,7 @@ contents:
           title:      简体中文
           base_dir:   cn
           lang:       zh_cn
+          asciidoctor: true
           sections:
             -
               title:      《Elasticsearch 权威指南》中文版

--- a/conf.yaml
+++ b/conf.yaml
@@ -1326,7 +1326,6 @@ contents:
           title:      简体中文
           base_dir:   cn
           lang:       zh_cn
-          asciidoctor: true
           sections:
             -
               title:      《Elasticsearch 权威指南》中文版
@@ -1338,6 +1337,7 @@ contents:
               lang:       zh_cn
               tags:       Elasticsearch/Definitive Guide
               subject:    Elasticsearch
+              asciidoctor: true
               sources:
                 -
                   repo: guide-cn


### PR DESCRIPTION
AsciiDoc is deprecated and we have to drop support for it.
