### PR TITLE
Add new attributes for the upcoming guides

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -60,6 +60,10 @@
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
+:metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
+:metrics-guide:        https://www.elastic.co/guide/en/metrics/guide/{branch}
+:logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
+:logs-guide:           https://www.elastic.co/guide/en/logs/guide/{branch}
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}


### PR DESCRIPTION
We're splitting the logging and metrics guides. Let's get the attributes
in first so we can build everything else a little more cleanly.
