### PR TITLE
Don't allow tables to escape

### DIFF
--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -1,4 +1,11 @@
 #guide {
+  .table-contents {
+    /* Without this tables will "expand" based on the widest elements, escape
+     * their containing width, and end up under the nav bar. With this they
+     * are harmlessly "contained". They might look ugly this way, but the
+     * damage is minimized. */
+    overflow: scroll;
+  }
   table {
     margin-bottom:1em;
     border: none;


### PR DESCRIPTION
This prevent super-wide tables from escaping their containers and ending
up under the nav.

Closes #1237
