### PR TITLE
Add navheader and navfooter to direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -4,6 +4,7 @@ require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative 'extra_docinfo'
 require_relative 'find_related'
+require_relative 'nav'
 
 ##
 # HTML5 converter that chunks like docbook.
@@ -39,6 +40,9 @@ module Chunker
         doc.attributes['home'] = title.main.strip
       end
       doc.attributes['next_section'] = find_next_in doc, 0
+      nav = Nav.new doc
+      doc.blocks.insert 0, nav.header
+      doc.blocks.append nav.footer
       yield
     end
 
@@ -63,7 +67,10 @@ module Chunker
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.
       subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, section)
+      nav = Nav.new subdoc
+      subdoc << nav.header
       subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
+      subdoc << nav.footer
       subdoc.convert
     end
 

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'link'
+
 module Chunker
   ##
   # Adds extra tags <link> tags to the <head> to emulate docbook.
   module ExtraDocinfo
+    include Link
+
     def docinfo(location = :head, suffix = nil)
       info = super
       info += extra_head if location == :head
@@ -22,31 +26,7 @@ module Chunker
     def link_rel(rel, related)
       return unless related
 
-      id = rel_id related
-      title = rel_title related
-      %(<link rel="#{rel}" href="#{id}.html" title="#{title}"/>)
-    end
-
-    def rel_id(related)
-      case related.context
-      when :section
-        related.id
-      when :document
-        'index'
-      else
-        raise "Can't link to #{related}"
-      end
-    end
-
-    def rel_title(related)
-      case related.context
-      when :section
-        related.title
-      when :document
-        related.doctitle(partition: true).main.strip
-      else
-        raise "Can't link to #{related}"
-      end
+      %(<link rel="#{rel}" #{link_href related} #{link_title related}/>)
     end
   end
 end

--- a/resources/asciidoctor/lib/chunker/find_related.rb
+++ b/resources/asciidoctor/lib/chunker/find_related.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'asciidoctor/extensions'
-require_relative '../delegating_converter'
-
 module Chunker
   ##
   # Looks for "related" pages to satisfy docbook's `next`, `prev`,

--- a/resources/asciidoctor/lib/chunker/link.rb
+++ b/resources/asciidoctor/lib/chunker/link.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Chunker
+  ##
+  # Helpers for making links.
+  module Link
+    def link_href(target)
+      case target.context
+      when :section
+        %(href="#{target.id}.html")
+      when :document
+        %(href="index.html")
+      else
+        raise "Can't link to #{target}"
+      end
+    end
+
+    def link_title(target)
+      case target.context
+      when :section
+        %(title="#{target.title}")
+      when :document
+        %(title="#{target.doctitle(partition: true).main.strip}")
+      else
+        raise "Can't link to #{target}"
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/lib/chunker/nav.rb
+++ b/resources/asciidoctor/lib/chunker/nav.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require_relative 'link'
+
+module Chunker
+  ##
+  # Generate the navigation header and footer.
+  class Nav
+    include Link
+
+    attr_reader :header, :footer
+
+    def initialize(doc)
+      body = nav_body doc
+      @header = Asciidoctor::Block.new(doc, :pass, source: <<~HTML)
+        <div class="navheader">
+        #{body}
+        </div>
+      HTML
+      @footer = Asciidoctor::Block.new(doc, :pass, source: <<~HTML)
+        <div class="navfooter">
+        #{body}
+        </div>
+      HTML
+    end
+
+    private
+
+    def nav_body(doc)
+      nav = [
+        %(<span class="prev">),
+        nav_link(doc.attr('prev_section'), '« ', ''),
+        %(</span>),
+        %(<span class="next">),
+        nav_link(doc.attr('next_section'), '', ' »'),
+        %(</span>),
+      ]
+      nav.compact.join "\n"
+    end
+
+    def nav_link(section, lmarker, rmarker)
+      return unless section
+
+      %(<a #{link_href section}>#{lmarker}#{section.title}#{rmarker}</a>)
+    end
+  end
+end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Chunker do
   let(:backend) { :html5 }
   let(:standalone) { true }
 
-  shared_examples 'healthy head' \
+  shared_examples 'standard page' \
     do |prev_page, prev_title, next_page, next_title|
     context 'the <head>' do
       it 'contains the charset' do
@@ -55,6 +55,46 @@ RSpec.describe Chunker do
       it "doesn't contain the builtin asciidoctor stylesheet" do
         # We turned the stylesheet off
         expect(contents).not_to include('<style')
+      end
+    end
+    context 'the <body>' do
+      it 'contains the navheader' do
+        expect(contents).to include('<div class="navheader">')
+      end
+      it 'contains the navfooter' do
+        expect(contents).to include('<div class="navfooter">')
+      end
+      if prev_page
+        it 'contains the prev nav' do
+          expect(contents).to include(<<~HTML)
+            <span class="prev">
+            <a href="#{prev_page}.html">« #{prev_title}</a>
+            </span>
+          HTML
+        end
+      else
+        it 'contains an empty prev nav' do
+          expect(contents).to include(<<~HTML)
+            <span class="prev">
+            </span>
+          HTML
+        end
+      end
+      if next_page
+        it 'contains the next nav' do
+          expect(contents).to include(<<~HTML)
+            <span class="next">
+            <a href="#{next_page}.html">#{next_title} »</a>
+            </span>
+          HTML
+        end
+      else
+        it 'contains an empty next nav' do
+          expect(contents).to include(<<~HTML)
+            <span class="next">
+            </span>
+          HTML
+        end
       end
     end
   end
@@ -97,7 +137,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'healthy head', nil, nil, 's1', 'Section 1'
+          include_examples 'standard page', nil, nil, 's1', 'Section 1'
           it 'contains a link to the first section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">Section 1</a></li>
@@ -110,7 +150,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's1.html' do
-          include_examples 'healthy head', 'index', 'Title', 's2', 'Section 2'
+          include_examples 'standard page', 'index', 'Title', 's2', 'Section 2'
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 1 | Title</title>')
@@ -123,7 +163,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the second section', 's2.html' do
-          include_examples 'healthy head', 's1', 'Section 1', nil, nil
+          include_examples 'standard page', 's1', 'Section 1', nil, nil
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 2 | Title</title>')
@@ -154,7 +194,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'healthy head', nil, nil, 'l1', 'Level 1'
+          include_examples 'standard page', nil, nil, 'l1', 'Level 1'
           it 'contains a link to the level 1 section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="l1.html">Level 1</a></li>
@@ -167,7 +207,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level one section', 'l1.html' do
-          include_examples 'healthy head', 'index', 'Title', nil, nil
+          include_examples 'standard page', 'index', 'Title', nil, nil
           include_examples 'subpage'
           it 'contains the header of the level 1 section' do
             expect(contents).to include('<h2 id="l1">Level 1</h2>')
@@ -229,7 +269,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'healthy head', nil, nil, 's1', 'S1'
+          include_examples 'standard page', nil, nil, 's1', 'S1'
           it 'contains a link to the level 1 sections' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">S1</a>
@@ -254,28 +294,28 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first level 1 section', 's1.html' do
-          include_examples 'healthy head', 'index', 'Title', 's1_1', 'S1_1'
+          include_examples 'standard page', 'index', 'Title', 's1_1', 'S1_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
           end
         end
         file_context 'the first level 2 section', 's1_1.html' do
-          include_examples 'healthy head', 's1', 'S1', 's2', 'S2'
+          include_examples 'standard page', 's1', 'S1', 's2', 'S2'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
           end
         end
         file_context 'the second level 1 section', 's2.html' do
-          include_examples 'healthy head', 's1_1', 'S1_1', 's2_1', 'S2_1'
+          include_examples 'standard page', 's1_1', 'S1_1', 's2_1', 'S2_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
-          include_examples 'healthy head', 's2', 'S2', 's2_2', 'S2_2'
+          include_examples 'standard page', 's2', 'S2', 's2_2', 'S2_2'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_1">S2_1</h3>')
@@ -285,7 +325,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the last level 2 section', 's2_2.html' do
-          include_examples 'healthy head', 's2_1', 'S2_1', nil, nil
+          include_examples 'standard page', 's2_1', 'S2_1', nil, nil
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -196,6 +196,60 @@ RSpec.describe DocbookCompat do
           end
         end
       end
+      context 'contains a navheader' do
+        # Emulates the chunker without trying to include it.
+        let(:input) do
+          <<~ASCIIDOC
+            = Title: Subtitle
+
+            [pass]
+            --
+            <div class="navheader">
+            nav nav nav
+            </div>
+            --
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the navheader' do
+          it 'is moved above the "book" wrapper' do
+            expect(converted).to include(<<~HTML)
+              <div class="navheader">
+              nav nav nav
+              </div>
+              <div class="book" lang="en">
+            HTML
+          end
+        end
+      end
+      context 'contains a navfooer' do
+        # Emulates the chunker without trying to include it.
+        let(:input) do
+          <<~ASCIIDOC
+            = Title: Subtitle
+
+            [pass]
+            --
+            <div class="navfooter">
+            nav nav nav
+            </div>
+            --
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the navfooter' do
+          it 'is moved below the "book" wrapper' do
+            expect(converted).to include(<<~HTML)
+              <div class="navfooter">
+              nav nav nav
+              </div>
+              </body>
+            HTML
+          end
+        end
+      end
       context 'when the head is disabled' do
         let(:convert_attributes) do
           {


### PR DESCRIPTION
Adds the `navheader` and `navfooter` elements to the output of
`--direct_html`.
