### PR TITLE
Retire 7.4 from the live stack releases

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -52,7 +52,7 @@ contents:
             current:    7.5
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.5, 7.4, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.5, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack


### PR DESCRIPTION
With the release of 7.5.0, the 7.4.x branches passed their maintenance date:
https://www.elastic.co/support/eol

This retires the 7.4 branch from the list of "live" Stack release branches in our docs.

I believe this is our first time doing this so let me know if we want to formalize the process a bit more. I see benefits in both keeping the branch around longer _or_ updating the list as part of release (or shortly after).

Appreciate any feedback!
