### PR TITLE
Adds shared attribute for wikipedia

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -68,7 +68,7 @@
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :subscriptions:        https://www.elastic.co/subscriptions
-
+:wikipedia:            https://www.wikipedia.org
 :forum:                https://discuss.elastic.co/
 :xpack-forum:          https://discuss.elastic.co/c/50-x-pack
 :security-forum:       https://discuss.elastic.co/c/x-pack/shield

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -68,7 +68,7 @@
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :subscriptions:        https://www.elastic.co/subscriptions
-:wikipedia:            https://www.wikipedia.org
+:wikipedia:            https://en.wikipedia.org/wiki
 :forum:                https://discuss.elastic.co/
 :xpack-forum:          https://discuss.elastic.co/c/50-x-pack
 :security-forum:       https://discuss.elastic.co/c/x-pack/shield


### PR DESCRIPTION
This PR adds a shared attribute for ":wikipedia:", since it is used in at least one page:
https://www.elastic.co/guide/en/elasticsearch/reference/master/setting-up-authentication.html

![image](https://user-images.githubusercontent.com/26471269/69664524-69a9b300-103d-11ea-9f7e-e1be871853fa.png)

Preview: http://docs_1465.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/setting-up-authentication.html