### PR TITLE
Adds shared monitoring content

### DIFF
--- a/shared/monitoring/master/beats-config.asciidoc
+++ b/shared/monitoring/master/beats-config.asciidoc
@@ -1,0 +1,117 @@
+//The following tagged sections pertain to configuring monitoring in Beats
+
+// Enable the HTTP endpoint
+tag::enable-http-endpoint[]
+Add the following setting in the {beatname_uc} configuration file
+(+{beatname_lc}.yml+):
+
+[source,yaml]
+----------------------------------
+http.enabled: true
+----------------------------------
+
+By default, metrics are exposed on port 5066. If you need to monitor multiple
+{beats} shippers running on the same server, set `http.port` to expose metrics
+for each shipper on a different port number:
+
+[source,yaml]
+----------------------------------
+http.port: 5067
+----------------------------------
+end::enable-http-endpoint[]
+
+// Enable the `beat-xpack` module in Metricbeat
+tag::enable-beat-module[]
+For example, to enable the default configuration in the `modules.d` directory, 
+run the following command, using the correct command syntax for your OS:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules enable beat-xpack
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/metricbeat-module-beat.html[beat module]. 
+end::enable-beat-module[]
+
+// Disable the system module in Metricbeat:
+tag::disable-system-module[]
+By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
+enabled. The information it collects, however, is not shown on the
+*Stack Monitoring* page in {kib}. Unless you want to use that information for
+other purposes, run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+end::disable-system-module[]
+
+// Disable the default collection of Beats monitoring metrics.
+tag::disable-beat-collection[]
+Add the following setting in the {beatname_uc} configuration file
+(+{beatname_lc}.yml+): 
+
+[source,yaml]
+----------------------------------
+monitoring.enabled: false
+----------------------------------
+end::disable-beat-collection[]
+
+// Configure the `beat-xpack` module in Metricbeat
+tag::configure-beat-module[]
+The `modules.d/beat-xpack.yml` file contains the following settings:
+
+[source,yaml]
+----------------------------------
+- module: beat
+  metricsets:
+    - stats
+    - state
+  period: 10s
+  hosts: ["http://localhost:5066"]
+  #username: "user"
+  #password: "secret"
+  xpack.enabled: true
+----------------------------------
+ 
+Set the `hosts`, `username`, and `password` settings as required by your
+environment. For other module settings, it's recommended that you accept the
+defaults.
+
+By default, the module collects {beatname_uc} monitoring data from
+`localhost:5066`. If you exposed the metrics on a different host or port when
+you enabled the HTTP endpoint, update the `hosts` setting.
+
+To monitor multiple 
+ifndef::apm-server[]
+{beats} agents,
+endif::[]
+ifdef::apm-server[]
+APM Server instances,
+endif::[]
+specify a list of hosts, for example:
+
+[source,yaml]
+----------------------------------
+hosts: ["http://localhost:5066","http://localhost:5067","http://localhost:5068"]
+----------------------------------
+
+If you configured {beatname_uc} to use encrypted communications, you must access
+it via HTTPS. For example, use a `hosts` setting like `https://localhost:5066`.
+end::configure-beat-module[]
+
+// Create remote monitoring user
+tag::remote-monitoring-user[]
+If the Elastic {security-features} are enabled, you must also provide a user 
+ID and password so that {metricbeat} can collect metrics successfully: 
+
+.. Create a user on the production cluster that has the 
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
+Alternatively, if it's available in your environment, use the
+`remote_monitoring_user` {ref}/built-in-users.html[built-in user].
+
+.. Add the `username` and `password` settings to the beat module configuration 
+file.
+end::remote-monitoring-user[]

--- a/shared/monitoring/master/kibana-config.asciidoc
+++ b/shared/monitoring/master/kibana-config.asciidoc
@@ -1,0 +1,79 @@
+// These tagged sections pertain to configuring monitoring in Kibana
+
+// Enable the Kibana X-Pack module in Metricbeat
+tag::enable-kibana-module[]
+For example, to enable the default configuration in the `modules.d` directory, 
+run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules enable kibana-xpack
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/metricbeat-module-kibana.html[{kib} module]. 
+end::enable-kibana-module[]
+
+// Disable the default collection of Kibana monitoring metrics
+tag::disable-kibana-collection[]
+Add the following setting in the {kib} configuration file (`kibana.yml`): 
+
+[source,yaml]
+----------------------------------
+xpack.monitoring.kibana.collection.enabled: false
+----------------------------------
+
+Leave the `xpack.monitoring.enabled` set to its default value (`true`). 
+end::disable-kibana-collection[]
+
+// Configure the Kibana X-Pack module in Metricbeat
+tag::configure-kibana-module[]
+The `modules.d/kibana-xpack.yml` file contains the following settings:
+
+[source,yaml]
+----------------------------------
+- module: kibana
+  metricsets:
+    - stats
+  period: 10s
+  hosts: ["localhost:5601"]
+  #basepath: ""
+  #username: "user"
+  #password: "secret"
+  xpack.enabled: true
+----------------------------------
+
+By default, the module collects {kib} monitoring metrics from `localhost:5601`.
+If that host and port number are not correct, you must update the `hosts`
+setting. If you configured {kib} to use encrypted communications, you must
+access it via HTTPS. For example, use a `hosts` setting like
+`https://localhost:5601`.
+end::configure-kibana-module[]
+
+// Disable the system module in Metricbeat
+tag::disable-system-module[]
+By default, the {metricbeat-ref}/metricbeat-module-system.html[system module] is
+enabled. The information it collects, however, is not shown on the *Monitoring*
+page in {kib}. Unless you want to use that information for other purposes, run
+the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+end::disable-system-module[]
+
+// Create a remote monitoring user
+tag::remote-monitoring-user[]
+If the Elastic {security-features} are enabled, you must also provide a user 
+ID and password so that {metricbeat} can collect metrics successfully: 
+
+.. Create a user on the production cluster that has the 
+`remote_monitoring_collector` {ref}/built-in-roles.html[built-in role]. 
+Alternatively, use the `remote_monitoring_user` 
+{ref}/built-in-users.html[built-in user].
+
+.. Add the `username` and `password` settings to the {kib} module configuration 
+file.
+end::remote-monitoring-user[]


### PR DESCRIPTION
This PR adds files that contain tagged regions related to configuring monitoring in Kibana and Beats.

These regions can then be used in multiple books from diverse repos. 

For example, this information currently appears in  https://www.elastic.co/guide/en/kibana/master/monitoring-metricbeat.html, https://www.elastic.co/guide/en/beats/metricbeat/master/monitoring-metricbeat-collection.html, and https://www.elastic.co/guide/en/elastic-stack-overview/master/esms.html

This file format is copied from how common API reference parameters are re-used in https://github.com/elastic/elasticsearch/blob/master/docs/reference/rest-api/common-parms.asciidoc

Ideally we can switch to using these shared files, as in https://github.com/elastic/elasticsearch/pull/48594
NOTE: The inclusion of the branch in the path for these files means that we can include the appropriate version of the files using attributes. For example:

> include::{docs-root}/shared/monitoring/{source_branch}/kibana-config.asciidoc[tag=disable-kibana-collection]

