### PR TITLE
Handle subtitles in direct_html

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -373,7 +373,7 @@ sub _add_extra_title_page {
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
         # Wrapping the extra in a div is a relic of docbook. But we're trying
         # to emulate docbook so here we are.
-        $contents =~ s|</h1>\n</div>|</h1>\n</div><div>\n$extra_title_page\n</div>| or
+        $contents =~ s|</h1></div>|</h1></div>\n<div>\n$extra_title_page\n</div>| or
             die "Couldn't add extra-title-page to $contents";
         $html_file->spew( iomode => '>:utf8', $contents );
     }

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe DocbookCompat do
       it "is wrapped in docbook's funny titlepage" do
         expect(converted).to include(<<~HTML)
           <div class="titlepage">
-          <div><div>
-          <h1 class="title"><a id="id-1"></a>Title</h1>
-          </div></div>
+          <div>
+          <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
+          </div>
           <hr>
           </div>
         HTML
@@ -103,9 +103,9 @@ RSpec.describe DocbookCompat do
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div><div>
-            <h1 class="title"><a id="title-id"></a>Title</h1>
-            </div></div>
+            <div>
+            <div><h1 class="title"><a id="title-id"></a>Title</h1></div>
+            </div>
             <hr>
             </div>
           HTML
@@ -137,9 +137,9 @@ RSpec.describe DocbookCompat do
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div><div>
-            <h1 class="title"><a id="id-1"></a>Title</h1>
-            </div></div>
+            <div>
+            <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
+            </div>
             <hr>
           HTML
         end
@@ -164,6 +164,33 @@ RSpec.describe DocbookCompat do
             </ul>
             </div>
           HTML
+        end
+      end
+      context 'when there is a subtitle' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title: Subtitle
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the title' do
+          it "doesn't include the subtitle" do
+            expect(converted).to include('<title>Title | Elastic</title>')
+          end
+        end
+        context 'the header' do
+          it 'includes the title and subtitle' do
+            expect(converted).to include(<<~HTML)
+              <div class="titlepage">
+              <div>
+              <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
+              <div><h2 class="subtitle">Subtitle</h2></div>
+              </div>
+              <hr>
+              </div>
+            HTML
+          end
         end
       end
     end


### PR DESCRIPTION
Handles subtitles in `--direct_html` the same way that we handle them in
docbook.
