### PR TITLE
Remove lingering Asciidoc (Python) reference from README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -147,12 +147,10 @@ users to specify their preferred language or client. You can do this by passing
 [source,bash]
 ----------------------------
 cd docs/
-./build_docs --doc README.asciidoc --open --asciidoctor \
+./build_docs --doc README.asciidoc --open \
     --alternatives console:js:integtest/readme_examples/js \
     --alternatives console:csharp:integtest/readme_examples/csharp
 ----------------------------
-
-NOTE: This is only supported by Asciidoctor, not AsciiDoc.
 
 == Correcting errors
 


### PR DESCRIPTION
The Elastic doc toolchain migrated from the original Python Asciidoc
to Asciidoctor, a re-implementation in Ruby (tracked in #505).

During the migration, the README referenced both Asciidoc and
Asciidoctor. After the migration, #1414 removed all references to the
original Asciidoc and standardized the README on Asciidoctor. However, I
found one lingering reference to the days when both tools were being
used.

Remove a reference to the obsolete `--asciidoctor` command line option
and a note about Asciidoc vs Asciidoctor.