### PR TITLE
Replace "simpara" style with one more explicit

### DIFF
--- a/resources/web/style/docbook.pcss
+++ b/resources/web/style/docbook.pcss
@@ -13,13 +13,6 @@
   .chapter div.section {
       margin-top: 2em;
   }
-
-  p.simpara+div {
-    &.orderedlist,
-    &.itemizedlist {
-      margin-top: -0.9em;
-    }
-  }
 }
 
 .guide-section {

--- a/resources/web/style/list.pcss
+++ b/resources/web/style/list.pcss
@@ -38,4 +38,14 @@
       }
     }
   }
+  /* Moves lists that directly follow paragraphs inside of dd and li close under
+   * the paragraph so they look more "togeter". */
+  dd, li {
+    & > p + div {
+      &.orderedlist,
+      &.itemizedlist {
+        margin-top: -0.9em;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Sometimes docsbook spits out `<p>` tags with `class="simpara"` and
sometimes it doesn't. I can't quite figure out the rules, but I'd like
it not to matter. And it *mostly* doesn't. There was just one css rule
that used `simpara` and of course it wasn't commented. But I've reverse
engineered it: it is designed to make lists that directly follow
paragraphs that are *inside* of `<dd>` or `<li>` closer to the
paragraph. Without it the lists look "lonely" and separate from the
paragraph.

So I replaced it with a css rule that explicitly looks for `<dd>` and
`<li>`.
