### PR TITLE
Fix a test bug in template

### DIFF
--- a/template/__test__/template.test.js
+++ b/template/__test__/template.test.js
@@ -154,13 +154,13 @@ describe(Template, () => {
     });
     describe("when it gets a document without a body", () => {
       test("throws an exception", () => {
-        expect(template.applyToString(`<html><head><script>foo</script></head></html>`))
-          .rejects.toThrow(/Couldn't find <body> in raw/);
+        return expect(template.applyToString(`<html><head><script>foo</script></head></html>`))
+          .rejects.toThrow(/Couldn't find <body in raw/);
       });
     });
     describe("when it gets a document with an unclosed body", () => {
       test("throws an exception", () => {
-        expect(template.applyToString(`<html><head><script>foo</script></head><body></html>`))
+        return expect(template.applyToString(`<html><head><script>foo</script></head><body></html>`))
           .rejects.toThrow(/Couldn't find <\/body> in raw/);
       });
     });


### PR DESCRIPTION
The template tests were missing a `return` which meant that the
assertion didn't trigger. That assertion started failing and we didn't
know! This fixes the `return` and the failing assertion.
