### PR TITLE
Improve direct html generation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -542,6 +542,7 @@ contents:
                 single:     1
                 tags:       Clients/Perl
                 subject:    Clients
+                direct_html: true
                 sources:
                   -
                     repo:   elasticsearch-perl

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -155,7 +155,7 @@ alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/doc
 
 alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 
-alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
+alias docbldepl='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
 alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
 

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -26,6 +26,18 @@ def normalize_html(html):
                 crunched = NavigableString(re.sub(r'\s+', ' ', part))
                 if crunched != part:
                     part.replace_with(crunched)
+    # Asciidoctor adds a "content" wrapper. It doesn't really change the layout
+    # so we're ok with it.
+    for e in soup.select('#content'):
+        e.unwrap()
+    # Asciidoctor adds a "ulist" class to all unordered lists which doesn't
+    # hurt anything so we can ignore it.
+    for e in soup.select('.itemizedlist.ulist'):
+        e['class'].remove('ulist')
+    # Docbook adds type="disc" to ul which is the default and isn't needed.
+    for e in soup.select('ul'):
+        if 'type' in e.attrs and e['type'] == 'disc':
+            del e['type']
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # docbook spits out the long-form charset and asciidoctor spits out the

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -456,6 +456,8 @@ RSpec.describe 'building all books' do
             before_first_build: lambda do |src, _config|
               book = src.book 'Test'
               book.direct_html = true
+              # For now direct_html only works with single page books.
+              book.single = true
             end,
             before_second_build: lambda do |src, _config|
               book = src.book 'Test'

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -439,6 +439,11 @@ RSpec.describe 'building all books' do
         end
         context 'because the book changes from docbook to direct_html' do
           build_one_book_out_of_one_repo_twice(
+            before_first_build: lambda do |src, _config|
+              book = src.book 'Test'
+              # For now direct_html only works with single page books.
+              book.single = true
+            end,
             before_second_build: lambda do |src, _config|
               book = src.book 'Test'
               book.direct_html = true

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -47,6 +47,10 @@ class Book
   # *all* branches being live.
   attr_accessor :live_branches
 
+  ##
+  # Is the book a single page book?
+  attr_accessor :single
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -56,7 +60,7 @@ class Book
     @current_branch = 'master'
     @lang = 'en'
     @respect_edit_url_overrides = @suppress_migration_warnings = false
-    @direct_html = @noindex = false
+    @direct_html = @noindex = @single = false
     @live_branches = nil
   end
 

--- a/integtest/spec/helper/book_conf.rb
+++ b/integtest/spec/helper/book_conf.rb
@@ -54,6 +54,7 @@ module BookConf
       direct_html: @direct_html ? true : nil,
       respect_edit_url_overrides: @respect_edit_url_overrides ? true : nil,
       suppress_migration_warnings: @suppress_migration_warnings ? 1 : nil,
+      single: @single ? 1 : nil,
     }
   end
 end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -273,6 +273,7 @@ sub _build_book {
                 branch => $branch,
                 roots => $roots,
                 relativize => 1,
+                direct_html => $self->{direct_html},
             );
         }
         else {
@@ -297,6 +298,7 @@ sub _build_book {
                 branch => $branch,
                 roots => $roots,
                 relativize => 1,
+                direct_html => $self->{direct_html},
             );
         }
         $checkout->rmtree;

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -105,6 +105,8 @@ sub build_chunked {
                 # Turn off style options because we'll provide our own
                 '-a' => 'stylesheet!',
                 '-a' => 'icons!',
+                # Turn off asciidoctor's default footer because we make our own
+                '-a' => 'nofooter',
                 # Pass chunking down
                 '-a' => 'chunk_level=' . ( $chunk + 1 ),
                 # Lock the destination file name to one we expect
@@ -264,6 +266,8 @@ sub build_single {
                 # Turn off style options because we'll provide our own
                 '-a' => 'stylesheet!',
                 '-a' => 'icons!',
+                # Turn off asciidoctor's default footer because we make our own
+                '-a' => 'nofooter',
                 # Add some metadata
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,

--- a/resources/asciidoctor/lib/docbook_compat/doc_munging.rb
+++ b/resources/asciidoctor/lib/docbook_compat/doc_munging.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to munge the document at the top level. All of these are a bit
+  # scary but required at this point for docbook compatibility.
+  module DocMunging
+    def munge_head(doc, html)
+      html.gsub!(%r{<title>(.+)</title>}, '<title>\1 | Elastic</title>') ||
+        raise("Couldn't munge <title> in #{html}")
+      munge_meta html
+      add_dc_meta doc, html
+    end
+
+    META_VIEWPORT = <<~HTML
+      <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    HTML
+    def munge_meta(html)
+      html.gsub!(
+        %(<meta http-equiv="X-UA-Compatible" content="IE=edge">\n), ''
+      ) || raise("Couldn't remove edge compat in #{html}")
+      html.gsub!(META_VIEWPORT, '') ||
+        raise("Couldn't remove viewport in #{html}")
+      html.gsub!(/<meta name="generator" content="Asciidoctor [^"]+">\n/, '') ||
+        raise("Couldn't remove generator in #{html}")
+    end
+
+    def add_dc_meta(doc, html)
+      meta = <<~HTML.strip
+        <meta name="DC.type" content="#{doc.attr 'dc.type'}"/>
+        <meta name="DC.subject" content="#{doc.attr 'dc.subject'}"/>
+        <meta name="DC.identifier" content="#{doc.attr 'dc.identifier'}"/>
+      HTML
+      html.gsub!('</title>', "</title>\n#{meta}") ||
+        raise("Couldn't add dc meta to #{html}")
+    end
+
+    def munge_body(doc, html)
+      wrapped_body = <<~HTML.strip
+        <body>
+        <div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">
+      HTML
+      html.gsub!(/<body[^>]+>/, wrapped_body) ||
+        raise("Couldn't wrap body in #{html}")
+      html.gsub!('</body>', '</div></body>') ||
+        raise("Couldn't wrap body in #{html}")
+    end
+
+    def munge_title(doc, html)
+      header_start = <<~HTML.strip
+        <div class="titlepage"><div><div>
+        <h1 class="title"><a id="id-1"></a>#{doc.title}</h1>
+        </div></div><hr></div>
+      HTML
+      html.gsub!(%r{<div id="header">\n<h1>.+</h1>\n</div>}, header_start) ||
+        raise("Couldn't wrap header in #{html}")
+    end
+  end
+end

--- a/resources/asciidoctor/lib/edit_me/extension.rb
+++ b/resources/asciidoctor/lib/edit_me/extension.rb
@@ -67,24 +67,45 @@ module EditMe
     end
 
     def convert_section(block)
-      yield.sub '</title>' do
-        "#{link_for block}</title>"
+      if block.document.basebackend? 'html'
+        block.attributes['edit_me_link'] = link_for block
+        yield
+      else
+        yield.sub '</title>' do
+          "#{link_for block}</title>"
+        end
       end
     end
 
     def convert_floating_title(block)
-      yield.sub '</bridgehead>' do
-        "#{link_for block}</bridgehead>"
+      if block.document.basebackend? 'html'
+        block.attributes['edit_me_link'] = link_for block
+        yield
+      else
+        yield.sub '</bridgehead>' do
+          "#{link_for block}</bridgehead>"
+        end
       end
     end
 
     def link_for(block)
       url = edit_url block
-      if url
-        %(<ulink role="edit_me" url="#{url}">Edit me</ulink>)
-      else
-        ''
-      end
+      return '' unless url
+      return html_link_for url if block.document.basebackend? 'html'
+
+      docbook_link_for url
+    end
+
+    def html_link_for(url)
+      <<~HTML.strip
+        <a class="edit_me" rel="nofollow" title="Edit this page on GitHub" href="#{url}">edit</a>
+      HTML
+    end
+
+    def docbook_link_for(url)
+      <<~DOCBOOK.strip
+        <ulink role="edit_me" url="#{url}">Edit me</ulink>
+      DOCBOOK
     end
 
     def edit_url(block)

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -21,11 +21,13 @@ Asciidoctor::Extensions.register do
   # for EditMe to get a nice location.
   document.sourcemap = true
 end
+# Adding DocbookCompat first lets it help rendering things like the
+# edit_me links
+Asciidoctor::Extensions.register DocbookCompat
 Asciidoctor::Extensions.register CareAdmonition
 Asciidoctor::Extensions.register ChangeAdmonition
 Asciidoctor::Extensions.register Chunker
 Asciidoctor::Extensions.register CopyImages
-Asciidoctor::Extensions.register DocbookCompat
 Asciidoctor::Extensions.register EditMe
 Asciidoctor::Extensions.register OpenInWidget
 Asciidoctor::Extensions.register RelativizeLink

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DocbookCompat do
   include_context 'convert without logs'
   let(:backend) { :html5 }
 
-  context 'the header' do
+  context 'the header and footer' do
     let(:standalone) { true }
     let(:convert_attributes) do
       # Shrink the output slightly so it is easier to read
@@ -82,12 +82,198 @@ RSpec.describe DocbookCompat do
       it "is wrapped in docbook's funny titlepage" do
         expect(converted).to include(<<~HTML)
           <div class="titlepage"><div><div>
-          <h1 class="title">
-          <a id="id-1"></a>Title
-          </h1>
+          <h1 class="title"><a id="id-1"></a>Title</h1>
           </div></div><hr></div>
         HTML
       end
+    end
+  end
+
+  context 'a level 1 section' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        [[section]]
+        == Section
+      ASCIIDOC
+    end
+    context 'the wrapper' do
+      it 'has the "chapter" class' do
+        expect(converted).to include '<div class="chapter">'
+      end
+    end
+    context 'the header' do
+      it "is wrapped in docbook's funny titlepage" do
+        expect(converted).to include(<<~HTML)
+          <div class="titlepage"><div><div>
+          <h1 class="title"><a id="section"></a>Section</h1>
+          </div></div></div>
+        HTML
+      end
+    end
+  end
+
+  context 'a level 2 section' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section 1
+
+        [[section-2]]
+        === Section 2
+      ASCIIDOC
+    end
+    context 'the wrapper' do
+      it 'has the "chapter" class' do
+        expect(converted).to include '<div class="section">'
+      end
+    end
+    context 'the header' do
+      it "is wrapped in docbook's funny titlepage" do
+        expect(converted).to include(<<~HTML)
+          <div class="titlepage"><div><div>
+          <h2 class="title"><a id="section-2"></a>Section 2</h2>
+          </div></div></div>
+        HTML
+      end
+    end
+  end
+
+  context 'a paragraph' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section
+        Words words words.
+      ASCIIDOC
+    end
+    it "isn't wrapped in a paragraph div" do
+      expect(converted).not_to include('<div class="paragraph">')
+    end
+    it 'contains the words' do
+      expect(converted).to include('<p>Words words words.</p>')
+    end
+  end
+
+  context 'a link' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section
+
+        Words #{link}.
+      ASCIIDOC
+    end
+    let(:url) { 'https://metacpan.org/module/Search::Elasticsearch' }
+    let(:link) { url }
+    it 'has ulink class' do
+      expect(converted).to include('class="ulink"')
+    end
+    it 'targets the _top' do
+      expect(converted).to include('target="_top"')
+    end
+    it 'references the url' do
+      expect(converted).to include(<<~HTML.strip)
+        href="#{url}"
+      HTML
+    end
+    it 'contains the link text' do
+      expect(converted).to include(">#{url}</a>")
+    end
+    context 'when the link text and window is overridden' do
+      let(:link) { "#{url}[docs,window=_blank]" }
+      it 'contains the overridden text' do
+        expect(converted).to include('>docs</a>')
+      end
+      it 'targets the overridden window' do
+        expect(converted).to include('target="_blank"')
+      end
+    end
+  end
+
+  context 'a listing block' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section
+        [source,sh]
+        ----
+        cpanm Search::Elasticsearch
+        ----
+      ASCIIDOC
+    end
+    it "is wrapped in docbook's funny wrapper" do
+      # It is important that there isn't any extra space around the <pre> tags
+      expect(converted).to include(<<~HTML)
+        <div class="pre_wrapper lang-sh">
+        <pre class="programlisting prettyprint lang-sh">cpanm Search::Elasticsearch</pre>
+        </div>
+      HTML
+    end
+  end
+
+  context 'an unordered list' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section
+        * Thing
+        * Other thing
+        * Third thing
+      ASCIIDOC
+    end
+    it 'is wrapped an itemizedlist div' do
+      expect(converted).to include('<div class="ulist itemizedlist">')
+    end
+    it 'has the itemizedlist class' do
+      expect(converted).to include('<ul class="itemizedlist"')
+    end
+    context 'the first item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Thing
+          </li>
+        HTML
+      end
+    end
+    context 'the second item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Other thing
+          </li>
+        HTML
+      end
+    end
+    context 'the third item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Third thing
+          </li>
+        HTML
+      end
+    end
+  end
+
+  context 'backticked code' do
+    let(:input) do
+      <<~ASCIIDOC
+        = Title
+
+        == Section
+        Words `backticked`.
+      ASCIIDOC
+    end
+    it 'is considered a "literal" by default' do
+      expect(converted).to include('<code class="literal">backticked</code>')
     end
   end
 end

--- a/template/__test__/template.test.js
+++ b/template/__test__/template.test.js
@@ -155,7 +155,7 @@ describe(Template, () => {
     describe("when it gets a document without a body", () => {
       test("throws an exception", () => {
         return expect(template.applyToString(`<html><head><script>foo</script></head></html>`))
-          .rejects.toThrow(/Couldn't find <body in raw/);
+          .rejects.toThrow(/Couldn't find <body> in raw/);
       });
     });
     describe("when it gets a document with an unclosed body", () => {

--- a/template/template.js
+++ b/template/template.js
@@ -107,12 +107,7 @@ module.exports = templateSource => {
         yield* template.gather("<!-- DOCS LANG -->");
         yield `lang="${lang}"`;
         yield* template.gather("<!-- DOCS BODY -->");
-        /*
-         * Docbook spits out <body> and asciidoctor spits out <body class=....>
-         * Either way, we just want what comes after the body tag.
-         */
-        await raw.dump("<body");
-        await raw.dump(">");
+        await raw.dump("<body>");
         yield* raw.gather("</body>");
         yield* template.gather("<!-- DOCS FINAL -->");
         yield `<script type="text/javascript">


### PR DESCRIPTION
This improves our plugin for direct html generation in Asciidoctor to
the point where the diff for the perl client's docs is empty. Now, that
isn't as big a feat as it sounds because:
1. Most of the perl client's docs are on CPAM so the docs we actually
build are pretty small.
2. I pull a few tricks with `html_diff` to ignore a few changes that
don't *look* like they make any visual difference to me.

Even with those two caveates, this is pretty good progress. It switches
the perl client to direct html, because, well, I did all the work to
make sure the diff is empty.
