### PR TITLE
Speed up building "normal" docker image

### DIFF
--- a/Dockerfile.dockerignore
+++ b/Dockerfile.dockerignore
@@ -1,0 +1,5 @@
+*
+!.docker
+!Gemfile*
+!package.json
+!yarn.lock

--- a/preview/Dockerfile.dockerignore
+++ b/preview/Dockerfile.dockerignore
@@ -1,11 +1,7 @@
 *
-!.docker
 !build_docs.pl
 !conf.yaml
-!Gemfile*
 !lib
-!package.json
 !preview
 !template
 !resources/web
-!yarn.lock


### PR DESCRIPTION
Our "normal" docker image was including context files needed for the
`preview` docker image because I didn't know how to make separate
`.dockerignore` files for each `Dockerfile`. I know now. So this fixes
up the main `.dockerignore` file.
