### PR TITLE
Add ruby changelog for 3.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1351,7 +1351,7 @@ contents:
                       -
                         repo:   apm-agent-ruby
                         path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 3.x, 1.x, 0.x ]
+                        exclude_branches:   [ 1.x, 0.x ]
                   -
                     title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js


### PR DESCRIPTION
This PR must be merged immediately after the next APM Ruby Agent release. It will fix the doc build before it has enough time to break.