### PR TITLE
Add version drop downs to raw

### DIFF
--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -236,6 +236,12 @@ RSpec.describe 'building all books' do
         page_context 'toc.html', "html/test/#{branch}/toc.html" do
           include_examples 'correct'
         end
+        page_context 'index.html', "raw/test/#{branch}/index.html" do
+          include_examples 'correct'
+        end
+        page_context 'toc.html', "raw/test/#{branch}/toc.html" do
+          include_examples 'correct'
+        end
       end
       context 'the master branch' do
         let(:master_selected) { ' selected' }

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -203,6 +203,10 @@ sub build {
                 $self->_update_title_and_version_drop_downs( $dir->subdir( $_ ), $_ );
             }
             $self->_update_title_and_version_drop_downs( $dir->subdir( 'current' ) , $self->current );
+            for ( @{ $self->branches } ) {
+                $self->_update_title_and_version_drop_downs( $self->{raw_dir}->subdir( $_ ), $_ );
+            }
+            $self->_update_title_and_version_drop_downs( $self->{raw_dir}->subdir( 'current' ) , $self->current );
         }
         return {
             title => "$title [" . $self->branch_title( $self->current ) . "\\]",


### PR DESCRIPTION
Adds the version drop down to the raw docs so they show up in the
preview. It'd be nice if the templating system did this on the fly, but
that is a problem for another day. This is a simple solution that fixes
the preview so we can keep doing other things.
