### PR TITLE
Switch the Japanese ES reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1385,6 +1385,7 @@ contents:
               lang:       ja
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
+              asciidoctor: true
               sources:
                 -
                   repo: elasticsearch


### PR DESCRIPTION
AsciiDoc is unmaintained and we need to drop support for it.
