### PR TITLE
Render ids for paragraphs in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -57,7 +57,13 @@ module DocbookCompat
 
     def convert_paragraph(node)
       # Asciidoctor adds a \n at the end of the paragraph so we don't.
-      %(<p>#{node.content}</p>)
+      %(<p>#{paragraph_id_part node}#{node.content}</p>)
+    end
+
+    def paragraph_id_part(node)
+      return if node.id.nil? || node.id.empty?
+
+      %(<a id="#{node.id}"></a>)
     end
 
     def convert_inline_quoted(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -578,6 +578,17 @@ RSpec.describe DocbookCompat do
     it 'contains the words' do
       expect(converted).to include('<p>Words words words.</p>')
     end
+    context 'has an id' do
+      let(:input) do
+        <<~ASCIIDOC
+          [[foo]]
+          Words.
+        ASCIIDOC
+      end
+      it 'contains a paragraph for each anchor' do
+        expect(converted).to include '<p><a id="foo"></a>Words.</p>'
+      end
+    end
   end
 
   context 'a link' do


### PR DESCRIPTION
It is possible to declare an id for a paragraph like so:

```
[[foo]]
Words in the paragraph.
```

Docbook renders this like:

```
<p><a id="foo"></a>Words in the paragraph</p>
```

So we should too.
