### PR TITLE
Drop simpara from direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -61,6 +61,12 @@ def normalize_html(html):
         if '.html#' in e['href']:
             e['class'].remove('xref')
             e['class'].append('link')
+    # Docbook sprinkles `class="simpara"` all over the place and I'm not 100%
+    # sure why. But we don't need it anyway.
+    for e in soup.select('.simpara'):
+        e['class'].remove('simpara')
+        if not e['class']:
+            del e['class']
     # Format the html with indentation so we can *see* things
     html = soup.prettify()
     # docbook spits out the long-form charset and asciidoctor spits out the

--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -19,11 +19,10 @@ module DocbookCompat
       html = yield
       node.items.each do |item|
         next unless item.text
+        next if item.blocks?
 
-        result = item.text
-        result = %(<p class="simpara">#{result}</p>) if item.blocks?
-        html.sub!("<p>#{item.text}</p>", result) ||
-          raise("Couldn't correct <p> for #{item.text} in #{html}")
+        html.sub!("<p>#{item.text}</p>", item.text) ||
+          raise("Couldn't remove <p> for #{item.text} in #{html}")
       end
       html
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe DocbookCompat do
       it 'wraps the text in a <p>' do
         expect(converted).to include(<<~HTML)
           <li class="listitem">
-          <p class="simpara">Foo</p>
+          <p>Foo</p>
         HTML
       end
       it 'include the complex content' do


### PR DESCRIPTION
Docbook adds `class="simpara"` all over the place but we don't use the
class. So this ignores it in our diff generater and drops it from the
`--direct_html` implementation.
