### PR TITLE
Implement noindex in direct_html

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -120,6 +120,7 @@ sub build_chunked {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $noindex ? ('-a' => 'noindex') : (),
             ) : (),
             '--destination-dir=' . $raw_dest,
             docinfo($index),
@@ -279,6 +280,7 @@ sub build_single {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $noindex ? ('-a' => 'noindex') : (),
                 # Turn on asciidoctor's table of contents generation if we want a TOC
                 $toc ? ('-a' => 'toc') : (),
             ) : (),

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -22,13 +22,20 @@ module DocbookCompat
     module ExtraDocinfo
       def docinfo(location = :head, suffix = nil)
         info = super
-        return info unless location == :head
+        info += head_extra if location == :head
+        info
+      end
 
-        info + <<~HTML
+      def head_extra
+        info = <<~HTML
           <meta name="DC.type" content="#{attributes['dc.type']}"/>
           <meta name="DC.subject" content="#{attributes['dc.subject']}"/>
           <meta name="DC.identifier" content="#{attributes['dc.identifier']}"/>
         HTML
+        info += <<~HTML if attributes['noindex']
+          <meta content="noindex,nofollow" name="robots"/>
+        HTML
+        info
       end
     end
 

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -325,6 +325,34 @@ RSpec.describe DocbookCompat do
         end
       end
     end
+    context 'when the head is disabled' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
+          # Set some metadata that will be included in the header
+          'dc.type' => 'FooType',
+          'dc.subject' => 'BarSubject',
+          'dc.identifier' => 'BazIdentifier',
+          # Turn off indexing
+          'noindex' => true,
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the head' do
+        it 'contains a directive to not follow or index the page' do
+          expect(converted).to include(
+            '<meta content="noindex,nofollow" name="robots"/>'
+          )
+        end
+      end
+    end
   end
 
   context 'sections' do


### PR DESCRIPTION
Implements the `noindex` flag in direct html which causes us to add a
header to the page that asks robots not to index or follow the page.
Docbook has this so we should too.
