### PR TITLE
Add processor doc folders to the conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -871,6 +871,10 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
               -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -872,7 +872,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
@@ -915,11 +915,11 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
-                path:   x-pack/filebeat/processors/*/docs/*.asciidoc
+                path:   x-pack/filebeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
@@ -954,7 +954,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
               -
                 repo:   docs
@@ -1003,7 +1003,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
@@ -1042,7 +1042,7 @@ contents:
                 exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
 
               -
@@ -1088,7 +1088,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
                 repo:   docs
@@ -1123,7 +1123,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
@@ -1156,7 +1156,7 @@ contents:
                 path:   libbeat/docs
               -
                 repo:   beats
-                path:   libbeat/processors/*/docs/*.asciidoc
+                path:   libbeat/processors/*/docs
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -914,6 +914,14 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
               -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   x-pack/filebeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
@@ -944,6 +952,10 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -990,6 +1002,10 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
               -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -1025,6 +1041,11 @@ contents:
                 path:   x-pack/libbeat/docs
                 exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
               -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
@@ -1052,7 +1073,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/auditbeat
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
                 repo:   beats
                 path:   auditbeat/module
@@ -1065,6 +1086,10 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1097,6 +1122,10 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
               -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -
@@ -1125,6 +1154,10 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*.asciidoc
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
Adds processor doc files so we can move them to a directory within the code modules.

~Currently only covers Packetbeat. I will copy to other beats after @nik9000 confirms that this approach will work.~ done

~This PR must be merged after https://github.com/elastic/beats/pull/14488~ done