### PR TITLE
Ignore empty <p> when comparing direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -107,6 +107,10 @@ def normalize_html(html):
     # particular way. Visually, it all looks the same.
     for e in soup.select('dd > p:only-child'):
         e.unwrap()
+    # Docbook would sometimes spit out empty <p> tags. We're fine with
+    # dropping those.
+    for e in soup.select('p:empty'):
+        e.extract()
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):


### PR DESCRIPTION
Docbook spits out empty `<p>` tags sometimes. I'm not sure why. But I'm
95% sure we don't want them. Sure enough that we can ignore them in the
diff and clean them up if anyone complains later.
