### PR TITLE
Add support for xpack tag in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -36,7 +36,7 @@ module DocbookCompat
       <<~HTML
         <div class="#{wrapper_class_for node}#{node.role ? " #{node.role}" : ''}">
         <div class="titlepage"><div><div>
-        <h#{node.level} class="title"><a id="#{node.id}"></a>#{node.title}#{node.attr 'edit_me_link', ''}</h#{node.level}>
+        <h#{node.level} class="title"><a id="#{node.id}"></a>#{node.title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{node.level}>
         </div></div></div>
         #{node.content}
         </div>
@@ -51,7 +51,7 @@ module DocbookCompat
       classes = [node.role].compact
       classes_html = classes.empty? ? '' : " class=#{classes.join ' '}"
       <<~HTML
-        <#{tag_name}#{classes_html}>#{anchor}#{node.title}#{node.attr 'edit_me_link', ''}</#{tag_name}>
+        <#{tag_name}#{classes_html}>#{anchor}#{node.title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</#{tag_name}>
       HTML
     end
 
@@ -100,6 +100,12 @@ module DocbookCompat
         #{node.content}
         </div>
       HTML
+    end
+
+    def xpack_tag(node)
+      return unless node.roles.include? 'xpack'
+
+      '<a class="xpack_tag" href="/subscriptions"></a>'
     end
 
     SECTION_WRAPPER_CLASSES = %w[part chapter].freeze

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -445,10 +445,17 @@ RSpec.describe DocbookCompat do
         end
       end
       context 'the header' do
+        let(:xpack_tag) do
+          if input.include? '.xpack'
+            '<a class="xpack_tag" href="/subscriptions"></a>'
+          else
+            ''
+          end
+        end
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
             <div class="titlepage"><div><div>
-            <h#{hlevel} class="title"><a id="#{id}"></a>#{title}</h#{hlevel}>
+            <h#{hlevel} class="title"><a id="#{id}"></a>#{title}#{xpack_tag}</h#{hlevel}>
             </div></div></div>
           HTML
         end
@@ -462,6 +469,15 @@ RSpec.describe DocbookCompat do
         ASCIIDOC
       end
       include_examples 'section basics', 'chapter', 1, '_section', 'Section'
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [.xpack]
+            == S1
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'chapter xpack', 1, '_s1', 'S1'
+      end
     end
 
     context 'level 2' do
@@ -471,6 +487,15 @@ RSpec.describe DocbookCompat do
         ASCIIDOC
       end
       include_examples 'section basics', 'section', 2, '_section_2', 'Section 2'
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [.xpack]
+            === S2
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'section xpack', 2, '_s2', 'S2'
+      end
     end
 
     context 'level 3' do
@@ -480,6 +505,15 @@ RSpec.describe DocbookCompat do
         ASCIIDOC
       end
       include_examples 'section basics', 'section', 3, '_section_3', 'Section 3'
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [.xpack]
+            ==== S3
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'section xpack', 3, '_s3', 'S3'
+      end
     end
 
     context 'a preface' do
@@ -491,6 +525,15 @@ RSpec.describe DocbookCompat do
         ASCIIDOC
       end
       include_examples 'section basics', 'preface', 1, '_preface', 'Preface'
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [preface.xpack]
+            == P
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'preface xpack', 1, '_p', 'P'
+      end
     end
   end
 
@@ -607,6 +650,19 @@ RSpec.describe DocbookCompat do
     end
     it 'has an inline anchor for docbook compatibility' do
       expect(converted).to include('<a id="_foo"></a>')
+    end
+    context 'with the xpack role' do
+      let(:input) do
+        <<~ASCIIDOC
+          [float.xpack]
+          ==== Foo
+        ASCIIDOC
+      end
+      it 'has the xpack tag' do
+        expect(converted).to include(
+          '<a class="xpack_tag" href="/subscriptions"></a></h4>'
+        )
+      end
     end
   end
 


### PR DESCRIPTION
We've customized docbook to add a spec "tag" to the title of pages that
are marked with `role=xpack`. This implements that customization in
direct_html. It was way, way, way, way easier than the docbook
customization.
