### PR TITLE
Handle two level lists in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -10,8 +10,9 @@ module DocbookCompat
     end
 
     def convert_olist(node, &block)
-      # Note: the style can be a symbol or the a string.....
-      override_style = node.style.nil? || node.style.to_s == 'arabic'
+      override_style = node.style.nil?
+      # The style can be a symbol or the a string.....
+      override_style ||= %w[arabic loweralpha].include? node.style.to_s
       node.style = 'orderedlist' if override_style
       convert_list node, &block
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -790,7 +790,6 @@ RSpec.describe DocbookCompat do
         end
       end
     end
-
     context 'with complex contents' do
       let(:input) do
         <<~ASCIIDOC
@@ -811,6 +810,29 @@ RSpec.describe DocbookCompat do
         expect(converted).to include(<<~HTML)
           <p>Complex</p>
           </li>
+        HTML
+      end
+    end
+    context 'second level' do
+      let(:input) do
+        <<~ASCIIDOC
+          . L1
+          .. L2
+          .. Thing 2
+        ASCIIDOC
+      end
+      it 'the outer list is wrapped an orderedlist div' do
+        expect(converted).to include <<~HTML
+          <div class="sectionbody">
+          <div class="olist orderedlist">
+          <ol class="orderedlist">
+        HTML
+      end
+      it 'the inner list is wrapped an orderedlist div' do
+        expect(converted).to include <<~HTML
+          <p>L1</p>
+          <div class="olist orderedlist">
+          <ol class="orderedlist">
         HTML
       end
     end


### PR DESCRIPTION
This fixes how we handle two level lists in `--direct_html` so they are
rendered in a docboook compatible way.
