### PR TITLE
Add Copy as cURL links for Cloud and ECE

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1050,13 +1050,22 @@ footnote to a particular line of code:
 <1> Here's the explanation
 ==================================
 
-[[console-snippets]]
-=== View in Console
+[[copy-as-curl]]
+=== Copy as cURL/View in Console
 
-Code blocks can be followed by a "View in Console" link which, when clicked,
-will open the code snippet in Console. This is how you do it:
+Code blocks can be followed by a "Copy as cURL" link which will convert the
+snippet into a sequence of calls to the ubiquitous
+https://curl.haxx.se/[cURL] tool that work in the bash shell and copy it to
+the clipboard. Similarly, if the target of the snippet is Elasticsearch we also
+add a "View in Console" link will open the code snippet in Console.
 
-.Code block with CONSOLE link
+You enable the it be setting the "language" of the snippet to a supported
+language. The options are "console" for Elasticsearch, "kibana" for Kibana,
+"ess" for Elastic Cloud, and "ece" for Elastic Cloud Enterprise.
+
+For Elasticsearch do this:
+
+.Code block with "Copy as cURL" and "View in Console" link for Elasticsearch
 ==================================
 [source,asciidoc]
 --
@@ -1067,26 +1076,84 @@ GET /_search
     "query": "foo bar" \<1>
 }
 ----------------------------------
-
 <1> Here's the explanation
 --
 ==================================
 
 Which renders as:
 
-[source,js]
+[source,console]
 ----------------------------------
 GET /_search
 {
     "query": "foo bar" <1>
 }
 ----------------------------------
-// CONSOLE
-
 <1> Here's the explanation
 
 NOTE: In older branches you'll see `// CONSOLE` after the snippet to trigger
       this behavior. That is deprecated.
+
+For Kibana do this:
+
+.Code block with "Copy as cURL" link for Kibana
+==================================
+[source,asciidoc]
+--
+[source,kibana]
+----------------------------------
+GET /
+----------------------------------
+<1> Here's the explanation
+--
+==================================
+
+Which renders as:
+
+[source,kibana]
+----------------------------------
+GET /
+----------------------------------
+
+For Elastic Cloud SAAS do this:
+
+.Code block with "Copy as cURL" link for Elastic Cloud SAAS
+==================================
+[source,asciidoc]
+--
+[source,ess]
+----------------------------------
+GET /
+----------------------------------
+--
+==================================
+
+Which renders as:
+
+[source,ess]
+----------------------------------
+GET /
+----------------------------------
+
+For Elastic Cloud Enterprise do this:
+
+.Code block with "Copy as cURL" link for Elastic Cloud Enterprise
+==================================
+[source,asciidoc]
+--
+[source,ece]
+----------------------------------
+GET /
+----------------------------------
+--
+==================================
+
+Which renders as:
+
+[source,ece]
+----------------------------------
+GET /
+----------------------------------
 
 ==== Responses
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1059,7 +1059,7 @@ https://curl.haxx.se/[cURL] tool that work in the bash shell and copy it to
 the clipboard. Similarly, if the target of the snippet is Elasticsearch we also
 add a "View in Console" link will open the code snippet in Console.
 
-You enable the it be setting the "language" of the snippet to a supported
+You enable the it by setting the "language" of the snippet to a supported
 language. The options are "console" for Elasticsearch, "kibana" for Kibana,
 "ess" for Elasticsearch Service (Elastic's official SaaS offering), and "ece"
 for Elastic Cloud Enterprise.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1061,7 +1061,8 @@ add a "View in Console" link will open the code snippet in Console.
 
 You enable the it be setting the "language" of the snippet to a supported
 language. The options are "console" for Elasticsearch, "kibana" for Kibana,
-"ess" for Elastic Cloud, and "ece" for Elastic Cloud Enterprise.
+"ess" for Elasticsearch Service (Elastic's official SaaS offering), and "ece"
+for Elastic Cloud Enterprise.
 
 For Elasticsearch do this:
 
@@ -1115,9 +1116,9 @@ Which renders as:
 GET /
 ----------------------------------
 
-For Elastic Cloud SAAS do this:
+For Elasticsearch Service do this:
 
-.Code block with "Copy as cURL" link for Elastic Cloud SAAS
+.Code block with "Copy as cURL" link for Elasticsearch Service
 ==================================
 [source,asciidoc]
 --

--- a/resources/web/docs_js/__tests__/utils.test.js
+++ b/resources/web/docs_js/__tests__/utils.test.js
@@ -19,13 +19,11 @@ describe("getCurlText", () => {
   test("it adds curl user and password only when both are present", () => {
     const result1 = utils.getCurlText({consoleText: snippetGen(),
                                        curl_host: "http://localhost:9200",
-                                       curl_user: "elastic",
-                                       langStrings});
+                                       curl_user: "elastic"});
     const result2 = utils.getCurlText({consoleText: snippetGen(),
                                        curl_host: "http://localhost:9200",
-                                       curl_pw: "elastic",
-                                       langStrings});
-    const expected = `curl -X GET "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
+                                       curl_pw: "elastic"});
+    const expected = `curl -X GET "http://localhost:9200/_search" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -40,9 +38,8 @@ describe("getCurlText", () => {
     const result = utils.getCurlText({consoleText: snippetGen(),
                                       curl_host: "http://localhost:9200",
                                       curl_user: "elastic",
-                                      curl_password: "abcde",
-                                      langStrings});
-    const expected = `curl -X GET -u elastic:abcde "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
+                                      curl_password: "abcde"});
+    const expected = `curl -X GET -u elastic:abcde "http://localhost:9200/_search" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -57,9 +54,24 @@ describe("getCurlText", () => {
                                       isKibana: true,
                                       curl_user: "elastic",
                                       curl_password: "abcde",
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
+                                      curl_host: "http://localhost:9200"});
     const expected = `curl -X GET -u elastic:abcde "http://localhost:9200/_search" -H 'kbn-xsrf: true' -H 'Content-Type: application/json' -d'
+{
+    "query": "foo bar" 
+}
+'
+`;
+
+    expect(result).toBe(expected);
+  });
+
+  test("it adds the pretty parameter when addKibana is true", () => {
+    const result = utils.getCurlText({consoleText: snippetGen(),
+                                      addPretty: true,
+                                      curl_user: "elastic",
+                                      curl_password: "abcde",
+                                      curl_host: "http://localhost:9200"});
+    const expected = `curl -X GET -u elastic:abcde "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -71,9 +83,8 @@ describe("getCurlText", () => {
 
   test("it appends 'pretty' to existing query string", () => {
     const result = utils.getCurlText({consoleText: snippetGen({path: "/_search?q=dev"}),
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
-    const expected = `curl -X GET "http://localhost:9200/_search?q=dev&pretty" -H 'Content-Type: application/json' -d'
+                                      curl_host: "http://localhost:9200"});
+    const expected = `curl -X GET "http://localhost:9200/_search?q=dev" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -86,9 +97,8 @@ describe("getCurlText", () => {
 
   test("it creates the '?pretty' query string when none is present", () => {
     const result = utils.getCurlText({consoleText: snippetGen({path: "/_search"}),
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
-    const expected = `curl -X GET "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
+                                      curl_host: "http://localhost:9200"});
+    const expected = `curl -X GET "http://localhost:9200/_search" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -100,9 +110,8 @@ describe("getCurlText", () => {
 
   test("it adds '-I' when the method is 'HEAD'", () => {
     const result = utils.getCurlText({consoleText: snippetGen({method: "HEAD"}),
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
-    const expected = `curl -I "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
+                                      curl_host: "http://localhost:9200"});
+    const expected = `curl -I "http://localhost:9200/_search" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -114,9 +123,8 @@ describe("getCurlText", () => {
 
   test("it adds '-X <method>' when the method is not 'HEAD'", () => {
     const result = utils.getCurlText({consoleText: snippetGen({method: "PUT"}),
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
-    const expected = `curl -X PUT "http://localhost:9200/_search?pretty" -H 'Content-Type: application/json' -d'
+                                      curl_host: "http://localhost:9200"});
+    const expected = `curl -X PUT "http://localhost:9200/_search" -H 'Content-Type: application/json' -d'
 {
     "query": "foo bar" 
 }
@@ -129,9 +137,8 @@ describe("getCurlText", () => {
 
   test("it handles no body", () => {
     const result = utils.getCurlText({consoleText: 'GET /_search?q=dev\n',
-                                      curl_host: "http://localhost:9200",
-                                      langStrings});
-    const expected = 'curl -X GET "http://localhost:9200/_search?q=dev&pretty"\n';
+                                      curl_host: "http://localhost:9200"});
+    const expected = 'curl -X GET "http://localhost:9200/_search?q=dev"\n';
     expect(result).toBe(expected);
   });
 });

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -7,7 +7,7 @@ import {openModal} from "../actions/modal";
 import {saveSettings} from "../actions/settings";
 import AlternativePicker from "./alternative_picker";
 
-const copyAsCurl = ({setting, consoleText, isKibana}) => (_, getState) => {
+const copyAsCurl = ({setting, consoleText, isKibana, addPretty}) => (_, getState) => {
   const state       = getState();
   const langStrings = state.settings.langStrings;
 
@@ -17,7 +17,7 @@ const copyAsCurl = ({setting, consoleText, isKibana}) => (_, getState) => {
     curl_password: prop(setting + "_curl_password", state.settings)
   };
 
-  const curlText = utils.getCurlText(merge(curlVals, {consoleText, isKibana, langStrings}))
+  const curlText = utils.getCurlText(merge(curlVals, {consoleText, isKibana, addPretty}))
   return utils.copyText(curlText, langStrings);
 }
 
@@ -77,7 +77,12 @@ export const ConsoleWidget = props => {
     <AlternativePicker />
     <div className="u-space-between">
       <a className="sense_widget copy_as_curl"
-        onClick={e => props.copyAsCurl({isKibana: props.isKibana, consoleText: props.consoleText, setting: props.setting})}>
+        onClick={e => props.copyAsCurl({
+          isKibana: props.isKibana,
+          consoleText: props.consoleText,
+          setting: props.setting,
+          addPretty: props.addPretty
+        })}>
         {props.langStrings('Copy as cURL')}
       </a>
       {props.view_in_text &&

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -213,8 +213,8 @@ $(function() {
 
     return mount(div, ConsoleWidget, {
       setting: "ess",
-      url_label: 'Enter the URL of Elastic Cloud',
-      configure_text: 'Configure Elastic Cloud URL',
+      url_label: 'Enter the endpoint URL of the Elasticsearch Service',
+      configure_text: 'Configure the Elasticsearch Service endpoint URL',
       consoleText,
       snippet
     });
@@ -226,8 +226,8 @@ $(function() {
 
     return mount(div, ConsoleWidget, {
       setting: "ece",
-      url_label: 'Enter the URL of Elastic Cloud',
-      configure_text: 'Configure Elastic Cloud URL',
+      url_label: 'Enter the endpoint URL of Elastic Cloud Enterprise',
+      configure_text: 'Configure the Elastic Cloud Enterprise endpoint URL',
       consoleText,
       snippet
     });

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -50,6 +50,7 @@ export function init_console_widgets() {
                                       url_label: 'Enter the URL of the Console editor',
                                       view_in_text: 'View in Console',
                                       configure_text: 'Configure Console URL',
+                                      addPretty: true,
                                       consoleText,
                                       snippet});
   });
@@ -65,6 +66,7 @@ export function init_sense_widgets() {
                                       url_label: 'Enter the URL of the Sense editor',
                                       view_in_text: 'View in Sense',
                                       configure_text: 'Configure Sense URL',
+                                      addPretty: true,
                                       consoleText,
                                       snippet});
   });
@@ -143,6 +145,8 @@ $(function() {
   const default_kibana_url  = 'http://localhost:5601',
         default_console_url = default_kibana_url + '/app/kibana#/dev_tools/console',
         default_sense_url   = default_kibana_url + '/app/sense/',
+        default_ess_url     = 'http://localhost:5601', // localhost is wrong, but we'll enhance this later
+        default_ece_url     = 'http://localhost:5601',
         base_url            = utils.get_base_url(window.location.href),
         LangStrings         = lang_strings(lang);
 
@@ -164,6 +168,14 @@ $(function() {
       sense_curl_host: Cookies.get("sense_curl_host") || "localhost:9200",
       sense_curl_user: Cookies.get("sense_curl_user"),
       sense_curl_password: "$ESPASS",
+      ess_url: Cookies.get("ess_url") || default_ess_url,
+      ess_curl_host: Cookies.get("ess_curl_host") || "localhost:5601",
+      ess_curl_user: Cookies.get("ess_curl_user"),
+      ess_curl_password: "$CLOUD_PASS",
+      ece_url: Cookies.get("ece_url") || default_ece_url,
+      ece_curl_host: Cookies.get("ece_curl_host") || "localhost:5601",
+      ece_curl_user: Cookies.get("ece_curl_user"),
+      ece_curl_password: "$ECE_PASS",
       consoleAlternative: Cookies.get('consoleAlternative') || "console",
     },
     /*
@@ -194,6 +206,32 @@ $(function() {
   init_sense_widgets();
   init_console_widgets();
   init_kibana_widgets();
+  $("div.ess_widget").each(function() {
+    const div         = $(this),
+          snippet     = div.attr('data-snippet'),
+          consoleText = div.prev().text() + '\n';
+
+    return mount(div, ConsoleWidget, {
+      setting: "ess",
+      url_label: 'Enter the URL of Elastic Cloud',
+      configure_text: 'Configure Elastic Cloud URL',
+      consoleText,
+      snippet
+    });
+  });
+  $("div.ece_widget").each(function() {
+    const div         = $(this),
+          snippet     = div.attr('data-snippet'),
+          consoleText = div.prev().text() + '\n';
+
+    return mount(div, ConsoleWidget, {
+      setting: "ece",
+      url_label: 'Enter the URL of Elastic Cloud',
+      configure_text: 'Configure Elastic Cloud URL',
+      consoleText,
+      snippet
+    });
+  });
 
   var div = $('div.toc');
 

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -8,11 +8,11 @@ export const lang_spec = {
   "Configure Kibana URL": {
     "zh_cn": "配置 Kibana URL"
   },
-  "Configure Elastic Cloud URL": {
-    "zh_cn": "配置 Elastic Cloud URL"
+  "Configure the Elasticsearch Service endpoint URL": {
+    "zh_cn": "配置 Elastic Cloud endpoint URL"
   },
-  "Configure Elastic Cloud Enterprise URL": {
-    "zh_cn": "配置 Elastic Cloud Enerprise URL"
+  "Configure the Elastic Cloud Enterprise endpoint URL'": {
+    "zh_cn": "配置 Elastic Cloud Enterprise endpoint URL"
   },
   "Copy as cURL": {
     "zh_cn": "拷贝为 cURL"

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -8,6 +8,12 @@ export const lang_spec = {
   "Configure Kibana URL": {
     "zh_cn": "配置 Kibana URL"
   },
+  "Configure Elastic Cloud URL": {
+    "zh_cn": "配置 Elastic Cloud URL"
+  },
+  "Configure Elastic Cloud Enterprise URL": {
+    "zh_cn": "配置 Elastic Cloud Enerprise URL"
+  },
   "Copy as cURL": {
     "zh_cn": "拷贝为 cURL"
   },

--- a/resources/web/docs_js/utils.js
+++ b/resources/web/docs_js/utils.js
@@ -54,7 +54,7 @@ export const getCurlText = ({consoleText,
                              curl_user,
                              curl_password,
                              isKibana,
-                             langStrings}) => {
+                             addPretty}) => {
   var regex    = console_regex(),
       curlText = '',
       match;
@@ -78,7 +78,7 @@ export const getCurlText = ({consoleText,
         curlText += `-u ${curl_user}:${curl_password} `;
       }
 
-      if (!isKibana) {
+      if (addPretty) {
         path += path.includes('?') ? '&pretty' : '?pretty';
       }
 

--- a/resources/web/style/console_widget.pcss
+++ b/resources/web/style/console_widget.pcss
@@ -1,5 +1,5 @@
 #guide {
-  div.console_widget, div.kibana_widget, div.sense_widget {
+  div.console_widget, div.kibana_widget, div.sense_widget, div.ess_widget, div.ece_widget {
     display: block;
     margin: -15px 0 15px auto;
     border-top: 1px solid #535966;

--- a/resources/website_common.xsl
+++ b/resources/website_common.xsl
@@ -306,7 +306,7 @@
       <xsl:apply-imports />
     </div>
     <!-- Asciidoctor's CONSOLE widget -->
-    <xsl:if test="@language = 'console' or @language = 'sense' or @language = 'kibana'">
+    <xsl:if test="@language = 'console' or @language = 'sense' or @language = 'kibana' or @language = 'ess' or @language = 'ece'">
       <xsl:variable name="widget_class">
         <xsl:value-of select="@language"/>_widget
         <xsl:value-of select="substring-after(@role, 'default')"/>


### PR DESCRIPTION
Adds "Copy as cURL" links for Elastic Cloud SAAS and Elastic Cloud
Enterprise.

Also removes the "langStrings" passed into the curl building code. We
don't need it.
