### PR TITLE
Differentiate X-Pack Reference and Stack Overview

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -3,7 +3,7 @@
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
-:xpack-ref:            https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
+:xpack-ref:            https://www.elastic.co/guide/en/x-pack/6.2
 :logstash-ref:         https://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}
 :beats-ref:            https://www.elastic.co/guide/en/beats/libbeat/{branch}


### PR DESCRIPTION
The :xpack-ref: shared attribute is defined in https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc such that it equates to the Stack Overview.  This helped avoid broken links when the Stack Overview was first created.

However, there are places in the Cloud documentation where we need to be able to refer to old books as well as new ones. This PR sets the :xpack-ref: attribute to the final 6.2 version for the X-Pack Reference book so those old references can still work.