### PR TITLE
Wrap toc in comments in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -107,9 +107,11 @@ module DocbookCompat
     def add_toc(doc, html)
       html.gsub! '<div id="content">', <<~HTML
         <div id="content">
+        <!--START_TOC-->
         <div class="#{doc.attr 'toc-class', 'toc'}">
         #{doc.converter.convert doc, 'outline'}
         </div>
+        <!--END_TOC-->
       HTML
     end
   end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -150,11 +150,13 @@ RSpec.describe DocbookCompat do
             <hr>
             </div>
             <div id="content">
+            <!--START_TOC-->
             <div class="toc">
           HTML
         end
         it 'looks like the docbook toc' do
           expect(converted).to include(<<~HTML)
+            <!--START_TOC-->
             <div class="toc">
             <ul class="toc">
             <li><span class="chapter"><a href="#_section_1">Section 1</a></span>
@@ -163,6 +165,7 @@ RSpec.describe DocbookCompat do
             </li>
             </ul>
             </div>
+            <!--END_TOC-->
           HTML
         end
       end


### PR DESCRIPTION
Our docbook extensions wrap the table of contents in `<!--START_TOC-->`
and `<!--END_TOC-->` to make some manipulation by the docs build
simpler. This adds those comments to the when generating the html
directly from Asciidoctor.
