### PR TITLE
Convert all single page books to direct html

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -320,6 +320,7 @@ contents:
             single:     1
             tags:       Elasticsearch/Resiliency Status
             subject:    Elasticsearch
+            direct_html: true
             sources:
               -
                 repo:   elasticsearch
@@ -497,6 +498,7 @@ contents:
                 single:     1
                 tags:       Clients/Go
                 subject:    Clients
+                direct_html: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -554,6 +556,7 @@ contents:
                 single:     1
                 tags:       Clients/Python
                 subject:    Clients
+                direct_html: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -568,6 +571,7 @@ contents:
                 single:     1
                 tags:       Clients/Community
                 subject:    Clients
+                direct_html: true
                 sources:
                   -
                     repo:   elasticsearch
@@ -1211,6 +1215,7 @@ contents:
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
+            direct_html: true
             sources:
               -
                 repo:   swiftype
@@ -1225,6 +1230,7 @@ contents:
             single:     1
             tags:       App Search/Reference
             subject:    Swiftype
+            direct_html: true
             sources:
               -
                 repo:   swiftype

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -133,7 +133,7 @@ alias docblddg='$GIT_HOME/docs/build_docs --suppress_migration_warnings --doc $G
 
 
 # Elasticsearch Extras
-alias docbldres='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
+alias docbldres='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/resiliency/index.asciidoc --single'
 
 alias docbldpls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/painless/index.asciidoc --chunk 1'
 
@@ -149,7 +149,7 @@ alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/do
 
 alias docbldegr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
-alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
+alias docbldego='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
 
 alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
@@ -157,9 +157,9 @@ alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/doc
 
 alias docbldepl='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
-alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
+alias docbldepy='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
 
-alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
+alias docbldecc='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 
 alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 


### PR DESCRIPTION
This replaces the xmllint/xslt steps with the ruby implementation we've
been working on. It is generally much faster and much easier to
customize.
