### PR TITLE
APM Agent Java: Build changelog on 1.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1467,6 +1467,10 @@ contents:
                       -
                         repo:   apm-agent-java
                         path:   docs
+                      -
+                        repo:   apm-agent-java
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 0.7, 0.6]
                   -
                     title:      APM .NET Agent
                     prefix:     dotnet


### PR DESCRIPTION
~Blocked by https://github.com/elastic/apm-agent-java/pull/948~.