### PR TITLE
Add support for abbreviated titles in direct_html

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -338,17 +338,38 @@ book.  See <<linking>>.
 
 By default, the link text used in the generated TOC is
 based on the title of each file. You can provide an
-abbreviated title by using the DocBook `<titleabbrev>`
-tag. For example:
+abbreviated title by using the using a `titleabbrev` in
+one of two ways:
 
+. If the doc is built with `--direct_html` you *should*
+add a `titleabbrev` attribute to the section:
++
+--
 [source,asciidoc]
-----------------------------------
+----
+[id=intro_to_xyz,titleabbrev=Intro]
 == Intro to XYZ
 
+Words.
+----
+--
+
+. If the doc is built with DocBook then you *must* use
+a pass block with `<titleabbrev>`. If the doc is built
+with `--direct_html` then you *may* use the pass block
+but it isn't recommended:
++
+--
+[source,asciidoc]
+----
+== Intro to XYZ
 ++++
 <titleabbrev>Intro</titleabbrev>
 ++++
-----------------------------------
+
+Words.
+----
+--
 
 [[multi-part]]
 == Multi-part books

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -347,7 +347,7 @@ add a `titleabbrev` attribute to the section:
 --
 [source,asciidoc]
 ----
-[id=intro_to_xyz,titleabbrev=Intro]
+[id=intro_to_xyz,titleabbrev=" XYZ Intro"]
 == Intro to XYZ
 
 Words.
@@ -364,7 +364,7 @@ but it isn't recommended:
 ----
 == Intro to XYZ
 ++++
-<titleabbrev>Intro</titleabbrev>
+<titleabbrev>XYZ Intro</titleabbrev>
 ++++
 
 Words.

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -338,7 +338,7 @@ book.  See <<linking>>.
 
 By default, the link text used in the generated TOC is
 based on the title of each file. You can provide an
-abbreviated title by using the using a `titleabbrev` in
+abbreviated title using a `titleabbrev` in
 one of two ways:
 
 . If the doc is built with `--direct_html` you *should*

--- a/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
@@ -20,7 +20,9 @@ module DocbookCompat
     def convert_outline_section(section, toclevels)
       return if section.roles.include? 'exclude'
 
-      link = %(<a href="##{section.id}">#{section.title}</a>)
+      title = section.attr 'titleabbrev'
+      title ||= section.title
+      link = %(<a href="##{section.id}">#{title}</a>)
       link = %(<span class="#{wrapper_class_for section}">#{link}</span>)
       [
         %(<li>#{link}),

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -10,6 +10,7 @@ require_relative 'convert_lists'
 require_relative 'convert_open'
 require_relative 'convert_outline'
 require_relative 'convert_table'
+require_relative 'titleabbrev_handler'
 
 ##
 # HTML5 converter that emulates Elastic's docbook generated html.
@@ -17,6 +18,7 @@ module DocbookCompat
   def self.activate(registry)
     return unless registry.document.basebackend? 'html'
 
+    registry.treeprocessor TitleabbrevHandler
     DelegatingConverter.setup(registry.document) { |d| Converter.new d }
   end
 

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -6,7 +6,7 @@ module DocbookCompat
   ##
   # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
   # parent section. This attribute is an abbreviated title used when rendering the
-  # when rendering the table of contents. This exists entirely for backwards
+  # the table of contents. This exists entirely for backwards
   # compatibility with docbook. It is simpler and recommended to set the
   # `titleabbrev` attribute directly on the section when the document is built
   # with `--direct_html`.

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -5,7 +5,7 @@ require_relative '../scaffold'
 module DocbookCompat
   ##
   # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
-  # parent section that is an abbreviated title usesd when rendering the
+  # parent section. This attribute is an abbreviated title used when rendering the
   # when rendering the table of contents. This exists entirely for backwards
   # compatibility with docbook. It is simpler and recommended to set the
   # `titleabbrev` attribute directly on the section when the document is built

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative '../scaffold'
+
+module DocbookCompat
+  ##
+  # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
+  # parent section that is an abbreviated title usesd when rendering the
+  # when rendering the table of contents. This exists entirely for backwards
+  # compatibility with docbook. It is simpler and recommended to set the
+  # `titleabbrev` attribute directly on the section when the document is built
+  # with `--direct_html`.
+  class TitleabbrevHandler < TreeProcessorScaffold
+    def process_block(block)
+      return unless block.context == :pass
+
+      process_pass block
+    end
+
+    def process_pass(block)
+      text = block.lines.join "\n"
+      return unless (m = text.match %r{<titleabbrev>([^<]+)</titleabbrev>\n?}m)
+
+      text.slice! m.begin(0), m.end(0)
+      block.lines = text.split "\n"
+
+      section = block.parent
+      section = section.parent until section.context == :section
+      section.attributes['titleabbrev'] = m[1]
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -5,11 +5,10 @@ require_relative '../scaffold'
 module DocbookCompat
   ##
   # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
-  # parent section. This attribute is an abbreviated title used when rendering the
-  # the table of contents. This exists entirely for backwards
-  # compatibility with docbook. It is simpler and recommended to set the
-  # `titleabbrev` attribute directly on the section when the document is built
-  # with `--direct_html`.
+  # parent section. This attribute is an abbreviated title used when rendering
+  # the table of contents. This exists entirely for backwards compatibility with
+  # docbook. It is simpler and recommended to set the `titleabbrev` attribute
+  # directly on the section when the document is built with `--direct_html`.
   class TitleabbrevHandler < TreeProcessorScaffold
     def process_block(block)
       return unless block.context == :pass

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -238,6 +238,70 @@ RSpec.describe DocbookCompat do
           end
         end
       end
+      context 'when a section has a titleabbrev' do
+        let(:convert_attributes) do
+          {
+            # Shrink the output slightly so it is easier to read
+            'stylesheet!' => false,
+            # Set some metadata that will be included in the header
+            'dc.type' => 'FooType',
+            'dc.subject' => 'BarSubject',
+            'dc.identifier' => 'BazIdentifier',
+            'toc' => '',
+            'toclevels' => 2,
+          }
+        end
+        shared_examples 'titleabbrev' do
+          context 'the table of contents' do
+            it 'includes the abbreviated title' do
+              expect(converted).to include <<~HTML
+                <li><span class="chapter"><a href="#_section_1">S1</a></span>
+              HTML
+            end
+            it 'includes the correct title for a subsection' do
+              expect(converted).to include <<~HTML
+                <li><span class="section"><a href="#_section_2">Section 2</a></span>
+              HTML
+            end
+          end
+          context 'the body' do
+            it "doesn't include the titleabbrev tag" do
+              expect(converted).not_to include '<titleabbrev>'
+            end
+            it 'includes the unabbreviated title' do
+              expect(converted).to include 'Section 1</h1>'
+            end
+          end
+        end
+        context 'using a pass block' do
+          let(:input) do
+            <<~ASCIIDOC
+              = Title
+
+              == Section 1
+              ++++
+              <titleabbrev>S1</titleabbrev>
+              ++++
+
+              === Section 2
+            ASCIIDOC
+          end
+          include_examples 'titleabbrev'
+        end
+        context 'using an attribute' do
+          let(:input) do
+            <<~ASCIIDOC
+              = Title
+
+              [titleabbrev=S1]
+              == Section 1
+
+              === Section 2
+            ASCIIDOC
+          end
+          include_examples 'titleabbrev'
+        end
+      end
     end
     context 'when there is a subtitle' do
       let(:input) do


### PR DESCRIPTION
In docbook we can abbreviate the title of a section in the table of
contents by doing something like this:

```
== Intro to XYZ
++++
<titleabbrev>Intro</titleabbrev>
++++

Words.
```

This is *very* docbook. `++++` mean "pass this output directly to the
generated doc" and `<titleabbrev>` is a docbook element.

This change adds support for abbreviating a title of a section in the
table of contents when using `--direct_html` using the following syntax:

```
[id=intro_to_xyz,titleabbrev=Intro]
== Intro to XYZ

Words.
```

It is both shorter and more AsciiDoc friendly. It isn't compatible with
docbook though.

This change *also* adds support for identifying the docbook-style title
abbreviate commands when running with `--direct_html` and having those
set the title abbreviation. In other words: you don't have to change the
old books, but new books that use `--direct_html` should probably use
the new syntax.
