### PR TITLE
Ignore direct_html's different link class

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -51,6 +51,12 @@ def normalize_html(html):
     for e in soup.select('.inlinemediaobject'):
         e['class'].remove('inlinemediaobject')
         e['class'].append('image')
+    # Docbook links with `<a class="link"` when linking from one page of a book
+    # to another. Asciidoctor emits `<a class="link"`. Both look fine.
+    for e in soup.select('a.xref'):
+        if '.html#' in e['href']:
+            e['class'].remove('xref')
+            e['class'].append('link')
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # docbook spits out the long-form charset and asciidoctor spits out the


### PR DESCRIPTION
Docbook links with `<a class="link"` when linking from one page of a book
to another. Asciidoctor emits `<a class="link"`. Both look fine. This
ignores the difference.
