### PR TITLE
Adds missing shared attribute for transforms

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -189,6 +189,7 @@ Common words and phrases
 :cdataframe-transforms:      continuous {transforms}
 :cdataframe-transforms-cap:  Continuous {transforms}
 :ctransform:                 continuous {transform}
+:ctransform-cap:             Continuous {transform}
 :ctransforms:                continuous {transforms}
 :ctransforms-cap:            Continuous {transforms}
 :oldetection:                outlier detection


### PR DESCRIPTION
This PR defines a shared attribute for `ctransform-cap`, since it is used by
https://www.elastic.co/guide/en/elasticsearch/reference/current/transform-limitations.html