### PR TITLE
Render deep toc in --direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
@@ -4,19 +4,28 @@ module DocbookCompat
   ##
   # Methods to convert the table of contents.
   module ConvertOutline
-    def convert_outline(node)
+    def convert_outline(node, opts = {})
       # Asciidoctor's implementation looks lovely but doesn't match docbook's
       # implementation. So we drop our own in. We should see if we can use
       # Asciidoctor's implementation ASAP though.
-      result = [%(<ul class="toc">\n)]
-      node.sections.each do |section|
-        result << <<~HTML
-          <li><span class="#{wrapper_class_for section}"><a href="##{section.id}">#{section.title}</a></span>
-          </li>
-        HTML
-      end
+      toclevels = opts[:toclevels] || node.document.attributes['toclevels'].to_i
+      result = [%(<ul class="toc">)]
+      result += node.sections.map { |s| outline_section s, toclevels }
       result << '</ul>'
-      result.join
+      result.join "\n"
+    end
+
+    def outline_section(section, toclevels)
+      link = %(<a href="##{section.id}">#{section.title}</a>)
+      link = %(<span class="#{wrapper_class_for section}">#{link}</span>)
+      result = [%(<li>#{link})]
+      if section.level < toclevels && section.sections?
+        result << '<ul>'
+        result += section.sections.map { |s| outline_section s, toclevels }
+        result << '</ul>'
+      end
+      result << '</li>'
+      result
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -99,7 +99,7 @@ module DocbookCompat
       HTML
     end
 
-    SECTION_WRAPPER_CLASSES = %w[unused chapter section].freeze
+    SECTION_WRAPPER_CLASSES = %w[part chapter section].freeze
     def wrapper_class_for(section)
       wrapper_class = section.attr 'style'
       wrapper_class ||= SECTION_WRAPPER_CLASSES[section.level]

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -126,6 +126,7 @@ RSpec.describe DocbookCompat do
           'dc.subject' => 'BarSubject',
           'dc.identifier' => 'BazIdentifier',
           'toc' => '',
+          'toclevels' => 1,
         }
       end
       let(:input) do
@@ -173,121 +174,154 @@ RSpec.describe DocbookCompat do
           HTML
         end
       end
-      context 'when there is a subtitle' do
-        let(:input) do
-          <<~ASCIIDOC
-            = Title: Subtitle
-
-            Words.
-          ASCIIDOC
-        end
-        context 'the title' do
-          it "doesn't include the subtitle" do
-            expect(converted).to include('<title>Title | Elastic</title>')
-          end
-        end
-        context 'the header' do
-          it 'includes the title and subtitle' do
-            expect(converted).to include(<<~HTML)
-              <div class="titlepage">
-              <div>
-              <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
-              <div><h2 class="subtitle">Subtitle</h2></div>
-              </div>
-              <hr>
-              </div>
-            HTML
-          end
-        end
-      end
-      context 'contains a navheader' do
-        # Emulates the chunker without trying to include it.
-        let(:input) do
-          <<~ASCIIDOC
-            = Title: Subtitle
-
-            [pass]
-            --
-            <div class="navheader">
-            nav nav nav
-            </div>
-            --
-
-            Words.
-          ASCIIDOC
-        end
-        context 'the navheader' do
-          it 'is moved above the "book" wrapper' do
-            expect(converted).to include(<<~HTML)
-              <div class="navheader">
-              nav nav nav
-              </div>
-              <div class="book" lang="en">
-            HTML
-          end
-        end
-      end
-      context 'contains a navfooer' do
-        # Emulates the chunker without trying to include it.
-        let(:input) do
-          <<~ASCIIDOC
-            = Title: Subtitle
-
-            [pass]
-            --
-            <div class="navfooter">
-            nav nav nav
-            </div>
-            --
-
-            Words.
-          ASCIIDOC
-        end
-        context 'the navfooter' do
-          it 'is moved below the "book" wrapper' do
-            expect(converted).to include(<<~HTML)
-              <div class="navfooter">
-              nav nav nav
-              </div>
-              </body>
-            HTML
-          end
-        end
-      end
-      context 'when the head is disabled' do
-        let(:convert_attributes) do
-          {
-            # Shrink the output slightly so it is easier to read
-            'stylesheet!' => false,
-            # Set some metadata that will be included in the header
-            'dc.type' => 'FooType',
-            'dc.subject' => 'BarSubject',
-            'dc.identifier' => 'BazIdentifier',
-            # Disable the head
-            'noheader' => true,
-          }
-        end
+      context 'when there is a level 0 section' do
         let(:input) do
           <<~ASCIIDOC
             = Title
 
-            Words.
+            = Part 1
+
+            == Section 1
+
+            == Section 2
           ASCIIDOC
         end
-        context 'the header' do
-          it "doesn't contain the title h1" do
-            expect(converted).not_to include('Title</h1>')
-          end
-        end
-        context 'the body' do
-          it "doesn't have attributes" do
-            expect(converted).to include('<body>')
-          end
-          it "doesn't include the 'book' wrapper" do
-            expect(converted).not_to include(<<~HTML)
-              <div class="book" lang="en">
+        context 'the table of contents' do
+          it 'looks like the docbook toc' do
+            expect(converted).to include(<<~HTML)
+              <!--START_TOC-->
+              <div class="toc">
+              <ul class="toc">
+              <li><span class="part"><a href="#_part_1">Part 1</a></span>
+              <ul>
+              <li><span class="chapter"><a href="#_section_1">Section 1</a></span>
+              </li>
+              <li><span class="chapter"><a href="#_section_2">Section 2</a></span>
+              </li>
+              </ul>
+              </li>
+              </ul>
+              </div>
+              <!--END_TOC-->
             HTML
           end
+        end
+      end
+    end
+    context 'when there is a subtitle' do
+      let(:input) do
+        <<~ASCIIDOC
+          = Title: Subtitle
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the title' do
+        it "doesn't include the subtitle" do
+          expect(converted).to include('<title>Title | Elastic</title>')
+        end
+      end
+      context 'the header' do
+        it 'includes the title and subtitle' do
+          expect(converted).to include(<<~HTML)
+            <div class="titlepage">
+            <div>
+            <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
+            <div><h2 class="subtitle">Subtitle</h2></div>
+            </div>
+            <hr>
+            </div>
+          HTML
+        end
+      end
+    end
+    context 'contains a navheader' do
+      # Emulates the chunker without trying to include it.
+      let(:input) do
+        <<~ASCIIDOC
+          = Title: Subtitle
+
+          [pass]
+          --
+          <div class="navheader">
+          nav nav nav
+          </div>
+          --
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the navheader' do
+        it 'is moved above the "book" wrapper' do
+          expect(converted).to include(<<~HTML)
+            <div class="navheader">
+            nav nav nav
+            </div>
+            <div class="book" lang="en">
+          HTML
+        end
+      end
+    end
+    context 'contains a navfooer' do
+      # Emulates the chunker without trying to include it.
+      let(:input) do
+        <<~ASCIIDOC
+          = Title: Subtitle
+
+          [pass]
+          --
+          <div class="navfooter">
+          nav nav nav
+          </div>
+          --
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the navfooter' do
+        it 'is moved below the "book" wrapper' do
+          expect(converted).to include(<<~HTML)
+            <div class="navfooter">
+            nav nav nav
+            </div>
+            </body>
+          HTML
+        end
+      end
+    end
+    context 'when the head is disabled' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
+          # Set some metadata that will be included in the header
+          'dc.type' => 'FooType',
+          'dc.subject' => 'BarSubject',
+          'dc.identifier' => 'BazIdentifier',
+          # Disable the head
+          'noheader' => true,
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the header' do
+        it "doesn't contain the title h1" do
+          expect(converted).not_to include('Title</h1>')
+        end
+      end
+      context 'the body' do
+        it "doesn't have attributes" do
+          expect(converted).to include('<body>')
+        end
+        it "doesn't include the 'book' wrapper" do
+          expect(converted).not_to include(<<~HTML)
+            <div class="book" lang="en">
+          HTML
         end
       end
     end


### PR DESCRIPTION
This enables rendering subsections in the table of contents in a way
that mimicks docbook. In doing so it fixes a crash when trying to
convert chunked books that have subsections caused by the chunker not
seeing the subsections in the toc. This adds them so it is happy.
