### PR TITLE
Fix presentation of 2 examples in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -221,6 +221,7 @@ To check links before you merge your changes:
   with the `--sub_dir` option. For example, if you are working on changes that will be merged
   into the master branch of the `elasticsearch` repo, run:
 +
+[source,bash]
 ----------------------------
 ./docs/build_docs --all --target_repo git@github.com:elastic/built-docs.git \
                   --open --keep_hash --sub_dir elasticsearch:master:./elasticsearch
@@ -235,6 +236,7 @@ NOTE: If there are no outstanding changes in the `../elasticsearch` directory
 To run a full build to mimic the website build, omit the `--sub_dir` and
 `--keep_hash` options:
 
+[source,bash]
 ----------------------------
 ./build_docs --all --target_repo git@github.com:elastic/built-docs.git --open
 ----------------------------


### PR DESCRIPTION
Two examples in the README are displaying inconsistently with the rest
because the blocks are missing the Asciidoc "source" attribute.

Add the missing attribute lists above the blocks to fix their
presentation.

**Before:**

![before](https://user-images.githubusercontent.com/362928/69552825-21bb5b00-0f6d-11ea-97ca-d17bfb6f4716.png)

**After:**

![after](https://user-images.githubusercontent.com/362928/69552844-27b13c00-0f6d-11ea-96e1-b9364fe831fc.png)