### PR TITLE
Added the alternative examples for Cloud

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -677,7 +677,7 @@ contents:
                 alternatives: { source_lang: csharp, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }
                 repo:   clients-team
@@ -727,6 +727,12 @@ contents:
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
+                  2.4: master
+                  2.3: master
+                  2.2: master
+                  2.1: master
+                  2.0: master
+                  1.1: master
                   1.0: master
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }

--- a/conf.yaml
+++ b/conf.yaml
@@ -672,6 +672,36 @@ contents:
               -
                 repo:   cloud
                 path:   docs/heroku
+              -
+                alternatives: { source_lang: csharp, alternative_lang: php }
+                repo:   clients-team
+                path:   examples/elastic-cloud/php
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: go }
+                repo:   clients-team
+                path:   examples/elastic-cloud/go
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                repo:   clients-team
+                path:   examples/elastic-cloud/ruby
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: java }
+                repo:   clients-team
+                path:   examples/elastic-cloud/java
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                repo:   clients-team
+                path:   examples/elastic-cloud/javascript
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: python }
+                repo:   clients-team
+                path:   examples/elastic-cloud/python
+                private: true
 
           -
             title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
@@ -691,6 +721,36 @@ contents:
                 repo:   cloud
                 path:   docs/shared
                 exclude_branches: [ 1.0 ]
+              -
+                alternatives: { source_lang: csharp, alternative_lang: php }
+                repo:   clients-team
+                path:   examples/elastic-cloud/php
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: go }
+                repo:   clients-team
+                path:   examples/elastic-cloud/go
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                repo:   clients-team
+                path:   examples/elastic-cloud/ruby
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: java }
+                repo:   clients-team
+                path:   examples/elastic-cloud/java
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                repo:   clients-team
+                path:   examples/elastic-cloud/javascript
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: python }
+                repo:   clients-team
+                path:   examples/elastic-cloud/python
+                private: true
 
           -
             title:      Elastic Cloud on Kubernetes

--- a/conf.yaml
+++ b/conf.yaml
@@ -624,32 +624,33 @@ contents:
                 alternatives: { source_lang: csharp, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
-                private: true
+                map_branches: &mapCloudSaasToClientsTeam
+                  release-ms-28: master
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
 
           -
             title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
@@ -681,27 +682,27 @@ contents:
                 alternatives: { source_lang: csharp, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
-                private: true
+                map_branches: *mapCloudSaasToClientsTeam
 
           -
             title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
@@ -725,32 +726,33 @@ contents:
                 alternatives: { source_lang: csharp, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
-                private: true
+                map_branches: &mapCloudEceToClientsTeam
+                  1.0: master
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
-                private: true
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
-                private: true
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
-                private: true
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
-                private: true
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: csharp, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
-                private: true
+                map_branches: *mapCloudEceToClientsTeam
 
           -
             title:      Elastic Cloud on Kubernetes

--- a/conf.yaml
+++ b/conf.yaml
@@ -619,6 +619,36 @@ contents:
               -
                 repo:   cloud
                 path:   docs/shared
+              -
+                alternatives: { source_lang: csharp, alternative_lang: php }
+                repo:   clients-team
+                path:   examples/elastic-cloud/php
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: go }
+                repo:   clients-team
+                path:   examples/elastic-cloud/go
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                repo:   clients-team
+                path:   examples/elastic-cloud/ruby
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: java }
+                repo:   clients-team
+                path:   examples/elastic-cloud/java
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                repo:   clients-team
+                path:   examples/elastic-cloud/javascript
+                private: true
+              -
+                alternatives: { source_lang: csharp, alternative_lang: python }
+                repo:   clients-team
+                path:   examples/elastic-cloud/python
+                private: true
 
           -
             title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users

--- a/conf.yaml
+++ b/conf.yaml
@@ -9,6 +9,7 @@ repos:
     apm-agent-dotnet:     https://github.com/elastic/apm-agent-dotnet.git
     azure-marketplace:    https://github.com/elastic/azure-marketplace.git
     beats:                https://github.com/elastic/beats.git
+    clients-team:         https://github.com/elastic/clients-team.git
     cloud:                https://github.com/elastic/cloud.git
     cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
     curator:              https://github.com/elastic/curator.git


### PR DESCRIPTION
This PR adds the alternative examples to the cloud docs. Currently only the SaaS book is currently subjected, as the display is still in PoC.

/cc @nik9000 & @russcam 