### PR TITLE
Improve docbook chunking emulation

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -25,25 +25,56 @@ module Chunker
     end
 
     def convert_section(node)
-      chunk_level = node.document.attr 'chunk_level'
+      doc = node.document
+      chunk_level = doc.attr 'chunk_level'
       return yield unless node.level == chunk_level
 
-      target = write node, node.id, yield
-      link_opts = {
-        type: :link,
-        target: target,
-      }
-      node.document.register :links, target
-      link = Asciidoctor::Inline.new node, :anchor, node.title, link_opts
+      html = form_section_into_page doc, yield
+      target = write doc, node.id, html
+      link_opts = { type: :link, target: target }
+      doc.register :links, target
+      link = Asciidoctor::Inline.new node.parent, :anchor, node.title, link_opts
       %(<li><span class="chapter">#{link.convert}</span></li>)
     end
 
-    def write(node, target, output)
-      dir = node.document.attr 'outdir'
+    def form_section_into_page(doc, html)
+      # We don't use asciidoctor's "parent" documents here because they don't
+      # seem to buy us much and they are an "internal" detail.
+      subdoc = Asciidoctor::Document.new [], subdoc_opts(doc)
+      subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
+      subdoc.convert
+    end
+
+    def subdoc_opts(doc)
+      {
+        attributes: subdoc_attrs(doc),
+        safe: doc.safe,
+        backend: doc.backend,
+        sourcemap: doc.sourcemap,
+        base_dir: doc.base_dir,
+        to_dir: doc.options[:to_dir],
+        standalone: true,
+      }
+    end
+
+    def subdoc_attrs(doc)
+      attrs = doc.attributes.dup
+      # Asciidoctor defaults these attribute to empty string if they aren't
+      # specified and setting them to `nil` clears them. Since we want to
+      # preserve the configuration from the parent into the child, we clear
+      # explicitly them if they aren't found in the parent. If we didn't then
+      # they'd default to fale.
+      attrs['stylesheet'] = nil unless attrs['stylesheet']
+      attrs['icons'] = nil unless attrs['icons']
+      attrs
+    end
+
+    def write(doc, target, html)
+      dir = doc.attr 'outdir'
       file = "#{target}.html"
       path = File.join dir, file
       File.open path, 'w:UTF-8' do |f|
-        f.write output
+        f.write html
       end
       file
     end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -15,6 +15,21 @@ RSpec.describe Chunker do
 
   include_context 'convert without logs'
   let(:backend) { :html5 }
+  let(:standalone) { true }
+
+  shared_examples 'healthy head' do
+    context 'the <head>' do
+      it 'contains the charset' do
+        expect(contents).to include(<<~HTML)
+          <meta charset="UTF-8">
+        HTML
+      end
+      it "doesn't contain the builtin asciidoctor stylesheet" do
+        # We turned the stylesheet off
+        expect(contents).not_to include('<style')
+      end
+    end
+  end
 
   context 'when outdir is configured' do
     let(:outdir) { Dir.mktmpdir }
@@ -24,6 +39,8 @@ RSpec.describe Chunker do
         {
           'outdir' => outdir,
           'chunk_level' => 1,
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
         }
       end
       context 'there is are two level 1 sections' do
@@ -43,6 +60,8 @@ RSpec.describe Chunker do
           ASCIIDOC
         end
         context 'the main output' do
+          let(:contents) { converted }
+          include_examples 'healthy head'
           it 'contains a link to the first section' do
             expect(converted).to include(<<~HTML.strip)
               <li><span class="chapter"><a href="s1.html">Section 1</a></span></li>
@@ -55,7 +74,8 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's1.html' do
-          it 'contains the header' do
+          include_examples 'healthy head'
+          it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">Section 1</h2>')
           end
           it 'contains the contents' do
@@ -63,7 +83,8 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's2.html' do
-          it 'contains the header' do
+          include_examples 'healthy head'
+          it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">Section 2</h2>')
           end
           it 'contains the contents' do

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -19,9 +19,10 @@ RSpec.describe DocbookCompat do
   context 'the header' do
     let(:standalone) { true }
     let(:convert_attributes) do
-      # Shrink the output slightly so it is easier to read
       {
+        # Shrink the output slightly so it is easier to read
         'stylesheet!' => false,
+        # Set some metadata that will be included in the header
         'dc.type' => 'FooType',
         'dc.subject' => 'BarSubject',
         'dc.identifier' => 'BazIdentifier',


### PR DESCRIPTION
Improves the docbook chunking emulation by generating proper headers for
the pages. This allows the templating system to work for them so
now multi-page books at least won't crash with `--direct_html`.
