### PR TITLE
Switch cloud's heroku docs to asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -645,6 +645,7 @@ contents:
             chunk:      1
             noindex:    1
             private:    1
+            asciidoctor: true
             sources:
               -
                 repo:   cloud


### PR DESCRIPTION
AsciiDoc is unmaintained and we need to drop support for it.
