### PR TITLE
Adds API reference ID recommendation

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -1,3 +1,4 @@
+// We recommend including "api" in the page ID and title for improved SEO.
 [[sample-api]]
 === Sample API
 ++++


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/937

This PR adds a comment to the API reference template. It recommends that we use "api" in the page title and anchor for consistency and SEO purposes.