### PR TITLE
Keep the diff tool working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -112,3 +112,6 @@ COPY --from=node_test /node_modules /node_modules
 COPY --from=ruby_test /var/lib/gems /var/lib/gems
 COPY --from=ruby_test /usr/local/bin/rspec /usr/local/bin/rspec
 COPY --from=ruby_test /usr/local/bin/rubocop /usr/local/bin/rubocop
+
+FROM py_test AS diff_tool
+RUN install_packages git


### PR DESCRIPTION
This adds a docker image for the diff tool. We used to be able to use
the regular build image for it but now that we stripped all the test
stuff out of it we'll need a named image for it.

Expect like, real tests and stuff for it to come in at some point. It is
an "expert" tool mostly used for migration, but it is important that it
works.
