### PR TITLE
Change current for ECE to 2.4

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -663,7 +663,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    2.3
+            current:    2.4
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1


### PR DESCRIPTION
With the release of ECE 2.4 imminent, let's prepare to point `current` to `2.4`. 

@elastic/cloud-writers could one of you approve, please? 

*** DO NOT MERGE UNTIL ECE 2.4 GOES GA ***