### PR TITLE
Fix compatibility for direct_html's dl

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -75,6 +75,11 @@ def normalize_html(html):
     # sure why. But we don't need it anyway.
     for e in soup.select('.simpara'):
         e['class'].remove('simpara')
+    # Docbook *never* makes a <dd> tag that contains only a <p> tag.
+    # Asciidoctor *can* do that if the description is formed in a very
+    # particular way. Visually, it all looks the same.
+    for e in soup.select('dd > p:only-child'):
+        e.unwrap()
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -54,7 +54,7 @@ module DocbookCompat
     end
 
     def convert_paragraph(node)
-      <<~HTML
+      <<~HTML.strip
         <p>#{node.content}</p>
       HTML
     end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -54,9 +54,8 @@ module DocbookCompat
     end
 
     def convert_paragraph(node)
-      <<~HTML.strip
-        <p>#{node.content}</p>
-      HTML
+      # Asciidoctor adds a \n at the end of the paragraph so we don't.
+      %(<p>#{node.content}</p>)
     end
 
     def convert_inline_quoted(node)


### PR DESCRIPTION
Implement docbook compatibility for direct_html's description lists.
This should be enough to convert our glossary to direct_html.

This also removes the double trailing new lines from `</p>`. Asciidoctor
already seems to add a newline for those.

This also cleans up a bug in list rendering that I encountered while
doing real world testing of the description lists: if you form an
ordered list with `1.` instead of `.` then it wasn't getting the
override. This fixes that.

This looks to be enough to unblock #1494.
