### PR TITLE
Configure "live" branches for stack books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -50,7 +50,7 @@ contents:
             current:    7.4
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       [ master, 7.x, 7.5, 7.4, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.5, 7.4, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -95,6 +95,7 @@ contents:
             current:    7.4
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
@@ -135,6 +136,7 @@ contents:
             current:    7.4
             index:      docs/en/stack/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Overview
             subject:    Elastic Stack
@@ -217,6 +219,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -347,6 +350,7 @@ contents:
             prefix:     en/elasticsearch/painless
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            live:       *stacklive
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -373,6 +377,7 @@ contents:
             current:    7.4
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            live:       *stacklive
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -405,6 +410,7 @@ contents:
                 prefix:     java-rest
                 current:    7.4
                 branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients
@@ -434,6 +440,7 @@ contents:
                 prefix:     java-api
                 current:    7.4
                 branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                live:       *stacklive
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients
@@ -579,6 +586,7 @@ contents:
             prefix:     en/elasticsearch/hadoop
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -707,6 +715,7 @@ contents:
             prefix:     en/kibana
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -740,6 +749,7 @@ contents:
             prefix:     en/logstash
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -798,6 +808,7 @@ contents:
             index:      libbeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -823,6 +834,7 @@ contents:
             index:      docs/devguide/index.asciidoc
             current:    master
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklive
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats
@@ -854,6 +866,7 @@ contents:
             index:      packetbeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
             chunk:      1
             tags:       Packetbeat/Reference
             respect_edit_url_overrides: true
@@ -889,6 +902,7 @@ contents:
             index:      filebeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
             chunk:      1
             tags:       Filebeat/Reference
             respect_edit_url_overrides: true
@@ -936,6 +950,7 @@ contents:
             index:      winlogbeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            live:       *stacklive
             chunk:      1
             tags:       Winlogbeat/Reference
             respect_edit_url_overrides: true
@@ -971,6 +986,7 @@ contents:
             index:      metricbeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       *stacklive
             chunk:      1
             tags:       Metricbeat/Reference
             respect_edit_url_overrides: true
@@ -1020,6 +1036,7 @@ contents:
             current:    7.4
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            live:       *stacklive
             chunk:      1
             tags:       Heartbeat/Reference
             respect_edit_url_overrides: true
@@ -1060,6 +1077,7 @@ contents:
             index:      auditbeat/docs/index.asciidoc
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklive
             chunk:      1
             tags:       Auditbeat/Reference
             respect_edit_url_overrides: true
@@ -1105,6 +1123,7 @@ contents:
             current:    7.4
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
             chunk:      1
             tags:       Functionbeat/Reference
             respect_edit_url_overrides: true
@@ -1138,6 +1157,7 @@ contents:
             current:    7.4
             index:      journalbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
             chunk:      1
             tags:       Journalbeat/Reference
             respect_edit_url_overrides: true
@@ -1226,6 +1246,7 @@ contents:
             prefix:     en/siem/guide
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2 ]
+            live:       *stacklive
             index:      docs/en/siem/index.asciidoc
             chunk:      1
             tags:       SIEM/Guide
@@ -1253,6 +1274,7 @@ contents:
                 index:      docs/guide/index.asciidoc
                 current:    7.4
                 branches:   [ master, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM
@@ -1269,6 +1291,7 @@ contents:
                 index:      docs/index.asciidoc
                 current:    7.4
                 branches:   [ master, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference
                 subject:    APM
@@ -1398,6 +1421,7 @@ contents:
             prefix:     en/logs/guide
             current:    7.5
             branches:   [ master, 7.x, 7.5 ]
+            live:       *stacklive
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1417,6 +1441,7 @@ contents:
             prefix:     en/metrics/guide
             current:    7.5
             branches:   [ master, 7.x, 7.5 ]
+            live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide
@@ -1436,6 +1461,7 @@ contents:
             prefix:     en/uptime
             current:    7.4
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2 ]
+            live:       *stacklive
             index:      docs/uptime-guide/index.asciidoc
             chunk:      1
             tags:       Uptime/Guide


### PR DESCRIPTION
Configures which branches are "live" for book that are versioned with
the stack.
