### PR TITLE
Properly handle level 3 sections in direct html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -101,11 +101,11 @@ module DocbookCompat
       HTML
     end
 
-    SECTION_WRAPPER_CLASSES = %w[part chapter section].freeze
+    SECTION_WRAPPER_CLASSES = %w[part chapter].freeze
     def wrapper_class_for(section)
       wrapper_class = section.attr 'style'
       wrapper_class ||= SECTION_WRAPPER_CLASSES[section.level]
-      wrapper_class ||= "sect#{section.level}"
+      wrapper_class ||= 'section'
       wrapper_class
     end
   end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -473,6 +473,15 @@ RSpec.describe DocbookCompat do
       include_examples 'section basics', 'section', 2, '_section_2', 'Section 2'
     end
 
+    context 'level 3' do
+      let(:input) do
+        <<~ASCIIDOC
+          ==== Section 3
+        ASCIIDOC
+      end
+      include_examples 'section basics', 'section', 3, '_section_3', 'Section 3'
+    end
+
     context 'a preface' do
       let(:input) do
         <<~ASCIIDOC


### PR DESCRIPTION
This fixes the wrapper class on level 3 sections in direct html.
Required for #1495.
