### PR TITLE
Create dedicated livenss endpoint

### DIFF
--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/docs/preview:13
+FROM docker.elastic.co/docs/preview:14
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 

--- a/air_gapped/build.sh
+++ b/air_gapped/build.sh
@@ -19,6 +19,6 @@ GIT_DIR=air_gapped/work/target_repo.git git fetch
 
 # Build the images
 ./build_docs --just-build-image
-docker build -t docker.elastic.co/docs/preview:13 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:14 -f preview/Dockerfile .
 # Use buildkit here to pick up the customized dockerignore file
 DOCKER_BUILDKIT=1 docker build -t docker.elastic.co/docs-private/air_gapped:latest -f air_gapped/Dockerfile .

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     watermark = SecureRandom.uuid
     let(:watermark) { watermark }
     let(:current_url) { 'guide/test/current' }
+    let(:liveness) { get watermark, branch, 'liveness' }
     let(:diff) { get watermark, branch, 'diff' }
     let(:robots_txt) { get watermark, branch, 'robots.txt' }
     let(:root) { get watermark, branch, '' }
@@ -109,6 +110,11 @@ RSpec.describe 'previewing built docs', order: :defined do
   include_examples 'the favicon'
 
   shared_examples 'serves some docs' do |supports_gapped: true|
+    context 'the liveness check' do
+      it '200s' do
+        expect(liveness).to serve(include("R'lyeh"))
+      end
+    end
     context 'the root' do
       it 'redirects to the guide root' do
         expect(root).to redirect_to(eq("http://#{host}:8000/guide/index.html"))
@@ -227,6 +233,11 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
   end
   shared_examples '404s' do
+    context 'the liveness check' do
+      it '200s' do
+        expect(liveness).to serve(include("R'lyeh"))
+      end
+    end
     it '404s for the docs root' do
       expect(guide_root.code).to eq('404')
     end

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -875,6 +875,9 @@ http {
     location = / {
       return 301 /guide/index.html;
     }
+    location = /liveness {
+      return 200 "Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn.";
+    }
     location = /robots.txt {
       return 200 "User-agent: *\nDisallow: /\n";
     }

--- a/preview/test.sh
+++ b/preview/test.sh
@@ -9,12 +9,12 @@ set -e
 
 cd $(git rev-parse --show-toplevel)
 ../infra/ansible/roles/git_fetch_reference/files/git-fetch-reference.sh git@github.com:elastic/built-docs.git
-docker build -t docker.elastic.co/docs/preview:13 -f preview/Dockerfile .
+docker build -t docker.elastic.co/docs/preview:14 -f preview/Dockerfile .
 id=$(docker run --rm \
           --publish 8000:8000/tcp \
           -v $HOME/.git-references:/root/.git-references \
           -d \
-          docker.elastic.co/docs/preview:13 \
+          docker.elastic.co/docs/preview:14 \
           /docs_build/build_docs.pl --in_standard_docker \
               --preview --reference /root/.git-references \
               --target_repo https://github.com/elastic/built-docs.git)

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -3,7 +3,7 @@
 set -e
 
 export BUILD=docker.elastic.co/docs/build:1
-export PREVIEW=docker.elastic.co/docs/preview:13
+export PREVIEW=docker.elastic.co/docs/preview:14
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image


### PR DESCRIPTION
Adds a `/liveness` endpoint which returns a 200 strait from nginx so it
will be considered "alive" very, very soon.
