### PR TITLE
Progress building chunked docs

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -123,7 +123,6 @@ sub build_local {
         );
     }
     else {
-        die '--direct_html not yet supported' if $Opts->{direct_html};
         build_chunked( $index, $raw_dir, $dir, %$Opts,
                 latest       => $latest,
                 alternatives => \@alternatives,

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -8,7 +8,11 @@ require_relative '../delegating_converter'
 module Chunker
   def self.activate(registry)
     return unless registry.document.attr 'outdir'
-    return unless registry.document.attr 'chunk_level'
+    return unless (chunk_level = registry.document.attr 'chunk_level')
+
+    if chunk_level.is_a? String
+      registry.document.attributes['chunk_level'] = chunk_level.to_i
+    end
 
     DelegatingConverter.setup(registry.document) { |d| Converter.new d }
   end
@@ -33,7 +37,6 @@ module Chunker
       }
       node.document.register :links, target
       link = Asciidoctor::Inline.new node, :anchor, node.title, link_opts
-      # <div class="toc"><ul class="toc">
       %(<li><span class="chapter">#{link.convert}</span></li>)
     end
 


### PR DESCRIPTION
This hooks the `chunker` extension added in #1390 to the docs build when
you do a multi-page book with `--direct_html`. Important: it crashes!
But I'll fix it with mostly ruby hacking and this is more perl stuff and
it is fairly selef contained. So I figure I should fix it in a follow up
change.
