### PR TITLE
Build 7.5 branch for APM documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1223,7 +1223,7 @@ contents:
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
                 current:    7.4
-                branches:   [ master, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM
@@ -1240,7 +1240,7 @@ contents:
                 prefix:     server
                 index:      docs/index.asciidoc
                 current:    7.4
-                branches:   [ master, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM


### PR DESCRIPTION
APM didn't make it into the 7.5 branch PR (https://github.com/elastic/docs/pull/1304). @lcawl I'm guessing you're doing some sort of find and replace for `master, 7.x, 7.4`. APM won't appear in that search because we don't build the `7.x` branch.