### PR TITLE
Switch ECS ref from version to current

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -66,7 +66,7 @@
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
-:ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
+:ecs-ref:              https://www.elastic.co/guide/en/ecs/current
 :subscriptions:        https://www.elastic.co/subscriptions
 
 :forum:                https://discuss.elastic.co/


### PR DESCRIPTION
Switch ECS ref attribute from version to current. When using the `{ecs_version)` variable, every ECS link in the SIEM and Kibana SIEM sections default to v1.1.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
