### PR TITLE
Switch Japanese Logstash reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1402,6 +1402,7 @@ contents:
               lang:       ja
               tags:       Logstash/Reference
               subject:    Logstash
+              asciidoctor: true
               sources:
                 -
                   repo: logstash


### PR DESCRIPTION
AsciiDoc is unmaintained and we need to drop support for it.
