### PR TITLE
Fix direct_html's complex admonitions

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -71,17 +71,16 @@ module DocbookCompat
     end
 
     def convert_admonition(node)
-      name = node.attr 'name'
-      <<~HTML
-        <div class="#{name} admon">
-        <div class="icon"></div>
-        <div class="admon_content">
-        <p>
-        #{node.content}
-        </p>
-        </div>
-        </div>
-      HTML
+      [
+        %(<div class="#{node.attr 'name'} admon">),
+        %(<div class="icon"></div>),
+        %(<div class="admon_content">),
+        node.blocks.empty? ? '<p>' : nil,
+        node.content,
+        node.blocks.empty? ? '</p>' : nil,
+        '</div>',
+        '</div>',
+      ].compact.join "\n"
     end
 
     def convert_literal(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -685,22 +685,50 @@ RSpec.describe DocbookCompat do
 
   context 'admonitions' do
     shared_examples 'standard admonition' do |key, admonclass|
-      let(:input) do
-        <<~ASCIIDOC
-          #{key}: words
-        ASCIIDOC
+      context 'with text' do
+        let(:input) do
+          <<~ASCIIDOC
+            #{key}: words
+          ASCIIDOC
+        end
+        it "renders with Elastic's custom template" do
+          expect(converted).to include(<<~HTML)
+            <div class="#{admonclass} admon">
+            <div class="icon"></div>
+            <div class="admon_content">
+            <p>
+            words
+            </p>
+            </div>
+            </div>
+          HTML
+        end
       end
-      it "renders with Elastic's custom template" do
-        expect(converted).to include(<<~HTML)
-          <div class="#{admonclass} admon">
-          <div class="icon"></div>
-          <div class="admon_content">
-          <p>
-          words
-          </p>
-          </div>
-          </div>
-        HTML
+      context 'with complex content' do
+        let(:input) do
+          <<~ASCIIDOC
+            [#{key}]
+            --
+            . words
+            --
+          ASCIIDOC
+        end
+        it "renders with Elastic's custom template" do
+          expect(converted).to include(<<~HTML)
+            <div class="#{admonclass} admon">
+            <div class="icon"></div>
+            <div class="admon_content">
+            <div class="olist orderedlist">
+            <ol class="orderedlist">
+            <li class="listitem">
+            words
+            </li>
+            </ol>
+            </div>
+            </div>
+            </div>
+          HTML
+        end
       end
     end
     context 'note' do


### PR DESCRIPTION
When an admonition has blocks inside it docbook doesn't wrap them all in
a `<p>` tag. But when it is doesn't have blocks and just has some text
then it *does* wrap the text in the `<p>` tag. So do that too.
