### PR TITLE
Fix title on direct_html's subpages

### DIFF
--- a/integtest/spec/helper/dsl/convert_single.rb
+++ b/integtest/spec/helper/dsl/convert_single.rb
@@ -9,12 +9,14 @@ module Dsl
     # into html and adds some basic assertions about the conversion process.
     # Pass a block that takes a `Repo` object and uses it to build and return
     # an index file to convert.
-    def convert_single_before_context
+    def convert_single_before_context(direct_html: false)
       convert_before do |src, dest|
         repo = src.repo 'src'
         from = yield repo
         repo.commit 'commit outstanding'
-        dest.prepare_convert_single(from, '.').convert
+        convert = dest.prepare_convert_single(from, '.')
+        convert.direct_html if direct_html
+        convert.convert
       end
       include_examples 'convert single'
     end

--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -51,7 +51,13 @@ module Dsl
       let(:head) do
         return unless contents
 
-        contents.sub(/.+<head>/, '').sub(%r{</head>.+}, '')
+        contents.sub(/.+<head>/m, '').sub(%r{</head>.+}m, '')
+      end
+      let(:head_title) do
+        m = head&.match %r{<title>(.+?)</title>}m
+        raise "can't find title in #{head}" unless m
+
+        m[1]
       end
       let(:body) do
         return unless contents

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe 'building a single book' do
   let(:zero_width_space) { "\u200b" }
 
   context 'for a minimal book' do
-    shared_context 'expected' do |file_name|
-      convert_single_before_context do |src|
+    shared_context 'expected' do |file_name, direct_html|
+      convert_single_before_context(direct_html: direct_html) do |src|
         src.write file_name, <<~ASCIIDOC
           #{HEADER}
           This is a minimal viable asciidoc file for use with build_docs. The
@@ -77,6 +77,9 @@ RSpec.describe 'building a single book' do
         it 'has a trailing newline' do
           expect(contents).to end_with("\n")
         end
+        it 'has the right title in head' do
+          expect(head_title).to match(/Title\s+\|\s+Elastic/m)
+        end
         it 'has the right title' do
           expect(title).to eq('Title')
         end
@@ -86,11 +89,17 @@ RSpec.describe 'building a single book' do
         end
       end
       page_context 'chapter.html' do
+        it 'has the right title in head' do
+          expect(head_title).to match(/Chapter\s+\|\s+Title\s+\|\s+Elastic/m)
+        end
         it 'has the right title' do
           expect(title).to eq('Chapter')
         end
       end
       page_context 'raw/chapter.html' do
+        it 'has the right title in head' do
+          expect(head_title).to match(/Chapter\s+\|\s+Title\s+\|\s+Elastic/m)
+        end
         it 'has the right title' do
           expect(title).to eq('Chapter')
         end
@@ -98,11 +107,15 @@ RSpec.describe 'building a single book' do
     end
 
     context 'when the file ends in .asciidoc' do
-      include_context 'expected', 'minimal.asciidoc'
+      include_context 'expected', 'minimal.asciidoc', false
     end
 
     context 'when the file ends in .adoc' do
-      include_context 'expected', 'minimal.adoc'
+      include_context 'expected', 'minimal.adoc', false
+    end
+
+    context 'when the we use direct_html' do
+      include_context 'expected', 'minimal.asciidoc', true
     end
   end
 

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -82,7 +82,7 @@ module Chunker
     def subdoc_attrs(doc, section)
       attrs = doc.attributes.dup
       maintitle = doc.doctitle partition: true
-      attrs['title'] = "#{section.title} | #{maintitle.main}"
+      attrs['doctitle'] = "#{section.title} | #{maintitle.main}"
       # Asciidoctor defaults these attribute to empty string if they aren't
       # specified and setting them to `nil` clears them. Since we want to
       # preserve the configuration from the parent into the child, we clear

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -14,7 +14,7 @@ module DocbookCompat
 
       html = yield
       munge_html doc, html, wants_toc
-      html
+      html + "\n"
     end
 
     ##
@@ -39,7 +39,6 @@ module DocbookCompat
       munge_body doc, html
       munge_title doc, title, html
       add_toc doc, html if wants_toc
-      html
     end
 
     def munge_html_tag(html)
@@ -49,7 +48,7 @@ module DocbookCompat
 
     def munge_head(title, html)
       html.gsub!(
-        %r{<title>(.+)</title>}, "<title>#{title.main} | Elastic</title>"
+        %r{<title>.+</title>}, "<title>#{title.main} | Elastic</title>"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -35,6 +35,10 @@ RSpec.describe DocbookCompat do
         Words.
       ASCIIDOC
     end
+    it 'ends in a single newline' do
+      expect(converted).to end_with("\n")
+      expect(converted).not_to end_with("\n\n")
+    end
     it 'has an empty html tag' do
       expect(converted).to include('<html>')
     end


### PR DESCRIPTION
`--direct_html` was producing incorrect `<title>`s on subpages. But it
worked in the unit tests! I tracked down the fix to us overwriting the
wrong attribute to force the subpage's title. But again, no luck testing
it in the unit tests.

So this starts testing direct_html in an integration test and adds all
of the right things to catch this.
