### PR TITLE
Add ECE 2.4 doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -662,7 +662,7 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    2.3
-            branches:   [ 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
With the versioned link switch to ECE 2.4, we need this PR to enable Cloud PR tests to pass.

Required by https://github.com/elastic/cloud/pull/42356.


