### PR TITLE
Add descriptive text for ecctl title

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -790,7 +790,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
-            title:      Elastic Cloud Control
+            title:      Elastic Cloud Control - The Command-Line Interface for ECE
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL


### PR DESCRIPTION
I noticed that we don't have descriptive text for ecctl, which was probably my omission. This PR fixes that. 