### PR TITLE
Drop wrapper div in subpages

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -68,14 +68,21 @@ module DocbookCompat
     end
 
     def munge_body(doc, html)
-      wrapped_body = <<~HTML.strip
-        <body>
-        <div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">
-      HTML
-      html.gsub!(/<body[^>]+>/, wrapped_body) ||
+      html.gsub!(/<body[^>]+>/, wrapped_body(doc)) ||
         raise("Couldn't wrap body in #{html}")
       html.gsub!('</body>', '</div></body>') ||
         raise("Couldn't wrap body in #{html}")
+    end
+
+    def wrapped_body(doc)
+      if doc.attr 'noheader'
+        '<body>'
+      else
+        <<~HTML.strip
+          <body>
+          <div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">
+        HTML
+      end
     end
 
     def munge_title(doc, title, html)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -221,6 +221,16 @@ RSpec.describe DocbookCompat do
             expect(converted).not_to include('Title</h1>')
           end
         end
+        context 'the body' do
+          it "doesn't have attributes" do
+            expect(converted).to include('<body>')
+          end
+          it "doesn't include the 'book' wrapper" do
+            expect(converted).not_to include(<<~HTML)
+              <div class="book" lang="en">
+            HTML
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Drops a wrapper `<div>` that declares that we're converting a `book` or
an `article` for subpages produced by `--direct_html`. This lines them
up *much* better with docbook.
