### PR TITLE
Added elasticsearch-js doc examples configuration

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -314,7 +314,7 @@ contents:
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
-                alternatives: { source_lang: console, alternative_lang: javascript }
+                alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -313,6 +313,11 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: javascript }
+                repo:   elasticsearch-js
+                path:   docs/doc_examples
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           -
             title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency


### PR DESCRIPTION
As titled, https://github.com/elastic/elasticsearch-js/pull/1011 contains all the doc examples.
Which one should I merge first?