### PR TITLE
Add go-elasticsearch to the list of alternative languages

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -313,7 +313,8 @@ contents:
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: { master: doc_examples }             
+                map_branches:
+                  master: doc_examples
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -20,6 +20,7 @@ repos:
     elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
     elasticsearch-py:     https://github.com/elastic/elasticsearch-py
     elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl
+    go-elasticsearch:     https://github.com/elastic/go-elasticsearch
     elasticsearch:        https://github.com/elastic/elasticsearch.git
     guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
     guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
@@ -307,6 +308,12 @@ contents:
                 repo:   elasticsearch-ruby
                 path:   examples/docs/spec
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: go }
+                repo:   go-elasticsearch
+                path:   .doc/examples/doc/
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: { master: doc_examples }             
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
This patch adds the Go to the list of alternative languages to choose from in the documentation.
