### PR TITLE
Add home link to direct html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -16,22 +16,27 @@ module Chunker
     doc.attributes['toclevels'] ||= doc.attributes['chunk_level']
 
     DelegatingConverter.setup(registry.document) { |d| Converter.new d }
-
-    def doc.docinfo(location = :head, suffix = nil)
-      info = super
-      return info unless location == :head
-
-      title = doctitle partition: true
-      info += <<~HTML
-        <link rel="home" href="index.html" title="#{title.main}"/>
-      HTML
-      info
-    end
   end
 
   ##
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
+    def convert_document(doc)
+      def doc.docinfo(location = :head, suffix = nil)
+        info = super
+        return info unless location == :head
+  
+        info + <<~HTML
+          <link rel="home" href="index.html" title="#{attr 'home'}"/>
+        HTML
+      end
+      unless doc.attr 'home'
+        title = doc.doctitle partition: true
+        doc.attributes['home'] = title.main
+      end
+      yield
+    end
+
     def convert_section(node)
       doc = node.document
       chunk_level = doc.attr 'chunk_level'

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -24,6 +24,20 @@ module Chunker
       super(delegate)
     end
 
+    def convert_document(doc)
+      def doc.docinfo(location = :head, suffix = nil)
+        info = super
+        return info unless location == :head
+
+        title = doctitle partition: true
+        info += <<~HTML
+          <link rel="home" href="index.html" title="#{title.main}"/>
+        HTML
+        info
+      end
+      yield
+    end
+
     def convert_section(node)
       doc = node.document
       chunk_level = doc.attr 'chunk_level'

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -22,14 +22,7 @@ module Chunker
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
     def convert_document(doc)
-      def doc.docinfo(location = :head, suffix = nil)
-        info = super
-        return info unless location == :head
-  
-        info + <<~HTML
-          <link rel="home" href="index.html" title="#{attr 'home'}"/>
-        HTML
-      end
+      doc.extend ExtraDocinfo
       unless doc.attr 'home'
         title = doc.doctitle partition: true
         doc.attributes['home'] = title.main
@@ -104,6 +97,19 @@ module Chunker
           raise("Couldn't fix section link for #{section.id} in #{outline}")
         cleanup_outline outline, section, toclevels if section.level < toclevels
       end
+    end
+  end
+
+  ##
+  # Adds extra tags <link> tags to the <head> to emulate docbook.
+  module ExtraDocinfo
+    def docinfo(location = :head, suffix = nil)
+      info = super
+      return info unless location == :head
+
+      info + <<~HTML
+        <link rel="home" href="index.html" title="#{attributes['home']}"/>
+      HTML
     end
   end
 end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -24,6 +24,11 @@ RSpec.describe Chunker do
           <meta charset="UTF-8">
         HTML
       end
+      it 'contains the home link' do
+        expect(contents).to include(<<~HTML)
+          <link rel="home" href="index.html" title="Title"/>
+        HTML
+      end
       it "doesn't contain the builtin asciidoctor stylesheet" do
         # We turned the stylesheet off
         expect(contents).not_to include('<style')


### PR DESCRIPTION
Docbook generates a `<link rel="home"` in the header. We should do so
too, if just to line up with docbook.
