### PR TITLE
Create a "live" branches config for books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -50,6 +50,7 @@ contents:
             current:    7.4
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       [ master, 7.x, 7.5, 7.4, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -30,6 +30,14 @@ RSpec.describe 'building all books' do
       book.source repo, 'index.asciidoc'
     end
     include_examples 'book basics', 'Test', 'test'
+    file_context 'raw/test/master/index.html' do
+      it "doesn't contain the noindex flag" do
+        expect(contents).not_to include(<<~HTML.strip)
+          <meta name="robots" content="noindex,nofollow" />
+        HTML
+      end
+    end
+
     def self.has_license(name, heading)
       it "has license for #{name}" do
         expect(contents).to include(<<~TXT)
@@ -530,6 +538,38 @@ RSpec.describe 'building all books' do
         it 'contains the snippet' do
           expect(contents).to include('CODE HERE')
         end
+      end
+    end
+  end
+  context 'when the book is configured with noindex' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'repo', 'test'
+
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      book.noindex = true
+    end
+    file_context 'raw/test/master/index.html' do
+      it 'contains the noindex flag' do
+        expect(contents).to include(<<~HTML.strip)
+          <meta name="robots" content="noindex,nofollow" />
+        HTML
+      end
+    end
+  end
+  context 'when the branch is not "live"' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'repo', 'test'
+
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      book.live_branches = []
+    end
+    file_context 'raw/test/master/index.html' do
+      it 'contains the noindex flag' do
+        expect(contents).to include(<<~HTML.strip)
+          <meta name="robots" content="noindex,nofollow" />
+        HTML
       end
     end
   end

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
+require_relative 'book_conf'
+
 class Book
+  include BookConf
   attr_reader :title, :prefix
 
   ##
@@ -33,6 +36,17 @@ class Book
   # Should this book built directly to html (true) or to docbook first (false).
   attr_accessor :direct_html
 
+  ##
+  # Should the book declare itself noindex? Defaults to false.
+  attr_accessor :noindex
+
+  ##
+  # List of branches that are considered "live" for a book. Branches that are
+  # not live will be marked as `noindex`. Defaults to nil, meaning don't emit
+  # the list of live branches. In that case the docs build will default to
+  # *all* branches being live.
+  attr_accessor :live_branches
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -40,10 +54,10 @@ class Book
     @sources = []
     @branches = ['master']
     @current_branch = 'master'
-    @respect_edit_url_overrides = false
     @lang = 'en'
-    @suppress_migration_warnings = false
-    @direct_html = false
+    @respect_edit_url_overrides = @suppress_migration_warnings = false
+    @direct_html = @noindex = false
+    @live_branches = nil
   end
 
   ##
@@ -69,37 +83,6 @@ class Book
   end
 
   ##
-  # The configuration needed to build the book.
-  def conf
-    # We can't use to_yaml here because it emits yaml 1.2 but the docs build
-    # only supports 1.0.....
-    conf = standard_conf
-    conf += "respect_edit_url_overrides: true\n" if @respect_edit_url_overrides
-    if @suppress_migration_warnings
-      conf += "suppress_migration_warnings: #{@suppress_migration_warnings}\n"
-    end
-    conf += <<~YAML
-      sources:
-      #{sources_conf}
-    YAML
-    indent conf, '    '
-  end
-
-  def standard_conf
-    <<~YAML
-      title:      #{@title}
-      prefix:     #{@prefix}
-      current:    #{@current_branch}
-      branches:   [ #{@branches.join ', '} ]
-      index:      #{@index}
-      tags:       test tag
-      subject:    Test
-      lang:       #{@lang}
-      direct_html: #{@direct_html}
-    YAML
-  end
-
-  ##
   # The html for a link to a particular branch of this book.
   def link_to(branch)
     url = "#{@prefix}/#{branch}/index.html"
@@ -108,46 +91,5 @@ class Book
       decoration = " [#{@current_branch}]"
     end
     %(<a class="ulink" href="#{url}" target="_top">#{@title}#{decoration}</a>)
-  end
-
-  private
-
-  def sources_conf
-    yaml = ''
-    @sources.each do |config|
-      yaml += "\n-\n#{source_conf config}"
-    end
-    indent yaml, '  '
-  end
-
-  def source_conf(config)
-    yaml = <<~YAML
-      repo:    #{config[:repo]}
-      path:    #{config[:path]}
-    YAML
-    yaml += alternatives_conf config[:alternatives]
-    yaml += "private: true\n" if config[:is_private]
-    yaml += map_branches_conf config[:map_branches]
-    indent yaml, '  '
-  end
-
-  def alternatives_conf(conf)
-    return '' unless conf
-
-    yaml = ''
-    yaml += "alternatives:\n"
-    yaml += "  source_lang: #{conf[:source_lang]}\n"
-    yaml += "  alternative_lang: #{conf[:alternative_lang]}\n"
-    yaml
-  end
-
-  def map_branches_conf(map_branches)
-    return '' unless map_branches
-
-    yaml = "map_branches:\n"
-    map_branches.each_pair do |key, value|
-      yaml += "  #{key}: #{value}\n"
-    end
-    yaml
   end
 end

--- a/integtest/spec/helper/book_conf.rb
+++ b/integtest/spec/helper/book_conf.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+##
+# Methods to build the config for a book.
+module BookConf
+  ##
+  # The configuration needed to build the book.
+  def conf
+    # We can't use to_yaml here because it emits yaml 1.2 but the docs build
+    # only supports 1.0.....
+    yaml = standard_conf
+    yaml += variable_conf
+    yaml += <<~YAML
+      sources:
+      #{sources_conf}
+    YAML
+    indent yaml, '    '
+  end
+
+  private
+
+  def standard_conf
+    <<~YAML
+      title:      #{@title}
+      prefix:     #{@prefix}
+      current:    #{@current_branch}
+      branches:   [ #{@branches.join ', '} ]
+      index:      #{@index}
+      tags:       test tag
+      subject:    Test
+      lang:       #{@lang}
+      direct_html: #{@direct_html}
+    YAML
+  end
+
+  def variable_conf
+    yaml = ''
+    yaml += "noindex: 1\n" if @noindex
+    yaml += "live: [ #{@live_branches.join ', '} ]\n" if @live_branches
+    yaml += "respect_edit_url_overrides: true\n" if @respect_edit_url_overrides
+    yaml += "suppress_migration_warnings: 1\n" if @suppress_migration_warnings
+    yaml
+  end
+
+  def sources_conf
+    yaml = ''
+    @sources.each do |config|
+      yaml += "\n-\n#{source_conf config}"
+    end
+    indent yaml, '  '
+  end
+
+  def source_conf(config)
+    yaml = <<~YAML
+      repo:    #{config[:repo]}
+      path:    #{config[:path]}
+    YAML
+    yaml += alternatives_conf config[:alternatives]
+    yaml += "private: true\n" if config[:is_private]
+    yaml += map_branches_conf config[:map_branches]
+    indent yaml, '  '
+  end
+
+  def alternatives_conf(conf)
+    return '' unless conf
+
+    yaml = ''
+    yaml += "alternatives:\n"
+    yaml += "  source_lang: #{conf[:source_lang]}\n"
+    yaml += "  alternative_lang: #{conf[:alternative_lang]}\n"
+    yaml
+  end
+
+  def map_branches_conf(map_branches)
+    return '' unless map_branches
+
+    yaml = "map_branches:\n"
+    map_branches.each_pair do |key, value|
+      yaml += "  #{key}: #{value}\n"
+    end
+    yaml
+  end
+end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -130,6 +130,7 @@ sub new {
         single        => $args{single},
         index         => $index,
         branches      => \@branches,
+        live_branches => $args{live} || \@branches,
         branch_titles => \%branch_titles,
         current       => $current,
         tags          => $tags,
@@ -259,7 +260,7 @@ sub _build_book {
                 lang          => $lang,
                 edit_urls     => $edit_urls,
                 private       => $self->private,
-                noindex       => $self->noindex,
+                noindex       => $self->noindex($branch),
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
                 section_title => $section_title,
@@ -283,7 +284,7 @@ sub _build_book {
                 lang          => $lang,
                 edit_urls     => $edit_urls,
                 private       => $self->private,
-                noindex       => $self->noindex,
+                noindex       => $self->noindex($branch),
                 chunk         => $self->chunk,
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
@@ -422,6 +423,16 @@ sub section_title {
 }
 
 #===================================
+sub noindex {
+#===================================
+    my ( $self, $branch ) = @_;
+    return 1 if $self->{noindex};
+    return 0 if grep( /^$branch$/, @{ $self->{live_branches} } );
+    return 1;
+}
+
+
+#===================================
 sub title            { shift->{title} }
 sub dir              { shift->{dir} }
 sub prefix           { shift->{prefix} }
@@ -434,7 +445,6 @@ sub branch_title     { shift->{branch_titles}->{ shift() } }
 sub current          { shift->{current} }
 sub is_multi_version { @{ shift->branches } > 1 }
 sub private          { shift->{private} }
-sub noindex          { shift->{noindex} }
 sub tags             { shift->{tags} }
 sub subject          { shift->{subject} }
 sub source           { shift->{source} }


### PR DESCRIPTION
We've wanted for a while to mark old versions of books as "noindex" and,
probably, to remove the `edit_me` links from them. This creates a config
entry for `conf.yaml` to mark branches as "live". If this list is
specified then everything *not* in the list will be marked as `noindex`.
In the future we might remove the edit links from it was well.

This applies that config change to the installation and upgrade guide,
just to apply it to something for testing. I think we'll want to apply
it to most books eventually.
