### PR TITLE
Add attribute for current version of the Stack Getting Started

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -45,6 +45,7 @@
 :stack-ref-70:         https://www.elastic.co/guide/en/elastic-stack/7.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
+:stack-gs-current:     https://www.elastic.co/guide/en/elastic-stack-get-started/current
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
 :jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}


### PR DESCRIPTION
I know, linking to current is (generally) evil, but I want to be able to link to the instructions/compose file for installing the latest available Docker images.