### PR TITLE
Build a dummy book where the new guides will go

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1389,6 +1389,38 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
+            title:      Log Monitoring Guide
+            prefix:     en/logs/guide
+            current:    master
+            branches:   [ master, 7.x, 7.5 ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       Logs/Guide
+            subject:    Logs
+            asciidoctor: true
+            sources:
+              -
+                # The perl client is a placeholder. We'll switch to the real docs once we're ready.
+                repo:   elasticsearch-perl
+                path:   docs/
+                map_branches: { 7.x: master, 7.5: master}
+          -
+            title:      Metrics Monitoring Guide
+            prefix:     en/metrics/guide
+            current:    master
+            branches:   [ master, 7.x, 7.5 ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       Metrics/Guide
+            subject:    Metrics
+            asciidoctor: true
+            sources:
+              -
+                # The perl client is a placeholder. We'll switch to the real docs once we're ready.
+                repo:   elasticsearch-perl
+                path:   docs/
+                map_branches: { 7.x: master, 7.5: master}
+          -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime
             current:    7.4


### PR DESCRIPTION
We're doing this so the kibana and beats docs will have somewhere to
link to until the real client builds.

We're going to use the perl client out of respect for perl's hacking
heritage.
