### PR TITLE
Shrink docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,98 +1,99 @@
+# This builds a "base" image that contains dependencies that are required at
+# runtime *and* to install dependencies like `ruby`. Then it builds images that
+# intall those dependencies. Then it builds a "final" image that copies the
+# dependencies and installs package that it needs at runtime. Compared to
+# installing everything in one go this shrinks the "final" docker image by
+# about 50%, mostly because we don't need things like `gcc` and `ruby-dev` in
+# the "final" image.
+
 # Debian builds the docs about 20% faster than alpine. The image is larger
 # and takes longer to build but that is worth it.
-FROM bitnami/minideb:buster
+FROM bitnami/minideb:buster AS base
 
-LABEL MAINTAINERS="Nik Everett <nik@elastic.co>"
+# TODO install_packages calls apt-get update and then nukes the list files after. We should avoid multiple calls to apt-get update.....
 
-# Setup repos for things like node and yarn
+# Setup the repo for node
 RUN install_packages apt-transport-https gnupg2 ca-certificates
-COPY .docker/apt/sources.list.d/* /etc/apt/sources.list.d/
-COPY .docker/apt/keys/* /
-RUN cat /nodesource.gpg | apt-key add - && rm /nodesource.gpg
-RUN cat /yarn.gpg | apt-key add - && rm yarn.gpg
-
-# Package inventory:
-# * To make life easier
-#   * bash
-#   * less
-# * Used by the docs build
-#   * libnss-wrapper
-#   * libxml-libxml-perl
-#   * libxml2-utils
-#   * nginx
-#   * openssh-client (used by git)
-#   * openssh-server (used to forward ssh auth for git when running with --all on macOS)
-#   * perl-base
-#   * python (is python2)
-#   * xsltproc
-# * To install rubygems for asciidoctor
-#   * bundler
-#   * build-essential
-#   * cmake
-#   * libxml2-dev
-#   * make
-#   * ruby
-#   * ruby-dev
-# * Used to check the docs build in CI
-#   * python3
-#   * python3-pip
-# * Used to check javascript
-#   * nodejs
-#   * yarn
+COPY .docker/apt/keys/nodesource.gpg /
+RUN apt-key add /nodesource.gpg
+COPY .docker/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/
 RUN install_packages \
-  bash \
-  build-essential \
-  bundler \
-  curl \
-  cmake \
-  git \
-  less \
-  libnss-wrapper \
-  libxml-libxml-perl \
-  libxml2-dev \
-  libxml2-utils \
-  make \
-  nodejs \
-  nginx \
-  openssh-client \
-  openssh-server \
-  perl-base \
-  python \
-  python3 \
-  python3-pip \
-  ruby \
-  ruby-dev \
-  unzip \
-  yarn \
-  xsltproc
+  nodejs python3 ruby \
+    # Used both to install dependencies and at run time
+  bash less
+    # Just in case you have to shell into the image
 
-# We mount these directories with tmpfs so we can write to them so they
-# have to be empty. So we delete them.
-RUN rm -rf /var/log/nginx && rm -rf /run/nginx
 
-# Wheel inventory:
-# * Used to test the docs build
-#   * beautifulsoup4
-#   * lxml
-#   * pycodestyle
+FROM base as py_deps
+RUN install_packages python3-pip
 RUN pip3 install \
   beautifulsoup4==4.7.1 \
   lxml==4.3.1 \
   pycodestyle==2.5.0
 
-# Install ruby deps with bundler to make things more standard for Ruby folks.
+
+FROM base AS ruby_deps
+RUN install_packages \
+  bundler \
+    # Fetches ruby dependencies
+  ruby-dev make cmake gcc libc-dev patch
+    # Required to compile some of the native dependencies
 RUN bundle config --global silence_root_warning 1
 COPY Gemfile* /
+# --frozen forces us to regenerate Gemfile.lock locally before using it in
+# docker which lets us lock the versions in place.
 RUN bundle install --binstubs --system --frozen
 COPY .docker/asciidoctor_2_0_10.patch /
 RUN cd /var/lib/gems/2.5.0/gems/asciidoctor-2.0.10 && patch -p1 < /asciidoctor_2_0_10.patch
-# --frozen forces us to regenerate Gemfile.lock locally before using it in
-# docker which is important because we need Gemfile.lock to lock the gems to a
-# consistent version and we can't rely on running bundler in docker to update
-# it because we can't copy from the image to the host machine while building
-# the image.
 
+
+FROM base AS node_deps
+COPY .docker/apt/keys/yarn.gpg /
+RUN apt-key add /yarn.gpg
+COPY .docker/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/
+RUN install_packages yarn
 COPY package.json /
 COPY yarn.lock /
 ENV YARN_CACHE_FOLDER=/tmp/.yarn-cache
+# --frozen-lockfile forces us to regenerate yarn.lock locally before using it
+# in docker which lets us lock the versions in place.
 RUN yarn install --frozen-lockfile
+
+
+FROM base AS final
+LABEL MAINTAINERS="Nik Everett <nik@elastic.co>"
+RUN install_packages \
+  git \
+    # Clone source repositories and commit to destination repositories
+  libnss-wrapper \
+    # Used to clean up user id differences in the docker image.
+  libxml-libxml-perl \
+    # Parses the sitemap
+  libxml2-utils \
+    # Validates the docsbook xml
+  make \
+    # Used by the tests
+  nginx \
+    # Serves docs during tests and when the container is used for "preview" or
+    # "air gapped" docs
+  openssh-client \
+    # Used by git
+  openssh-server \
+    # Used to forward git authentication to the image on OSX
+  perl-base \
+    # The "glue" of the docs build is written in perl
+  python \
+    # AKA python2. Runs AsciiDoc but *not* Asciidoctor.
+  xsltproc
+    # Converts the docbook xml into html
+COPY --from=node_deps /node_modules /node_modules
+COPY --from=py_deps /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages
+COPY --from=py_deps /usr/local/bin/pycodestyle /usr/local/bin/pycodestyle
+COPY --from=ruby_deps /var/lib/gems /var/lib/gems
+COPY --from=ruby_deps /usr/local/bin/asciidoctor /usr/local/bin/asciidoctor
+COPY --from=ruby_deps /usr/local/bin/rspec /usr/local/bin/rspec
+COPY --from=ruby_deps /usr/local/bin/rubocop /usr/local/bin/rubocop
+
+# We mount these directories with tmpfs so we can write to them so they
+# have to be empty. So we delete them.
+RUN rm -rf /var/log/nginx && rm -rf /run/nginx


### PR DESCRIPTION
This *massively* shrinks our docker images, most importantly, the air
gapped docs image:
```
-rw-------. 1 manybubbles manybubbles 1.1G Oct 31 17:16 /home/manybubbles/Downloads/air_gapped_after.tar
-rw-------. 1 manybubbles manybubbles 1.6G Oct 31 17:09 /home/manybubbles/Downloads/air_gapped_before.tar
```

It does so by using the "multi-stage builds" feature from docker's
buildkit. It allows you to create multiple docker images in the same
Dockerfile and copy parts each image into another. We use that to build
images that *just* install dependencies and then we copy those
dependencies from those images into a "final" image.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
