### PR TITLE
Fix direct_html chunking

### DIFF
--- a/.docker/asciidoctor_2_0_10.patch
+++ b/.docker/asciidoctor_2_0_10.patch
@@ -12,3 +12,19 @@ index 5f4d21bb..1530641c 100644
          # handles: id
          elsif doc.catalog[:refs][fragment]
            refid, target = fragment, %(##{fragment})
+
+
+Tracked at https://github.com/asciidoctor/asciidoctor/issues/3491
+diff --git a/lib/asciidoctor/converter/html5.rb b/lib/asciidoctor/converter/html5.rb
+index df411a16..b933f4a4 100644
+--- a/lib/asciidoctor/converter/html5.rb
++++ b/lib/asciidoctor/converter/html5.rb
+@@ -216,7 +216,7 @@ class Converter::Html5Converter < Converter::Base
+         if sectioned && (node.attr? 'toc') && (node.attr? 'toc-placement', 'auto')
+           result << %(<div id="toc" class="#{node.attr 'toc-class', 'toc'}">
+ <div id="toctitle">#{node.attr 'toc-title'}</div>
+-#{convert_outline node}
++#{node.converter.convert node, 'outline'}
+ </div>)
+         end
+       end

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -109,6 +109,8 @@ sub build_chunked {
                 '-a' => 'nofooter',
                 # Pass chunking down
                 '-a' => 'chunk_level=' . ( $chunk + 1 ),
+                # Render the table of contents
+                '-a' => 'toc',
                 # Lock the destination file name to one we expect
                 '--out-file' => 'index.html',
                 # Asciidoctor doesn't pass the destination directory down to

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -7,12 +7,13 @@ require_relative '../delegating_converter'
 # HTML5 converter that chunks like docbook.
 module Chunker
   def self.activate(registry)
-    return unless registry.document.attr 'outdir'
-    return unless (chunk_level = registry.document.attr 'chunk_level')
+    doc = registry.document
+    return unless doc.attr 'outdir'
+    return unless (chunk_level = doc.attr 'chunk_level')
 
-    if chunk_level.is_a? String
-      registry.document.attributes['chunk_level'] = chunk_level.to_i
-    end
+    doc.attributes['chunk_level'] = chunk_level.to_i if chunk_level.is_a? String
+
+    doc.attributes['toclevels'] ||= doc.attributes['chunk_level']
 
     DelegatingConverter.setup(registry.document) { |d| Converter.new d }
   end
@@ -20,21 +21,22 @@ module Chunker
   ##
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
-    def initialize(delegate)
-      super(delegate)
-    end
-
     def convert_section(node)
       doc = node.document
       chunk_level = doc.attr 'chunk_level'
-      return yield unless node.level == chunk_level
+      return yield unless node.level <= chunk_level
 
       html = form_section_into_page doc, yield
-      target = write doc, node.id, html
-      link_opts = { type: :link, target: target }
-      doc.register :links, target
-      link = Asciidoctor::Inline.new node.parent, :anchor, node.title, link_opts
-      %(<li><span class="chapter">#{link.convert}</span></li>)
+      write doc, "#{node.id}.html", html
+      ''
+    end
+
+    def convert_outline(node, opts = {})
+      # Fix links in the toc
+      toclevels = opts[:toclevels] || node.document.attributes['toclevels'].to_i
+      outline = yield
+      cleanup_outline outline, node, toclevels
+      outline
     end
 
     def form_section_into_page(doc, html)
@@ -69,14 +71,21 @@ module Chunker
       attrs
     end
 
-    def write(doc, target, html)
+    def write(doc, file, html)
       dir = doc.attr 'outdir'
-      file = "#{target}.html"
       path = File.join dir, file
       File.open path, 'w:UTF-8' do |f|
         f.write html
       end
       file
+    end
+
+    def cleanup_outline(outline, node, toclevels)
+      node.sections.each do |section|
+        outline.gsub!(%(href="##{section.id}"), %(href="#{section.id}.html")) ||
+          raise("Couldn't fix section link for #{section.id} in #{outline}")
+        cleanup_outline outline, section, toclevels if section.level < toclevels
+      end
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -80,7 +80,7 @@ module DocbookCompat
       html.gsub! '<div id="content">', <<~HTML
         <div id="content">
         <div class="#{doc.attr 'toc-class', 'toc'}">
-        #{convert doc, 'outline'}
+        #{doc.converter.convert doc, 'outline'}
         </div>
       HTML
     end


### PR DESCRIPTION
`--direct_html`'s chunking was broken in two ways:
1. It'd only chunk when the section level matched the chunk level
exactly. It is supposed to chunk when it is less than or equal to the
level. This does that.
2. It wasn't using the standard table of contents mechanism to build the
table of contents. Which is trouble because our fancy table of contents
rendering code wasn't kicking in *and* because the table of contents was
getting scattered across the chunked pages. This fixes that too.
