### PR TITLE
Handle single-level TOCs in direct html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -63,7 +63,7 @@ module DocbookCompat
 
     def munge_title(doc, html)
       id = doc.id || 'id-1'
-      # Important: we're not replacing he whole header - it still will have a
+      # Important: we're not replacing the whole header - it still will have a
       # closing </div>.
       header_start = <<~HTML
         <div class="titlepage">

--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert lists.
+  module ConvertLists
+    def convert_ulist(node)
+      node.style ||= 'itemizedlist'
+      node.items.each { |item| item.attributes['role'] ||= 'listitem' }
+      html = yield
+      node.items.each do |item|
+        next unless item.text
+
+        html.sub!("<p>#{item.text}</p>", item.text) ||
+          raise("Couldn't remove <p> for #{item.text} in #{html}")
+      end
+      html
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert the table of contents.
+  module ConvertOutline
+    def convert_outline(node)
+      # Asciidoctor's implementation looks lovely but doesn't match docbook's
+      # implementation. So we drop our own in. We should see if we can use
+      # Asciidoctor's implementation ASAP though.
+      result = [%(<ul class="toc">\n)]
+      node.sections.each do |section|
+        result << <<~HTML
+          <li><span class="#{wrapper_class_for section}"><a href="##{section.id}">#{section.title}</a></span>
+          </li>
+        HTML
+      end
+      result << '</ul>'
+      result.join
+    end
+  end
+end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -81,9 +81,12 @@ RSpec.describe DocbookCompat do
     context 'the header' do
       it "is wrapped in docbook's funny titlepage" do
         expect(converted).to include(<<~HTML)
-          <div class="titlepage"><div><div>
+          <div class="titlepage">
+          <div><div>
           <h1 class="title"><a id="id-1"></a>Title</h1>
-          </div></div><hr></div>
+          </div></div>
+          <hr>
+          </div>
         HTML
       end
     end
@@ -99,45 +102,71 @@ RSpec.describe DocbookCompat do
       context 'the header' do
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
-            <div class="titlepage"><div><div>
+            <div class="titlepage">
+            <div><div>
             <h1 class="title"><a id="title-id"></a>Title</h1>
-            </div></div><hr></div>
+            </div></div>
+            <hr>
+            </div>
           HTML
         end
       end
     end
-    # Next!
-    # context 'when there is a table of contents' do
-    #   let(:convert_attributes) do
-    #     {
-    #       # Shrink the output slightly so it is easier to read
-    #       'stylesheet!' => false,
-    #       # Set some metadata that will be included in the header
-    #       'dc.type' => 'FooType',
-    #       'dc.subject' => 'BarSubject',
-    #       'dc.identifier' => 'BazIdentifier',
-    #       'toc' => '',
-    #     }
-    #   end
-    #   let(:input) do
-    #     <<~ASCIIDOC
-    #       = Title
+    context 'when there is a table of contents' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
+          # Set some metadata that will be included in the header
+          'dc.type' => 'FooType',
+          'dc.subject' => 'BarSubject',
+          'dc.identifier' => 'BazIdentifier',
+          'toc' => '',
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
 
-    #       == Section 1
+          == Section 1
 
-    #       == Section 2
-    #     ASCIIDOC
-    #   end
-    #   context 'the header' do
-    #     it "is wrapped in docbook's funny titlepage" do
-    #       expect(converted).to include(<<~HTML)
-    #         <div class="titlepage"><div><div>
-    #         <h1 class="title"><a id="title-id"></a>Title</h1>
-    #         </div></div><hr></div>
-    #       HTML
-    #     end
-    #   end
-    # end
+          == Section 2
+        ASCIIDOC
+      end
+      context 'the header' do
+        it "is wrapped in docbook's funny titlepage" do
+          expect(converted).to include(<<~HTML)
+            <div class="titlepage">
+            <div><div>
+            <h1 class="title"><a id="id-1"></a>Title</h1>
+            </div></div>
+            <hr>
+          HTML
+        end
+      end
+      context 'the table of contents' do
+        it 'is outside the titlepage' do
+          expect(converted).to include(<<~HTML)
+            <hr>
+            </div>
+            <div id="content">
+            <div class="toc">
+          HTML
+        end
+        it 'looks like the docbook toc' do
+          expect(converted).to include(<<~HTML)
+            <div class="toc">
+            <ul class="toc">
+            <li><span class="chapter"><a href="#_section_1">Section 1</a></span>
+            </li>
+            <li><span class="chapter"><a href="#_section_2">Section 2</a></span>
+            </li>
+            </ul>
+            </div>
+          HTML
+        end
+      end
+    end
   end
 
   context 'sections' do


### PR DESCRIPTION
This modifies the docbook_compat plugin to add the table of contents to
the same location that docbook adds it and to generate it in the same
style that docbook uses. It only works for a single level, but that
should be fine for now. We'll improve it in further work.
