### PR TITLE
Add basic table implementation to direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert tables.
+  module ConvertTable
+    def convert_table(node)
+      [
+        '<div class="informaltable">',
+        '<table border="1" cellpadding="4px">',
+        table_parts(node),
+        '</table>',
+        '</div>',
+      ].flatten.join "\n"
+    end
+
+    def table_parts(node)
+      head, body, foot = pull_table_parts node
+      result = []
+      result += table_head head unless head.empty?
+      result += table_body body unless body.empty?
+      result += table_foot foot unless foot.empty?
+      result
+    end
+
+    def pull_table_parts(node)
+      ((_head, head), (_body, body), (_foot, foot)) = node.rows.by_section
+      [head, body, foot]
+    end
+
+    def table_head(rows)
+      [
+        '<thead>',
+        rows.map { |row| table_row row, 'th' },
+        '</thead>',
+      ].flatten
+    end
+
+    def table_body(rows)
+      [
+        '<tbody>',
+        rows.map { |row| table_row row, 'td', false },
+        '</tbody>',
+      ].flatten
+    end
+
+    def table_foot(rows)
+      [
+        '<tbody>',
+        rows.map { |row| table_row row, 'td', true },
+        '</tbody>',
+      ].flatten
+    end
+
+    def table_row(row, data_tag, wrap_bare_data)
+      [
+        '<tr>',
+        row.map { |cell| table_cell cell, data_tag, wrap_bare_data },
+        '</tr>',
+      ].flatten
+    end
+
+    def table_cell(cell, data_tag, wrap_bare_data)
+      [
+        '<', data_tag, ' align="left" valign="top">',
+        cell.blocks? nil : '<p>',
+        cell.content.join(''),
+        cell.blocks? nil : '</p>',
+        '</', data_tag, '>'
+      ].compact.join
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -8,6 +8,7 @@ require_relative 'convert_listing'
 require_relative 'convert_lists'
 require_relative 'convert_open'
 require_relative 'convert_outline'
+require_relative 'convert_table'
 
 ##
 # HTML5 converter that emulates Elastic's docbook generated html.
@@ -27,6 +28,7 @@ module DocbookCompat
     include ConvertLists
     include ConvertOpen
     include ConvertOutline
+    include ConvertTable
 
     def convert_section(node)
       <<~HTML

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -810,4 +810,49 @@ RSpec.describe DocbookCompat do
       end
     end
   end
+
+  context 'tables' do
+    context 'basic' do
+      let(:input) do
+        <<~ASCIIDOC
+          |===
+          |Col 1 | Col 2
+
+          |Foo   | Bar
+          |Baz   | Bort
+          |===
+        ASCIIDOC
+      end
+      it 'is wrapped in informaltable' do
+        expect(converted).to include <<~HTML
+          <div class="informaltable">
+          <table border="1" cellpadding="4px">
+        HTML
+      end
+      it 'contains the head' do
+        expect(converted).to include <<~HTML
+          <thead>
+          <tr>
+          <th align="left" valign="top">Col 1</th>
+          <th align="left" valign="top">Col 2</th>
+          </tr>
+          </thead>
+        HTML
+      end
+      it 'contains the body' do
+        expect(converted).to include <<~HTML
+          <tbody>
+          <tr>
+          <td align="left" valign="top"><p>Foo</p></td>
+          <td align="left" valign="top"><p>Bar</p></td>
+          </tr>
+          <tr>
+          <td align="left" valign="top"><p>Baz</p></td>
+          <td align="left" valign="top"><p>Bort</p></td>
+          </tr>
+          </tbody>
+        HTML
+      end
+    end
+  end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -829,6 +829,14 @@ RSpec.describe DocbookCompat do
           <table border="1" cellpadding="4px">
         HTML
       end
+      it 'contains the colgroups' do
+        expect(converted).to include <<~HTML
+          <colgroup>
+          <col class="col_1"/>
+          <col class="col_2"/>
+          </colgroup>
+        HTML
+      end
       it 'contains the head' do
         expect(converted).to include <<~HTML
           <thead>


### PR DESCRIPTION
Asciidoctor's default able implementation doesn't line up with
docbook's. So we're going to have to customize it! This adds a very
basic table implemenation that works for the getting started books. And
probably quite a few others. But it is only a start! Tables can get
pretty intricate. We'll get there.