### PR TITLE
Clean up yaml generation in tests

### DIFF
--- a/integtest/spec/all_books_sources_spec.rb
+++ b/integtest/spec/all_books_sources_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'building all books' do
           extra_branches.each { |b| repo.switch_to_new_branch b }
           docs_repo = init_docs_repo src
           book = src.book 'Test'
-          book.branches << extra_branches
+          book.branches += extra_branches
           book.source repo, 'index.asciidoc'
           book.source docs_repo, 'shared/versions/stack/{branch}.asciidoc'
         end

--- a/integtest/spec/helper/book_conf.rb
+++ b/integtest/spec/helper/book_conf.rb
@@ -6,78 +6,54 @@ module BookConf
   ##
   # The configuration needed to build the book.
   def conf
-    # We can't use to_yaml here because it emits yaml 1.2 but the docs build
-    # only supports 1.0.....
-    yaml = standard_conf
-    yaml += variable_conf
-    yaml += <<~YAML
-      sources:
-      #{sources_conf}
-    YAML
-    indent yaml, '    '
+    conf = basic_conf
+    conf.merge! branches_conf
+    conf.merge! flags_conf
+    conf[:sources] = @sources.map { |source| source_conf source }
+    conf.compact
   end
 
   private
 
-  def standard_conf
-    <<~YAML
-      title:      #{@title}
-      prefix:     #{@prefix}
-      current:    #{@current_branch}
-      branches:   [ #{@branches.join ', '} ]
-      index:      #{@index}
-      tags:       test tag
-      subject:    Test
-      lang:       #{@lang}
-      direct_html: #{@direct_html}
-    YAML
+  def basic_conf
+    {
+      title: @title,
+      prefix: @prefix,
+      index: @index,
+      lang: @lang,
+      tags: 'test tag',
+      subject: 'Test',
+    }
   end
 
-  def variable_conf
-    yaml = ''
-    yaml += "noindex: 1\n" if @noindex
-    yaml += "live: [ #{@live_branches.join ', '} ]\n" if @live_branches
-    yaml += "respect_edit_url_overrides: true\n" if @respect_edit_url_overrides
-    yaml += "suppress_migration_warnings: 1\n" if @suppress_migration_warnings
-    yaml
+  def source_conf(source)
+    {
+      repo: source[:repo],
+      path: source[:path],
+      private: source[:is_private] ? true : nil,
+      map_branches: source[:map_branches],
+      alternatives: source[:alternatives],
+    }.compact
   end
 
-  def sources_conf
-    yaml = ''
-    @sources.each do |config|
-      yaml += "\n-\n#{source_conf config}"
-    end
-    indent yaml, '  '
+  def branches_conf
+    {
+      current: @current_branch,
+      branches: @branches,
+      live: @live_branches,
+    }
   end
 
-  def source_conf(config)
-    yaml = <<~YAML
-      repo:    #{config[:repo]}
-      path:    #{config[:path]}
-    YAML
-    yaml += alternatives_conf config[:alternatives]
-    yaml += "private: true\n" if config[:is_private]
-    yaml += map_branches_conf config[:map_branches]
-    indent yaml, '  '
-  end
-
-  def alternatives_conf(conf)
-    return '' unless conf
-
-    yaml = ''
-    yaml += "alternatives:\n"
-    yaml += "  source_lang: #{conf[:source_lang]}\n"
-    yaml += "  alternative_lang: #{conf[:alternative_lang]}\n"
-    yaml
-  end
-
-  def map_branches_conf(map_branches)
-    return '' unless map_branches
-
-    yaml = "map_branches:\n"
-    map_branches.each_pair do |key, value|
-      yaml += "  #{key}: #{value}\n"
-    end
-    yaml
+  ##
+  # Config for "flags" on the book. Some are "perl style" and take "1" when
+  # true. Others are "normal style" and take "true" when "true". Either way,
+  # when they are false we leave them out entirely.
+  def flags_conf
+    {
+      noindex: @noindex ? 1 : nil,
+      direct_html: @direct_html ? true : nil,
+      respect_edit_url_overrides: @respect_edit_url_overrides ? true : nil,
+      suppress_migration_warnings: @suppress_migration_warnings ? 1 : nil,
+    }
   end
 end

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -96,7 +96,6 @@ class Source
   ##
   # Build the config file that can build all books declared in this source.
   def conf(relative_path: false)
-    puts "ADFADF #{build_conf}"
     path = write 'conf.yaml', build_conf
     return path unless relative_path
 

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'yaml'
 
 require_relative 'book'
 require_relative 'repo'
@@ -95,13 +96,8 @@ class Source
   ##
   # Build the config file that can build all books declared in this source.
   def conf(relative_path: false)
-    # We can't use to_yaml here because it emits yaml 1.2 but the docs build
-    # only supports 1.0.....
-    path = write 'conf.yaml', <<~YAML
-      #{common_conf}
-      repos:#{repos_conf}
-      contents:#{books_conf}
-    YAML
+    puts "ADFADF #{build_conf}"
+    path = write 'conf.yaml', build_conf
     return path unless relative_path
 
     Pathname.new(path)
@@ -111,28 +107,13 @@ class Source
 
   private
 
-  def common_conf
-    <<~YAML
-      template:
-        defaults:
-      contents_title: Test
-    YAML
-  end
-
-  def repos_conf
-    repos_yaml = ''
-    @repos.each_value do |repo|
-      repos_yaml += "\n  #{repo.name}: #{repo.root}"
-    end
-    repos_yaml
-  end
-
-  def books_conf
-    books_yaml = ''
-    @books.each_value do |book|
-      books_yaml += "\n  -\n"
-      books_yaml += book.conf
-    end
-    books_yaml
+  def build_conf
+    conf = {
+      contents_title: 'Test',
+      repos: @repos.values.map { |repo| [repo.name, repo.root] }.to_h,
+      contents: @books.values.map(&:conf),
+    }
+    conf = desymbolize_keys conf
+    conf.to_yaml
   end
 end

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -43,8 +43,18 @@ def files_in(dir)
   end
 end
 
-def indent(str, indentation)
-  str.split("\n").map { |s| indentation + s }.join "\n"
+##
+# Replace symbols in hash keys with their to_s. Building hashes out of symbols
+# is much more "ruby", but those symbols make "funny" keys when you convert the
+# hash into yaml.
+def desymbolize_keys(thing)
+  if thing.is_a? Hash
+    thing.each_with_object({}) { |(k, v), r| r[k.to_s] = desymbolize_keys v }
+  elsif thing.is_a? Array
+    thing.map { |v| desymbolize_keys v }
+  else
+    thing
+  end
 end
 
 ##

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -43,6 +43,10 @@ def files_in(dir)
   end
 end
 
+def indent(str, indentation)
+  str.split("\n").map { |s| indentation + s }.join "\n"
+end
+
 ##
 # Replace symbols in hash keys with their to_s. Building hashes out of symbols
 # is much more "ruby", but those symbols make "funny" keys when you convert the


### PR DESCRIPTION
The integration tests used a lot of code to properly generate yaml that
the docs build could parse, mostly because the docs build used an old
yaml parser that had a few bugs. But we recently upgraded the yaml
parser and it looks like it doesn't have the bugs any more! So this
replaces the "by hand" yaml generation with ruby's built in `.to_yaml`
which is much simpler to do.
