### PR TITLE
Emulate docbook chunking

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+require_relative '../delegating_converter'
+
+##
+# HTML5 converter that chunks like docbook.
+module Chunker
+  def self.activate(registry)
+    return unless registry.document.attr 'outdir'
+    return unless registry.document.attr 'chunk_level'
+
+    DelegatingConverter.setup(registry.document) { |d| Converter.new d }
+  end
+
+  ##
+  # A Converter implementation that copies images as it sees them.
+  class Converter < DelegatingConverter
+    def initialize(delegate)
+      super(delegate)
+    end
+
+    # TODO: tests don't seem to pick up the headers because "embedded". Bad?
+
+    def convert_section(node)
+      chunk_level = node.document.attr 'chunk_level'
+      return yield unless node.level == chunk_level
+
+      target = write node, node.id, yield
+      link_opts = {
+        type: :link,
+        target: target,
+      }
+      node.document.register :links, target
+      link = Asciidoctor::Inline.new node, :anchor, node.title, link_opts
+      # <div class="toc"><ul class="toc">
+      %(<li><span class="chapter">#{link.convert}</span></li>)
+    end
+
+    def write(node, target, output)
+      dir = node.document.attr 'outdir'
+      file = "#{target}.html"
+      path = File.join dir, file
+      File.open path, 'w:UTF-8' do |f|
+        f.write output
+      end
+      file
+    end
+  end
+end

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -3,6 +3,7 @@
 require_relative 'alternative_language_lookup/extension'
 require_relative 'care_admonition/extension'
 require_relative 'change_admonition/extension'
+require_relative 'chunker/extension'
 require_relative 'copy_images/extension'
 require_relative 'cramped_include/extension'
 require_relative 'docbook45/converter'
@@ -21,6 +22,7 @@ Asciidoctor::Extensions.register do
 end
 Asciidoctor::Extensions.register CareAdmonition
 Asciidoctor::Extensions.register ChangeAdmonition
+Asciidoctor::Extensions.register Chunker
 Asciidoctor::Extensions.register CopyImages
 Asciidoctor::Extensions.register EditMe
 Asciidoctor::Extensions.register OpenInWidget

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'chunker/extension'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Chunker do
+  before(:each) do
+    Asciidoctor::Extensions.register Chunker
+  end
+
+  after(:each) do
+    Asciidoctor::Extensions.unregister_all
+  end
+
+  include_context 'convert without logs'
+  let(:backend) { :html5 }
+
+  context 'when outdir is configured' do
+    let(:outdir) { Dir.mktmpdir }
+    after(:example) { FileUtils.remove_entry outdir }
+    context 'when chunk level is 1' do
+      let(:convert_attributes) do
+        {
+          'outdir' => outdir,
+          'chunk_level' => 1,
+        }
+      end
+      context 'there is are two level 1 sections' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [[s1]]
+            == Section 1
+
+            Words words.
+
+            [[s2]]
+            == Section 2
+
+            Words again.
+          ASCIIDOC
+        end
+        context 'the main output' do
+          it 'contains a link to the first section' do
+            expect(converted).to include(<<~HTML.strip)
+              <li><span class="chapter"><a href="s1.html">Section 1</a></span></li>
+            HTML
+          end
+          it 'contains a link to the second section' do
+            expect(converted).to include(<<~HTML.strip)
+              <li><span class="chapter"><a href="s1.html">Section 1</a></span></li>
+            HTML
+          end
+        end
+        file_context 'the first section', 's1.html' do
+          it 'contains the header' do
+            expect(contents).to include('<h2 id="s1">Section 1</h2>')
+          end
+          it 'contains the contents' do
+            expect(contents).to include '<p>Words words.</p>'
+          end
+        end
+        file_context 'the first section', 's2.html' do
+          it 'contains the header' do
+            expect(contents).to include('<h2 id="s2">Section 2</h2>')
+          end
+          it 'contains the contents' do
+            expect(contents).to include '<p>Words again.</p>'
+          end
+        end
+      end
+      context 'there is a level 2 section' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [[l1]]
+            == Level 1
+
+            Words words.
+
+            [[l2]]
+            === Level 2
+
+            Words again.
+          ASCIIDOC
+        end
+        context 'the main output' do
+          it 'contains a link to the level 1 section' do
+            expect(converted).to include(<<~HTML.strip)
+              <li><span class="chapter"><a href="l1.html">Level 1</a></span></li>
+            HTML
+          end
+          it "doesn't contain a link to the level 2 section" do
+            expect(converted).not_to include(<<~HTML.strip)
+              <a href="l2.html">
+            HTML
+          end
+        end
+        file_context 'the level one section', 'l1.html' do
+          it 'contains the header of the level 1 section' do
+            expect(contents).to include('<h2 id="l1">Level 1</h2>')
+          end
+          it 'contains first paragraph' do
+            expect(contents).to include('<p>Words words.</p>')
+          end
+          it 'contains the header of the level 2 section' do
+            expect(contents).to include('<h3 id="l2">Level 2</h3>')
+          end
+          it 'contains the contents of the level 2 section' do
+            expect(contents).to include('<p>Words again.</p>')
+          end
+          it "doesn't contain a link to the level 2 section" do
+            expect(converted).not_to include(<<~HTML.strip)
+              <a href="l2.html">
+            HTML
+          end
+        end
+        it 'there is no file named for the level 2 section' do
+          expect(File.join(outdir, 'l2.html')).not_to file_exist
+        end
+      end
+    end
+  end
+  context "when outdir isn't configured" do
+    context 'the plugin does nothing' do
+    end
+  end
+end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -19,16 +19,17 @@ $VERBOSE = true
 
 ##
 # Used by the `convert with logs` and `convert without logs` contexts
-def internal_convert(input, convert_logger, extra_attributes)
+def internal_convert(input, convert_logger, backend, extra_attributes)
   attributes = { 'docdir' => File.dirname(__FILE__) }
   attributes.merge! extra_attributes
-  Asciidoctor.convert input, internal_convert_args(convert_logger, attributes)
+  args = internal_convert_args convert_logger, backend, attributes
+  Asciidoctor.convert input, args
 end
 
-def internal_convert_args(convert_logger, attributes)
+def internal_convert_args(convert_logger, backend, attributes)
   {
     safe: :unsafe, # Used to include "funny" files.
-    backend: :docbook45, # The only target the docs build understands
+    backend: backend,
     logger: convert_logger,
     doctype: :book,
     attributes: attributes,
@@ -41,6 +42,7 @@ end
 #
 # In:
 #   input            - asciidoc text to convert
+#   backend          - the conversion backend - defaults to :docbook45
 #   extra_attributes - attributes added to the conversion - defaults to {}
 #
 # Out:
@@ -53,7 +55,8 @@ RSpec.shared_context 'convert with logs' do
     # `converted` in the let for `logs` but it'd cause `converted` to be
     # evaluated before `before(:example)` blocks
     extra_attributes = defined?(convert_attributes) ? convert_attributes : {}
-    internal_convert input, convert_logger, extra_attributes
+    explicit_backend = defined?(backend) ? backend : :docbook45
+    internal_convert input, convert_logger, explicit_backend, extra_attributes
   end
   let(:logs) do
     # Evaluate converted because it populates the logger as a side effect.
@@ -71,6 +74,7 @@ end
 #
 # In:
 #   input            - asciidoc text to convert
+#   backend          - the conversion backend - defaults to :docbook45
 #   extra_attributes - attributes added to the conversion - defaults to {}
 #
 # Out:
@@ -79,7 +83,10 @@ RSpec.shared_context 'convert without logs' do
   let(:converted) do
     convert_logger = Asciidoctor::MemoryLogger.new
     extra_attributes = defined?(convert_attributes) ? convert_attributes : {}
-    converted = internal_convert input, convert_logger, extra_attributes
+    explicit_backend = defined?(backend) ? backend : :docbook45
+    converted = internal_convert(
+      input, convert_logger, explicit_backend, extra_attributes
+    )
     if convert_logger.messages.empty? == false
       raise "Expected no logs but got:\n" +
             convert_logger.messages
@@ -87,5 +94,49 @@ RSpec.shared_context 'convert without logs' do
                           .join("\n")
     end
     converted
+  end
+end
+
+##### TODO: This should be shared with integ tests
+##
+# Create a context to assert things about a file. By default it just
+# asserts that the file was created but if you pass a block you can add
+# assertions on `contents`.
+def file_context(name, file_name = name, &block)
+  context "for #{name}" do
+    include_context 'Dsl_file', file_name
+
+    # Yield to the block to add more tests.
+    class_exec(&block) if block
+  end
+end
+RSpec.shared_context 'Dsl_file' do |file_name|
+  let(:file) do
+    converted # force the conversion so the file will exist
+    File.join outdir, file_name
+  end
+  let(:contents) do
+    File.open file, 'r:UTF-8', &:read if File.exist? file
+  end
+
+  it 'is created' do
+    expect(file).to file_exist
+  end
+end
+##
+# Match paths that refer to an existing file.
+# Prefer this instead of `expect(File).to exist('path')` because the failure
+# message is worlds better
+RSpec::Matchers.define :file_exist do
+  match do |actual|
+    File.exist? actual
+  end
+  failure_message do |actual|
+    msg = "expected that #{actual} exists"
+    parent = File.expand_path '..', actual
+    parent = File.expand_path '..', parent until Dir.exist? parent
+
+    entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
+    msg + " but only #{parent}/#{entries.sort} exist"
   end
 end


### PR DESCRIPTION
We'd very much like to avoid having to use docbook to generate our HTML
because it is slow and difficult to customize. This creates the
beginnings of an Asciidoctor plugin that emulates docbook's chunking.
The plan is to enable it on the perl side with a command line flag and a
flag in conf.yaml in a follow up change.

Relates to #1390.
