### PR TITLE
Boilerplate for EOL/OOM notices.

### DIFF
--- a/shared/notices/README.txt
+++ b/shared/notices/README.txt
@@ -1,0 +1,9 @@
+This directory contains boilerplate notices for versions that have reached 
+the end of their maintenance period or end of life. 
+For the official Elastic product maintenance/EOL schedule, see https://www.elastic.co/support/eol. 
+
+To use, set the version and product name and save as page_header.html
+alongside the book's index.asciidoc file. 
+
+Note that you can create a custom page header for any version of a book. 
+The header must be valid HTML and cannot contain comments.

--- a/shared/notices/page_header-EOL.html
+++ b/shared/notices/page_header-EOL.html
@@ -1,0 +1,10 @@
+<p>
+  <strong>WARNING</strong>: Version {version} of {product} has passed its 
+  <a href="https://www.elastic.co/support/eol">EOL date</a>. 
+</p>  
+<p>
+  This documentation is no longer being maintained and may be removed. 
+  If you are running this version, we strongly advise you to upgrade. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>

--- a/shared/notices/page_header-OOM.html
+++ b/shared/notices/page_header-OOM.html
@@ -1,0 +1,9 @@
+<p>
+  <strong>IMPORTANT</strong>: Version {version} of {product} has passed its 
+  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
+</p>  
+<p>
+  This documentation is no longer being updated. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>


### PR DESCRIPTION
The default banner for versions older than the current version does not distinguish between versions that are still being actively maintained and versions that are out of maintenance or EOL. 

Changes that we've been discussing around our backporting policy, "live" docs, and sunsetting old versions mean we need to more clearly communicate to readers when they are looking at a version that is OOM or EOL. 

The intent is that these boilerplate messages will be set on a per-version basis for stack docs that have reached OOM or EOL. Going forward, we'll need some process for adding the notices as versions age.

**Out of maintenance notice:** 
![image](https://user-images.githubusercontent.com/362578/69198220-d9bdb380-0ae8-11ea-8497-8a16147a8199.png)

**EOL notice:**
![image](https://user-images.githubusercontent.com/362578/69198145-9f541680-0ae8-11ea-90ab-491bae51b20f.png)

Relates to: https://github.com/elastic/docs/issues/1407, https://github.com/elastic/docs/issues/1419, https://github.com/elastic/elasticsearch/pull/49131