### PR TITLE
Finish a ruby migration

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -626,7 +626,6 @@ contents:
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   cloud

--- a/conf.yaml
+++ b/conf.yaml
@@ -626,6 +626,7 @@ contents:
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
+            asciidoctor: true
             sources:
               -
                 repo:   cloud

--- a/integtest/.rubocop.yml
+++ b/integtest/.rubocop.yml
@@ -1,6 +1,0 @@
-inherit_from: ../.rubocop.yml
-
-
-Metrics/ClassLength:
-  Exclude:
-    - spec/helper/dest.rb

--- a/integtest/spec/air_gapped_spec.rb
+++ b/integtest/spec/air_gapped_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe 'air gapped deploy', order: :defined do
     ASCIIDOC
     book = src.book 'Test'
     book.source repo, 'index.asciidoc'
-    dest.convert_all src.conf
+    dest.prepare_convert_all(src.conf).convert
   end
   before(:context) do
     @air_gapped = @dest.start_air_gapped

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -47,30 +47,8 @@ class Dest
     ConvertSingle.new from, to, self
   end
 
-  ##
-  # Convert a single book.
-  def convert_single(from, to,
-                     expect_failure: false,
-                     suppress_migration_warnings: false,
-                     asciidoctor:)
-    # TODO: replace all calls with prepare_convert_single
-    convert = prepare_convert_single from, to
-    convert.asciidoctor if asciidoctor
-    convert.suppress_migration_warnings if suppress_migration_warnings
-    convert.convert expect_failure: expect_failure
-  end
-
   def prepare_convert_all(conf)
     ConvertAll.new conf, @repos_cache, bare_repo, self
-  end
-
-  ##
-  # Convert a conf file worth of books and check it out.
-  def convert_all(conf, expect_failure: false, target_branch: nil)
-    # TODO: remove this in favor of prepare_convert_all
-    convert = prepare_convert_all conf
-    convert.target_branch target_branch if target_branch
-    convert.convert expect_failure: expect_failure
   end
 
   ##

--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -10,11 +10,13 @@ module Dsl
     # 2. Configure the books that should be built
     def convert_all_before_context(relative_conf: false, target_branch: nil,
                                    init_from_shell: true)
+      # TODO: simplify this in the style of builders
       convert_before do |src, dest|
         yield src
         dest.init_from_shell = init_from_shell
-        dest.convert_all src.conf(relative_path: relative_conf),
-                         target_branch: target_branch
+        c = dest.prepare_convert_all(src.conf(relative_path: relative_conf))
+        c.target_branch(target_branch) if target_branch
+        c.convert
         dest.checkout_conversion branch: target_branch
       end
       include_examples 'convert all'

--- a/integtest/spec/helper/dsl/convert_single.rb
+++ b/integtest/spec/helper/dsl/convert_single.rb
@@ -19,11 +19,11 @@ module Dsl
         repo = src.repo 'src'
         from = yield repo
         repo.commit 'commit outstanding'
-        dest.convert_single from, '.', asciidoctor: true
+        dest.prepare_convert_single(from, '.').asciidoctor.convert
         # Convert a second time with the legacy `AsciiDoc` tool and stick the
         # result into the `asciidoc` directory. We will compare the results of
         # this conversion with the results of the `Asciidoctor` conversion.
-        dest.convert_single from, 'asciidoc', asciidoctor: false
+        dest.prepare_convert_single(from, 'asciidoc').convert
       end
       include_examples 'convert single'
     end

--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     book = src.book 'Test'
     book.source repo, 'index.asciidoc'
     book.source repo, 'resources'
-    dest.convert_all src.conf
+    dest.prepare_convert_all(src.conf).convert
   end
   before(:context) do
     @preview = @dest.start_preview
@@ -344,7 +344,7 @@ RSpec.describe 'previewing built docs', order: :defined do
         Some text.
       ASCIIDOC
       repo.commit 'test change for test branch'
-      @dest.convert_all @src.conf, target_branch: 'test'
+      @dest.prepare_convert_all(@src.conf).target_branch('test').convert
     end
     it 'logs the fetch' do
       wait_for_logs(/\[new branch\]\s+test\s+->\s+test/)
@@ -492,7 +492,7 @@ RSpec.describe 'previewing built docs', order: :defined do
         image::resources/very_large.jpg[Not a jpg but very big]
       ASCIIDOC
       repo.commit 'test change for test_noop branch2'
-      @dest.convert_all @src.conf, target_branch: 'test_noop'
+      @dest.prepare_convert_all(@src.conf).target_branch('test_noop').convert
     end
     it 'logs the fetch' do
       wait_for_logs(/\[new branch\]\s+test_noop\s+->\s+test_noop/)
@@ -533,7 +533,9 @@ RSpec.describe 'previewing built docs', order: :defined do
         'examples',
         alternatives: { source_lang: 'console', alternative_lang: 'csharp' }
       )
-      @dest.convert_all @src.conf, target_branch: 'alternative_examples'
+      @dest.prepare_convert_all(@src.conf)
+           .target_branch('alternative_examples')
+           .convert
     end
     it 'logs the fetch' do
       wait_for_logs(
@@ -563,7 +565,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     before(:context) do
       book = @src.book 'Test'
       book.lang = 'foo'
-      @dest.convert_all @src.conf, target_branch: 'foolang'
+      @dest.prepare_convert_all(@src.conf).target_branch('foolang').convert
     end
     it 'logs the fetch' do
       wait_for_logs(
@@ -602,7 +604,7 @@ RSpec.describe 'previewing built docs', order: :defined do
   describe 'when we can pull again' do
     before(:context) do
       FileUtils.mv '/tmp/backup', @dest.bare_repo
-      @dest.convert_all @src.conf, target_branch: 'restored'
+      @dest.prepare_convert_all(@src.conf).target_branch('restored').convert
     end
     it 'fetches' do
       wait_for_logs(

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -687,7 +687,9 @@ RSpec.describe 'building a single book' do
       worktree = src.path 'worktree'
       repo.create_worktree worktree, 'HEAD'
       FileUtils.rm_rf repo.root
-      dest.convert_single "#{worktree}/index.asciidoc", '.', asciidoctor: true
+      dest.prepare_convert_single("#{worktree}/index.asciidoc", '.')
+          .asciidoctor
+          .convert
     end
     page_context 'chapter.html' do
       it 'complains about not being able to find the repo toplevel' do
@@ -707,10 +709,10 @@ RSpec.describe 'building a single book' do
           CODE HERE
           ----
         ASCIIDOC
-        dest.convert_single "#{repo.root}/index.asciidoc", '.',
-                            asciidoctor: true,
-                            expect_failure: !suppress,
-                            suppress_migration_warnings: suppress
+        c = dest.prepare_convert_single("#{repo.root}/index.asciidoc", '.')
+        c.asciidoctor
+        c.suppress_migration_warnings if suppress
+        c.convert(expect_failure: !suppress)
       end
     end
     context 'and they are not suppressed' do
@@ -744,9 +746,9 @@ RSpec.describe 'building a single book' do
       repo = src.repo_with_index 'src', <<~ASCIIDOC
         include::missing.asciidoc[]
       ASCIIDOC
-      dest.convert_single "#{repo.root}/index.asciidoc", '.',
-                          asciidoctor: true,
-                          expect_failure: true
+      dest.prepare_convert_single("#{repo.root}/index.asciidoc", '.')
+          .asciidoctor
+          .convert(expect_failure: true)
     end
     it 'fails with an appropriate error status' do
       expect(statuses[0]).to eq(255)


### PR DESCRIPTION
A while back I started migrating my calls to "convert" documents in the
integration tests from a single method into a fluent builder style
because we've grown so many parameters for the conversion. This finishes
that migration.
