### PR TITLE
Improve error messsage when no elastic remote

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -197,7 +197,7 @@ sub _pick_best_remote {
         # but two books are in elastic but elasticsearch-cn is special.
         return $1;
     }
-    say "Couldn't an Elastic remote for $toplevel";
+    say "Couldn't find an Elastic remote for $toplevel. Generating edit links targeting the first remote instead.";
     if ($remotes =~ m|\s+(\S+[/:]\S+/\S+)|) {
         return $1;
     }

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -116,7 +116,14 @@ RSpec.describe 'building a single book' do
         paragraph here is required.
       ASCIIDOC
     end
-
+    let(:repo) { src.repo 'src' }
+    context 'the logs' do
+      it 'say they are using the first remote intead' do
+        expect(outputs[0]).to include(<<~LOG)
+          Couldn't find an Elastic remote for #{repo.root}. Generating edit links targeting the first remote instead.
+        LOG
+      end
+    end
     page_context 'chapter.html' do
       it 'has an "unknown" edit url' do
         expect(body).to include(<<~HTML.strip)


### PR DESCRIPTION
When you build docs with `--doc` and the source files don't live in a
git repo with an Elastic remote we log a line about how we can't find
the Elastic remote. We really only need the remote to build edit urls
so if we don't find it then it is *probably* ok because we just use the
first remote. The edit urls are less realistic but that isn't a big
deal usually.

This modifies the message we log to make it clear that it is just about
the edit links.
