### PR TITLE
Shrink production images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ unit_test: style asciidoctor_check web_check template_check preview_check
 
 .PHONY: style
 style: build_docs
-	$(DOCKER) pycodestyle build_docs
+	$(DOCKER) py_test pycodestyle build_docs
 
 .PHONY: asciidoctor_check
 asciidoctor_check:

--- a/build_docs
+++ b/build_docs
@@ -50,7 +50,11 @@ logger = logging.getLogger('build_docs')
 environ['DOCKER_BUILDKIT'] = '1'
 
 
-def build_docker_image():
+def docker_tag(name):
+    return 'docker.elastic.co/docs/' + name + ':latest'
+
+
+def build_docker_image(name):
     docker_logger = logging.getLogger('docker build')
     # We attempt to spool up the output from docker build so we can hide it
     # if the command is successful *and* runs quickly. If it takes longer
@@ -62,10 +66,11 @@ def build_docker_image():
 
     def handle_line(line):
         if time.time() >= start_logging_at:
-            docker_logger.info(
-                'Building the docker image that will build the docs. Expect ' +
-                'this to take somewhere between a couple seconds and ' +
-                'five minutes.')
+            if acc:
+                docker_logger.info(
+                    'Building the docker image that will build the docs. ' +
+                    'Expect this to take somewhere between a couple seconds ' +
+                    'and five minutes.')
             for line in acc:
                 docker_logger.info(line)
             del acc[:]
@@ -73,7 +78,11 @@ def build_docker_image():
         else:
             acc.append(line)
 
-    cmd = ["docker", "image", "build", "-t", DOCKER_TAG, DIR]
+    cmd = [
+        "docker", "image", "build",
+        "--target", name,
+        "--tag", docker_tag(name),
+        DIR]
     build = common_popen(cmd)
     handle_popen(build, handle_line)
     if build.returncode != 0:
@@ -599,23 +608,26 @@ if __name__ == '__main__':
     from sys import argv, stdout
     try:
         logging.basicConfig(level=logging.INFO)
-        build_docker_image()
         if len(argv) >= 2 and '--docker-run' == argv[1]:
             cwd = realpath('.')
             if not cwd.startswith(DIR):
                 raise ArgError(
-                    '--self-test must be invoked from within the repo')
+                    '--docker-run must be invoked from within the repo')
             docker_cwd = '/docs_build/' + cwd[len(DIR):]
+            image = argv[2]
+            build_docker_image(image)
             cmd = ['docker', 'run']
             cmd.extend(standard_docker_args())
             cmd.extend(['--workdir', docker_cwd])
             if stdout.isatty():
                 cmd.append('-t')
-            cmd.append(DOCKER_TAG)
-            cmd.extend(argv[2:])
+            cmd.append(docker_tag(image))
+            cmd.extend(argv[3:])
             returncode = subprocess.call(cmd)
             exit(returncode)
-        elif not ['--just-build-image'] == argv[1:]:
+
+        build_docker_image("build")
+        if not ['--just-build-image'] == argv[1:]:
             exit(run_build_docs(argv[1:]))
     except ArgError as e:
         print(e)

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -8,12 +8,12 @@ style: pycodestyle rubocop
 
 .PHONY: pycodestyle
 pycodestyle: html_diff
-	$(DOCKER) pycodestyle html_diff
+	$(DOCKER) py_test pycodestyle html_diff
 
 .PHONY: rubocop
 rubocop:
-	$(DOCKER) rubocop
+	$(DOCKER) ruby_test rubocop
 
 .PHONY: rspec
 rspec:
-	$(DOCKER) rspec
+	$(DOCKER) integ_test rspec

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "devDependencies": {
     "jest": "^24.8.0",
     "nock": "^10.0.6",
-    "parcel": "^1.12.3",
     "rmfr": "^2.0.0"
   },
   "scripts": {
@@ -19,6 +18,7 @@
     "js-cookie": "^2.1.0",
     "jquery": "^1.11.3",
     "linkstate": "^1.1.1",
+    "parcel": "^1.12.3",
     "postcss-assets": "^5.0.0",
     "preact": "^8.4.2",
     "preact-context": "^1.1.3",

--- a/preview/Makefile
+++ b/preview/Makefile
@@ -5,4 +5,4 @@ check: jest
 
 .PHONY: jest
 jest:
-	$(DOCKER) /node_modules/jest/bin/jest.js ./__test__/**
+	$(DOCKER) integ_test /node_modules/jest/bin/jest.js ./__test__/**

--- a/resources/asciidoctor/Makefile
+++ b/resources/asciidoctor/Makefile
@@ -5,8 +5,8 @@ check: rspec rubocop
 
 .PHONY: rspec
 rspec:
-	$(DOCKER) rspec
+	$(DOCKER) ruby_test rspec
 
 .PHONY: rubocop
 rubocop:
-	$(DOCKER) rubocop
+	$(DOCKER) ruby_test rubocop

--- a/resources/web/Makefile
+++ b/resources/web/Makefile
@@ -5,9 +5,9 @@ check: jest
 
 .PHONY: jest
 jest: tests
-	$(DOCKER) /node_modules/jest/bin/jest.js ./tests/** ./__test__/**
+	$(DOCKER) node_test /node_modules/jest/bin/jest.js ./tests/** ./__test__/**
 
 .PHONY: tests
 tests:
 	rm -rf tests
-	$(DOCKER) /node_modules/parcel/bin/cli.js build ./docs_js/__tests__/**/* ./docs_js/__tests__/* -d ./tests/ --target node --no-minify --no-source-maps
+	$(DOCKER) node_test /node_modules/parcel/bin/cli.js build ./docs_js/__tests__/**/* ./docs_js/__tests__/* -d ./tests/ --target node --no-minify --no-source-maps

--- a/template/Makefile
+++ b/template/Makefile
@@ -5,4 +5,4 @@ check: jest
 
 .PHONY: jest
 jest:
-	$(DOCKER) /node_modules/jest/bin/jest.js ./__test__/**
+	$(DOCKER) node_test /node_modules/jest/bin/jest.js ./__test__/**


### PR DESCRIPTION
This shrinks the build, preview, and air gapped images by moving the
test dependencies out of them. This is also nice because changing test
dependencies won't cause us to have to rebuild the production images.
The cost is that it'll be a little slower to run the tests the first
time. This isn't a problem locally, but will slow down CI. We can
mostly mitigate that in a follow up change though.

Before:
```
-rw------- 1 manybubbles manybubbles 1.1G Nov 12 19:06 air_gapped_with_test.tar
```

After:
```
-rw------- 1 manybubbles manybubbles 930M Nov 12 19:01 air_gapped_no_test.tar
```

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
