### PR TITLE
Switch uptime docs to Asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1315,6 +1315,7 @@ contents:
             chunk:      1
             tags:       Uptime/Guide
             subject:    Uptime
+            asciidoctor: true
             sources:
               -
                 repo:   kibana


### PR DESCRIPTION
AsciiDoc is unmaintained and we should drop support for it.
