### PR TITLE
Fix rendering of no lang listings in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -5,16 +5,24 @@ module DocbookCompat
   # Methods code listings and their paired callout lists.
   module ConvertListing
     def convert_listing(node)
-      lang = node.attr 'language'
       title = convert_listing_title node
-      body = <<~HTML
-        <div class="pre_wrapper lang-#{lang}">
-        <pre class="programlisting prettyprint lang-#{lang}">#{node.content || ''}</pre>
-        </div>
-      HTML
+      body = convert_listing_body node
       return body unless title
 
       title + body
+    end
+
+    def convert_listing_body(node)
+      if (lang = node.attr 'language')
+        pre_classes = "programlisting prettyprint lang-#{lang}"
+        [
+          %(<div class="pre_wrapper lang-#{lang}">),
+          %(<pre class="#{pre_classes}">#{node.content || ''}</pre>),
+          %(</div>),
+        ].join "\n"
+      else
+        %(<pre class="screen">#{node.content || ''}</pre>)
+      end
     end
 
     def convert_listing_title(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -627,6 +627,13 @@ RSpec.describe DocbookCompat do
         </div>
       HTML
     end
+    it "isn't followed by an extra blank line" do
+      expect(converted).to include(<<~HTML)
+        </pre>
+        </div>
+        </div>
+      HTML
+    end
 
     context 'paired with a callout list' do
       let(:input) do
@@ -679,6 +686,43 @@ RSpec.describe DocbookCompat do
           <p><strong>Title</strong></p>
           <div class="pre_wrapper lang-sh">
         HTML
+      end
+    end
+    context "when the listing doesn't have a language" do
+      let(:input) do
+        <<~ASCIIDOC
+          ----
+          cpanm Search::Elasticsearch
+          ----
+        ASCIIDOC
+      end
+      it "is wrapped in docbook's funny wrapper" do
+        # It is important that there isn't any extra space around the <pre> tags
+        expect(converted).to include(<<~HTML)
+          <pre class="screen">cpanm Search::Elasticsearch</pre>
+        HTML
+      end
+      it "isn't followed by an extra blank line" do
+        expect(converted).to include(<<~HTML)
+          </pre>
+          </div>
+        HTML
+      end
+      context 'with a title' do
+        let(:input) do
+          <<~ASCIIDOC
+            .Title
+            ----
+            cpanm Search::Elasticsearch
+            ----
+          ASCIIDOC
+        end
+        it "the title is before in docbook's funny wrapper" do
+          expect(converted).to include(<<~HTML)
+            <p><strong>Title</strong></p>
+            <pre class="screen">cpanm Search::Elasticsearch</pre>
+          HTML
+        end
       end
     end
   end


### PR DESCRIPTION
When you declare a code listing without a language docbook renders it
quite differently than one *with* a language. This makes direct_html do
the same.
