### PR TITLE
Switch Korea Logstash reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1476,6 +1476,7 @@ contents:
               lang:       ko
               tags:       Logstash/Reference
               subject:    Logstash
+              asciidoctor: true
               sources:
                 -
                   repo: logstash


### PR DESCRIPTION
AsciiDoc is unmaintained and we need to drop support for it.
