### PR TITLE
Make doc repo dependencies explicit in Beats documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -804,6 +804,14 @@ contents:
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
           -
             title:      Beats Developer Guide
             prefix:     en/beats/devguide
@@ -828,6 +836,14 @@ contents:
               -
                 repo:   beats
                 path:   metricbeat/scripts
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0 ]
           -
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
@@ -852,6 +868,14 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
           -
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
@@ -884,6 +908,14 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
           -
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
@@ -908,6 +940,14 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
           -
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
@@ -946,6 +986,14 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
@@ -974,6 +1022,14 @@ contents:
                 repo:   beats
                 path:   x-pack/libbeat/docs
                 exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
           -
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
@@ -1008,6 +1064,14 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0 ]
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
@@ -1032,6 +1096,12 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
@@ -1056,6 +1126,12 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Legacy Topbeat Reference
             prefix:     en/beats/topbeat


### PR DESCRIPTION
Adds explicit paths for shared attributes and versions used by the Beats documentation.