### PR TITLE
Add the option to skip docbook for single page

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -125,6 +125,7 @@ sub build_local {
         );
     }
     else {
+        die '--direct_html not yet supported' if $Opts->{direct_html};
         build_chunked( $index, $raw_dir, $dir, %$Opts,
                 latest       => $latest,
                 alternatives => \@alternatives,
@@ -906,6 +907,7 @@ sub command_line_opts {
         # Options only compatible with --doc
         'doc=s',
         'alternatives=s@',
+        'direct_html',
         'chunk=i',
         'lang=s',
         'lenient',
@@ -956,6 +958,8 @@ sub usage {
           --chunk 1         Also chunk sections into separate files
           --alternatives <source_lang>:<alternative_lang>:<dir>
                             Examples in alternative languages.
+          --direct_html     Generate html directly from Asciidoctor without
+                            using docbook.
           --lang            Defaults to 'en'
           --lenient         Ignore linking errors
           --out dest/dir/   Defaults to ./html_docs.
@@ -1033,6 +1037,7 @@ sub check_opts {
         die('--alternatives only compatible with --doc') if $Opts->{alternatives};
         die('--chunk only compatible with --doc') if $Opts->{chunk};
         # Lang will be 'en' even if it isn't specified so we don't check it.
+        die('--direct_html only compatible with --doc') if $Opts->{direct_html};
         die('--lenient only compatible with --doc') if $Opts->{lenient};
         die('--out only compatible with --doc') if $Opts->{out};
         die('--pdf only compatible with --doc') if $Opts->{pdf};

--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -37,7 +37,6 @@ sub write {
     build_single( $adoc_file, $raw_dir, $dir,
             type        => 'article',
             lang        => $self->lang,
-            direct_html => 1,
             is_toc      => 1,
             latest      => 1,   # Run all of our warnings
             private     => 1,   # Don't generate edit me urls

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -192,7 +192,7 @@ sub build_single {
     my $branch = $opts{branch};
     my $roots = $opts{roots};
     my $relativize = $opts{relativize};
-    my $direct_html = $opts{direct_html};
+    my $direct_html = $opts{direct_html} || 0;
 
     die "Can't find index [$index]" unless -f $index;
 

--- a/template/template.js
+++ b/template/template.js
@@ -52,7 +52,6 @@ module.exports = templateSource => {
            * at the end of the chunk in case the marker is on the edge. */
           const slice = Math.max(0, chunk.length - preserve);
           chunk = chunk.slice(slice) + result.value;
-          // TODO check if slice + keeps a copy of internal memory. This implementation assumes it *doesn't*
         } else {
           chunk = result.value;
         }
@@ -108,7 +107,12 @@ module.exports = templateSource => {
         yield* template.gather("<!-- DOCS LANG -->");
         yield `lang="${lang}"`;
         yield* template.gather("<!-- DOCS BODY -->");
-        await raw.dump("<body>");
+        /*
+         * Docbook spits out <body> and asciidoctor spits out <body class=....>
+         * Either way, we just want what comes after the body tag.
+         */
+        await raw.dump("<body");
+        await raw.dump(">");
         yield* raw.gather("</body>");
         yield* template.gather("<!-- DOCS FINAL -->");
         yield `<script type="text/javascript">
@@ -189,7 +193,8 @@ module.exports = templateSource => {
         const out = apply(raw[Symbol.asyncIterator](), lang, initialJsState);
         write.on("close", resolve);
         write.on("error", reject);
-        out.on("error", write.destroy);
+        // out.on("error", write.destroy) doesn't properly forward the error!
+        out.on("error", err => write.destroy(err));
         out.pipe(write);
       }).finally(() => raw.close());
     };


### PR DESCRIPTION
This adds the option to generate html directly from asciidoctor for
single page books with `--direct_html`. Right now no books use this but
we'd like to migrate all of them too it once we're sure the output looks
good for them!

Relates to #743
