### PR TITLE
Properly chunk footnotes in direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/footnotes.rb
+++ b/resources/asciidoctor/lib/chunker/footnotes.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Chunker
+  ##
+  # Generate the footnotes.
+  module Footnotes
+    def footnotes(doc, subdoc)
+      return unless doc.footnotes?
+
+      source = [
+        '<div id="footnotes">',
+        doc.footnotes.map { |f| doc.converter.convert f, 'footnote' },
+        '</div>',
+      ].join "\n"
+      doc.footnotes.clear
+
+      Asciidoctor::Block.new subdoc, :pass, source: source
+    end
+
+    def convert_footnote(footnote)
+      <<~HTML.strip
+        <div class="footnote" id="_footnotedef_#{footnote.index}">
+        <sup>[<a href="#_footnoteref_#{footnote.index}">#{footnote.index}</a>]</sup> #{footnote.text}
+        </div>
+      HTML
+    end
+  end
+end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Chunker do
             == Section 1
 
             [[linkme]]
-            Words words.
+            Words words.footnote:[foo]
 
             <<s2>>
 
@@ -140,6 +140,8 @@ RSpec.describe Chunker do
             <<linkme,override text>>
 
             <<s1,override text>>
+
+            footnote:[bar]
           ASCIIDOC
         end
         context 'the main output' do
@@ -158,6 +160,9 @@ RSpec.describe Chunker do
           it "doesn't contain breadcrumbs" do
             expect(converted).not_to include('<div class="breadcrumbs">')
           end
+          it "doesn't contain any footnotes" do
+            expect(converted).not_to include('<div id="footnotes">')
+          end
         end
         file_context 'the first section', 's1.html' do
           include_examples 'standard page', 'index', 'Title', 's2', 'Section 2'
@@ -169,7 +174,9 @@ RSpec.describe Chunker do
             expect(contents).to include('<h2 id="s1">Section 1</h2>')
           end
           it 'contains the contents' do
-            expect(contents).to include '<p>Words words.</p>'
+            expect(contents).to include <<~HTML
+              <p>Words words.<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup></p>
+            HTML
           end
           it 'contains the breadcrumbs' do
             expect(contents).to include <<~HTML
@@ -182,6 +189,15 @@ RSpec.describe Chunker do
           end
           it 'contains a link to the second section' do
             expect(contents).to include('<a href="s2.html">Section 2</a>')
+          end
+          it 'contains the footnote' do
+            expect(contents).to include <<~HTML
+              <div id="footnotes">
+              <div class="footnote" id="_footnotedef_1">
+              <sup>[<a href="#_footnoteref_1">1</a>]</sup> foo
+              </div>
+              </div>
+            HTML
           end
         end
         file_context 'the second section', 's2.html' do
@@ -212,6 +228,15 @@ RSpec.describe Chunker do
           end
           it 'contains a link to the first section with override text' do
             expect(contents).to include('<a href="s1.html">override text</a>')
+          end
+          it 'contains the footnote' do
+            expect(contents).to include <<~HTML
+              <div id="footnotes">
+              <div class="footnote" id="_footnotedef_2">
+              <sup>[<a href="#_footnoteref_2">2</a>]</sup> bar
+              </div>
+              </div>
+            HTML
           end
         end
       end

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -18,7 +18,7 @@ export function init_headers(right_col, lang_strings) {
   var ul = $('<ul></ul>').appendTo(this_page);
   var items = 0;
 
-  $('#guide a[id]').each(
+  $('#guide a[id]:not([href])').each(
     function() {
       // Make headers into real links for permalinks
       this.href = '#' + this.id;


### PR DESCRIPTION
Asciidoctor allows you to make footnotes and we use them. This makes
sure that they end up on the same page as they are declared. Without it
the footnotes end up on the "index" page which is super confusing.

NOTE: I'm note really making an effort to make this line up perfectly
with docbook's output. These *should* be rare enough that I can verify
them by hand. We really don't use *that* many footnotes.
