### PR TITLE
Be slightly less picky in normalizing links

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -68,9 +68,8 @@ def normalize_html(html):
     # Docbook links with `<a class="link"` when linking from one page of a book
     # to another. Asciidoctor emits `<a class="link"`. Both look fine.
     for e in soup.select('a.xref'):
-        if '.html#' in e['href']:
-            e['class'].remove('xref')
-            e['class'].append('link')
+        e['class'].remove('xref')
+        e['class'].append('link')
     # Docbook sprinkles `class="simpara"` all over the place and I'm not 100%
     # sure why. But we don't need it anyway.
     for e in soup.select('.simpara'):


### PR DESCRIPTION
There were some cases where we Asciidoctor and Docbook don't agree on
the classes on links. Those classes don't make and visual difference so
this ignores them. We actually already *tried* to ignore them, but we
didn't do it all the time.
