### PR TITLE
Disable headers in direct_html subpages

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -51,16 +51,14 @@ module Chunker
     def form_section_into_page(doc, title, html)
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.
-      subdoc = Asciidoctor::Document.new [], subdoc_opts(doc)
+      subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, title)
       subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
-      maintitle = doc.doctitle partition: true
-      subdoc.attributes['title'] = "#{title} | #{maintitle.main}"
       subdoc.convert
     end
 
-    def subdoc_opts(doc)
+    def subdoc_opts(doc, title)
       {
-        attributes: subdoc_attrs(doc),
+        attributes: subdoc_attrs(doc, title),
         safe: doc.safe,
         backend: doc.backend,
         sourcemap: doc.sourcemap,
@@ -70,7 +68,7 @@ module Chunker
       }
     end
 
-    def subdoc_attrs(doc)
+    def subdoc_attrs(doc, title)
       attrs = doc.attributes.dup
       # Asciidoctor defaults these attribute to empty string if they aren't
       # specified and setting them to `nil` clears them. Since we want to
@@ -79,6 +77,9 @@ module Chunker
       # they'd default to fale.
       attrs['stylesheet'] = nil unless attrs['stylesheet']
       attrs['icons'] = nil unless attrs['icons']
+      maintitle = doc.doctitle partition: true
+      attrs['title'] = "#{title} | #{maintitle.main}"
+      attrs['noheader'] = true
       attrs
     end
 

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -79,6 +79,8 @@ module DocbookCompat
     end
 
     def munge_title(doc, title, html)
+      return if doc.attr 'noheader'
+
       # Important: we're not replacing the whole header - it still will have a
       # closing </div>.
       header_start = <<~HTML

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -36,6 +36,12 @@ RSpec.describe Chunker do
     end
   end
 
+  shared_examples 'subpage' do
+    it "doesn't contain the main title" do
+      expect(contents).not_to include('<h1>Title</h1>')
+    end
+  end
+
   context 'when outdir is configured' do
     let(:outdir) { Dir.mktmpdir }
     after(:example) { FileUtils.remove_entry outdir }
@@ -82,6 +88,7 @@ RSpec.describe Chunker do
         end
         file_context 'the first section', 's1.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 1 | Title</title>')
           end
@@ -94,6 +101,7 @@ RSpec.describe Chunker do
         end
         file_context 'the first section', 's2.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 2 | Title</title>')
           end
@@ -134,6 +142,8 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level one section', 'l1.html' do
+          include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the header of the level 1 section' do
             expect(contents).to include('<h2 id="l1">Level 1</h2>')
           end
@@ -220,24 +230,28 @@ RSpec.describe Chunker do
         end
         file_context 'the first level 1 section', 's1.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
           end
         end
         file_context 'the first level 2 section', 's1_1.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
           end
         end
         file_context 'the second level 1 section', 's2.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_1">S2_1</h3>')
           end
@@ -247,6 +261,7 @@ RSpec.describe Chunker do
         end
         file_context 'the last level 2 section', 's2_2.html' do
           include_examples 'healthy head'
+          include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')
           end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -193,6 +193,32 @@ RSpec.describe DocbookCompat do
           end
         end
       end
+      context 'when the head is disabled' do
+        let(:convert_attributes) do
+          {
+            # Shrink the output slightly so it is easier to read
+            'stylesheet!' => false,
+            # Set some metadata that will be included in the header
+            'dc.type' => 'FooType',
+            'dc.subject' => 'BarSubject',
+            'dc.identifier' => 'BazIdentifier',
+            # Disable the head
+            'noheader' => true,
+          }
+        end
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the header' do
+          it "doesn't contain the title h1" do
+            expect(converted).not_to include('Title</h1>')
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This disables the "header" parts of `--direct_html`'s "subpages". These
pages only really *want* the contents of the subpage, not the
"titlepage" that comes with a "full" book.
