### PR TITLE
Prevent informal table from escaping

### DIFF
--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -1,5 +1,5 @@
 #guide {
-  .table-contents {
+  .table-contents, .informaltable {
     /* Without this tables will "expand" based on the widest elements, escape
      * their containing width, and end up under the nav bar. With this they
      * are harmlessly "contained". They might look ugly this way, but the


### PR DESCRIPTION
It turn out that tables that don't have a title don't have a
`table-contents` class. They have an `informaltable` class intead.
:shrug: This prevents those sorts of table from escaping under the nav
as well.
