### PR TITLE
Add breadcrumbs to direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative 'link'
+
+module Chunker
+  ##
+  # Builds the "breadcrumbs" at the top of the page.
+  module Breadcrumbs
+    include Link
+
+    def generate_breadcrumbs(doc, section)
+      result = ['<div class="breadcrumbs">']
+      result += generate_breadcrumb_links(section).reverse
+      result << %(<span class="breadcrumb-node">#{section.title}</span>)
+      result << '</div>'
+      Asciidoctor::Block.new doc, :pass, source: result.join("\n")
+    end
+
+    def generate_breadcrumb_links(section)
+      result = []
+      parent = section
+      while (parent = parent.parent)
+        result << <<~HTML.strip
+          <span class="breadcrumb-link"><a #{link_href parent}>#{link_text parent}</a></span>
+          »
+        HTML
+      end
+      result
+    end
+  end
+end

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -2,6 +2,7 @@
 
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
+require_relative 'breadcrumbs'
 require_relative 'extra_docinfo'
 require_relative 'find_related'
 
@@ -26,6 +27,7 @@ module Chunker
   ##
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
+    include Chunker::Breadcrumbs
     include Chunker::FindRelated
 
     def initialize(delegate, chunk_level)
@@ -63,6 +65,7 @@ module Chunker
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.
       subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, section)
+      subdoc << generate_breadcrumbs(doc, section)
       subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
       subdoc.convert
     end

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -15,7 +15,7 @@ module Chunker
     return unless doc.attr 'outdir'
     return unless (chunk_level = doc.attr 'chunk_level')
 
-    doc.extend Chunker::ExtraDocinfo
+    doc.extend ExtraDocinfo
     return if doc.attr 'subdoc'
 
     doc.attributes['toclevels'] ||= doc.attributes['chunk_level']
@@ -28,8 +28,8 @@ module Chunker
   ##
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
-    include Chunker::Breadcrumbs
-    include Chunker::FindRelated
+    include Breadcrumbs
+    include FindRelated
 
     def initialize(delegate, chunk_level)
       super(delegate)

--- a/resources/asciidoctor/lib/chunker/link.rb
+++ b/resources/asciidoctor/lib/chunker/link.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Chunker
+  ##
+  # Helpers for making links.
+  module Link
+    def link_href(target)
+      case target.context
+      when :section
+        %(href="#{target.id}.html")
+      when :document
+        %(href="index.html")
+      else
+        raise "Can't link to #{target}"
+      end
+    end
+
+    def link_title(target)
+      %(title="#{link_text target}")
+    end
+
+    def link_text(target)
+      case target.context
+      when :section
+        target.title
+      when :document
+        target.doctitle(partition: true).main.strip
+      else
+        raise "Can't link to #{target}"
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -108,6 +108,9 @@ RSpec.describe Chunker do
               <li><a href="s2.html">Section 2</a></li>
             HTML
           end
+          it "doesn't contain breadcrumbs" do
+            expect(converted).not_to include('<div class="breadcrumbs">')
+          end
         end
         file_context 'the first section', 's1.html' do
           include_examples 'healthy head', 'index', 'Title', 's2', 'Section 2'
@@ -121,6 +124,15 @@ RSpec.describe Chunker do
           it 'contains the contents' do
             expect(contents).to include '<p>Words words.</p>'
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-node">Section 1</span>
+              </div>
+            HTML
+          end
         end
         file_context 'the second section', 's2.html' do
           include_examples 'healthy head', 's1', 'Section 1', nil, nil
@@ -133,6 +145,15 @@ RSpec.describe Chunker do
           end
           it 'contains the contents' do
             expect(contents).to include '<p>Words again.</p>'
+          end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-node">Section 2</span>
+              </div>
+            HTML
           end
         end
       end
@@ -259,6 +280,15 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-node">S1</span>
+              </div>
+            HTML
+          end
         end
         file_context 'the first level 2 section', 's1_1.html' do
           include_examples 'healthy head', 's1', 'S1', 's2', 'S2'
@@ -266,12 +296,32 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-link"><a href="s1.html">S1</a></span>
+              »
+              <span class="breadcrumb-node">S1_1</span>
+              </div>
+            HTML
+          end
         end
         file_context 'the second level 1 section', 's2.html' do
           include_examples 'healthy head', 's1_1', 'S1_1', 's2_1', 'S2_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
+          end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-node">S2</span>
+              </div>
+            HTML
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
@@ -283,12 +333,34 @@ RSpec.describe Chunker do
           it 'contains the level 3 section' do
             expect(contents).to include('<h4 id="s2_1_1">S2_1_1</h4>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-link"><a href="s2.html">S2</a></span>
+              »
+              <span class="breadcrumb-node">S2_1</span>
+              </div>
+            HTML
+          end
         end
         file_context 'the last level 2 section', 's2_2.html' do
           include_examples 'healthy head', 's2_1', 'S2_1', nil, nil
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')
+          end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              »
+              <span class="breadcrumb-link"><a href="s2.html">S2</a></span>
+              »
+              <span class="breadcrumb-node">S2_2</span>
+              </div>
+            HTML
           end
         end
       end


### PR DESCRIPTION
Adds the breadcrumbs at the top of the page to `--direct_html`.
