### PR TITLE
Track direct-to-html conversions

### DIFF
--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -437,6 +437,28 @@ RSpec.describe 'building all books' do
           include_examples 'second build is not a noop'
           include_examples 'second build only changes chapter2'
         end
+        context 'because the book changes from docbook to direct_html' do
+          build_one_book_out_of_one_repo_twice(
+            before_second_build: lambda do |src, _config|
+              book = src.book 'Test'
+              book.direct_html = true
+            end
+          )
+          include_examples 'second build is not a noop'
+        end
+        context 'because the book changes from direct_html to docbook' do
+          build_one_book_out_of_one_repo_twice(
+            before_first_build: lambda do |src, _config|
+              book = src.book 'Test'
+              book.direct_html = true
+            end,
+            before_second_build: lambda do |src, _config|
+              book = src.book 'Test'
+              book.direct_html = false
+            end
+          )
+          include_examples 'second build is not a noop'
+        end
         context 'because there is a target_branch and we have changes' do
           # We always fork the target_branch from master so if the target
           # branch contains any changes from master we rebuild them every time.

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -29,6 +29,10 @@ class Book
   # version? Defaults to false.
   attr_accessor :suppress_migration_warnings
 
+  ##
+  # Should this book built directly to html (true) or to docbook first (false).
+  attr_accessor :direct_html
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -39,6 +43,7 @@ class Book
     @respect_edit_url_overrides = false
     @lang = 'en'
     @suppress_migration_warnings = false
+    @direct_html = false
   end
 
   ##
@@ -90,6 +95,7 @@ class Book
       tags:       test tag
       subject:    Test
       lang:       #{@lang}
+      direct_html: #{@direct_html}
     YAML
   end
 

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -139,6 +139,7 @@ sub new {
         lang          => $lang,
         respect_edit_url_overrides => $respect_edit_url_overrides,
         suppress_migration_warnings => $args{suppress_migration_warnings} || 0,
+        direct_html => ( $args{direct_html} || 'false' ) eq 'true',
     }, $class;
 }
 
@@ -157,7 +158,7 @@ sub build {
         $Opts->{procs},
         sub {
             my ( $pid, $error, $branch ) = @_;
-            $self->source->mark_done( $title, $branch, 0 );
+            $self->source->mark_done( $title, $branch, $self->{direct_html} );
         }
     );
 
@@ -241,7 +242,7 @@ sub _build_book {
     my $lang          = $self->lang;
 
     return 0 unless $rebuild ||
-        $source->has_changed( $self->title, $branch, 0 );
+        $source->has_changed( $self->title, $branch, $self->{direct_html} );
 
     my ( $checkout, $edit_urls, $first_path, $alternatives, $roots ) =
         $source->prepare($self->title, $branch);

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -157,7 +157,7 @@ sub build {
         $Opts->{procs},
         sub {
             my ( $pid, $error, $branch ) = @_;
-            $self->source->mark_done( $title, $branch, 1 );
+            $self->source->mark_done( $title, $branch, 0 );
         }
     );
 
@@ -241,7 +241,7 @@ sub _build_book {
     my $lang          = $self->lang;
 
     return 0 unless $rebuild ||
-        $source->has_changed( $self->title, $branch, 1 );
+        $source->has_changed( $self->title, $branch, 0 );
 
     my ( $checkout, $edit_urls, $first_path, $alternatives, $roots ) =
         $source->prepare($self->title, $branch);

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -51,7 +51,7 @@ sub add_sub_dir {
 sub has_changed {
 #===================================
     my $self = shift;
-    my ( $title, $branch, $path, $asciidoctor ) = @_;
+    my ( $title, $branch, $path, $direct_html ) = @_;
 
     $path = $self->normalize_path( $path, $branch );
     $branch = $self->normalize_branch( $branch );
@@ -83,7 +83,7 @@ sub has_changed {
                 . $self->name);
     }
     my $new_info = $new;
-    $new_info .= '|asciidoctor' if $asciidoctor;
+    $new_info .= '|direct_html' if $direct_html;
 
     # We check sub_dirs *after* the checks above so we can handle sub_dir for
     # new sources specially.
@@ -93,11 +93,11 @@ sub has_changed {
         return $old_info ne $new_info ? 'changed' : 'not_changed';
     }
     return 'not_changed' if $old_info eq $new_info;
-    # If the asciidoctor-ness of the previous build doesn't match this one then
+    # If the direct_html-ness of the previous build doesn't match this one then
     # we've changed. It'd be nice if build-info were a class but we'll be
-    # dropping asciidoctor as soon as we've migrated all of the books and this
+    # dropping direct_html as soon as we've migrated all of the books and this
     # is sort of a local minima of effort.
-    return 'changed' unless ($old_info =~ /\|asciidoctor$/) == $asciidoctor;
+    return 'changed' unless ($old_info =~ /\|direct_html$/) == $direct_html;
 
     my $changed;
     eval {
@@ -115,7 +115,7 @@ sub has_changed {
 sub mark_done {
 #===================================
     my $self = shift;
-    my ( $title, $branch, $path, $asciidoctor ) = @_;
+    my ( $title, $branch, $path, $direct_html ) = @_;
 
     my $new;
     if ( exists $self->{sub_dirs}->{$branch} ) {
@@ -126,7 +126,7 @@ sub mark_done {
     } else {
         $new = $self->sha_for_branch( $branch );
     }
-    $new .= '|asciidoctor' if $asciidoctor;
+    $new .= '|direct_html' if $direct_html;
 
     $self->tracker->set_sha_for_branch( $self->name,
         $self->_tracker_branch(@_), $new );
@@ -371,18 +371,18 @@ sub show_file {
 }
 
 #===================================
-# Information about the last commit, *not* including flags like `asciidoctor.`
+# Information about the last commit, *not* including flags like `direct_html.`
 #===================================
 sub _last_commit {
 #===================================
     my $self = shift;
     my $sha = $self->_last_commit_info(@_);
-    $sha =~ s/\|.+$//;  # Strip |asciidoctor if it is in the hash
+    $sha =~ s/\|.+$//;  # Strip |direct_html if it is in the hash
     return $sha;
 }
 
 #===================================
-# Information about the last commit, including flags like `asciidoctor.`
+# Information about the last commit, including flags like `direct_html.`
 #===================================
 sub _last_commit_info {
 #===================================

--- a/lib/ES/Source.pm
+++ b/lib/ES/Source.pm
@@ -45,13 +45,13 @@ sub has_changed {
     my $self   = shift;
     my $title  = shift;
     my $branch = shift;
-    my $asciidoctor = shift;
+    my $direct_html = shift;
     # If any of the repos have changed then we'll return 1. 
     my $all_new_sub_dir = 1;
     for my $source ( $self->_sources_for_branch($branch) ) {
         my $repo_branch = $source->{map_branches}->{$branch} || $branch;
         my $has_changed = $source->{repo}->has_changed(
-            $title, $repo_branch, $source->{path}, $asciidoctor
+            $title, $repo_branch, $source->{path}, $direct_html
         );
         if ( $has_changed eq 'new_sub_dir' ) {
             # sub_dirs for new sources are special: They don't count as
@@ -78,10 +78,10 @@ sub mark_done {
     my $self   = shift;
     my $title  = shift;
     my $branch = shift;
-    my $asciidoctor = shift;
+    my $direct_html = shift;
     for my $source ( $self->_sources_for_branch($branch) ) {
         my $repo_branch = $source->{map_branches}->{$branch} || $branch;
-        $source->{repo}->mark_done( $title, $repo_branch, $source->{path}, $asciidoctor );
+        $source->{repo}->mark_done( $title, $repo_branch, $source->{path}, $direct_html );
     }
     return;
 }

--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -37,7 +37,7 @@ sub write {
     build_single( $adoc_file, $raw_dir, $dir,
             type        => 'article',
             lang        => $self->lang,
-            asciidoctor => 1,
+            direct_html => 1,
             is_toc      => 1,
             root_dir    => '',  # Required but thrown on the floor with asciidoctor
             latest      => 1,   # Run all of our warnings


### PR DESCRIPTION
Replaces the mechanism that we used track the Asciidoctor migration with
a new mechanism that we will use to track the "direct to html"
migration.
