### PR TITLE
Drop asciidoc stuff from the README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -285,7 +285,7 @@ it generates valid DocBook output.
 Below I include most of the Asciidoc syntax that you will
 need.  For more, you can take a look at the
 https://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual], or the
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoctor Quick Syntax].
+http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoc Syntax Quick Reference].
 --
 
 [[structure]]

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -293,9 +293,8 @@ it generates valid DocBook output.
 
 Below I include most of the Asciidoc syntax that you will
 need.  For more, you can take a look at the
-http://powerman.name/doc/asciidoc[Asciidoc Cheat Sheet],
-http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoctor Quick Syntax]
-or the official http://www.methods.co.nz/asciidoc/userguide.html[Asciidoc User Guide].
+https://asciidoctor.org/docs/user-manual/[Asciidoc User Manual], or the
+http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoctor Quick Syntax].
 --
 
 [[structure]]
@@ -401,7 +400,7 @@ A paragraph introducing this Part
 ----------------------------------
 
 Longer `partintro` blocks should be wrapped in an
-http://www.methods.co.nz/asciidoc/userguide.html#X29[_open block_]
+https://asciidoctor.org/docs/user-manual/#open-blocks[_open block_]
 which starts and ends with two dashes: `--`:
 
 ["source","asciidoc",subs="attributes,callouts,macros"]
@@ -1067,33 +1066,9 @@ ifndef::asciidoctor[\<1> Here's the explanation]
 === View in Console
 
 Code blocks can be followed by a "View in Console" link which, when clicked,
-will open the code snippet in Console. There are two ways to do this, the
-"AsciiDoc" way and the "Asciidoctor" way. The "AsciiDoc" way is preferred in
-the Elaticsearch repository because it can recognize it to make tests. The
-"Asciidoctor" way is preferred in other books, but only if they are built with
-"Asciidoctor". Try it first and if it works then use it. Otherwise, use the
-"AsciiDoc" way.
+will open the code snippet in Console. This is how you do it:
 
-.Code block with CONSOLE link (AsciiDoc way)
-==================================
-[source,asciidoc]
---
-[source,console]
-----------------------------------
-GET /_search
-{
-    "query": "foo bar" \<1>
-}
-----------------------------------
-// CONSOLE <1>
-
-ifdef::asciidoctor[<1> Here's the explanation]
-ifndef::asciidoctor[\<1> Here's the explanation]
---
-==================================
-<1> The `// CONSOLE` line must follow immediately after the code block, before any callouts.
-
-.Code block with CONSOLE link (Asciidoctor way)
+.Code block with CONSOLE link
 ==================================
 [source,asciidoc]
 --
@@ -1105,12 +1080,11 @@ GET /_search
 }
 ----------------------------------
 
-ifdef::asciidoctor[<1> Here's the explanation]
-ifndef::asciidoctor[\<1> Here's the explanation]
+<1> Here's the explanation
 --
 ==================================
 
-Both render as:
+Which renders as:
 
 [source,js]
 ----------------------------------
@@ -1123,19 +1097,8 @@ GET /_search
 
 <1> Here's the explanation
 
-[NOTE]
-================================
-The "View in Console" links will only work if the docs are viewed in web-browser mode, as follows:
-
-[source,sh]
----------------
-build_docs -d my_doc.asciidoc --open <1>
----------------
-<1> The `--open` option usually opens the docs in the web browser, served directly from the file system.
-
-The local web browser can be stopped with `Ctrl-C`.
-
-================================
+NOTE: In older branches you'll see `// CONSOLE` after the snippet to trigger
+      this behavior. That is deprecated.
 
 ==== Responses
 
@@ -1643,7 +1606,7 @@ ePub, etc.
 
 It's almost always better to use <<horizonta-defn-list>>
 instead, but if you really want to use tables, you
-can read about them http://www.methods.co.nz/asciidoc/userguide.html#_tables[here].
+can read about them https://asciidoctor.org/docs/user-manual/#tables[here].
 
 [[edit_me]]
 == Edit links

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -3,15 +3,6 @@
 include::{docs-root}/shared/versions/stack/current.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-////
-This file contains the sequence `&#x5f;` to escape from around Elastic's
-Asciidoctor plugin that provides Asciidoc compatibility. It automatically
-translates things like `beta[]` into their Asciidoctor compatible form
-which looks like `beta::[]`. We use `beta&#x5f;]` inside of asciidoc
-examples so we can output `beta[]`. Once we no longer support Asciidoc
-we can drop these sequences.
-////
-
 == Conditions of use
 
 This documentation build process is provided to the public purely for the
@@ -468,8 +459,7 @@ and
 <1> Any headers in the appendix or in the preface start
     out-of-sequence at `level 2`, not at `level 1`.
 
-ifdef::asciidoctor[[section]]
-ifndef::asciidoctor[[sect3]]
+[[section]]
 === Glossary
 
 [source,asciidoc]
@@ -1047,9 +1037,7 @@ footnote to a particular line of code:
     "query": "foo bar" \<1>
 }
 ----------------------------------
-
-ifdef::asciidoctor[<1> Here's the explanation]
-ifndef::asciidoctor[\<1> Here's the explanation]
+<1> Here's the explanation
 --
 
 [source,js]

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -284,7 +284,7 @@ it generates valid DocBook output.
 
 Below I include most of the Asciidoc syntax that you will
 need.  For more, you can take a look at the
-https://asciidoctor.org/docs/user-manual/[Asciidoc User Manual], or the
+https://asciidoctor.org/docs/user-manual/[Asciidoctor User Manual], or the
 http://asciidoctor.org/docs/asciidoc-syntax-quick-reference/[Asciidoctor Quick Syntax].
 --
 


### PR DESCRIPTION
Replace it was Asciidoctor stuff where needed.
