### PR TITLE
Clean up direct_html difference in titled images

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -61,6 +61,34 @@ def normalize_html(html):
     for e in soup.select('.informalfigure'):
         e['class'].remove('informalfigure')
         e['class'].append('imageblock')
+    # Docbook emits images with titles as 'figure' but docbook just uses
+    # 'imageblock'. And all kinds of other things are different. But they don't
+    # *look* different.
+    for e in soup.select('.imageblock.text-center'):
+        e['class'].remove('text-center')
+    for e in soup.select('.imageblock[id]'):
+        anchor = soup.new_tag('a')
+        anchor['id'] = e['id']
+        e.insert(0, anchor)
+        del e['id']
+    for e in soup.select('.figure'):
+        e['class'].remove('figure')
+        e['class'].append('imageblock')
+        for i in e.select('img[align=middle]'):
+            del i['align']
+        for a in e.select('a'):
+            if a['id'].startswith('id-'):
+                a.extract()
+        for t in e.select('.title'):
+            t.extract()
+            new_t = soup.new_tag("div")
+            new_t['class'] = ['title']
+            new_t.append(t.contents[0].extract().contents[0])
+            e.append(new_t)
+        for c in e.select('.figure-contents'):
+            c['class'].remove('figure-contents')
+            c['class'].append('mediaobject')
+            c.contents[0].unwrap()
     # Same for mediaobject and content
     for e in soup.select('.content'):
         e['class'].remove('content')

--- a/resources/web/style/img.pcss
+++ b/resources/web/style/img.pcss
@@ -5,6 +5,15 @@
     img {
       max-width: 100%;
     }
+    .title {
+      font-weight: bold;
+      margin-bottom: 1em;
+    }
+  }
+  .imageblock {
+    /* Asciidoctor emits the title *after* the image but we want it above. */
+    display: flex;
+    flex-direction: column-reverse;
   }
   .screenshot img {
     margin: 20px 0 20px 0;


### PR DESCRIPTION
`--direct_html` produces html for images with titles that is fairly
different than what docbook makes. But with a little CSS this makes them
*look* the same. And with a little more python code this makes the diff
tool ignore the changes to the html.
