### PR TITLE
Tolerate direct_html's toc

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -350,7 +350,7 @@ sub _update_title_and_version_drop_downs {
         next unless -e $file;
 
         my $html = $file->slurp( iomode => "<:encoding(UTF-8)" );
-        my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?<li>/<ul class="toc">${title}<li>/);
+        my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?\n?<li>/<ul class="toc">${title}<li>/);
         die "couldn't update version" unless $success;
         $file->spew( iomode => '>:utf8', $html );
     }


### PR DESCRIPTION
We use perl code to hack the book's title into the table of contents.
Because we like it there. *Technically* we could use an Asciidoctor
customerization to do it in direct_html but in the spirit of keeping the
changes as small as possible I've just fixed the perl code to tolerate
direct_html output.
