### PR TITLE
Normalize direct_html's ordered lists

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -38,6 +38,14 @@ def normalize_html(html):
     for e in soup.select('ul'):
         if 'type' in e.attrs and e['type'] == 'disc':
             del e['type']
+    # Asciidoctor adds a "olist" class to all ordered lists which doesn't
+    # hurt anything so we can ignore it.
+    for e in soup.select('.orderedlist.olist'):
+        e['class'].remove('olist')
+    # Docbook adds type="1" to ol which is the default and isn't needed.
+    for e in soup.select('ol'):
+        if 'type' in e.attrs and e['type'] == '1':
+            del e['type']
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # docbook spits out the long-form charset and asciidoctor spits out the

--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -4,8 +4,17 @@ module DocbookCompat
   ##
   # Methods to convert lists.
   module ConvertLists
-    def convert_ulist(node)
+    def convert_ulist(node, &block)
       node.style ||= 'itemizedlist'
+      convert_list node, &block
+    end
+
+    def convert_olist(node, &block)
+      node.style = 'orderedlist' if node.style.nil? || node.style == 'arabic'
+      convert_list node, &block
+    end
+
+    def convert_list(node)
       node.items.each { |item| item.attributes['role'] ||= 'listitem' }
       html = yield
       node.items.each do |item|

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -395,6 +395,48 @@ RSpec.describe DocbookCompat do
       end
     end
   end
+  context 'an ordered list' do
+    let(:input) do
+      <<~ASCIIDOC
+        . Thing
+        . Other thing
+        . Third thing
+      ASCIIDOC
+    end
+    it 'is wrapped an orderedlist div' do
+      expect(converted).to include('<div class="olist orderedlist">')
+    end
+    it 'has the itemizedlist class' do
+      expect(converted).to include('<ol class="orderedlist"')
+    end
+    context 'the first item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Thing
+          </li>
+        HTML
+      end
+    end
+    context 'the second item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Other thing
+          </li>
+        HTML
+      end
+    end
+    context 'the third item' do
+      it 'has the listitem class' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          Third thing
+          </li>
+        HTML
+      end
+    end
+  end
 
   context 'backticked code' do
     let(:input) do


### PR DESCRIPTION
This makes `--direct_html`'s ordered lists look visually the same as
docbook's ordered lists by removing the extra `<p`> tags on the entries
and adding docbook's standard classes. Docbook adds some extra "stuff"
to the lists which `--direct_html` doesn't even after this change but it
doesn't make a visual difference so we normalize those differences away
with `html_diff`.
