### PR TITLE
Fix preview's root redirect

### DIFF
--- a/integtest/spec/preview_spec.rb
+++ b/integtest/spec/preview_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe 'previewing built docs', order: :defined do
     end
     context 'the root' do
       it 'redirects to the guide root' do
-        expect(root).to redirect_to(eq("http://#{host}:8000/guide/index.html"))
+        expect(root).to redirect_to(eq('/guide/index.html'))
       end
       it 'logs the access to the docs root' do
         wait_for_access '/'

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -871,9 +871,6 @@ http {
 
   server {
     listen 8000;
-    location = / {
-      return 301 /guide/index.html;
-    }
     location = /liveness {
       return 200 "Ph'nglui mglw'nafh Cthulhu R'lyeh wgah'nagl fhtagn.";
     }

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -28,6 +28,12 @@ const Template = require("../template/template");
 const port = 3000;
 
 const requestHandler = async (core, parsedUrl, response) => {
+  if (parsedUrl.pathname === '/') {
+    response.statusCode = 301;
+    response.setHeader('Location', '/guide/index.html');
+    response.end();
+    return;
+  }
   if (parsedUrl.pathname === '/diff') {
     return new Promise((resolve, reject) => {
       pipeToResponse(core.diff(), response, resolve, reject);


### PR DESCRIPTION
The preview was redirecting to port `8000` because that is the port
nginx runs on. But k8s serves the actual result out of port `80`! While
we *could* turn off setting the port in nginx, it feels simpler to send
a relative redirect. Every modern browser supports this and the preview
app does it all the time. So this delegates the redirect for `/` to the
preview application.
