### PR TITLE
Render listing titles in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -6,10 +6,22 @@ module DocbookCompat
   module ConvertListing
     def convert_listing(node)
       lang = node.attr 'language'
-      <<~HTML
+      title = convert_listing_title node
+      body = <<~HTML
         <div class="pre_wrapper lang-#{lang}">
         <pre class="programlisting prettyprint lang-#{lang}">#{node.content || ''}</pre>
         </div>
+      HTML
+      return body unless title
+
+      title + body
+    end
+
+    def convert_listing_title(node)
+      return unless node.title
+
+      <<~HTML
+        <p><strong>#{node.title}</strong></p>
       HTML
     end
 

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -664,6 +664,23 @@ RSpec.describe DocbookCompat do
         end
       end
     end
+    context 'with a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          [source,sh]
+          ----
+          cpanm Search::Elasticsearch
+          ----
+        ASCIIDOC
+      end
+      it "the title is before in docbook's funny wrapper" do
+        expect(converted).to include(<<~HTML)
+          <p><strong>Title</strong></p>
+          <div class="pre_wrapper lang-sh">
+        HTML
+      end
+    end
   end
 
   context 'an unordered list' do


### PR DESCRIPTION
When a code listing has a title docbook wraps it in `<p><strong>`. So
should we.
