### PR TITLE
Removes unnecessary repos from Stack Overview

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -144,17 +144,7 @@ contents:
                 path:   docs/en/stack
               -
                 repo:   elasticsearch
-                path:   x-pack/docs
-              -
-                repo:   elasticsearch
                 path:   docs
-              -
-                repo:   kibana
-                path:   docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-                exclude_branches:   [ 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -52,10 +52,10 @@ alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gl
 alias docbldgs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'
 
 # Stack Overview
-alias docbldso='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --resource=$GIT_HOME/beats/libbeat/docs/ --chunk 1'
+alias docbldso='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
 
 # Stack Overview versions 6.3-7.2
-alias docbldsoold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/stack/index.asciidoc --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/elasticsearch/x-pack/docs --resource=$GIT_HOME/elasticsearch/docs --chunk 1'
+alias docbldsoold=docbldso
 
 # Deploying Azure
 alias docbldaz='$GIT_HOME/docs/build_docs --asciidodctor --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/693

This PR removes references to the Kibana,  Beats, and X-Pack Elasticsearch repos from the Stack Overview, since those dependencies are no longer required.