### PR TITLE
Drop explicit asciidoctor

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -53,7 +53,6 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -98,7 +97,6 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -117,7 +115,6 @@ contents:
             branches:   [ master ]
             tags:       Elastic Stack/Glossary
             subject:    Elastic Stack
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -140,7 +137,6 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -176,7 +172,6 @@ contents:
             chunk:      1
             tags:       Elastic Common Schema (ECS)/Reference
             subject:    Elastic Common Schema (ECS)
-            asciidoctor: true
             sources:
               -
                 repo:   ecs
@@ -190,7 +185,6 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template
-            asciidoctor: true
             sources:
               -
                 repo:   azure-marketplace
@@ -204,7 +198,6 @@ contents:
             chunk:      1
             tags:       Elastic Stack/Google
             subject:    Elastic Stack
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -227,7 +220,6 @@ contents:
             chunk:      1
             tags:       Elasticsearch/Reference
             subject:    Elasticsearch
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch
@@ -334,7 +326,6 @@ contents:
             single:     1
             tags:       Elasticsearch/Resiliency Status
             subject:    Elasticsearch
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch
@@ -359,7 +350,6 @@ contents:
             chunk:      1
             tags:       Elasticsearch/Painless
             subject:    Elasticsearch
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch
@@ -385,7 +375,6 @@ contents:
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch
@@ -419,7 +408,6 @@ contents:
                 tags:       Clients/JavaREST
                 subject:    Clients
                 chunk:      1
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -449,7 +437,6 @@ contents:
                 tags:       Clients/Java
                 subject:    Clients
                 chunk:      1
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -487,7 +474,6 @@ contents:
                 index:      docs/index.asciidoc
                 tags:       Clients/JavaScript
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-js
@@ -500,7 +486,6 @@ contents:
                 index:      docs/index.asciidoc
                 tags:       Clients/Ruby
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-ruby
@@ -514,7 +499,6 @@ contents:
                 single:     1
                 tags:       Clients/Go
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -530,7 +514,6 @@ contents:
                 tags:       Clients/.Net
                 subject:    Clients
                 chunk:      1
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-net
@@ -544,7 +527,6 @@ contents:
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-php
@@ -559,7 +541,6 @@ contents:
                 single:     1
                 tags:       Clients/Perl
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch-perl
@@ -574,7 +555,6 @@ contents:
                 single:     1
                 tags:       Clients/Python
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -589,7 +569,6 @@ contents:
                 single:     1
                 tags:       Clients/Community
                 subject:    Clients
-                asciidoctor: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -602,7 +581,6 @@ contents:
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch-hadoop
@@ -616,7 +594,6 @@ contents:
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
             subject:    Clients
-            asciidoctor: true
             sources:
               -
                 repo:   curator
@@ -635,7 +612,6 @@ contents:
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   cloud
@@ -655,7 +631,6 @@ contents:
             chunk:      1
             noindex:    1
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   cloud
@@ -677,7 +652,6 @@ contents:
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   cloud
@@ -696,7 +670,6 @@ contents:
             branches:   [ master, 1.0, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
-            asciidoctor: true
             sources:
               -
                 repo:   cloud-on-k8s
@@ -721,7 +694,6 @@ contents:
             branches:   [ master ]
             index:      docs/index.asciidoc
             chunk:      1
-            asciidoctor: true
             sources:
               -
                 repo:   ecctl
@@ -738,7 +710,6 @@ contents:
             chunk:      1
             tags:       Kibana/Reference
             subject:    Kibana
-            asciidoctor: true
             sources:
               -
                 repo:   kibana
@@ -773,7 +744,6 @@ contents:
             tags:       Logstash/Reference
             subject:    Logstash
             respect_edit_url_overrides: true
-            asciidoctor: true
             sources:
               -
                 repo:   logstash
@@ -810,7 +780,6 @@ contents:
             noindex:    1
             tags:       Logstash/Plugin Reference
             subject:    Logstash
-            asciidoctor: true
             sources:
               -
                 repo:   logstash-docs
@@ -832,7 +801,6 @@ contents:
             tags:       Libbeat/Reference
             subject:    libbeat
             respect_edit_url_overrides: true
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -858,7 +826,6 @@ contents:
             tags:       Devguide/Reference
             subject:    Beats
             respect_edit_url_overrides: true
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -890,7 +857,6 @@ contents:
             tags:       Packetbeat/Reference
             respect_edit_url_overrides: true
             subject:    Packetbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -922,7 +888,6 @@ contents:
             tags:       Filebeat/Reference
             respect_edit_url_overrides: true
             subject:    Filebeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -962,7 +927,6 @@ contents:
             tags:       Winlogbeat/Reference
             respect_edit_url_overrides: true
             subject:    Winlogbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -994,7 +958,6 @@ contents:
             tags:       Metricbeat/Reference
             respect_edit_url_overrides: true
             subject:    Metricbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1040,7 +1003,6 @@ contents:
             tags:       Heartbeat/Reference
             respect_edit_url_overrides: true
             subject:    Heartbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1076,7 +1038,6 @@ contents:
             tags:       Auditbeat/Reference
             respect_edit_url_overrides: true
             subject:    Auditbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1118,7 +1079,6 @@ contents:
             tags:       Functionbeat/Reference
             respect_edit_url_overrides: true
             subject:    Functionbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1148,7 +1108,6 @@ contents:
             tags:       Journalbeat/Reference
             respect_edit_url_overrides: true
             subject:    Journalbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1179,7 +1138,6 @@ contents:
             tags:       Legacy/Topbeat/Reference
             respect_edit_url_overrides: true
             subject:    Topbeat
-            asciidoctor: true
             sources:
               -
                 repo:   beats
@@ -1204,7 +1162,6 @@ contents:
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
-            asciidoctor: true
             sources:
               -
                 repo:   swiftype
@@ -1219,7 +1176,6 @@ contents:
             single:     1
             tags:       App Search/Reference
             subject:    Swiftype
-            asciidoctor: true
             sources:
               -
                 repo:   swiftype
@@ -1236,7 +1192,6 @@ contents:
             chunk:      1
             tags:       SIEM/Guide
             subject:    SIEM
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -1263,7 +1218,6 @@ contents:
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM
-                asciidoctor: true
                 sources:
                   -
                     repo:   apm-server
@@ -1280,7 +1234,6 @@ contents:
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM
-                asciidoctor: true
                 sources:
                   -
                     repo:   apm-server
@@ -1305,7 +1258,6 @@ contents:
                     tags:       APM Go Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-go
@@ -1319,7 +1271,6 @@ contents:
                     tags:       APM Java Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-java
@@ -1333,7 +1284,6 @@ contents:
                     tags:       APM .NET Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-dotnet
@@ -1350,7 +1300,6 @@ contents:
                     tags:       APM Node.js Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-nodejs
@@ -1368,7 +1317,6 @@ contents:
                     tags:       APM Python Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-python
@@ -1382,7 +1330,6 @@ contents:
                     tags:       APM Ruby Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-ruby
@@ -1400,7 +1347,6 @@ contents:
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
                     subject:    APM
                     chunk:      1
-                    asciidoctor: true
                     sources:
                       -
                         repo:   apm-agent-rum-js
@@ -1414,7 +1360,6 @@ contents:
             chunk:      1
             tags:       Logs/Guide
             subject:    Logs
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -1434,7 +1379,6 @@ contents:
             chunk:      1
             tags:       Metrics/Guide
             subject:    Metrics
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -1454,7 +1398,6 @@ contents:
             chunk:      1
             tags:       Uptime/Guide
             subject:    Uptime
-            asciidoctor: true
             sources:
               -
                 repo:   kibana
@@ -1477,7 +1420,6 @@ contents:
               lang:       zh_cn
               tags:       Elasticsearch/Definitive Guide
               subject:    Elasticsearch
-              asciidoctor: true
               suppress_migration_warnings: true
               sources:
                 -
@@ -1492,7 +1434,6 @@ contents:
               lang:       zh_cn
               tags:       Elasticsearch/PHP
               subject:    Elasticsearch
-              asciidoctor: true
               sources:
                 -
                   repo: elasticsearch-php-cn
@@ -1507,7 +1448,6 @@ contents:
               chunk:      1
               tags:       Kibana/Reference
               subject:    Kibana
-              asciidoctor: true
               sources:
                 -
                   repo: kibana-cn
@@ -1527,7 +1467,6 @@ contents:
               lang:       ja
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
-              asciidoctor: true
               sources:
                 -
                   repo: elasticsearch
@@ -1545,7 +1484,6 @@ contents:
               lang:       ja
               tags:       Logstash/Reference
               subject:    Logstash
-              asciidoctor: true
               sources:
                 -
                   repo: logstash
@@ -1560,7 +1498,6 @@ contents:
               lang:       ja
               tags:       Kibana/Reference
               subject:    Kibana
-              asciidoctor: true
               sources:
                 -
                   repo: kibana
@@ -1575,7 +1512,6 @@ contents:
               lang:       ja
               tags:       X-Pack/Reference
               subject:    X-Pack
-              asciidoctor: true
               sources:
                 -
                   repo: x-pack
@@ -1603,7 +1539,6 @@ contents:
               lang:       ko
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
-              asciidoctor: true
               sources:
                 -
                   repo: elasticsearch
@@ -1621,7 +1556,6 @@ contents:
               lang:       ko
               tags:       Logstash/Reference
               subject:    Logstash
-              asciidoctor: true
               sources:
                 -
                   repo: logstash
@@ -1636,7 +1570,6 @@ contents:
               lang:       ko
               tags:       Kibana/Reference
               subject:    Kibana
-              asciidoctor: true
               sources:
                 -
                   repo: kibana
@@ -1651,7 +1584,6 @@ contents:
               lang:       ko
               tags:       X-Pack/Reference
               subject:    X-Pack
-              asciidoctor: true
               sources:
                 -
                   repo: x-pack
@@ -1677,7 +1609,6 @@ contents:
             chunk:      1
             tags:       Infrastructure/Guide
             subject:    Infrastructure
-            asciidoctor: true
             sources:
               -
                 repo:   stack-docs
@@ -1699,7 +1630,6 @@ contents:
             index:      docs/en/index.asciidoc
             private:    1
             branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1725,7 +1655,6 @@ contents:
             tags:       Legacy/Elasticsearch/Definitive Guide
             subject:    Elasticsearch
             suppress_migration_warnings: true
-            asciidoctor: true
             sources:
               -
                 repo:   guide
@@ -1740,7 +1669,6 @@ contents:
             noindex:    1
             tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
-            asciidoctor: true
             sources:
               -
                 repo:   sense
@@ -1756,7 +1684,6 @@ contents:
             index:      docs/public/marvel/index.asciidoc
             private:    1
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1772,7 +1699,6 @@ contents:
             index:      docs/public/shield/index.asciidoc
             private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1788,7 +1714,6 @@ contents:
             index:      docs/public/watcher/index.asciidoc
             private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1804,7 +1729,6 @@ contents:
             index:      docs/public/reporting/index.asciidoc
             branches:   [ 2.4 ]
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1821,7 +1745,6 @@ contents:
             index:      docs/public/graph/index.asciidoc
             branches:   [ 2.4, 2.3 ]
             private:    1
-            asciidoctor: true
             sources:
               -
                 repo:   x-pack
@@ -1835,7 +1758,6 @@ contents:
             noindex:    1
             tags:       Legacy/Clients/Groovy
             subject:    Clients
-            asciidoctor: true
             sources:
               -
                 repo:   elasticsearch

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -12,25 +12,25 @@
 
 
 # Elasticsearch
-alias docbldesx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
 
 alias docbldes=docbldesx
 
 # Elasticsearch 6.2 and earlier
 
-alias docbldesold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
+alias docbldesold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'
 
 # Kibana
-alias docbldkbx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
+alias docbldkbx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.asciidoc --chunk 1'
 
 alias docbldkb=docbldkbx
 
 # Kibana 6.2 to 5.3
 
-alias docbldkbold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
+alias docbldkbold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/index.x.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs/ --chunk 1'
 
 # Logstash
-alias docbldlsx='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
+alias docbldlsx='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/logstash/docs/index.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --chunk 1'
 
 alias docbldls=docbldlsx
 
@@ -39,139 +39,139 @@ alias docbldls=docbldlsx
 alias docbldlsold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'
 
 # Installation and Upgrade Guide 7.0 and later
-alias docbldstk='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --chunk 1'
+alias docbldstk='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --chunk 1'
 
 # Installation and Upgrade Guide 6.7 and earlier
-alias docbldstkold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --chunk 1'
+alias docbldstkold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --chunk 1'
 
 
 # Glossary
-alias docbldgls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs'
+alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs'
 
 # Getting started
-alias docbldgs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
+alias docbldgs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
 # Stack Overview
-alias docbldso='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --resource=$GIT_HOME/beats/libbeat/docs/ --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --resource=$GIT_HOME/beats/libbeat/docs/ --chunk 1'
 
 # Stack Overview versions 6.3-7.2
-alias docbldsoold='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
+alias docbldsoold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
 # Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldmet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/metrics/index.asciidoc --chunk 1'
+alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/metrics/index.asciidoc --chunk 1'
 
-alias docbldlog='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/logs/index.asciidoc --chunk 1'
+alias docbldlog='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/logs/index.asciidoc --chunk 1'
 
-alias docbldup='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
+alias docbldup='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
 
-alias docbldsec='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/siem/index.asciidoc --chunk 1'
+alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/siem/index.asciidoc --chunk 1'
 
 # Curator
-alias docbldcr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
+alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
 # Cloud
-alias docbldec='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
 # Cloud - Elastic Cloud Enterprise
-alias docbldece='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
-alias docbldech='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/cloud/docs/heroku/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud/docs/saas --chunk 1'
+alias docbldech='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/heroku/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud/docs/saas --chunk 1'
 
 # Cloud - Elastic Cloud Control
-alias docbldecctl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/ecctl/docs/index.asciidoc --chunk 1'
+alias docbldecctl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecctl/docs/index.asciidoc --chunk 1'
 
 # Cloud - Elastic Cloud for K8s
-alias docbldk8s='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
+alias docbldk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
 # Beats
-alias docbldbpr='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'
+alias docbldbpr='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldbdg='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/docs/devguide/index.asciidoc --chunk 1'
+alias docbldbdg='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/docs/devguide/index.asciidoc --chunk 1'
 
-alias docbldpb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/packetbeat/docs/index.asciidoc --chunk 1'
+alias docbldpb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/packetbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldfb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --chunk 1'
+alias docbldfb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --chunk 1'
 
-alias docbldwb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/winlogbeat/docs/index.asciidoc --chunk 1'
+alias docbldwb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/winlogbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldmb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/metricbeat/docs/index.asciidoc --chunk 1'
+alias docbldmb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/metricbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldhb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
+alias docbldhb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldab='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
-alias docbldabx='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
+alias docbldab='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
+alias docbldabx='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
 
-alias docbldfnb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/x-pack/functionbeat/docs/index.asciidoc --chunk 1'
+alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/x-pack/functionbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldjb='$GIT_HOME/docs/build_docs --asciidoctor --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
+alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
 # APM
-alias docbldamg='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
+alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 
-alias docbldamr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
+alias docbldamr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/index.asciidoc --chunk 1'
 
-alias docbldamn='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1'
+alias docbldamn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1'
 
-alias docbldamp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
+alias docbldamp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
 
-alias docbldamry='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
+alias docbldamry='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
 
-alias docbldamj='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
+alias docbldamj='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
 
-alias docbldamjs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
+alias docbldamjs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
 
-alias docbldamgo='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-go/docs/index.asciidoc --chunk 1'
+alias docbldamgo='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-go/docs/index.asciidoc --chunk 1'
 
-alias docbldamnet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/apm-agent-dotnet/docs/index.asciidoc --chunk 1'
+alias docbldamnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-dotnet/docs/index.asciidoc --chunk 1'
 
 
 # Definitive Guide
-alias docblddg='$GIT_HOME/docs/build_docs --asciidoctor --suppress_migration_warnings --doc $GIT_HOME/elasticsearch-definitive-guide/book.asciidoc --chunk 1'
+alias docblddg='$GIT_HOME/docs/build_docs --suppress_migration_warnings --doc $GIT_HOME/elasticsearch-definitive-guide/book.asciidoc --chunk 1'
 
 
 # Elasticsearch Extras
-alias docbldres='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
+alias docbldres='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
 
-alias docbldpls='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
+alias docbldpls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
 
-alias docbldepi='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
+alias docbldepi='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
 
-alias docbldjvr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/java-rest/index.asciidoc --chunk 1'
+alias docbldjvr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-rest/index.asciidoc --chunk 1'
 
-alias docbldejv='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/java-api/index.asciidoc --chunk 1'
+alias docbldejv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-api/index.asciidoc --chunk 1'
 
-alias docbldejs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
+alias docbldejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
 
-alias docblderb='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
+alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
 
-alias docbldegr='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
+alias docbldegr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
-alias docbldego='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
+alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
 
-alias docbldnet='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
+alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
-alias docbldphp='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
+alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 
-alias docbldepl='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
+alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
-alias docbldepy='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
+alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
 
-alias docbldecc='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
+alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 
-alias docbldesh='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
+alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
 # X-Pack Reference 5.4 to 6.2
 
-alias docbldx='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
+alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
 
 # ECS
-alias docbldecs='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'
+alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'
 
 # GKE
-alias docbldgke='$GIT_HOME/docs/build_docs --asciidoctor --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
+alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
 
 # Build all
 alias docbldall='$GIT_HOME/docs/build_docs --all --target_repo git@github.com:elastic/built-docs.git'


### PR DESCRIPTION
Drop the `asciidoctor` flag from `conf.yaml` and `doc_build_aliases.sh`.
It isn't needed any more.
