### PR TITLE
small grammatical fix

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -176,7 +176,7 @@ The most common errors are:
   unclosed block delimiters, ie `======` or `------`
 * incorrect order of elements, eg `= Title` followed by
   a `=== Level 3` header
-* Linking to an non-existent ID
+* Linking to a non-existent ID
 
 Errors may be thrown either by Asciidoc or by DocBook.  Asciidoc errors refer
 to the actual `.asciidoc` page where the error occurred,  but DocBook errors


### PR DESCRIPTION
'Linking to an non-existent ID'  --->  'Linking to a non-existent ID'


