### PR TITLE
Update styles for direct_html's screenshots

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -55,6 +55,12 @@ def normalize_html(html):
     for e in soup.select('.inlinemediaobject'):
         e['class'].remove('inlinemediaobject')
         e['class'].append('image')
+    # Docbook emits screenshot images with the 'informalfigure' class and
+    # Asciidoctor has the 'imageblock' class. We've updated our styles to make
+    # both work.
+    for e in soup.select('.informalfigure'):
+        e['class'].remove('informalfigure')
+        e['class'].append('imageblock')
     # Docbook links with `<a class="link"` when linking from one page of a book
     # to another. Asciidoctor emits `<a class="link"`. Both look fine.
     for e in soup.select('a.xref'):

--- a/resources/web/style/img.pcss
+++ b/resources/web/style/img.pcss
@@ -1,7 +1,7 @@
 #guide {
-  /* 'inlinemediaobject' and 'mediaobject' are for docbook. 'image' is
-   * for Asciidoctor. */
-  .image, .inlinemediaobject, .mediaobject {
+  /* 'inlinemediaobject' and 'mediaobject' are for docbook. 'image' and
+   * 'imageblock' are for Asciidoctor. */
+  .image, .imageblock, .inlinemediaobject, .mediaobject {
     img {
       max-width: 100%;
     }


### PR DESCRIPTION
When we make a screenshot `--direct_html` emits a different class. It is
pretty simple to update the css to pick that class up. Much simpler than
making `--direct_html` emit the docbook classes. So this updates the
styles to render the new class and the html diff tool to ignore the
difference in classes.
