### PR TITLE
Add "live" branches for APM agents

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1292,6 +1292,7 @@ contents:
                     prefix:     go
                     current:    1.x
                     branches:   [ master, 1.x, 0.5 ]
+                    live:       [ master, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
                     subject:    APM
@@ -1305,6 +1306,7 @@ contents:
                     prefix:     java
                     current:    1.x
                     branches:   [ master, 1.x, 0.7, 0.6 ]
+                    live:       [ master, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
                     subject:    APM
@@ -1318,6 +1320,7 @@ contents:
                     prefix:     dotnet
                     current:    1.x
                     branches:   [ master, 1.x ]
+                    live:       [ master, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM
@@ -1334,6 +1337,7 @@ contents:
                     prefix:     nodejs
                     current:    3.x
                     branches:   [ master, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ master, 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM
@@ -1351,6 +1355,7 @@ contents:
                     prefix:     python
                     current:    5.x
                     branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ master, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM
@@ -1368,6 +1373,7 @@ contents:
                     prefix:     ruby
                     current:    3.x
                     branches:   [ master, 3.x, 2.x, 1.x ]
+                    live:       [ master, 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
                     subject:    APM
@@ -1385,6 +1391,7 @@ contents:
                     prefix:     rum-js
                     current:    4.x
                     branches:   [ master, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ master, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Full details in https://github.com/elastic/docs/pull/1421 & https://github.com/elastic/docs/issues/1419. To summarize:

> We've wanted for a while to mark old versions of books as "noindex" and,
probably, to remove the `edit_me` links from them. This creates a config
entry for conf.yaml to mark branches as "live".

This PR sets _live_ branches for the APM agents. Specifically, it marks only `master` and the `current` version of each agent as _live_. @lreuven (or maybe @axw?) can you confirm there are no other branches that should also be marked as _live_?