### PR TITLE
Switch headings to Inter

### DIFF
--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -2,7 +2,7 @@
   h1, h2, h3, h4, h5, h6 {
     /* Relative position allows laying out the edit me links inside the header. */
     position: relative;
-    font-family: aktiv-grotesk, sans-serif;
+    font-family: Inter;
     /* Override the "funny" line height from bootstrap. */
     line-height: normal;
     &:hover a[id][href] {


### PR DESCRIPTION
We don't depend on the aktiv-grotesk font any more but we still declare
that headings should have it. That causes them to look radically
different on different platforms. We should just use Inter like we do
with anything else.
