### PR TITLE
Update the PHP docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -530,8 +530,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    7.2
-                branches:   [ master, 7.2, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
+                current:    7.4
+                branches:   [ master, 7.4, 7.2, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients


### PR DESCRIPTION
This PR updates the docs for [elasticsearch-php](https://github.com/elastic/elasticsearch-php) 7.4 branch.
