### PR TITLE
Add extra header support to direct_html

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -120,6 +120,7 @@ sub build_chunked {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $page_header ? ('-a' => "page-header=$page_header") : (),
             ) : (),
             '--destination-dir=' . $raw_dest,
             docinfo($index),
@@ -279,6 +280,7 @@ sub build_single {
                 '-a' => 'dc.type=Learn/Docs/' . $section,
                 '-a' => 'dc.subject=' . $subject,
                 '-a' => 'dc.identifier=' . $version,
+                $page_header ? ('-a' => "page-header=$page_header") : (),
                 # Turn on asciidoctor's table of contents generation if we want a TOC
                 $toc ? ('-a' => 'toc') : (),
             ) : (),

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -10,11 +10,13 @@ module Chunker
 
     def docinfo(location = :head, suffix = nil)
       info = super
-      info += extra_head if location == :head
+      info += extra_chunker_head if location == :head
       info
     end
 
-    def extra_head
+    private
+
+    def extra_chunker_head
       [
         %(<link rel="home" href="index.html" title="#{attributes['home']}"/>),
         link_rel('up', attributes['up_section']),

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require_relative 'extra_docinfo'
+require_relative 'munge_body'
+
 module DocbookCompat
   ##
   # Methods to convert the document at the top level. All of these are a bit
   # scary but required at this point for docbook compatibility.
   module ConvertDocument
+    include MungeBody
+
     def convert_document(doc)
       # We'll manually add the toc ourselves if it was requested.
       wants_toc = doc.attr?('toc') && doc.attr?('toc-placement', 'auto')
@@ -15,21 +20,6 @@ module DocbookCompat
       html = yield
       munge_html doc, html, wants_toc
       html + "\n"
-    end
-
-    ##
-    # Adds extra tags <link> tags to the <head> to emulate docbook.
-    module ExtraDocinfo
-      def docinfo(location = :head, suffix = nil)
-        info = super
-        return info unless location == :head
-
-        info + <<~HTML
-          <meta name="DC.type" content="#{attributes['dc.type']}"/>
-          <meta name="DC.subject" content="#{attributes['dc.subject']}"/>
-          <meta name="DC.identifier" content="#{attributes['dc.identifier']}"/>
-        HTML
-      end
     end
 
     def munge_html(doc, html, wants_toc)
@@ -64,36 +54,6 @@ module DocbookCompat
         raise("Couldn't remove viewport in #{html}")
       html.gsub!(/<meta name="generator" content="Asciidoctor [^"]+">\n/, '') ||
         raise("Couldn't remove generator in #{html}")
-    end
-
-    def munge_body(doc, html)
-      if doc.attr 'noheader'
-        html.gsub!(/<body[^>]+>/, '<body>')
-      else
-        munge_body_and_header_open doc, html
-        munge_body_and_header_close html
-      end
-    end
-
-    def munge_body_and_header_open(doc, html)
-      # Note nav header and footer should be *outside* the div wrapping the body
-      wrapped = [
-        %(<body>),
-        html.slice!(%r{<div class="navheader">.+?<\/div>\n}m)&.strip,
-        %(<div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">),
-      ].compact.join "\n"
-      html.gsub!(/<body[^>]+>/, wrapped) ||
-        raise("Couldn't wrap body in #{html}")
-    end
-
-    def munge_body_and_header_close(html)
-      wrapped = [
-        '</div>',
-        html.slice!(%r{<div class="navfooter">.+?<\/div>\n}m),
-        '</body>',
-      ].compact.join
-      html.gsub!('</body>', wrapped) ||
-        raise("Couldn't wrap body in #{html}")
     end
 
     def munge_title(doc, title, html)

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Adds extra meta stuff to the <head> and header
+  module ExtraDocinfo
+    def docinfo(location = :head, suffix = nil)
+      case location
+      when :head
+        super + extra_docbook_compat_head
+      else
+        super
+      end
+    end
+
+    private
+
+    def extra_docbook_compat_head
+      <<~HTML
+        <meta name="DC.type" content="#{attributes['dc.type']}"/>
+        <meta name="DC.subject" content="#{attributes['dc.subject']}"/>
+        <meta name="DC.identifier" content="#{attributes['dc.identifier']}"/>
+      HTML
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/munge_body.rb
+++ b/resources/asciidoctor/lib/docbook_compat/munge_body.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to munge the generated html around the `<body>` tags.
+  module MungeBody
+    def munge_body(doc, html)
+      if doc.attr 'noheader'
+        html.gsub!(/<body[^>]+>/, "<body>#{extra_page_header doc}")
+      else
+        munge_body_and_header_open doc, html
+        munge_body_and_header_close html
+      end
+    end
+
+    def munge_body_and_header_open(doc, html)
+      # Note nav header and footer should be *outside* the div wrapping the body
+      wrapped = [
+        %(<body>),
+        extra_page_header(doc),
+        html.slice!(%r{<div class="navheader">.+?<\/div>\n}m)&.strip,
+        %(<div class="#{doc.doctype}" lang="#{doc.attr 'lang', 'en'}">),
+      ].compact.join "\n"
+      html.gsub!(/<body[^>]+>/, wrapped) ||
+        raise("Couldn't wrap body in #{html}")
+    end
+
+    def extra_page_header(doc)
+      return unless (extra = doc.attr 'page-header')
+
+      <<~HTML.strip
+        <div class="page_header">
+        #{extra}
+        </div>
+      HTML
+    end
+
+    def munge_body_and_header_close(html)
+      wrapped = [
+        '</div>',
+        html.slice!(%r{<div class="navfooter">.+?<\/div>\n}m),
+        '</body>',
+      ].compact.join
+      html.gsub!('</body>', wrapped) ||
+        raise("Couldn't wrap body in #{html}")
+    end
+  end
+end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -289,15 +289,35 @@ RSpec.describe DocbookCompat do
         end
       end
     end
+    context 'when there is a page-header' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
+          'page-header' => '<div class="foo" />',
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the header' do
+        it 'contains the page-header right after the body tag' do
+          expect(converted).not_to include <<~HTML
+            <body>
+            <div class="foo" />
+          HTML
+        end
+      end
+    end
     context 'when the head is disabled' do
       let(:convert_attributes) do
         {
           # Shrink the output slightly so it is easier to read
           'stylesheet!' => false,
-          # Set some metadata that will be included in the header
-          'dc.type' => 'FooType',
-          'dc.subject' => 'BarSubject',
-          'dc.identifier' => 'BazIdentifier',
           # Disable the head
           'noheader' => true,
         }
@@ -322,6 +342,32 @@ RSpec.describe DocbookCompat do
           expect(converted).not_to include(<<~HTML)
             <div class="book" lang="en">
           HTML
+        end
+      end
+
+      context 'when there is a page-header' do
+        let(:convert_attributes) do
+          {
+            # Shrink the output slightly so it is easier to read
+            'stylesheet!' => false,
+            'noheader' => true,
+            'page-header' => '<div class="foo" />',
+          }
+        end
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the header' do
+          it 'contains the page-header right after the body tag' do
+            expect(converted).not_to include <<~HTML
+              <body>
+              <div class="foo" />
+            HTML
+          end
         end
       end
     end


### PR DESCRIPTION
We use "extra" header elements on the page to convey things like "this
version is out of date" or "this version has yet to be released".
`--direct_html` was ignoring those extra headers. This adds support for
it.
