### PR TITLE
Add version to some titles in direct_html

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -120,6 +120,7 @@ sub build_chunked {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             ) : (),
             '--destination-dir=' . $raw_dest,
             docinfo($index),
@@ -279,6 +280,7 @@ sub build_single {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $multi ? ( '-a' => "title-extra= [$version]" ) : (),
                 # Turn on asciidoctor's table of contents generation if we want a TOC
                 $toc ? ('-a' => 'toc') : (),
             ) : (),

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -20,8 +20,9 @@ module Chunker
       result = []
       parent = section
       while (parent = parent.parent)
+        extra = parent.context == :document ? parent.attr('title-extra') : ''
         result << <<~HTML.strip
-          <span class="breadcrumb-link"><a #{link_href parent}>#{link_text parent}</a></span>
+          <span class="breadcrumb-link"><a #{link_href parent}>#{link_text parent}#{extra}</a></span>
           »
         HTML
       end

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -37,14 +37,10 @@ module Chunker
     end
 
     def convert_document(doc)
-      unless doc.attr 'home'
-        title = doc.doctitle partition: true
-        doc.attributes['home'] = title.main.strip
-      end
+      title = doc.doctitle partition: true
+      doc.attributes['home'] = title.main.strip + doc.attr('title-extra', '')
       doc.attributes['next_section'] = find_next_in doc, 0
-      nav = Nav.new doc
-      doc.blocks.insert 0, nav.header
-      doc.blocks.append nav.footer
+      add_nav doc
       yield
     end
 
@@ -68,6 +64,12 @@ module Chunker
     def convert_inline_anchor(node)
       correct_xref node if node.type == :xref
       yield
+    end
+
+    def add_nav(doc)
+      nav = Nav.new doc
+      doc.blocks.insert 0, nav.header
+      doc.blocks.append nav.footer
     end
 
     def correct_xref(node)

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -26,7 +26,9 @@ module Chunker
     def link_rel(rel, related)
       return unless related
 
-      %(<link rel="#{rel}" #{link_href related} #{link_title related}/>)
+      extra = related.context == :document ? related.attr('title-extra') : ''
+      title = %(title="#{link_text related}#{extra}")
+      %(<link rel="#{rel}" #{link_href related} #{title}/>)
     end
   end
 end

--- a/resources/asciidoctor/lib/chunker/link.rb
+++ b/resources/asciidoctor/lib/chunker/link.rb
@@ -15,10 +15,6 @@ module Chunker
       end
     end
 
-    def link_title(target)
-      %(title="#{link_text target}")
-    end
-
     def link_text(target)
       case target.context
       when :section

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -35,7 +35,7 @@ module DocbookCompat
     def munge_html(doc, html, wants_toc)
       title = doc.doctitle partition: true
       munge_html_tag html
-      munge_head title, html
+      munge_head doc.attr('title-extra'), title, html
       munge_body doc, html
       munge_title doc, title, html
       add_toc doc, html if wants_toc
@@ -46,9 +46,10 @@ module DocbookCompat
         raise("Coudn't fix html in #{html}")
     end
 
-    def munge_head(title, html)
+    def munge_head(title_extra, title, html)
       html.gsub!(
-        %r{<title>.+</title>}, "<title>#{title.main} | Elastic</title>"
+        %r{<title>.+</title>},
+        "<title>#{title.main}#{title_extra} | Elastic</title>"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
     end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Chunker do
       end
       it 'contains the home link' do
         expect(contents).to include(<<~HTML)
-          <link rel="home" href="index.html" title="Title"/>
+          <link rel="home" href="index.html" title="Title#{convert_attributes['title-extra']}"/>
         HTML
       end
       if prev_page
@@ -318,6 +318,47 @@ RSpec.describe Chunker do
           end
           it 'contains contents' do
             expect(contents).to include('<p>Words again.</p>')
+          end
+        end
+      end
+      context 'when there is title-extra' do
+        let(:convert_attributes) do
+          {
+            'outdir' => outdir,
+            'chunk_level' => 1,
+            # Shrink the output slightly so it is easier to read
+            'stylesheet!' => false,
+            # We always enable the toc for multi-page books
+            'toc' => '',
+            'title-extra' => ' [fooo]',
+          }
+        end
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [[s1]]
+            == Section 1
+          ASCIIDOC
+        end
+        context 'the main output' do
+          let(:contents) { converted }
+          include_examples 'standard page', nil, nil, 's1', 'Section 1'
+          it 'contains the correct title' do
+            expect(contents).to include('<title>Title</title>')
+          end
+        end
+        file_context 'the section', 's1.html' do
+          include_examples 'standard page', 'index', 'Title [fooo]', nil, nil
+          include_examples 'subpage'
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="index.html">Title [fooo]</a></span>
+              »
+              <span class="breadcrumb-node">Section 1</span>
+              </div>
+            HTML
           end
         end
       end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -325,6 +325,35 @@ RSpec.describe DocbookCompat do
         end
       end
     end
+    context 'when there is title-extra' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
+          # Set some metadata that will be included in the header
+          'dc.type' => 'FooType',
+          'dc.subject' => 'BarSubject',
+          'dc.identifier' => 'BazIdentifier',
+          'toc' => '',
+          'toclevels' => 1,
+          'title-extra' => ' [fooo]',
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          == Section 1
+
+          == Section 2
+        ASCIIDOC
+      end
+      context 'the title' do
+        it 'includes Elastic' do
+          expect(converted).to include('<title>Title [fooo] | Elastic</title>')
+        end
+      end
+    end
   end
 
   context 'sections' do


### PR DESCRIPTION
Docbook adds the version of the book to some title attributes on some
links. This teaches `--direct_html` to add them there too.
