### PR TITLE
Switch to docker's buildkit everywhere

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -71,7 +71,7 @@ def build_docker_image():
             acc.append(line)
 
     cmd = ["docker", "image", "build", "-t", DOCKER_TAG, DIR]
-    build = common_popen(cmd)
+    build = common_popen(cmd, env={'DOCKER_BUILDKIT':'1'})
     handle_popen(build, handle_line)
     if build.returncode != 0:
         for line in acc:
@@ -495,7 +495,7 @@ class Args:
         return next_arg
 
 
-def common_popen(cmd):
+def common_popen(cmd, env=None):
     """Start a subprocess in a way that is compatible with handle_popen.
     """
     # Use a PIPE for stdin so if our process dies then the docs build sees
@@ -503,7 +503,8 @@ def common_popen(cmd):
     return subprocess.Popen(cmd,
                             stdin=subprocess.PIPE,
                             stdout=subprocess.PIPE,
-                            stderr=subprocess.STDOUT)
+                            stderr=subprocess.STDOUT,
+                            env=env)
 
 
 def handle_popen(popen, handle_line):

--- a/build_docs
+++ b/build_docs
@@ -71,7 +71,7 @@ def build_docker_image():
             acc.append(line)
 
     cmd = ["docker", "image", "build", "-t", DOCKER_TAG, DIR]
-    build = common_popen(cmd, env={'DOCKER_BUILDKIT':'1'})
+    build = common_popen(cmd, env={'DOCKER_BUILDKIT': '1'})
     handle_popen(build, handle_line)
     if build.returncode != 0:
         for line in acc:

--- a/publish_docker.sh
+++ b/publish_docker.sh
@@ -7,7 +7,7 @@ export PREVIEW=docker.elastic.co/docs/preview:14
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --just-build-image
-docker build -t $PREVIEW -f preview/Dockerfile .
+DOCKER_BUILDKIT=1 docker build -t $PREVIEW -f preview/Dockerfile .
 docker tag $BUILD push.$BUILD
 docker push push.$BUILD
 docker tag $PREVIEW push.$PREVIEW


### PR DESCRIPTION
I hadn't used it when I first migrated the docs build to docker because
it was slower when the image was already cached. But it is now a little
faster for me. And it is the future of the docker project. And it gives
more features which we will use eventually.
