### PR TITLE
Improve list rendering in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -20,8 +20,10 @@ module DocbookCompat
       node.items.each do |item|
         next unless item.text
 
-        html.sub!("<p>#{item.text}</p>", item.text) ||
-          raise("Couldn't remove <p> for #{item.text} in #{html}")
+        result = item.text
+        result = %(<p class="simpara">#{result}</p>) if item.blocks?
+        html.sub!("<p>#{item.text}</p>", result) ||
+          raise("Couldn't correct <p> for #{item.text} in #{html}")
       end
       html
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_open.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_open.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert open blocks.
+  module ConvertOpen
+    def convert_open(node)
+      # If the open block is *totally* unadorned then it is entirely invisible.
+      return yield unless node.style == 'open'
+      return yield if node.id
+      return yield if node.title?
+
+      node.content
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -6,6 +6,7 @@ require_relative 'convert_document'
 require_relative 'convert_links'
 require_relative 'convert_listing'
 require_relative 'convert_lists'
+require_relative 'convert_open'
 require_relative 'convert_outline'
 
 ##
@@ -24,6 +25,7 @@ module DocbookCompat
     include ConvertLinks
     include ConvertListing
     include ConvertLists
+    include ConvertOpen
     include ConvertOutline
 
     def convert_section(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -632,6 +632,31 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+
+    context 'with complex contents' do
+      let(:input) do
+        <<~ASCIIDOC
+          . Foo
+          +
+          --
+          Complex
+          --
+        ASCIIDOC
+      end
+      it 'wraps the text in a <p>' do
+        expect(converted).to include(<<~HTML)
+          <li class="listitem">
+          <p class="simpara">Foo</p>
+        HTML
+      end
+      it 'include the complex content' do
+        expect(converted).to include(<<~HTML)
+          <p>Complex</p>
+
+          </li>
+        HTML
+      end
+    end
   end
 
   context 'backticked code' do
@@ -733,6 +758,28 @@ RSpec.describe DocbookCompat do
 
         </div>
       HTML
+    end
+  end
+
+  context 'an open block' do
+    context 'that is empty' do
+      let(:input) do
+        <<~ASCIIDOC
+          --
+          Words.
+          --
+        ASCIIDOC
+      end
+      it 'just renders its contents' do
+        expect(converted).to eq <<~HTML.strip
+          <div id="preamble">
+          <div class="sectionbody">
+          <p>Words.</p>
+
+          </div>
+          </div>
+        HTML
+      end
     end
   end
 end


### PR DESCRIPTION
List items always have text and *sometimes* have complex content. If the
list item has complex content then docbook wraps the text in
`<p class="sempara>`. We should do that too for compatibility.
