### PR TITLE
Add libbeat/outputs dirs to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -882,6 +882,10 @@ contents:
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
@@ -930,6 +934,10 @@ contents:
                 path:   x-pack/filebeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
@@ -965,6 +973,10 @@ contents:
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1016,6 +1028,10 @@ contents:
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -1055,7 +1071,10 @@ contents:
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
-
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1103,6 +1122,10 @@ contents:
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0 ]
@@ -1139,6 +1162,10 @@ contents:
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -
@@ -1172,6 +1199,10 @@ contents:
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
                 exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
Adds path statements to get asciidoc source files from directories under libbeat/outputs/docs.

Prep work for more refactoring of libbeat.