### PR TITLE
Fix bug when source contains *

### DIFF
--- a/integtest/spec/all_books_sub_dir_spec.rb
+++ b/integtest/spec/all_books_sub_dir_spec.rb
@@ -163,6 +163,16 @@ RSpec.describe 'building all books' do
         include_examples 'log merge', '.'
         include_examples 'contains the new master and subbed changes'
       end
+      describe 'when the source path has a *' do
+        def self.setup_book(src, repo)
+          book = src.book 'Test'
+          book.index = 'docs/index.adoc'
+          book.source repo, '/*/'
+        end
+        convert_with_sub
+        include_examples 'log merge', '*'
+        include_examples 'contains the new master and subbed changes'
+      end
       describe 'when the subbed dir has already been merged' do
         # This simulates what github will do if you ask it to build the "sha"
         # of the merged PR instead of the "head" of the branch.

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -196,6 +196,7 @@ sub _prepare_sub_dir {
     delete local $ENV{GIT_DIR};
     my $merge_branch = "${resolved_branch}_${subbed_head}_$path";
     $merge_branch =~ s|/|_|g;
+    $merge_branch =~ s|\*|splat|g;
     $merge_branch =~ s|\.$||g; # Fix funny shaped paths
 
     # Check if we've already merged this path by looking for the merged_branch


### PR DESCRIPTION
When a source contained `*` the merging logic used by `--sub_dir
--keep_hash` would cause git errors because it attempted to name a
branch with a `*` in the name. This fixes that error so the `*`s work.
