### PR TITLE
Simplify open_in_widget

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -4,11 +4,9 @@ inherit_from: ../../.rubocop.yml
 
 Metrics/AbcSize:
   Exclude:
-    - lib/open_in_widget/extension.rb
     - lib/elastic_compat_tree_processor/extension.rb
 
 Metrics/MethodLength:
   Exclude:
-    - lib/open_in_widget/extension.rb
     - lib/elastic_compat_preprocessor/extension.rb
     - lib/elastic_include_tagged/extension.rb

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -22,6 +22,7 @@ Asciidoctor::Extensions.register CareAdmonition
 Asciidoctor::Extensions.register ChangeAdmonition
 Asciidoctor::Extensions.register CopyImages
 Asciidoctor::Extensions.register EditMe
+Asciidoctor::Extensions.register OpenInWidget
 Asciidoctor::Extensions.register RelativizeLink
 Asciidoctor::Extensions.register do
   block_macro LangOverride
@@ -31,6 +32,5 @@ Asciidoctor::Extensions.register do
   # The tree processors after this must come after ElasticComptTreeProcessor
   # or they won't see the right tree.
   treeprocessor AlternativeLanguageLookup::AlternativeLanguageLookup
-  treeprocessor OpenInWidget
   include_processor ElasticIncludeTagged
 end

--- a/resources/asciidoctor/lib/open_in_widget/extension.rb
+++ b/resources/asciidoctor/lib/open_in_widget/extension.rb
@@ -2,9 +2,9 @@
 
 require 'fileutils'
 
+require_relative '../delegating_converter'
 require_relative '../migration_log'
 require_relative '../log_util'
-require_relative '../scaffold'
 
 ##
 # Extensions for enriching certain source blocks with "OPEN IN CONSOLE",
@@ -38,99 +38,111 @@ require_relative '../scaffold'
 #   GET /
 #   ---------
 #
-class OpenInWidget < TreeProcessorScaffold
-  include LogUtil
-  include MigrationLog
-
-  CALLOUT_SCAN_RX = / ?#{Asciidoctor::CalloutScanRx}/
-
-  def process_block(block)
-    return unless block.context == :listing && block.style == 'source'
-
-    lang = block.attr 'language'
-    return unless %w[console sense kibana].include? lang
-
-    snippet_path = snippet_path block, lang, block.attr('snippet')
-
-    block.set_attr(
-      'snippet_link', "<ulink type=\"snippet\" url=\"#{snippet_path}\"/>"
-    )
-    block.document.register :links, snippet_path
-
-    def block.content
-      "#{@attributes['snippet_link']}#{super}"
-    end
-  end
-
-  def snippet_path(block, lang, snippet)
-    return handle_override_snippet block, snippet if snippet
-
-    handle_implicit_snippet block, lang
-  end
-
-  ##
-  # Copy explicitly configured snippets to the right path so kibana can pick
-  # them up and warn the user that they are lame.
-  def handle_override_snippet(block, snippet)
-    snippet_path = "snippets/#{snippet}"
-    normalized = block.normalize_system_path(
-      snippet_path, block.document.base_dir
-    )
-    if File.readable? normalized
-      copy_override_snippet block, normalized, snippet_path
-      migration_warn block, block.source_location, 'override-snippet',
-                     'reading snippets from a path makes the book harder ' \
-                     'to read'
-    else
-      error block: block, message: "can't read snippet from #{normalized}"
-    end
-    snippet_path
-  end
-
-  ##
-  # Handles non-override snippets by assigning them a number and copying them
-  # some place that kibana can read them.
-  def handle_implicit_snippet(block, lang)
-    snippet_number = block.document.attr 'snippet_number', 1
-    snippet = "#{snippet_number}.#{lang}"
-    block.document.set_attr 'snippet_number', snippet_number + 1
-
-    snippet_path = "snippets/#{snippet}"
-    source = block.source.gsub(CALLOUT_SCAN_RX, '') + "\n"
-    write_snippet block, source, snippet_path
-    snippet_path
-  end
-
-  ##
-  # Copies an override snippet from the filesystem into the snippets directory.
-  def copy_override_snippet(block, source, uri)
-    info block: block, message: "copying snippet #{source}"
-    copy_proc = block.document.attr 'copy_snippet'
-    if copy_proc
-      # Delegate to a proc for copying if one is defined. Used for testing.
-      copy_proc.call(uri, source)
-    else
-      destination = ::File.join block.document.options[:to_dir], uri
-      destination_dir = ::File.dirname destination
-      FileUtils.mkdir_p destination_dir
-      FileUtils.cp source, destination
+module OpenInWidget
+  def self.activate(registry)
+    DelegatingConverter.setup(registry.document) do |doc|
+      Converter.new doc
     end
   end
 
   ##
-  # Writes a snippet extracted from the asciidoc file into the
-  # snippets directory.
-  def write_snippet(block, snippet, uri)
-    info block: block, message: "writing snippet #{uri}"
-    write_proc = block.document.attr 'write_snippet'
-    if write_proc
-      # Delegate to a proc for copying if one is defined. Used for testing.
-      write_proc.call(uri, snippet)
-    else
-      destination = ::File.join block.document.options[:to_dir], uri
-      destination_dir = ::File.dirname destination
-      FileUtils.mkdir_p destination_dir
-      File.open(destination, 'w') { |file| file.write(snippet) }
+  # Converter implementation that adds the "open in" links
+  class Converter < DelegatingConverter
+    include LogUtil
+    include MigrationLog
+
+    CALLOUT_SCAN_RX = / ?#{Asciidoctor::CalloutScanRx}/
+
+    def listing(block)
+      return yield unless block.style == 'source'
+
+      lang = block.attr 'language'
+      return yield unless %w[console sense kibana].include? lang
+
+      snippet_path = snippet_path block, lang, block.attr('snippet')
+      yield.gsub(
+        '</programlisting>',
+        "<ulink type=\"snippet\" url=\"#{snippet_path}\"/></programlisting>"
+      )
+    end
+
+    def snippet_path(block, lang, snippet)
+      return handle_override_snippet block, snippet if snippet
+
+      handle_implicit_snippet block, lang
+    end
+
+    ##
+    # Copy explicitly configured snippets to the right path so kibana can pick
+    # them up when you click "open in console" and then warn the user that they
+    # are lame.
+    def handle_override_snippet(block, snippet)
+      snippet_path = "snippets/#{snippet}"
+      normalized = block.normalize_system_path snippet_path
+      if File.readable? normalized
+        copy_override_snippet block, normalized, snippet_path
+        warn_override_snippet block
+      else
+        error block: block, message: "can't read snippet from #{normalized}"
+      end
+      snippet_path
+    end
+
+    ##
+    # Handles non-override snippets by assigning them a number and copying them
+    # some place that kibana can read them.
+    def handle_implicit_snippet(block, lang)
+      snippet_number = block.document.attr 'snippet_number', 1
+      snippet = "#{snippet_number}.#{lang}"
+      block.document.set_attr 'snippet_number', snippet_number + 1
+
+      snippet_path = "snippets/#{snippet}"
+      source = block.source.gsub(CALLOUT_SCAN_RX, '') + "\n"
+      write_snippet block, source, snippet_path
+      snippet_path
+    end
+
+    ##
+    # Copies an override snippet from the filesystem into the
+    # snippets directory.
+    def copy_override_snippet(block, source, uri)
+      info block: block, message: "copying snippet #{source}"
+      copy_proc = block.document.attr 'copy_snippet'
+      if copy_proc
+        # Delegate to a proc for copying if one is defined. Used for testing.
+        copy_proc.call(uri, source)
+      else
+        destination = ::File.join block.document.options[:to_dir], uri
+        destination_dir = ::File.dirname destination
+        FileUtils.mkdir_p destination_dir
+        FileUtils.cp source, destination
+      end
+    end
+
+    ##
+    # Writes a snippet extracted from the asciidoc file into the
+    # snippets directory.
+    def write_snippet(block, snippet, uri)
+      info block: block, message: "writing snippet #{uri}"
+      write_proc = block.document.attr 'write_snippet'
+      if write_proc
+        # Delegate to a proc for copying if one is defined. Used for testing.
+        write_proc.call(uri, snippet)
+      else
+        destination = ::File.join block.document.options[:to_dir], uri
+        destination_dir = ::File.dirname destination
+        FileUtils.mkdir_p destination_dir
+        File.open(destination, 'w') { |file| file.write(snippet) }
+      end
+    end
+
+    def warn_override_snippet(block)
+      migration_warn(
+        block,
+        block.source_location,
+        'override-snippet',
+        'reading snippets from a path makes the book harder to read'
+      )
     end
   end
 end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe ElasticCompatPreprocessor do
   before(:each) do
     Asciidoctor::Extensions.register CareAdmonition
     Asciidoctor::Extensions.register ChangeAdmonition
+    Asciidoctor::Extensions.register OpenInWidget
     Asciidoctor::Extensions.register do
       block_macro LangOverride
       preprocessor ElasticCompatPreprocessor
       include_processor ElasticIncludeTagged
       treeprocessor ElasticCompatTreeProcessor
-      treeprocessor OpenInWidget
     end
   end
 

--- a/resources/asciidoctor/spec/open_in_widget_spec.rb
+++ b/resources/asciidoctor/spec/open_in_widget_spec.rb
@@ -4,9 +4,7 @@ require 'open_in_widget/extension'
 
 RSpec.describe OpenInWidget do
   before(:each) do
-    Asciidoctor::Extensions.register do
-      treeprocessor OpenInWidget
-    end
+    Asciidoctor::Extensions.register OpenInWidget
   end
 
   after(:each) do


### PR DESCRIPTION
I've been wanting to remove our fairly complex `TreeProcessorScaffold`
for a while now because it mirror's Asciidoctor's `Conveter` except it
doesn't properly handle attributes. This migrates `open_in_widget` off
of the scaffold to a converter. This also has the advantage of giving a
clear path to implement the converter if we target html instead of
docbook, which we'd very much like to do.
