### PR TITLE
Switch the Korean ES reference to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1459,6 +1459,7 @@ contents:
               lang:       ko
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
+              asciidoctor: true
               sources:
                 -
                   repo: elasticsearch


### PR DESCRIPTION
AsciiDoc is unmaintained and we need to drop support for it.
