### PR TITLE
Ignore difference between <em> rendering

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -30,6 +30,10 @@ def normalize_html(html):
     # so we're ok with it.
     for e in soup.select('#content'):
         e.unwrap()
+    # Docbook adds <span class="emphasis"> around <em> tags. We don't need them
+    # and it isn't worth making Asciidoctor make them.
+    for e in soup.select('.emphasis'):
+        e.unwrap()
     # Asciidoctor adds a "ulist" class to all unordered lists which doesn't
     # hurt anything so we can ignore it.
     for e in soup.select('.itemizedlist.ulist'):


### PR DESCRIPTION
Docbook wraps `<em>` tags in `<span class="emphasis">`. Asciidoctor
doesn't. We don't need the it. This ignores it as part of the diffs.
