### PR TITLE
Update ESS and Heroku doc builds to use release-ms-28

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -621,8 +621,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-25
-            branches:   [ release-ms-25 ]
+            current:    release-ms-28
+            branches:   [ release-ms-28 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -639,8 +639,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-25
-            branches:   [ release-ms-25 ]
+            current:    release-ms-28
+            branches:   [ release-ms-28 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
With the production release of `release-ms-28` early this coming week, let's get our doc builds ready. 

**DO NOT MERGE UNTIL MS 28 GOES OUT**