### PR TITLE
Speed up tests

### DIFF
--- a/.ci/clean_preview_branches.sh
+++ b/.ci/clean_preview_branches.sh
@@ -12,7 +12,7 @@ export HOME=$JENKINS_HOME
 export REPO=git@github.com:elastic/built-docs.git
 export IMAGE=docker.elastic.co/docs/build:latest
 
-./build_docs --just-build-image
+./build_docs --docker-build build
 ssh-agent bash -c '
     ssh-add &&
     docker run --rm \

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-ROOT=$(dirname $(dirname $(realpath "$0")))
+set -eo pipefail
 
-$ROOT/build_docs --just-build-image
-
+cd $(git rev-parse --show-toplevel)
+for IMAGE in build py_test node_test ruby_test integ_test diff_tool; do
+  echo Building $IMAGE
+  ./build_docs --docker-build $IMAGE
+done

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -9,12 +9,5 @@ set -eo pipefail
 echo "Building packer cache"
 ./.ci/packer_cache.sh
 
-# Configure the git author and committer information. The tests expect there
-# to be *something* set ut don't care what it is.
-export GIT_AUTHOR_NAME='Jenkins CI'
-export GIT_AUTHOR_EMAIL='jenkins@elasticsearch-ci.elastic.co'
-export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME
-export GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
-
 cd $(git rev-parse --show-toplevel)
 make

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,6 +2,7 @@
 
 set -eo pipefail
 
+cd $(git rev-parse --show-toplevel)
 
 # It'd be a real shame if we couldn't build the packer cache the morning after
 # we merge. So let's test that. We'll use the images that it builds to run the
@@ -9,5 +10,4 @@ set -eo pipefail
 echo "Building packer cache"
 ./.ci/packer_cache.sh
 
-cd $(git rev-parse --show-toplevel)
 make

--- a/.ci/test.sh
+++ b/.ci/test.sh
@@ -2,6 +2,12 @@
 
 set -eo pipefail
 
+# It'd be a real shame if we couldn't build the packer cache the morning after
+# we merge. So let's test that. We'll use the images that it builds to run the
+# rests of the tests anyway.
+echo "Building packer cache"
+./.ci/packer_cache.sh
+
 # Configure the git author and committer information. The tests expect there
 # to be *something* set ut don't care what it is.
 export GIT_AUTHOR_NAME='Jenkins CI'

--- a/build_docs
+++ b/build_docs
@@ -40,7 +40,6 @@ import webbrowser
 
 # The tag we use for our docker image. This should line up with the tags
 # in preview/Dockerfile and publish_docker.sh
-DOCKER_TAG = 'docker.elastic.co/docs/build:latest'
 DOCKER_BUILD_QUIET_TIME = 3  # seconds
 SSH_AGENT_HELP = 'https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#adding-your-ssh-key-to-the-ssh-agent'  # noqa
 
@@ -339,7 +338,7 @@ def run_build_docs(args):
     cmd = []
     cmd.extend(['docker', 'run'])
     cmd.extend(docker_args)
-    cmd.extend([DOCKER_TAG, '/docs_build/build_docs.pl'])
+    cmd.extend([docker_tag('build'), '/docs_build/build_docs.pl'])
     cmd.extend(build_docs_args)
     docker_run = common_popen(cmd)
 
@@ -611,13 +610,16 @@ if __name__ == '__main__':
     from sys import argv, stdout
     try:
         logging.basicConfig(level=logging.INFO)
-        if len(argv) >= 2 and '--docker-run' == argv[1]:
+        if '--docker-run' == argv[1]:
+            if len(argv) < 4:
+                raise ArgError(
+                    'Usage: build_docs --docker-run <image> <args>')
+            image = argv[2]
             cwd = realpath('.')
             if not cwd.startswith(DIR):
                 raise ArgError(
                     '--docker-run must be invoked from within the repo')
             docker_cwd = '/docs_build/' + cwd[len(DIR):]
-            image = argv[2]
             build_docker_image(image)
             cmd = ['docker', 'run']
             cmd.extend(standard_docker_args())
@@ -628,10 +630,16 @@ if __name__ == '__main__':
             cmd.extend(argv[3:])
             returncode = subprocess.call(cmd)
             exit(returncode)
+        if '--docker-build' == argv[1]:
+            if len(argv) != 3:
+                raise ArgError(
+                    'Usage: build_docs --build-image <image>')
+            image = argv[2]
+            build_docker_image(image)
+            exit(0)
 
         build_docker_image("build")
-        if not ['--just-build-image'] == argv[1:]:
-            exit(run_build_docs(argv[1:]))
+        exit(run_build_docs(argv[1:]))
     except ArgError as e:
         print(e)
         exit(1)

--- a/preview/build.sh
+++ b/preview/build.sh
@@ -7,6 +7,6 @@ set -eo pipefail
 export PREVIEW=docker.elastic.co/docs/preview:15
 
 cd $(git rev-parse --show-toplevel)
-./build_docs --just-build-image
+./build_docs --docker-build build
 DOCKER_BUILDKIT=1 docker build -t $PREVIEW -f preview/Dockerfile .
 


### PR DESCRIPTION
Builds the testing docker images during the packer cached step of the
process that builds the images that run the docs build. So *usually*
we'll be able to use the cached copy. Which speeds up the tests.
