### PR TITLE
Fixup cross references in direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -59,6 +59,23 @@ module Chunker
       ''
     end
 
+    def convert_inline_anchor(node)
+      correct_xref node if node.type == :xref
+      yield
+    end
+
+    def correct_xref(node)
+      refid = node.attributes['refid']
+      return unless (ref = node.document.catalog[:refs][refid])
+
+      page = ref
+      while page.context != :section || page.level > @chunk_level
+        page = ref.parent
+      end
+      node.target = "#{page.id}.html"
+      node.target += "##{ref.id}" unless page == ref
+    end
+
     def form_section_into_page(doc, section, html)
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -68,12 +68,17 @@ module Chunker
       refid = node.attributes['refid']
       return unless (ref = node.document.catalog[:refs][refid])
 
-      page = ref
-      while page.context != :section || page.level > @chunk_level
-        page = ref.parent
-      end
+      page = page_containing ref
       node.target = "#{page.id}.html"
       node.target += "##{ref.id}" unless page == ref
+    end
+
+    def page_containing(node)
+      page = node
+      while page.context != :section || page.level > @chunk_level
+        page = page.parent
+      end
+      page
     end
 
     def form_section_into_page(doc, section, html)

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -87,12 +87,17 @@ RSpec.describe Chunker do
             [[s1]]
             == Section 1
 
+            [[linkme]]
             Words words.
+
+            <<s2>>
 
             [[s2]]
             == Section 2
 
             Words again.
+
+            <<linkme>>
           ASCIIDOC
         end
         context 'the main output' do
@@ -121,6 +126,9 @@ RSpec.describe Chunker do
           it 'contains the contents' do
             expect(contents).to include '<p>Words words.</p>'
           end
+          it 'contains a link to the second section' do
+            expect(contents).to include('<a href="s2.html">Section 2</a>')
+          end
         end
         file_context 'the second section', 's2.html' do
           include_examples 'healthy head', 's1', 'Section 1', nil, nil
@@ -133,6 +141,9 @@ RSpec.describe Chunker do
           end
           it 'contains the contents' do
             expect(contents).to include '<p>Words again.</p>'
+          end
+          it 'contains a link to an element in the first section' do
+            expect(contents).to include('<a href="s1.html#linkme">[linkme]</a>')
           end
         end
       end
@@ -211,6 +222,8 @@ RSpec.describe Chunker do
             [[s1]]
             == S1
 
+            <<S2_1_1>>
+
             [[s1_1]]
             === S1_1
 
@@ -258,6 +271,9 @@ RSpec.describe Chunker do
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
+          end
+          it 'contains a link to the level 3 section' do
+            expect(contents).to include('<a href="s2_1.html#s2_1_1">S2_1_1</a>')
           end
         end
         file_context 'the first level 2 section', 's1_1.html' do


### PR DESCRIPTION
This fixes up the destination of the links producted by `--direct_html`
so they include the page that contains thing being linked to.
