### PR TITLE
Handle complex content in tables in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -76,14 +76,16 @@ module DocbookCompat
     end
 
     def convert_cell(cell, data_tag, wrap_bare_data)
-      should_wrap = wrap_bare_data && !cell.blocks?
-      [
-        '<', data_tag, ' align="left" valign="top">',
-        should_wrap ? '<p>' : nil,
-        cell.content.join(''),
-        should_wrap ? '</p>' : nil,
-        '</', data_tag, '>'
-      ].compact.join
+      result = ['<', data_tag, ' align="left" valign="top">']
+      if cell.inner_document
+        result << "\n" << cell.content << "\n"
+      else
+        result << '<p>' if wrap_bare_data
+        result << cell.text
+        result << '</p>' if wrap_bare_data
+      end
+      result << '</' << data_tag << '>'
+      result.join
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -67,22 +67,22 @@ module DocbookCompat
       ].flatten
     end
 
-    def convert_row(row, data_tag, wrap_bare_data)
+    def convert_row(row, data_tag, wrap_text)
       [
         '<tr>',
-        row.map { |cell| convert_cell cell, data_tag, wrap_bare_data },
+        row.map { |cell| convert_cell cell, data_tag, wrap_text },
         '</tr>',
       ].flatten
     end
 
-    def convert_cell(cell, data_tag, wrap_bare_data)
+    def convert_cell(cell, data_tag, wrap_text)
       result = ['<', data_tag, ' align="left" valign="top">']
       if cell.inner_document
         result << "\n" << cell.content << "\n"
       else
-        result << '<p>' if wrap_bare_data
+        result << '<p>' if wrap_text
         result << cell.text
-        result << '</p>' if wrap_bare_data
+        result << '</p>' if wrap_text
       end
       result << '</' << data_tag << '>'
       result.join

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1090,5 +1090,30 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with asciidoc content' do
+      let(:input) do
+        <<~ASCIIDOC
+          |===
+          |Col 1
+
+          a|
+          . Foo
+          |===
+        ASCIIDOC
+      end
+      it 'contains the asciidoc content' do
+        expect(converted).to include <<~HTML
+          <td align="left" valign="top">
+          <div class="olist orderedlist">
+          <ol class="orderedlist">
+          <li class="listitem">
+          Foo
+          </li>
+          </ol>
+          </div>
+          </td>
+        HTML
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds support for complex content inside of tables like lists and
things to `--direct_html`. Without this change complex content would
cause us to crash!

Required for #1505
