### PR TITLE
Drop index from direct_html's nav

### DIFF
--- a/resources/asciidoctor/lib/chunker/nav.rb
+++ b/resources/asciidoctor/lib/chunker/nav.rb
@@ -40,6 +40,8 @@ module Chunker
 
     def nav_link(section, lmarker, rmarker)
       return unless section
+      # section could be the document itself which shouldn't render.
+      return unless section.context == :section
 
       %(<a #{link_href section}>#{lmarker}#{section.title}#{rmarker}</a>)
     end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Chunker do
       it 'contains the navfooter' do
         expect(contents).to include('<div class="navfooter">')
       end
-      if prev_page
+      if prev_page && prev_page != 'index'
         it 'contains the prev nav' do
           expect(contents).to include(<<~HTML)
             <span class="prev">


### PR DESCRIPTION
It turns out that docbook doesn't add the `index.html` as a "prev" page
in docbook's nav even though it *does* add it as `<link rel="prev"`.
Funny thing, that. Anyway, this makes us line up with docbook.
