### PR TITLE
Fix callout lists in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods code listings and their paired callout lists.
+  module ConvertListing
+    def convert_listing(node)
+      lang = node.attr 'language'
+      <<~HTML
+        <div class="pre_wrapper lang-#{lang}">
+        <pre class="programlisting prettyprint lang-#{lang}">#{node.content || ''}</pre>
+        </div>
+      HTML
+    end
+
+    def convert_inline_callout(node)
+      %(<a id="#{node.id}"></a><i class="conum" data-value="#{node.text}"></i>)
+    end
+
+    def convert_colist(node)
+      [
+        '<div class="calloutlist">',
+        '<table border="0" summary="Callout list">',
+        node.items.map { |item| convert_colist_item item },
+        '</table>',
+        '</div>',
+      ].flatten.compact.join "\n"
+    end
+
+    def convert_colist_item(item)
+      [
+        '<tr>',
+        convert_colist_item_head(item),
+        convert_colist_item_body(item),
+        '</tr>',
+      ]
+    end
+
+    def convert_colist_item_head(item)
+      [
+        '<td align="left" valign="top" width="5%">',
+        "<p>#{convert_colist_item_coids item}</p>",
+        '</td>',
+      ]
+    end
+
+    def convert_colist_item_body(item)
+      [
+        '<td align="left" valign="top">',
+        "<p>#{item.text}</p>",
+        item.blocks? ? item.content : nil,
+        '</td>',
+      ]
+    end
+
+    def convert_colist_item_coids(item)
+      return '' unless (coids = item.attr 'coids')
+
+      result = []
+      coids.split(' ').each do |coid|
+        num = coid.split('-')[1]
+        result << '<a href="#' << coid << '">'
+        result << '<i class="conum" data-value="' << num << '"></i></a>'
+      end
+      result.join
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -4,6 +4,7 @@ require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative 'convert_document'
 require_relative 'convert_links'
+require_relative 'convert_listing'
 require_relative 'convert_lists'
 require_relative 'convert_outline'
 
@@ -21,6 +22,7 @@ module DocbookCompat
   class Converter < DelegatingConverter
     include ConvertDocument
     include ConvertLinks
+    include ConvertListing
     include ConvertLists
     include ConvertOutline
 
@@ -50,15 +52,6 @@ module DocbookCompat
     def convert_paragraph(node)
       <<~HTML
         <p>#{node.content}</p>
-      HTML
-    end
-
-    def convert_listing(node)
-      lang = node.attr 'language'
-      <<~HTML
-        <div class="pre_wrapper lang-#{lang}">
-        <pre class="programlisting prettyprint lang-#{lang}">#{node.content || ''}</pre>
-        </div>
       HTML
     end
 

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -405,6 +405,43 @@ RSpec.describe DocbookCompat do
         </div>
       HTML
     end
+
+    context 'paired with a callout list' do
+      let(:input) do
+        <<~ASCIIDOC
+          [source,sh]
+          ----
+          cpanm Search::Elasticsearch <1>
+          ----
+          <1> Foo
+        ASCIIDOC
+      end
+      context 'the listing' do
+        it 'includes the callout' do
+          expect(converted).to include <<~HTML.strip
+            cpanm Search::Elasticsearch <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+          HTML
+        end
+      end
+      context 'the callout list' do
+        it 'is rendered like a docbook callout list' do
+          expect(converted).to include <<~HTML
+            <div class="calloutlist">
+            <table border="0" summary="Callout list">
+            <tr>
+            <td align="left" valign="top" width="5%">
+            <p><a href="#CO1-1"><i class="conum" data-value="1"></i></a></p>
+            </td>
+            <td align="left" valign="top">
+            <p>Foo</p>
+            </td>
+            </tr>
+            </table>
+            </div>
+          HTML
+        end
+      end
+    end
   end
 
   context 'an unordered list' do


### PR DESCRIPTION
Asciidoctor doesn't *quite* render callout lists the same way that
docbook does. So we have to overwrite that too!
