### PR TITLE
Generate related links for direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -62,14 +62,14 @@ module Chunker
     def form_section_into_page(doc, section, html)
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.
-      subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, title)
+      subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, section)
       subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
       subdoc.convert
     end
 
-    def subdoc_opts(doc, title)
+    def subdoc_opts(doc, section)
       {
-        attributes: subdoc_attrs(doc, title),
+        attributes: subdoc_attrs(doc, section),
         safe: doc.safe,
         backend: doc.backend,
         sourcemap: doc.sourcemap,
@@ -79,10 +79,10 @@ module Chunker
       }
     end
 
-    def subdoc_attrs(doc, title)
+    def subdoc_attrs(doc, section)
       attrs = doc.attributes.dup
       maintitle = doc.doctitle partition: true
-      attrs['title'] = "#{title} | #{maintitle.main}"
+      attrs['title'] = "#{section.title} | #{maintitle.main}"
       # Asciidoctor defaults these attribute to empty string if they aren't
       # specified and setting them to `nil` clears them. Since we want to
       # preserve the configuration from the parent into the child, we clear

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Chunker
+  ##
+  # Adds extra tags <link> tags to the <head> to emulate docbook.
+  module ExtraDocinfo
+    def docinfo(location = :head, suffix = nil)
+      info = super
+      info += extra_head if location == :head
+      info
+    end
+
+    def extra_head
+      [
+        %(<link rel="home" href="index.html" title="#{attributes['home']}"/>),
+        link_rel('up', attributes['up_section']),
+        link_rel('prev', attributes['prev_section']),
+        link_rel('next', attributes['next_section']),
+      ].compact.join "\n"
+    end
+
+    def link_rel(rel, related)
+      return unless related
+
+      id = rel_id related
+      title = rel_title related
+      %(<link rel="#{rel}" href="#{id}.html" title="#{title}"/>)
+    end
+
+    def rel_id(related)
+      case related.context
+      when :section
+        related.id
+      when :document
+        'index'
+      else
+        raise "Can't link to #{related}"
+      end
+    end
+
+    def rel_title(related)
+      case related.context
+      when :section
+        related.title
+      when :document
+        related.doctitle(partition: true).main.strip
+      else
+        raise "Can't link to #{related}"
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/lib/chunker/find_related.rb
+++ b/resources/asciidoctor/lib/chunker/find_related.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+require_relative '../delegating_converter'
+
+module Chunker
+  ##
+  # Looks for "related" pages to satisfy docbook's `next`, `prev`,
+  # and `up` links.
+  module FindRelated
+    def find_related(section)
+      return {} unless (index = section.parent.blocks.find_index section)
+
+      {
+        'up_section' => section.parent,
+        'prev_section' => find_prev_in(section.parent, index - 1),
+        'next_section' => find_next(section, index),
+      }
+    end
+
+    ##
+    # Find the page that comes before the page at `parent.blocks[index + 1]`.
+    def find_prev_in(parent, index)
+      while index >= 0
+        c = parent.blocks[index]
+        if c.context == :section
+          return c if c.level == @chunk_level
+
+          parent = c
+          index = c.blocks.length
+        end
+        index -= 1
+      end
+      # index was for the first section in the parent so the previous page
+      # *is* the parent.
+      parent
+    end
+
+    def find_next(section, index)
+      if section.level < @chunk_level
+        find_next_in section, 0
+      else
+        find_next_in section.parent, index + 1
+      end
+    end
+
+    ##
+    # Find the page that comes after the page at `parent.blocks[index - 1]`
+    def find_next_in(parent, index)
+      loop do
+        while (c = parent.blocks[index])
+          return c if c.context == :section && c.level <= @chunk_level
+
+          index += 1
+        end
+        return unless parent.parent
+        return unless (index = parent.parent.blocks&.find_index parent)
+
+        parent = parent.parent
+        index += 1
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/lib/chunker/find_related.rb
+++ b/resources/asciidoctor/lib/chunker/find_related.rb
@@ -19,7 +19,8 @@ module Chunker
     end
 
     ##
-    # Find the page that comes before the page at `parent.blocks[index + 1]`.
+    # Find the page that comes before the page at `parent.blocks[index + 1]` in
+    # "table of contents order".
     def find_prev_in(parent, index)
       while index >= 0
         c = parent.blocks[index]
@@ -45,7 +46,8 @@ module Chunker
     end
 
     ##
-    # Find the page that comes after the page at `parent.blocks[index - 1]`
+    # Find the page that comes after the page at `parent.blocks[index - 1]` in
+    # "table of contents order".
     def find_next_in(parent, index)
       loop do
         while (c = parent.blocks[index])

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Chunker do
   let(:backend) { :html5 }
   let(:standalone) { true }
 
-  shared_examples 'healthy head' do
+  shared_examples 'healthy head' \
+    do |prev_page, prev_title, next_page, next_title|
     context 'the <head>' do
       it 'contains the charset' do
         expect(contents).to include(<<~HTML)
@@ -28,6 +29,28 @@ RSpec.describe Chunker do
         expect(contents).to include(<<~HTML)
           <link rel="home" href="index.html" title="Title"/>
         HTML
+      end
+      if prev_page
+        it 'contains the prev link' do
+          expect(contents).to include(<<~HTML)
+            <link rel="prev" href="#{prev_page}.html" title="#{prev_title}"/>
+          HTML
+        end
+      else
+        it "doesn't contain the prev link" do
+          expect(contents).not_to include('rel="prev"')
+        end
+      end
+      if next_page
+        it 'contains the next link' do
+          expect(contents).to include(<<~HTML)
+            <link rel="next" href="#{next_page}.html" title="#{next_title}"/>
+          HTML
+        end
+      else
+        it "doesn't contain the next link" do
+          expect(contents).not_to include('rel="next"')
+        end
       end
       it "doesn't contain the builtin asciidoctor stylesheet" do
         # We turned the stylesheet off
@@ -68,7 +91,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'healthy head'
+          include_examples 'healthy head', nil, nil, 's1', 'Section 1'
           it 'contains a link to the first section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">Section 1</a></li>
@@ -81,7 +104,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's1.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 'index', 'Title', 's2', 'Section 2'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 1 | Title</title>')
           end
@@ -92,8 +115,8 @@ RSpec.describe Chunker do
             expect(contents).to include '<p>Words words.</p>'
           end
         end
-        file_context 'the first section', 's2.html' do
-          include_examples 'healthy head'
+        file_context 'the second section', 's2.html' do
+          include_examples 'healthy head', 's1', 'Section 1', nil, nil
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 2 | Title</title>')
           end
@@ -122,6 +145,8 @@ RSpec.describe Chunker do
           ASCIIDOC
         end
         context 'the main output' do
+          let(:contents) { converted }
+          include_examples 'healthy head', nil, nil, 'l1', 'Level 1'
           it 'contains a link to the level 1 section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="l1.html">Level 1</a></li>
@@ -134,6 +159,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level one section', 'l1.html' do
+          include_examples 'healthy head', 'index', 'Title', nil, nil
           it 'contains the header of the level 1 section' do
             expect(contents).to include('<h2 id="l1">Level 1</h2>')
           end
@@ -168,7 +194,7 @@ RSpec.describe Chunker do
           'toc' => '',
         }
       end
-      context 'there is are two level 1 sections' do
+      context 'there is are a few sections' do
         let(:input) do
           <<~ASCIIDOC
             = Title
@@ -194,7 +220,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'healthy head'
+          include_examples 'healthy head', nil, nil, 's1', 'S1'
           it 'contains a link to the level 1 sections' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">S1</a>
@@ -219,25 +245,25 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first level 1 section', 's1.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 'index', 'Title', 's1_1', 'S1_1'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
           end
         end
         file_context 'the first level 2 section', 's1_1.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 's1', 'S1', 's2', 'S2'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
           end
         end
         file_context 'the second level 1 section', 's2.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 's1_1', 'S1_1', 's2_1', 'S2_1'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 's2', 'S2', 's2_2', 'S2_2'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_1">S2_1</h3>')
           end
@@ -246,7 +272,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the last level 2 section', 's2_2.html' do
-          include_examples 'healthy head'
+          include_examples 'healthy head', 's2_1', 'S2_1', nil, nil
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')
           end

--- a/test
+++ b/test
@@ -1,6 +1,0 @@
-make -C resources/asciidoctor/ && make -C integtest/ style &&
-   ../docs/build_docs --doc ../stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1 --direct_html &&
-   cp html_docs/raw/index.html /tmp/direct.html &&
-   ../docs/build_docs --doc ../stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1 &&
-   cp html_docs/raw/index.html /tmp/docbook.html &&
-   docker run -it --rm --user 1000:1000 -v $(pwd):/docs_build -v /tmp:/tmp --security-opt seccomp=unconfined docker.elastic.co/docs/diff_tool:latest /docs_build/integtest/html_diff /tmp/docbook.html /tmp/direct.html | tee diff


### PR DESCRIPTION
Adds the `<link rel="home"`, `<link rel="up"`, `<link rel="pre"`,
and `<link rel="next"` tags to the header for direct_html.
