### PR TITLE
Don't include "role=exclude" entries from the toc

### DIFF
--- a/resources/asciidoctor/lib/chunker/convert_outline.rb
+++ b/resources/asciidoctor/lib/chunker/convert_outline.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Chunker
+  ##
+  # Clean up the generated outline.
+  module ConvertOutline
+    def convert_outline(node, opts = {})
+      # Fix links in the toc
+      toclevels = opts[:toclevels] || node.document.attributes['toclevels'].to_i
+      outline = yield
+      cleanup_outline outline, node, toclevels
+      outline
+    end
+
+    private
+
+    def cleanup_outline(outline, node, toclevels)
+      node.sections.each do |section|
+        next if section.roles.include? 'exclude'
+
+        outline.gsub!(%(href="##{section.id}"), %(href="#{section.id}.html")) ||
+          raise("Couldn't fix section link for #{section.id} in #{outline}")
+        cleanup_outline outline, section, toclevels if section.level < toclevels
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -3,6 +3,7 @@
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative 'breadcrumbs'
+require_relative 'convert_outline'
 require_relative 'extra_docinfo'
 require_relative 'find_related'
 require_relative 'footnotes'
@@ -30,6 +31,7 @@ module Chunker
   # A Converter implementation that chunks like docbook.
   class Converter < DelegatingConverter
     include Breadcrumbs
+    include ConvertOutline
     include FindRelated
     include Footnotes
 
@@ -44,14 +46,6 @@ module Chunker
       doc.attributes['next_section'] = find_next_in doc, 0
       add_nav doc
       yield
-    end
-
-    def convert_outline(node, opts = {})
-      # Fix links in the toc
-      toclevels = opts[:toclevels] || node.document.attributes['toclevels'].to_i
-      outline = yield
-      cleanup_outline outline, node, toclevels
-      outline
     end
 
     def convert_section(section)
@@ -144,14 +138,6 @@ module Chunker
         f.write html
       end
       file
-    end
-
-    def cleanup_outline(outline, node, toclevels)
-      node.sections.each do |section|
-        outline.gsub!(%(href="##{section.id}"), %(href="#{section.id}.html")) ||
-          raise("Couldn't fix section link for #{section.id} in #{outline}")
-        cleanup_outline outline, section, toclevels if section.level < toclevels
-      end
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -212,6 +212,32 @@ RSpec.describe DocbookCompat do
           end
         end
       end
+      context 'when a section has role=exclude' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            == Section 1
+
+            [.exclude]
+            == Section 2
+          ASCIIDOC
+        end
+        context 'the table of contents' do
+          it "doesn't include the excluded section" do
+            expect(converted).to include(<<~HTML)
+              <!--START_TOC-->
+              <div class="toc">
+              <ul class="toc">
+              <li><span class="chapter"><a href="#_section_1">Section 1</a></span>
+              </li>
+              </ul>
+              </div>
+              <!--END_TOC-->
+            HTML
+          end
+        end
+      end
     end
     context 'when there is a subtitle' do
       let(:input) do


### PR DESCRIPTION
Docbook uses the `role=exclude` mechanism to exclude pages from the
table of contents. This makes direct_html do the same.
