### PR TITLE
Flip the current version of the new books to 7.5

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1382,7 +1382,7 @@ contents:
           -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    master
+            current:    7.5
             branches:   [ master, 7.x, 7.5 ]
             index:      docs/en/logs/index.asciidoc
             chunk:      1
@@ -1402,7 +1402,7 @@ contents:
           -
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    master
+            current:    7.5
             branches:   [ master, 7.x, 7.5 ]
             index:      docs/en/metrics/index.asciidoc
             chunk:      1


### PR DESCRIPTION
The current version of the stack is 7.4 but we don't have a 7.4 version
of those books.
