### PR TITLE
Support title on admonitions in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -78,9 +78,8 @@ module DocbookCompat
         %(<div class="#{node.attr 'name'} admon">),
         %(<div class="icon"></div>),
         %(<div class="admon_content">),
-        node.blocks.empty? ? '<p>' : nil,
-        node.content,
-        node.blocks.empty? ? '</p>' : nil,
+        node.title? ? "<h3>#{node.title}</h3>" : nil,
+        node.blocks.empty? ? "<p>#{node.content}</p>" : node.content,
         '</div>',
         '</div>',
       ].compact.join "\n"

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1029,9 +1029,7 @@ RSpec.describe DocbookCompat do
             <div class="#{admonclass} admon">
             <div class="icon"></div>
             <div class="admon_content">
-            <p>
-            words
-            </p>
+            <p>words</p>
             </div>
             </div>
           HTML
@@ -1058,6 +1056,28 @@ RSpec.describe DocbookCompat do
             </li>
             </ol>
             </div>
+            </div>
+            </div>
+          HTML
+        end
+      end
+      context 'with a title' do
+        let(:input) do
+          <<~ASCIIDOC
+            [#{key}]
+            .Title
+            --
+            words
+            --
+          ASCIIDOC
+        end
+        it "renders with Elastic's custom template" do
+          expect(converted).to include(<<~HTML)
+            <div class="#{admonclass} admon">
+            <div class="icon"></div>
+            <div class="admon_content">
+            <h3>Title</h3>
+            <p>words</p>
             </div>
             </div>
           HTML


### PR DESCRIPTION
You can add a title to admonitions with
```
[WARNING]
.Title goes here
--
Content goes here
--
```

This makes direct_html produce the same output as docbook for those
titles.

Required for #1506.