### PR TITLE
Default to built-docs repo

### DIFF
--- a/air_gapped/Dockerfile
+++ b/air_gapped/Dockerfile
@@ -2,5 +2,4 @@ FROM docker.elastic.co/docs/preview:15
 
 COPY air_gapped/work/target_repo.git /docs_build/.repos/target_repo.git
 
-CMD ["/docs_build/build_docs.pl", "--in_standard_docker", "--gapped", \
-     "--preview", "--target_repo", "https://github.com/elastic/built-docs.git"]
+CMD ["/docs_build/build_docs.pl", "--in_standard_docker", "--gapped", "--preview"]

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -249,7 +249,7 @@ sub _guess_repo_name {
 #===================================
 sub build_all {
 #===================================
-    die "--target_repo is required with --all" unless ( $Opts->{target_repo} );
+    $Opts->{target_repo} = 'git@github.com:elastic/built-docs.git' unless ( $Opts->{target_repo} );
 
     my ( $repos_dir, $temp_dir, $reference_dir ) = init_dirs();
 
@@ -640,7 +640,7 @@ sub init_repos {
 #===================================
 sub preview {
 #===================================
-    die "--target_repo is required with --preview" unless $Opts->{target_repo};
+    $Opts->{target_repo} = 'git@github.com:elastic/built-docs.git' unless ( $Opts->{target_repo} );
 
     my $nginx_config = file('/tmp/nginx.conf');
     write_nginx_preview_config( $nginx_config );
@@ -953,7 +953,7 @@ sub usage {
 
     Build docs from all repos in conf.yaml:
 
-        build_docs --all --target_repo <target> [opts]
+        build_docs --all [opts]
 
         Opts:
           --keep_hash       Build docs from the same commit hash as last time

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -25,5 +25,4 @@ COPY preview /docs_build/preview
 COPY template /docs_build/template
 COPY resources /docs_build/resources
 
-CMD ["/docs_build/build_docs.pl", "--in_standard_docker", \
-     "--preview", "--target_repo", "git@github.com:elastic/built-docs.git"]
+CMD ["/docs_build/build_docs.pl", "--in_standard_docker", "--preview"]


### PR DESCRIPTION
`--target_repo` has been required with `--all` for a while now, but we
only ever really call it with
`--target_repo git@github.com:elastic/built-docs.git`. We typically use
`--target_branch` for experimentation. So let's just assume `built-docs`
unless someone passes `--target_repo`.
