### PR TITLE
Remove non-live versions from the drop downs

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -326,11 +326,15 @@ sub _update_title_and_version_drop_downs {
     my ( $self, $branch_dir, $branch ) = @_;
 
     my $title = '<li id="book_title"><span>' . $self->title . ': <select>';
-    for ( @{ $self->branches } ) {
-        $title .= '<option value="' . $_ . '"';
-        $title .= ' selected'  if $branch eq $_;
-        $title .= '>' . $self->branch_title($_);
-        $title .= ' (current)' if $self->current eq $_;
+    for my $b ( @{ $self->branches } ) {
+        my $live = grep( /^$b$/, @{ $self->{live_branches} } );
+        next unless $live || $branch eq $b;
+
+        $title .= '<option value="' . $b . '"';
+        $title .= ' selected'  if $branch eq $b;
+        $title .= '>' . $self->branch_title($b);
+        $title .= ' (current)' if $self->current eq $b;
+        $title .= ' (out of date)' unless $live;
         $title .= '</option>';
     }
     $title .= '</select></span></li>';


### PR DESCRIPTION
Removes non-live versions from the version drop downs. We still publish
the non-live versions but we don't want to point folks to them
accidentally.

Closes #1431
