### PR TITLE
Cleanup attributes after docs split

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -235,5 +235,4 @@ Common words and phrases
 //////////
 Legacy definitions
 //////////
-// Superseded in 7.5
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,4 +1,3 @@
-
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
@@ -60,7 +59,6 @@
 :blog-ref:             https://www.elastic.co/blog/
 :curator-ref:          https://www.elastic.co/guide/en/elasticsearch/client/curator/{branch}
 :curator-ref-current:  https://www.elastic.co/guide/en/elasticsearch/client/curator/current
-:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
 :metrics-ref:          https://www.elastic.co/guide/en/metrics/{branch}
 :metrics-guide:        https://www.elastic.co/guide/en/metrics/guide/{branch}
 :logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
@@ -79,9 +77,8 @@
 :graph-forum:          https://discuss.elastic.co/c/x-pack/graph
 :apm-forum:            https://discuss.elastic.co/c/apm
 
-
 //////////
-Commonly referneced paths in commonly referenced repositories.
+Commonly referenced paths in commonly referenced repositories.
 //////////
 ifdef::elasticsearch-root[]
 :es-ref-dir: {elasticsearch-root}/docs/reference
@@ -235,3 +232,8 @@ Common words and phrases
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
 
+//////////
+Legacy definitions
+//////////
+// Superseded in 7.5
+:infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}


### PR DESCRIPTION
We planned to do these attributes updates as part of #1312 but we split
them out to speed up the deploy. This adds them back.
