### PR TITLE
Fix fairly strange error

### DIFF
--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,5 +2,12 @@
 
 set -eo pipefail
 
+# Configure the git author and committer information. The tests expect there
+# to be *something* set ut don't care what it is.
+export GIT_AUTHOR_NAME='Jenkins CI'
+export GIT_AUTHOR_EMAIL='jenkins@elasticsearch-ci.elastic.co'
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
+export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+
 cd $(git rev-parse --show-toplevel)
 make

--- a/build_docs
+++ b/build_docs
@@ -279,21 +279,6 @@ def run_build_docs(args):
             docker_args.extend(['-v', '%s:/out:delegated' % dirname(out_dir)])
             build_docs_args.append('/out/%s' % basename(out_dir))
             saw_out = True
-        elif arg == '--push':
-            author_name = from_env_or_git_config(
-                    'GIT_AUTHOR_NAME', 'user.name')
-            author_email = from_env_or_git_config(
-                    'GIT_AUTHOR_EMAIL', 'user.email')
-            committer_name = from_env_or_git_config(
-                    'GIT_COMMITTER_NAME', 'user.name')
-            committer_email = from_env_or_git_config(
-                    'GIT_COMMITTER_EMAIL', 'user.email')
-            docker_args.extend([
-                    '-e', 'GIT_AUTHOR_NAME=%s' % author_name,
-                    '-e', 'GIT_AUTHOR_EMAIL=%s' % author_email,
-                    '-e', 'GIT_COMMITTER_NAME=%s' % committer_name,
-                    '-e', 'GIT_COMMITTER_EMAIL=%s' % committer_email,
-            ])
         elif arg == '--reference':
             reference_dir = realpath(args.next_arg_or_err())
             if not exists(reference_dir):
@@ -588,6 +573,24 @@ def standard_docker_args():
                         '--tmpfs', '/var/lib/nginx/proxy',
                         '--tmpfs', '/var/lib/nginx/uwsgi',
                         '--tmpfs', '/var/lib/nginx/scgi'])
+    # Set the git author and committer information so we can commit in the
+    # branch. Useful when we `--push` and when we `--keep_hash --sub_dir` and
+    # when we run tests.
+    author_name = from_env_or_git_config(
+            'GIT_AUTHOR_NAME', 'user.name')
+    author_email = from_env_or_git_config(
+            'GIT_AUTHOR_EMAIL', 'user.email')
+    committer_name = from_env_or_git_config(
+            'GIT_COMMITTER_NAME', 'user.name')
+    committer_email = from_env_or_git_config(
+            'GIT_COMMITTER_EMAIL', 'user.email')
+    docker_args.extend([
+            '-e', 'GIT_AUTHOR_NAME=%s' % author_name,
+            '-e', 'GIT_AUTHOR_EMAIL=%s' % author_email,
+            '-e', 'GIT_COMMITTER_NAME=%s' % committer_name,
+            '-e', 'GIT_COMMITTER_EMAIL=%s' % committer_email,
+    ])
+
     return docker_args
 
 

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -3,6 +3,7 @@
 require 'net/http'
 
 RSpec.describe 'building all books' do
+  let(:committer) { ENV['GIT_COMMITTER_NAME'] }
   shared_examples 'book basics' do |title, prefix|
     context "for the #{title} book" do
       page_context 'the book index', "html/#{prefix}/index.html" do
@@ -600,7 +601,7 @@ RSpec.describe 'building all books' do
         expect(statuses[0]).to eq(2)
       end
       it 'logs the init' do
-        expect(outputs[0]).to match(/init \(.+\) <Test>/)
+        expect(outputs[0]).to match(/init \(.+\) <#{committer}>/)
       end
       it 'logs the failure from asciidoc' do
         expect(outputs[0]).to match(/
@@ -622,7 +623,7 @@ RSpec.describe 'building all books' do
       end
       include_examples 'error logging'
       it 'logs the utf8 line' do
-        expect(outputs[0]).to match(/utf8: á \(.+\) <Test>/)
+        expect(outputs[0]).to match(/utf8: á \(.+\) <#{committer}>/)
       end
     end
   end

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -14,11 +14,6 @@ require_relative 'helper/source'
 require 'tmpdir'
 require 'fileutils'
 
-ENV['GIT_AUTHOR_NAME'] = 'Test'
-ENV['GIT_AUTHOR_EMAIL'] = 'test@example.com'
-ENV['GIT_COMMITTER_NAME'] = 'Test'
-ENV['GIT_COMMITTER_EMAIL'] = 'test@example.com'
-
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/preview/__test__/clean.test.js
+++ b/preview/__test__/clean.test.js
@@ -13,15 +13,7 @@ async function prepareCleaner(extra_branches = []) {
 
   // Create an empty repo
   const repo = await fs.mkdtemp(`${tmp}/input`);
-  const opts = {
-    cwd: repo,
-    env: {
-      'GIT_AUTHOR_NAME': 'Test',
-      'GIT_AUTHOR_EMAIL': 'test@example.com',
-      'GIT_COMMITTER_NAME': 'Test',
-      'GIT_COMMITTER_EMAIL': 'test@example.com',
-    },
-  };
+  const opts = {cwd: repo};
   await exec_git(['init'], opts);
   await exec_git(['commit', '--allow-empty', '-m', 'init'], opts);
   for (const branch of extra_branches) {

--- a/preview/__test__/git.test.js
+++ b/preview/__test__/git.test.js
@@ -33,15 +33,7 @@ const unlink = promisify(fs.unlink);
 const writeFile = promisify(fs.writeFile);
 
 const tmp = "/tmp/git.test";
-const gitOpts = {
-  cwd: tmp,
-  env: {
-    GIT_AUTHOR_NAME: "test",
-    GIT_AUTHOR_EMAIL: "test@example.com",
-    GIT_COMMITTER_NAME: "test",
-    GIT_COMMITTER_EMAIL: "test@example.com",
-  },
-};
+const gitOpts = {cwd: tmp};
 
 const collect = async stream => {
   let all = '';


### PR DESCRIPTION
Fixes a fairly esoteric error that you get when you do
```
./build_docs --keep_hash --sub_dir blah:blah:blah
```
without `--push`.

It fixes it by *always* passing the git username and email to the docker
image all the time. It also cleans up the tests a little bit in the ways
that that change implies.
