### PR TITLE
Invert Makefile control

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -3,4 +3,4 @@
 set -eo pipefail
 
 cd $(git rev-parse --show-toplevel)
-./build_docs --self-test
+make

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-# We expect this to be run in the a docker container managed by
-#   build_docs --self-test
-
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include common.mk
 
 .PHONY: check
 check: unit_test integration_test
@@ -12,7 +8,7 @@ unit_test: style asciidoctor_check web_check template_check preview_check
 
 .PHONY: style
 style: build_docs
-	pycodestyle build_docs
+	$(DOCKER) pycodestyle build_docs
 
 .PHONY: asciidoctor_check
 asciidoctor_check:

--- a/build_docs
+++ b/build_docs
@@ -52,9 +52,6 @@ environ['DOCKER_BUILDKIT'] = '1'
 
 def build_docker_image():
     docker_logger = logging.getLogger('docker build')
-    docker_logger.info('Building the docker image that will build the docs. ' +
-                       'Expect this to take somewhere between a hundred ' +
-                       'milliseconds and five minutes.')
     # We attempt to spool up the output from docker build so we can hide it
     # if the command is successful *and* runs quickly. If it takes longer
     # than the DOCKER_BUILD_QUIET_TIME then we log all of the output. I
@@ -65,6 +62,10 @@ def build_docker_image():
 
     def handle_line(line):
         if time.time() >= start_logging_at:
+            docker_logger.info(
+                'Building the docker image that will build the docs. Expect ' +
+                'this to take somewhere between a couple seconds and ' +
+                'five minutes.')
             for line in acc:
                 docker_logger.info(line)
             del acc[:]
@@ -599,7 +600,7 @@ if __name__ == '__main__':
     try:
         logging.basicConfig(level=logging.INFO)
         build_docker_image()
-        if len(argv) >= 2 and '--self-test' == argv[1]:
+        if len(argv) >= 2 and '--docker-run' == argv[1]:
             cwd = realpath('.')
             if not cwd.startswith(DIR):
                 raise ArgError(
@@ -610,8 +611,7 @@ if __name__ == '__main__':
             cmd.extend(['--workdir', docker_cwd])
             if stdout.isatty():
                 cmd.append('-t')
-            cmd.extend([DOCKER_TAG, 'make'])
-            cmd.extend(['--no-builtin-rules'])
+            cmd.append(DOCKER_TAG)
             cmd.extend(argv[2:])
             returncode = subprocess.call(cmd)
             exit(returncode)

--- a/common.mk
+++ b/common.mk
@@ -1,0 +1,3 @@
+SHELL = /bin/bash -eu -o pipefail
+TOP = $(shell git rev-parse --show-toplevel)
+DOCKER = $(TOP)/build_docs --docker-run

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -1,5 +1,4 @@
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include ../common.mk
 
 .PHONY: check
 check: rspec style
@@ -9,12 +8,12 @@ style: pycodestyle rubocop
 
 .PHONY: pycodestyle
 pycodestyle: html_diff
-	pycodestyle html_diff
+	$(DOCKER) pycodestyle html_diff
 
 .PHONY: rubocop
 rubocop:
-	rubocop
+	$(DOCKER) rubocop
 
 .PHONY: rspec
 rspec:
-	rspec
+	$(DOCKER) rspec

--- a/preview/Makefile
+++ b/preview/Makefile
@@ -1,12 +1,8 @@
-# We expect this to be run in the a docker container managed by
-#   build_docs --self-test
-
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include ../common.mk
 
 .PHONY: check
 check: jest
 
 .PHONY: jest
 jest:
-	/node_modules/jest/bin/jest.js ./__test__/**
+	$(DOCKER) /node_modules/jest/bin/jest.js ./__test__/**

--- a/resources/asciidoctor/Makefile
+++ b/resources/asciidoctor/Makefile
@@ -1,16 +1,12 @@
-# We expect this to be run in the a docker container managed by
-#   build_docs --self-test
-
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include ../../common.mk
 
 .PHONY: check
 check: rspec rubocop
 
 .PHONY: rspec
 rspec:
-	rspec
+	$(DOCKER) rspec
 
 .PHONY: rubocop
 rubocop:
-	rubocop
+	$(DOCKER) rubocop

--- a/resources/web/Makefile
+++ b/resources/web/Makefile
@@ -1,22 +1,13 @@
-# We expect this to be run in the a docker container managed by
-#   build_docs --self-test
-
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include ../../common.mk
 
 .PHONY: check
 check: jest
 
-.PHONY: test_watch
-test_watch: tests
-	/node_modules/parcel/bin/cli.js watch ./docs_js/__tests__/**/* ./docs_js/__tests__/* -d ./tests/ --target node --no-source-maps &
-	/node_modules/jest/bin/jest.js ./tests/** --watch
-
 .PHONY: jest
 jest: tests
-	/node_modules/jest/bin/jest.js ./tests/** ./__test__/**
+	$(DOCKER) /node_modules/jest/bin/jest.js ./tests/** ./__test__/**
 
 .PHONY: tests
 tests:
 	rm -rf tests
-	/node_modules/parcel/bin/cli.js build ./docs_js/__tests__/**/* ./docs_js/__tests__/* -d ./tests/ --target node --no-minify --no-source-maps
+	$(DOCKER) /node_modules/parcel/bin/cli.js build ./docs_js/__tests__/**/* ./docs_js/__tests__/* -d ./tests/ --target node --no-minify --no-source-maps

--- a/template/Makefile
+++ b/template/Makefile
@@ -1,12 +1,8 @@
-# We expect this to be run in the a docker container managed by
-#   build_docs --self-test
-
-SHELL = /bin/bash -eux -o pipefail
-MAKEFLAGS += --silent
+include ../common.mk
 
 .PHONY: check
 check: jest
 
 .PHONY: jest
 jest:
-	/node_modules/jest/bin/jest.js ./__test__/**
+	$(DOCKER) /node_modules/jest/bin/jest.js ./__test__/**


### PR DESCRIPTION
Previously we ran make inside of our docker container. Long ago this was
important because we did complex things in make. We don't any more
though because that was a stygian nightmare. This flips the `Makefile`s
so *they* run docker. This is nice because:
1. It is now possible to `cd` into any directory you like and run `make`
to run the tests.
2. We can use different docker images for different tests. We *don't* do
that right now, but we certainly *can* do that with this change in the
future.

This routes all execution of docker through the `build_docs` script,
which is nice because docker requires a bunch of command line options to
properly run the scripts, particularly in the integration tests. It'd
be nice if we could limit those options to just the tests that need
them, but that is a problem for another change.

Routing docker execution through `build_docs` also makes sure the docker
containers are always up to date, which is nice too.
