### PR TITLE
Add "other versions" link to versions drop down

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -601,11 +601,11 @@ RSpec.describe 'building all books' do
   context 'when the book has "live" branches' do
     convert_all_before_context do |src|
       repo = src.repo_with_index 'repo', 'test'
-      repo.switch_to_new_branch 'other'
+      repo.switch_to_new_branch 'nonlive'
 
       book = src.book 'Test'
       book.source repo, 'index.asciidoc'
-      book.branches << 'other'
+      book.branches << 'nonlive'
       book.live_branches = ['master']
     end
     page_context 'the live branch', 'html/test/master/index.html' do
@@ -617,12 +617,12 @@ RSpec.describe 'building all books' do
       context 'the version drop down' do
         it 'contains only the live branch' do
           expect(body).to include(<<~HTML.strip)
-            <select><option value="master" selected>master (current)</option></select>
+            <select><option value="master" selected>master (current)</option><option value="other">other versions</option></select>
           HTML
         end
       end
     end
-    page_context 'the dead branch', 'html/test/other/index.html' do
+    page_context 'the dead branch', 'html/test/nonlive/index.html' do
       it 'contains the noindex flag' do
         expect(contents).to include(<<~HTML.strip)
           <meta name="robots" content="noindex,nofollow" />
@@ -631,7 +631,7 @@ RSpec.describe 'building all books' do
       context 'the version drop down' do
         it 'contains the deprecated branch' do
           expect(body).to include(<<~HTML.strip)
-            <select><option value="master">master (current)</option><option value="other" selected>other (out of date)</option></select>
+            <select><option value="master">master (current)</option><option value="nonlive" selected>nonlive (out of date)</option></select>
           HTML
         end
       end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -330,9 +330,13 @@ sub _update_title_and_version_drop_downs {
     my ( $self, $branch_dir, $branch ) = @_;
 
     my $title = '<li id="book_title"><span>' . $self->title . ': <select>';
+    my $removed_any = 0;
     for my $b ( @{ $self->branches } ) {
         my $live = grep( /^$b$/, @{ $self->{live_branches} } );
-        next unless $live || $branch eq $b;
+        unless ( $live || $branch eq $b ) {
+            $removed_any = 1;
+            next;
+        }
 
         $title .= '<option value="' . $b . '"';
         $title .= ' selected'  if $branch eq $b;
@@ -341,6 +345,7 @@ sub _update_title_and_version_drop_downs {
         $title .= ' (out of date)' unless $live;
         $title .= '</option>';
     }
+    $title .= '<option value="other">other versions</option>' if $removed_any;
     $title .= '</select></span></li>';
     for ( 'toc.html', 'index.html' ) {
         my $file = $branch_dir->file($_);

--- a/resources/web/docs_js/utils.js
+++ b/resources/web/docs_js/utils.js
@@ -9,6 +9,7 @@ const VERSION_REGEX = /[^\/]+\/+([^\/]+\.html)/;
 export function get_current_page_in_version(version) {
   if (version === "other") {
     location.href = location.href.replace(VERSION_REGEX, "index.html");
+    return;
   }
   var url = location.href.replace(VERSION_REGEX, version + "/$1");
   return $.get(url).done(function() {

--- a/resources/web/docs_js/utils.js
+++ b/resources/web/docs_js/utils.js
@@ -5,9 +5,12 @@ export function get_base_url(href) {
              .replace(/^http:/, 'https:');
 }
 
+const VERSION_REGEX = /[^\/]+\/+([^\/]+\.html)/;
 export function get_current_page_in_version(version) {
-  var url = location.href;
-  var url = location.href.replace(/[^\/]+\/+([^\/]+\.html)/, version + "/$1");
+  if (version === "other") {
+    location.href = location.href.replace(VERSION_REGEX, "index.html");
+  }
+  var url = location.href.replace(VERSION_REGEX, version + "/$1");
   return $.get(url).done(function() {
     location.href = url
   });


### PR DESCRIPTION
This adds an "other versions" link to the versions drop downs if we
stripped any versions from the drop down because they aren't "live". We
remove non-"live" versions from the drop down because we don't want
folks accidentally picking up an old version and because the list just
gets too long with all the versions listed. But we still publish all the
old versions in case some unfortunate soul is stuck on that version.
This adds an "other versions" option to the versions drop down so those
folks can find their version.
