### PR TITLE
Plumbing for "extra" HTML in TOCs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -40,6 +40,7 @@ repos:
 
 contents_title:     Elastic Stack and Product Documentation
 
+toc_extra: extra/docs_landing.html
 contents:
     -
         title:      Elastic Stack
@@ -711,6 +712,7 @@ contents:
             chunk:      1
             tags:       Kibana/Reference
             subject:    Kibana
+            toc_extra:  extra/kibana_landing.html
             sources:
               -
                 repo:   kibana

--- a/extra/README
+++ b/extra/README
@@ -1,0 +1,1 @@
+HTML files included into built docs without modification.

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -1,0 +1,1 @@
+<div style="visibility: hidden;"></div>

--- a/extra/kibana_landing.html
+++ b/extra/kibana_landing.html
@@ -1,0 +1,1 @@
+<div style="visibility: hidden;"></div>

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -501,6 +501,47 @@ RSpec.describe 'building all books' do
     end
   end
 
+  context 'when the config has toc_extra' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'repo', 'words'
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      src.write 'toc_extra.html', '<p>extra html</p>'
+      book.toc_extra = 'toc_extra.html'
+      src.toc_extra = 'toc_extra.html'
+    end
+    file_context 'the toc', 'raw/index.html' do
+      it 'includes the extra html' do
+        expect(contents).to include(<<~HTML)
+          <div id="extra">
+          <p>extra html</p>
+          </div>
+        HTML
+      end
+    end
+  end
+  context 'when a book has toc_extra' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'repo', 'words'
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      src.write 'toc_extra.html', '<p>extra html</p>'
+      book.toc_extra = 'toc_extra.html'
+      # Add a second branch to the book so it gets "versions" table of contents
+      repo.switch_to_new_branch 'other'
+      book.branches << 'other'
+    end
+    file_context 'the toc', 'raw/test/index.html' do
+      it 'includes the extra html' do
+        expect(contents).to include(<<~HTML)
+          <div id="extra">
+          <p>extra html</p>
+          </div>
+        HTML
+      end
+    end
+  end
+
   context 'when a book contains migration warnings' do
     shared_context 'convert with migration warnings' do |suppress|
       convert_before do |src, dest|

--- a/integtest/spec/helper/book.rb
+++ b/integtest/spec/helper/book.rb
@@ -51,6 +51,10 @@ class Book
   # Is the book a single page book?
   attr_accessor :single
 
+  ##
+  # Path to extra html to write into the book's table of contents.
+  attr_accessor :toc_extra
+
   def initialize(title, prefix)
     @title = title
     @prefix = prefix
@@ -61,7 +65,7 @@ class Book
     @lang = 'en'
     @respect_edit_url_overrides = @suppress_migration_warnings = false
     @direct_html = @noindex = @single = false
-    @live_branches = nil
+    @live_branches = @toc_extra = nil
   end
 
   ##

--- a/integtest/spec/helper/book_conf.rb
+++ b/integtest/spec/helper/book_conf.rb
@@ -23,6 +23,7 @@ module BookConf
       lang: @lang,
       tags: 'test tag',
       subject: 'Test',
+      toc_extra: @toc_extra,
     }
   end
 

--- a/integtest/spec/helper/source.rb
+++ b/integtest/spec/helper/source.rb
@@ -11,11 +11,14 @@ require_relative 'repo'
 class Source
   attr_reader :books
 
+  attr_accessor :toc_extra
+
   def initialize(tmp)
     @root = File.expand_path 'src', tmp
     Dir.mkdir @root
     @repos = Hash.new { |hash, name| hash[name] = Repo.new name, path(name) }
     @books = {}
+    @toc_extra = nil
   end
 
   ##
@@ -109,9 +112,10 @@ class Source
   def build_conf
     conf = {
       contents_title: 'Test',
+      toc_extra: @toc_extra,
       repos: @repos.values.map { |repo| [repo.name, repo.root] }.to_h,
       contents: @books.values.map(&:conf),
-    }
+    }.compact
     conf = desymbolize_keys conf
     conf.to_yaml
   end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -141,15 +141,17 @@ sub new {
         respect_edit_url_overrides => $respect_edit_url_overrides,
         suppress_migration_warnings => $args{suppress_migration_warnings} || 0,
         direct_html => ( $args{direct_html} || 'false' ) eq 'true',
+        toc_extra => $args{toc_extra} || '',
     }, $class;
 }
 
 #===================================
 sub build {
 #===================================
-    my ( $self, $rebuild ) = @_;
+    my ( $self, $rebuild, $conf_path ) = @_;
 
-    my $toc = ES::Toc->new( $self->title );
+    my $toc_extra = $self->{toc_extra} ? $conf_path->parent->file( $self->{toc_extra} ) : 0;
+    my $toc = ES::Toc->new( $self->title, $toc_extra );
     my $dir = $self->dir;
     $dir->mkpath;
 

--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -8,11 +8,12 @@ use ES::Util qw(build_single);
 #===================================
 sub new {
 #===================================
-    my ( $class, $title, $lang ) = @_;
+    my ( $class, $title, $extra, $lang ) = @_;
     $lang ||= 'en';
     bless {
-        title   => $title,
-        lang    => $lang,
+        title => $title,
+        extra => $extra,
+        lang => $lang,
         entries => []
     }, $class;
 }
@@ -34,6 +35,7 @@ sub write {
     my $adoc_file = $temp_dir->file( 'index.asciidoc' );
     $adoc_file->spew( iomode => '>:utf8', $adoc );
 
+    my $extra = $self->{extra} ? $self->{extra}->slurp( iomode => "<:encoding(UTF-8)" ) : 0;
     build_single( $adoc_file, $raw_dir, $dir,
             type        => 'article',
             lang        => $self->lang,
@@ -42,6 +44,7 @@ sub write {
             private     => 1,   # Don't generate edit me urls
             branch => '', # TOCs don't have a branch but it is a required arg
             relativize => 1,
+            extra => $extra,
     );
     $adoc_file->remove;
 }

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -214,6 +214,7 @@ sub build_single {
     my $roots = $opts{roots};
     my $relativize = $opts{relativize};
     my $direct_html = $opts{direct_html} || 0;
+    my $extra = $opts{extra} || 0;
 
     die "Can't find index [$index]" unless -f $index;
 
@@ -336,6 +337,13 @@ sub build_single {
     unless ( $direct_html ) {
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
         $contents = _html5ify( $contents );
+        $html_file->spew( iomode => '>:utf8', $contents );
+    }
+
+    if ( $extra ) {
+        my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
+        $contents =~ s{<div class="(article|book)"}{<div id="extra">\n$extra\n</div>\n<div class="$1"} or
+            die "Couldn't add toc_extra to $contents";
         $html_file->spew( iomode => '>:utf8', $contents );
     }
 


### PR DESCRIPTION
This adds the perl plumbing for "extra" HTML that is added to the table
of contents after it is rendered. This *probably* won't be enough
for #1338 but it is a good start.
