### PR TITLE
Remove 7.x and 7.5 from excludes for processor refactoring

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -873,7 +873,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -916,11 +916,11 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   x-pack/filebeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -955,7 +955,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1004,7 +1004,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1043,7 +1043,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
 
               -
                 repo:   docs
@@ -1089,7 +1089,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1124,7 +1124,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1157,7 +1157,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
Do not merge until *after* https://github.com/elastic/beats/pull/14571 and https://github.com/elastic/beats/pull/14570 are merged.

docs CI will fail until the dependencies are meged.