### PR TITLE
Handle the direct_html's different image class

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -38,6 +38,11 @@ def normalize_html(html):
     for e in soup.select('ul'):
         if 'type' in e.attrs and e['type'] == 'disc':
             del e['type']
+    # Docbook emits images with the 'inlinemediaobject' class and Asciidoctor
+    # has the 'image' class. We've updated our styles to make both work.
+    for e in soup.select('.inlinemediaobject'):
+        e['class'].remove('inlinemediaobject')
+        e['class'].append('image')
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # docbook spits out the long-form charset and asciidoctor spits out the

--- a/resources/web/style/img.pcss
+++ b/resources/web/style/img.pcss
@@ -1,5 +1,7 @@
 #guide {
-  .inlinemediaobject, .mediaobject {
+  /* 'inlinemediaobject' and 'mediaobject' are for docbook. 'image' is
+   * for Asciidoctor. */
+  .image, .inlinemediaobject, .mediaobject {
     img {
       max-width: 100%;
     }


### PR DESCRIPTION
`--direct_html` emits images wrapped in `<span class="image">` while
docbook emits them as `<span class="inlinemediaobject">`. This updates
the style so they both render the same and updates the `html_diff` tool
so we ignore that difference.
