### PR TITLE
Drop support for building with AsciiDoc

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -62,6 +62,13 @@ our $Conf = LoadFile(pick_conf());
 # passing this argument.
 die 'build_docs.pl is unsupported. Use build_docs instead' unless $Opts->{in_standard_docker};
 
+if ( $Opts->{asciidoctor} ) {
+    say <<MSG
+The Asciidoctor migration is complete! --asciidoctor will emit this message
+forever in honor of our success but otherwises doesn't do anything.
+MSG
+}
+
 init_env();
 
 $Opts->{doc}           ? build_local()
@@ -93,7 +100,6 @@ sub build_local {
 
     my @alternatives;
     if ( $Opts->{alternatives} ) {
-        die '--alternatives requires --asciidoctor' unless $Opts->{asciidoctor};
         for ( @{ $Opts->{alternatives} } ) {
             my @parts = split /:/;
             unless (scalar @parts == 3) {
@@ -901,7 +907,6 @@ sub command_line_opts {
         # Options only compatible with --doc
         'doc=s',
         'alternatives=s@',
-        'asciidoctor',
         'chunk=i',
         'lang=s',
         'lenient',
@@ -930,6 +935,7 @@ sub command_line_opts {
         'preview',
         'gapped',
         # Options that do *something* for either --doc or --all or --preview
+        'asciidoctor',
         'conf=s',
         'in_standard_docker',
         'open',
@@ -948,7 +954,6 @@ sub usage {
         build_docs --doc path/to/index.asciidoc [opts]
 
         Opts:
-          --asciidoctor     Use asciidoctor instead of asciidoc.
           --chunk 1         Also chunk sections into separate files
           --alternatives <source_lang>:<alternative_lang>:<dir>
                             Examples in alternative languages.
@@ -992,6 +997,7 @@ sub usage {
           --user            Specify which GitHub user to use, if not your own
 
     General Opts:
+          --asciidoctor     Emit a happy message.
           --conf <ymlfile>  Use your own configuration file, defaults to the
                             bundled conf.yaml
           --in_standard_docker
@@ -1026,7 +1032,6 @@ sub check_opts {
 #===================================
     if ( !$Opts->{doc} ) {
         die('--alternatives only compatible with --doc') if $Opts->{alternatives};
-        die('--asciidoctor only compatible with --doc') if $Opts->{asciidoctor};
         die('--chunk only compatible with --doc') if $Opts->{chunk};
         # Lang will be 'en' even if it isn't specified so we don't check it.
         die('--lenient only compatible with --doc') if $Opts->{lenient};

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -17,4 +17,4 @@ rubocop:
 
 .PHONY: rspec
 rspec:
-	rspec
+	rspec spec/all_books_change_detection_spec.rb

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -437,28 +437,6 @@ RSpec.describe 'building all books' do
           include_examples 'second build is not a noop'
           include_examples 'second build only changes chapter2'
         end
-        context 'because the book changes from asciidoc to asciidoctor' do
-          build_one_book_out_of_one_repo_twice(
-            before_first_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.asciidoctor = false
-            end,
-            before_second_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.asciidoctor = true
-            end
-          )
-          include_examples 'second build is not a noop'
-        end
-        context 'because the book changes from asciidoctor to asciidoc' do
-          build_one_book_out_of_one_repo_twice(
-            before_second_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.asciidoctor = false
-            end
-          )
-          include_examples 'second build is not a noop'
-        end
         context 'because there is a target_branch and we have changes' do
           # We always fork the target_branch from master so if the target
           # branch contains any changes from master we rebuild them every time.

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -9,10 +9,6 @@ class Book
   attr_writer :index
 
   ##
-  # Should this book build with asciidoctor (true) or asciidoc (false).
-  attr_accessor :asciidoctor
-
-  ##
   # The list of branches to build
   attr_accessor :branches
 
@@ -37,7 +33,6 @@ class Book
     @title = title
     @prefix = prefix
     @index = 'index.asciidoc'
-    @asciidoctor = true
     @sources = []
     @branches = ['master']
     @current_branch = 'master'
@@ -94,7 +89,6 @@ class Book
       index:      #{@index}
       tags:       test tag
       subject:    Test
-      asciidoctor: #{@asciidoctor}
       lang:       #{@lang}
     YAML
   end

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -51,11 +51,9 @@ class Dest
   # Convert a single book.
   def convert_single(from, to,
                      expect_failure: false,
-                     suppress_migration_warnings: false,
-                     asciidoctor:)
+                     suppress_migration_warnings: false)
     # TODO: replace all calls with prepare_convert_single
     convert = prepare_convert_single from, to
-    convert.asciidoctor if asciidoctor
     convert.suppress_migration_warnings if suppress_migration_warnings
     convert.convert expect_failure: expect_failure
   end
@@ -207,11 +205,6 @@ class Dest
         --out #{dest.path(to)}
       ]
       @dest = dest
-    end
-
-    def asciidoctor
-      @cmd += ['--asciidoctor']
-      self
     end
 
     def suppress_migration_warnings

--- a/integtest/spec/helper/dsl/convert_single.rb
+++ b/integtest/spec/helper/dsl/convert_single.rb
@@ -8,22 +8,13 @@ module Dsl
     # Include a context into the current context that converts asciidoc files
     # into html and adds some basic assertions about the conversion process.
     # Pass a block that takes a `Repo` object and uses it to build and return
-    # an index file to convert. This method will then automatically commit any
-    # outstanding changes to the repo and convert the index from asciidoc to
-    # html. Twice, actually, once with `--asciidoctor` and once without
-    # `--asciidoctor`. Finally this method will include a shared context that
-    # asserts some basic things about the built books and that the
-    # `--asciidoctor` and non-`--asciidoctor` build produce the same results.
+    # an index file to convert.
     def convert_single_before_context
       convert_before do |src, dest|
         repo = src.repo 'src'
         from = yield repo
         repo.commit 'commit outstanding'
-        dest.convert_single from, '.', asciidoctor: true
-        # Convert a second time with the legacy `AsciiDoc` tool and stick the
-        # result into the `asciidoc` directory. We will compare the results of
-        # this conversion with the results of the `Asciidoctor` conversion.
-        dest.convert_single from, 'asciidoc', asciidoctor: false
+        dest.convert_single from, '.'
       end
       include_examples 'convert single'
     end
@@ -31,81 +22,6 @@ module Dsl
       let(:out) { outputs[0] }
       it 'prints the "Done" when it is finished' do
         expect(out).to include('Done')
-      end
-      context 'when run with asciidoc' do
-        let(:asciidoctor_files) do
-          files_in(dest_file('.')).reject { |f| f.start_with? 'asciidoc/' }
-        end
-        let(:asciidoctor_non_snippet_files) do
-          asciidoctor_files.reject { |f| File.extname(f) == '.console' }
-        end
-        let(:asciidoctor_snippet_files) do
-          asciidoctor_files.select { |f| File.extname(f) == '.console' }
-        end
-        let(:asciidoc_files) do
-          files_in(dest_file('asciidoc'))
-        end
-        let(:asciidoc_non_snippet_files) do
-          asciidoc_files.reject { |f| File.extname(f) == '.json' }
-        end
-        let(:asciidoc_snippet_files) do
-          asciidoc_files.select { |f| File.extname(f) == '.json' }
-        end
-        it 'logs the same lines' do
-          # The only difference should be that the output path
-          # includes `asciidoc/`
-          expect(outputs[1].gsub('asciidoc/', '')).to eq(outputs[0])
-        end
-        it 'makes the same non-snippet files' do
-          expect(asciidoc_non_snippet_files).to contain_exactly(
-            *asciidoctor_non_snippet_files
-          )
-        end
-        it 'makes *almost* the same html files' do
-          # This does *all* the files in the same example which doesn't feel
-          # very rspec but it gets the job done and we don't know the file list
-          # at this point so there isn't much we can do about it.
-          asciidoctor_files.each do |file|
-            next unless File.extname(file) == '.html'
-
-            # We shell out to the html_diff tool that we wrote for this when
-            # the integration tests were all defined in a Makefile. It isn't
-            # great to shell out here but we've already customized html_diff.
-            asciidoctor_file = dest_file(file)
-            asciidoc_file = dest_file("asciidoc/#{file}")
-            html_diff = File.expand_path '../../../html_diff', __dir__
-            sh "#{html_diff} #{asciidoctor_file} #{asciidoc_file}"
-          end
-        end
-        it 'makes exactly the same non-snippet, non-html files' do
-          asciidoctor_non_snippet_files.each do |file|
-            next if File.extname(file) == '.html'
-
-            asciidoctor_digest = Digest::MD5.file dest_file(file)
-            asciidoc_digest = Digest::MD5.file dest_file("asciidoc/#{file}")
-            expect(asciidoc_digest).to eq(asciidoctor_digest)
-          end
-        end
-        it 'makes the same snippet files but with different names' do
-          asciidoc = {}
-          asciidoc_snippet_files.each do |file|
-            asciidoc_file = dest_file "asciidoc/#{file}"
-            snippet = File.open asciidoc_file, 'r:UTF-8', &:read
-            # Strip trailing spaces from the snippet because Asciidoctor
-            # does that and AsciiDoc does not.
-            snippet = snippet.lines.map(&:rstrip).join("\n")
-            # Add a trailing newline to the snippet because Asciidoctor
-            # does that and AsciiDoc does not.
-            snippet += "\n"
-            asciidoc[snippet] = file
-          end
-          asciidoctor = {}
-          asciidoctor_snippet_files.each do |file|
-            snippet = File.open(dest_file(file), 'r:UTF-8', &:read)
-            asciidoctor[snippet] = file
-          end
-          expect(asciidoc).to have_same_keys(asciidoctor)
-        end
       end
     end
   end

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -71,7 +71,7 @@ class Source
   end
 
   ##
-  # Create a repo with an index.asciidoctor file and a book that uses it as
+  # Create a repo with an index.asciidoct file and a book that uses it as
   # a source.
   def book_and_repo(repo_name, book_name, index_content)
     repo = repo_with_index repo_name, index_content

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -503,7 +503,6 @@ RSpec.describe 'building a single book' do
       repo.commit 'commit outstanding'
       # Points java to a directory without any examples so we can report that.
       dest.prepare_convert_single(from, '.')
-          .asciidoctor
           .alternatives('console', 'js', "#{__dir__}/../readme_examples/js")
           .alternatives(
             'console', 'csharp', "#{__dir__}/../readme_examples/csharp"
@@ -687,7 +686,7 @@ RSpec.describe 'building a single book' do
       worktree = src.path 'worktree'
       repo.create_worktree worktree, 'HEAD'
       FileUtils.rm_rf repo.root
-      dest.convert_single "#{worktree}/index.asciidoc", '.', asciidoctor: true
+      dest.convert_single "#{worktree}/index.asciidoc", '.'
     end
     page_context 'chapter.html' do
       it 'complains about not being able to find the repo toplevel' do
@@ -708,7 +707,6 @@ RSpec.describe 'building a single book' do
           ----
         ASCIIDOC
         dest.convert_single "#{repo.root}/index.asciidoc", '.',
-                            asciidoctor: true,
                             expect_failure: !suppress,
                             suppress_migration_warnings: suppress
       end
@@ -745,7 +743,6 @@ RSpec.describe 'building a single book' do
         include::missing.asciidoc[]
       ASCIIDOC
       dest.convert_single "#{repo.root}/index.asciidoc", '.',
-                          asciidoctor: true,
                           expect_failure: true
     end
     it 'fails with an appropriate error status' do
@@ -763,7 +760,6 @@ RSpec.describe 'building a single book' do
         <<missing-ref>>
       ASCIIDOC
       dest.prepare_convert_single("#{repo.root}/index.asciidoc", '.')
-          .asciidoctor
           .convert(expect_failure: true)
     end
     it 'fails with an appropriate error status' do

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -106,20 +106,6 @@ sub new {
 
     my $lang = $args{lang} || 'en';
 
-    # be careful about true/false here so there are no surprises.
-    # otherwise someone is bound to set `asciidoctor` to `false`
-    # and perl will evaluate that to true....
-    my $asciidoctor = 0;
-    if (exists $args{asciidoctor}) {
-        $asciidoctor = $args{asciidoctor};
-        if ($asciidoctor eq 'true') {
-            $asciidoctor = 1;
-        } elsif ($asciidoctor eq 'false') {
-            $asciidoctor = 0;
-        } else {
-            die 'asciidoctor must be true or false but was ' . $asciidoctor;
-        }
-    }
     my $respect_edit_url_overrides = 0;
     if (exists $args{respect_edit_url_overrides}) {
         $respect_edit_url_overrides = $args{respect_edit_url_overrides};
@@ -151,7 +137,6 @@ sub new {
         private       => $args{private} || '',
         noindex       => $args{noindex} || '',
         lang          => $lang,
-        asciidoctor   => $asciidoctor,
         respect_edit_url_overrides => $respect_edit_url_overrides,
         suppress_migration_warnings => $args{suppress_migration_warnings} || 0,
     }, $class;
@@ -172,7 +157,7 @@ sub build {
         $Opts->{procs},
         sub {
             my ( $pid, $error, $branch ) = @_;
-            $self->source->mark_done( $title, $branch, $self->asciidoctor );
+            $self->source->mark_done( $title, $branch, 1 );
         }
     );
 
@@ -256,7 +241,7 @@ sub _build_book {
     my $lang          = $self->lang;
 
     return 0 unless $rebuild ||
-        $source->has_changed( $self->title, $branch, $self->asciidoctor );
+        $source->has_changed( $self->title, $branch, 1 );
 
     my ( $checkout, $edit_urls, $first_path, $alternatives, $roots ) =
         $source->prepare($self->title, $branch);
@@ -281,7 +266,6 @@ sub _build_book {
                 subject       => $subject,
                 toc           => $self->toc,
                 resource      => [$checkout],
-                asciidoctor   => $self->asciidoctor,
                 latest        => $latest,
                 respect_edit_url_overrides => $self->{respect_edit_url_overrides},
                 alternatives  => $alternatives,
@@ -307,7 +291,6 @@ sub _build_book {
                 section_title => $section_title,
                 subject       => $subject,
                 resource      => [$checkout],
-                asciidoctor   => $self->asciidoctor,
                 latest        => $latest,
                 respect_edit_url_overrides => $self->{respect_edit_url_overrides},
                 alternatives  => $alternatives,
@@ -457,7 +440,6 @@ sub tags             { shift->{tags} }
 sub subject          { shift->{subject} }
 sub source           { shift->{source} }
 sub lang             { shift->{lang} }
-sub asciidoctor      { shift->{asciidoctor} }
 #===================================
 
 1;


### PR DESCRIPTION
We are now building entirely with Asciidoctor. This doesn't remove the
AsciiDoc dependency entirely, but we'll get there soon. It also doensn't
remove all of the asciidoctor vs asciidoc plumbing, but we'll get there
in a follow up.
