### PR TITLE
Tweak diff algorithm for direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -38,17 +38,17 @@ def normalize_html(html):
     # hurt anything so we can ignore it.
     for e in soup.select('.itemizedlist.ulist'):
         e['class'].remove('ulist')
-    # Docbook adds type="disc" to ul which is the default and isn't needed.
+    # Docbook adds type which we override in css.
     for e in soup.select('ul'):
-        if 'type' in e.attrs and e['type'] == 'disc':
+        if 'type' in e.attrs:
             del e['type']
     # Asciidoctor adds a "olist" class to all ordered lists which doesn't
     # hurt anything so we can ignore it.
     for e in soup.select('.orderedlist.olist'):
         e['class'].remove('olist')
-    # Docbook adds type="1" to ol which is the default and isn't needed.
+    # Docbook adds type="1" to ol which we override with css.
     for e in soup.select('ol'):
-        if 'type' in e.attrs and e['type'] == '1':
+        if 'type' in e.attrs:
             del e['type']
     # Docbook emits images with the 'inlinemediaobject' class and Asciidoctor
     # has the 'image' class. We've updated our styles to make both work.
@@ -117,6 +117,10 @@ def normalize_html(html):
     # dropping those.
     for e in soup.select('p:empty'):
         e.extract()
+    # Docbook makes `<code class="literal"><code class="literal">` sometimes.
+    # Just one `<code>` is fine though.
+    for e in soup.select("code.literal > code.literal"):
+        e.unwrap()
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):


### PR DESCRIPTION
When I built the diff for logstash I discovered a few small tweaks I
could make to the diff algorithm:
1. Totally ignore any "type" attributes on `ul` and `li` because we
override the type in css.
2. Ignore "double wrapping" of `<code>` tags that docbook can sometimes
make.

Required for #1512
