### PR TITLE
Fix override text on xref in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_links.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_links.rb
@@ -23,7 +23,7 @@ module DocbookCompat
       ref = node.document.catalog[:refs][refid]
       return "#{xref}>#{refid}</a>" unless ref
 
-      text = ref_text_for ref, node
+      text = node.text || ref_text_for(ref, node)
       title = ref.respond_to?(:title) ? ref.title : nil
       <<~HTML.strip
         #{xref}#{title ? %(title="#{title}") : ''}>#{text}</a>

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -137,7 +137,9 @@ RSpec.describe Chunker do
 
             Words again.
 
-            <<linkme>>
+            <<linkme,override text>>
+
+            <<s1,override text>>
           ASCIIDOC
         end
         context 'the main output' do
@@ -204,7 +206,12 @@ RSpec.describe Chunker do
             HTML
           end
           it 'contains a link to an element in the first section' do
-            expect(contents).to include('<a href="s1.html#linkme">[linkme]</a>')
+            expect(contents).to include(
+              '<a href="s1.html#linkme">override text</a>'
+            )
+          end
+          it 'contains a link to the first section with override text' do
+            expect(contents).to include('<a href="s1.html">override text</a>')
           end
         end
       end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -391,21 +391,6 @@ RSpec.describe DocbookCompat do
         expect(converted).to include('target="_blank"')
       end
     end
-    context 'when the link is to an inline anchor' do
-      let(:input) do
-        <<~ASCIIDOC
-          [[target]]`target`:: foo
-
-          <<target>>
-        ASCIIDOC
-      end
-      it 'references the url' do
-        expect(converted).to include('href="#target"')
-      end
-      it 'has the right title' do
-        expect(converted).to include('><code class="literal">target</code></a>')
-      end
-    end
   end
 
   context 'a cross reference' do
@@ -428,6 +413,34 @@ RSpec.describe DocbookCompat do
     end
     it 'wraps the title in <em>' do
       expect(converted).to include('><em>Foo</em></a>')
+    end
+    context 'when the link text is overridden' do
+      let(:input) do
+        <<~ASCIIDOC
+          Words <<foo,override text>>.
+
+          [[foo]]
+          == Foo
+        ASCIIDOC
+      end
+      it 'contains the overridden text' do
+        expect(converted).to include('>override text</a>')
+      end
+    end
+    context 'when the cross reference is to an inline anchor' do
+      let(:input) do
+        <<~ASCIIDOC
+          [[target]]`target`:: foo
+
+          <<target>>
+        ASCIIDOC
+      end
+      it 'references the url' do
+        expect(converted).to include('href="#target"')
+      end
+      it 'has the right title' do
+        expect(converted).to include('><code class="literal">target</code></a>')
+      end
     end
   end
 


### PR DESCRIPTION
Stops us from ignoring explicit link text like `<<target,override text>>`
on cross references in direct_html. I was so concerned with getting he
text right in the complex cases I didn't do the obvious case where it is
specified....
