### PR TITLE
Add support for horizontal dlists to direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert lists.
+  module ConvertDList
+    def convert_dlist(node)
+      style = node.style || 'vertical'
+      node.converter.convert node, "#{style}_dlist"
+    end
+
+    def convert_vertical_dlist(node)
+      [
+        '<div class="variablelist">',
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+        '<dl class="variablelist">',
+        node.items.map { |terms, dd| convert_vertical_dlist_item terms, dd },
+        '</dl>',
+        '</div>',
+      ].flatten.compact.join "\n"
+    end
+
+    HORIZONTAL_DLIST_INTRO = [
+      '<div class="informaltable">',
+      '<table border="0" cellpadding="4px">',
+      '<colgroup>',
+      '<col/>',
+      '<col/>',
+      '</colgroup>',
+      '<tbody valign="top">',
+    ].freeze
+    HORIZONTAL_DLIST_OUTRO = [
+      '</tbody>',
+      '</table>',
+      '</div>',
+    ].freeze
+    def convert_horizontal_dlist(node)
+      [
+        HORIZONTAL_DLIST_INTRO,
+        node.items.map { |terms, dd| convert_horizontal_dlist_item terms, dd },
+        HORIZONTAL_DLIST_OUTRO,
+      ].flatten
+    end
+
+    private
+
+    def convert_vertical_dlist_item(terms, definition)
+      [
+        terms.map { |term| convert_vertical_dlist_term term },
+        convert_vertical_dlist_definition(definition),
+      ].flatten
+    end
+
+    def convert_vertical_dlist_term(term)
+      [
+        '<dt>',
+        '<span class="term">',
+        term.convert,
+        '</span>',
+        '</dt>',
+      ]
+    end
+
+    def convert_vertical_dlist_definition(definition)
+      return unless definition
+
+      ['<dd>', definition.convert, '</dd>']
+    end
+
+    def convert_horizontal_dlist_item(terms, definition)
+      [
+        '<tr>',
+        '<td valign="top">',
+        terms.map { |term| convert_horizontal_dlist_term term },
+        '</td>',
+        convert_horizontal_dlist_definition(definition),
+        '</tr>',
+      ].flatten
+    end
+
+    def convert_horizontal_dlist_term(term)
+      ['<p>', term.convert, '</p>']
+    end
+
+    def convert_horizontal_dlist_definition(definition)
+      ['<td valign="top">', '<p>', definition&.convert, '</p>', '</td>'].compact
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -16,17 +16,6 @@ module DocbookCompat
       convert_list node, &block
     end
 
-    def convert_dlist(node)
-      [
-        '<div class="variablelist">',
-        node.id ? %(<a id="#{node.id}"></a>) : nil,
-        '<dl class="variablelist">',
-        node.items.map { |terms, dd| convert_dlist_item terms, dd },
-        '</dl>',
-        '</div>',
-      ].flatten.compact.join "\n"
-    end
-
     def convert_list_item(item)
       return item.text unless item.blocks?
       return item.content unless item.text
@@ -52,29 +41,6 @@ module DocbookCompat
           raise("Couldn't remove <p> for #{item.text} in #{html}")
       end
       html
-    end
-
-    def convert_dlist_item(terms, definition)
-      [
-        terms.map { |term| convert_dlist_term term },
-        convert_dlist_definition(definition),
-      ].flatten
-    end
-
-    def convert_dlist_term(term)
-      [
-        '<dt>',
-        '<span class="term">',
-        term.convert,
-        '</span>',
-        '</dt>',
-      ]
-    end
-
-    def convert_dlist_definition(definition)
-      return unless definition
-
-      ['<dd>', definition.convert, '</dd>']
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -3,6 +3,7 @@
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative 'convert_document'
+require_relative 'convert_dlist'
 require_relative 'convert_links'
 require_relative 'convert_listing'
 require_relative 'convert_lists'
@@ -23,6 +24,7 @@ module DocbookCompat
   # A Converter implementation that emulates Elastic's docbook generated html.
   class Converter < DelegatingConverter
     include ConvertDocument
+    include ConvertDList
     include ConvertLinks
     include ConvertListing
     include ConvertLists

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -870,7 +870,6 @@ RSpec.describe DocbookCompat do
         expect(converted).not_to include '<dd>'
       end
     end
-
     context 'with complex content' do
       let(:input) do
         <<~ASCIIDOC
@@ -897,7 +896,6 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
-
     context 'when the anchor is on the previous line' do
       let(:input) do
         <<~ASCIIDOC
@@ -910,6 +908,63 @@ RSpec.describe DocbookCompat do
           <div class="variablelist">
           <a id="bar"></a>
           <dl class="variablelist">
+        HTML
+      end
+    end
+    context 'horizontally styled' do
+      let(:input) do
+        <<~ASCIIDOC
+          [horizontal]
+          Foo:: The foo.
+          Bar:: The bar.
+        ASCIIDOC
+      end
+      it 'is rendered like a table' do
+        expect(converted).to include <<~HTML
+          <div class="informaltable">
+          <table border="0" cellpadding="4px">
+          <colgroup>
+          <col/>
+          <col/>
+          </colgroup>
+          <tbody valign="top">
+        HTML
+        expect(converted).to include <<~HTML
+          </tbody>
+          </table>
+          </div>
+        HTML
+      end
+      it 'contains a row for the first entry' do
+        expect(converted).to include <<~HTML
+          <tr>
+          <td valign="top">
+          <p>
+          Foo
+          </p>
+          </td>
+          <td valign="top">
+          <p>
+          The foo.
+          </p>
+          </td>
+          </tr>
+        HTML
+      end
+      it 'contains a row for the second entry' do
+        expect(converted).to include <<~HTML
+          <tr>
+          <td valign="top">
+          <p>
+          Bar
+          </p>
+          </td>
+          <td valign="top">
+          <p>
+          The bar.
+          </p>
+          </td>
+          </tr>
         HTML
       end
     end


### PR DESCRIPTION
This adds docbook-style horizontal dlist support to direct_html.
Required for #1506.
