### PR TITLE
Create docbook workalike plugin

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -26,31 +26,13 @@ def normalize_html(html):
                 crunched = NavigableString(re.sub(r'\s+', ' ', part))
                 if crunched != part:
                     part.replace_with(crunched)
-    # Remove empty paragraph tags inside of table cells. AsciiDoc fills empty
-    # table cells with these empty tags. Asciidoctor doesn't. Either way
-    # is fine.
-    for e in soup.select('td>p'):
-        if e.contents == []:
-            e.extract()
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
-    # Remove the zero width space that asciidoctor adds after each horizontal
-    # ellipsis. They don't hurt anything but asciidoc doesn't make them
-    html = html.replace('\u2026\u200b', '\u2026')
-    # Remove the zero width space that asciidoctor adds after each em dash that
-    # is between words. They are actively nice to have but asciidoc doesn't
-    # make them.
-    html = html.replace('\u2014\u200b', '\u2014')
-    # We intentionally changed lang-js to lang-console because in Asciidoctor
-    # because that is more accurate
-    html = html.replace('"programlisting prettyprint lang-js"',
-                        '"programlisting prettyprint lang-console"')
-    html = html.replace('"pre_wrapper lang-js"',
-                        '"pre_wrapper lang-console"')
-    # Asciidoctor relativizes https://www.elatic.co/ into /.
-    html = html.replace('https://www.elastic.co/', '/')
-    # The URL for the console snippets has changed
-    html = re.sub(r'data-snippet="[^"]+"', 'data-snippet="snippet"', html)
+    # docbook spits out the long-form charset and asciidoctor spits out the
+    # short form but they are equivalent
+    html = html.replace(
+        '<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>',
+        '<meta charset="utf-8"/>')
     return html
 
 

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -112,6 +112,10 @@ sub build_chunked {
                 # Asciidoctor doesn't pass the destination directory down to
                 # the converter so we do so here explicitly
                 '-a' => 'outdir=' . $raw_dest,
+                # Add some metadata
+                '-a' => 'dc.type=Learn/Docs/' . $section,
+                '-a' => 'dc.subject=' . $subject,
+                '-a' => 'dc.identifier=' . $version,
             ) : (),
             '--destination-dir=' . $raw_dest,
             docinfo($index),
@@ -260,6 +264,10 @@ sub build_single {
                 # Turn off style options because we'll provide our own
                 '-a' => 'stylesheet!',
                 '-a' => 'icons!',
+                # Add some metadata
+                '-a' => 'dc.type=Learn/Docs/' . $section,
+                '-a' => 'dc.subject=' . $subject,
+                '-a' => 'dc.identifier=' . $version,
             ) : (),
             '--destination-dir=' . $raw_dest,
             docinfo($index),

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -18,13 +18,11 @@ module Chunker
   end
 
   ##
-  # A Converter implementation that copies images as it sees them.
+  # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
     def initialize(delegate)
       super(delegate)
     end
-
-    # TODO: tests don't seem to pick up the headers because "embedded". Bad?
 
     def convert_section(node)
       chunk_level = node.document.attr 'chunk_level'

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+require_relative '../delegating_converter'
+
+##
+# HTML5 converter that emulates Elastic's docbook generated html.
+module DocbookCompat
+  def self.activate(registry)
+    return unless registry.document.basebackend? 'html'
+
+    DelegatingConverter.setup(registry.document) { |d| Converter.new d }
+  end
+
+  ##
+  # A Converter implementation that emulates Elastic's docbook generated html.
+  class Converter < DelegatingConverter
+    def initialize(delegate)
+      super(delegate)
+    end
+
+    def convert_document(doc)
+      html = yield
+      html.gsub!(/<html lang="[^"]+">/, '<html>') ||
+        raise("Coudn't fix html in #{html}")
+      munge_head doc, html
+      munge_body doc, html
+      munge_title html
+      html
+    end
+
+    def munge_head(doc, html)
+      html.gsub!(%r{<title>(.+)</title>}, '<title>\1 | Elastic</title>') ||
+        raise("Couldn't munge <title> in #{html}")
+      munge_meta html
+      add_dc_meta doc, html
+    end
+
+    META_VIEWPORT = <<~HTML
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    HTML
+    def munge_meta(html)
+      html.gsub!(
+        %(<meta http-equiv="X-UA-Compatible" content="IE=edge">\n), ''
+      ) || raise("Couldn't remove edge compat in #{html}")
+      html.gsub!(META_VIEWPORT, '') ||
+        raise("Couldn't remove viewport in #{html}")
+      html.gsub!(/<meta name="generator" content="Asciidoctor [^"]+">\n/, '') ||
+        raise("Couldn't remove generator in #{html}")
+    end
+
+    def add_dc_meta(doc, html)
+      meta = <<~HTML.strip
+        <meta name="DC.type" content="#{doc.attr 'dc.type'}"/>
+        <meta name="DC.subject" content="#{doc.attr 'dc.subject'}"/>
+        <meta name="DC.identifier" content="#{doc.attr 'dc.identifier'}"/>
+      HTML
+      html.gsub!('</title>', "</title>\n#{meta}") ||
+        raise("Couldn't add dc meta to #{html}")
+    end
+
+    def munge_body(doc, html)
+      wrapped_body = <<~HTML.strip
+        <body>
+        <div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">
+      HTML
+      html.gsub!(/<body[^>]+>/, wrapped_body) ||
+        raise("Couldn't wrap body in #{html}")
+      html.gsub!('</body>', '</div></body>') ||
+        raise("Couldn't wrap body in #{html}")
+    end
+
+    def munge_title(html)
+      html.gsub!(/<div id="header">/, '<div class="titlepage"><div><div>') ||
+        raise("Couldn't wrap header in #{html}")
+      ided_title = <<~HTML.strip
+        <h1 class="title">
+        <a id="id-1"></a>
+      HTML
+      html.gsub!('<h1>', ided_title) || raise("Coudln't wrap h1 in #{html}")
+      html.gsub!("</h1>\n</div>", "\n</h1>\n</div></div><hr></div>") ||
+        raise("Couldn't wrap h1 in #{html}")
+    end
+  end
+end

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -6,6 +6,7 @@ require_relative 'change_admonition/extension'
 require_relative 'chunker/extension'
 require_relative 'copy_images/extension'
 require_relative 'cramped_include/extension'
+require_relative 'docbook_compat/extension'
 require_relative 'docbook45/converter'
 require_relative 'edit_me/extension'
 require_relative 'elastic_compat_tree_processor/extension'
@@ -24,6 +25,7 @@ Asciidoctor::Extensions.register CareAdmonition
 Asciidoctor::Extensions.register ChangeAdmonition
 Asciidoctor::Extensions.register Chunker
 Asciidoctor::Extensions.register CopyImages
+Asciidoctor::Extensions.register DocbookCompat
 Asciidoctor::Extensions.register EditMe
 Asciidoctor::Extensions.register OpenInWidget
 Asciidoctor::Extensions.register RelativizeLink

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'docbook_compat/extension'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe DocbookCompat do
+  before(:each) do
+    Asciidoctor::Extensions.register DocbookCompat
+  end
+
+  after(:each) do
+    Asciidoctor::Extensions.unregister_all
+  end
+
+  include_context 'convert without logs'
+  let(:backend) { :html5 }
+
+  context 'the header' do
+    let(:standalone) { true }
+    let(:convert_attributes) do
+      # Shrink the output slightly so it is easier to read
+      {
+        'stylesheet!' => false,
+        'dc.type' => 'FooType',
+        'dc.subject' => 'BarSubject',
+        'dc.identifier' => 'BazIdentifier',
+      }
+    end
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        [[section]]
+        == Section
+      ASCIIDOC
+    end
+    it 'has an empty html tag' do
+      expect(converted).to include('<html>')
+    end
+    it "doesn't declare edge compatibility" do
+      expect(converted).not_to include('content="IE=edge"')
+    end
+    it "doesn't declare a viewport" do
+      expect(converted).not_to include('name="viewport"')
+    end
+    it "doesn't declare a generator" do
+      expect(converted).not_to include('name="generator"')
+    end
+    it 'has DC.type' do
+      expect(converted).to include(<<~HTML)
+        <meta name="DC.type" content="FooType"/>
+      HTML
+    end
+    it 'has DC.subject' do
+      expect(converted).to include(<<~HTML)
+        <meta name="DC.subject" content="BarSubject"/>
+      HTML
+    end
+    it 'has DC.identifier' do
+      expect(converted).to include(<<~HTML)
+        <meta name="DC.identifier" content="BazIdentifier"/>
+      HTML
+    end
+    context 'the title' do
+      it 'includes Elastic' do
+        expect(converted).to include('<title>Title | Elastic</title>')
+      end
+    end
+    context 'the body' do
+      it "doesn't have attributes" do
+        expect(converted).to include('<body>')
+      end
+      it 'is immediately followed by wrappers' do
+        expect(converted).to include(<<~HTML)
+          <body>
+          <div class="book" lang="en">
+        HTML
+      end
+    end
+    context 'the header' do
+      it "is wrapped in docbook's funny titlepage" do
+        expect(converted).to include(<<~HTML)
+          <div class="titlepage"><div><div>
+          <h1 class="title">
+          <a id="id-1"></a>Title
+          </h1>
+          </div></div><hr></div>
+        HTML
+      end
+    end
+  end
+end


### PR DESCRIPTION
Creates a plugin to "work like" Elastic's docbook customizations. The
idea here is to replace docbook with as close to 0 diffs as possible.
But in some cases, that isn't worth it. So this also alters `html_diff`
to start to normalize all of the diffs that we don't care about. Right
now there is only one, but I'm sure we'll have a hand full.

The actual asciidoctor plugin munges the header and title into the
correct form with string manipulation. I don't feel *too* bad about that
because:
1. It is in the grand tradition of bubble gum and duct tape that holds
all of the important bits of the internet together.
2. We'll be able to *remove* it piece by piece once we're done. It'll be
*much* easier to visually verify that removing each piece is safe if we
can do it one by one.
3. Further work on the plugin will *probably* be cleaner because the
other parts of the document are generated much more precisely so we
*should* be able to override more carefully.
