### PR TITLE
Handle title captions in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -121,6 +121,10 @@ def normalize_html(html):
     # Just one `<code>` is fine though.
     for e in soup.select("code.literal > code.literal"):
         e.unwrap()
+    # Docbook adds non-breaking spaces inside the title attributes for some
+    # links. It doesn't seem like we need that.
+    for e in soup.select('link[title]'):
+        e['title'] = e['title'].replace('\xa0', ' ')
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):
@@ -136,6 +140,7 @@ def normalize_html(html):
     html = html.replace(
         '<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>',
         '<meta charset="utf-8"/>')
+    html = re.sub(r'(Appendix\s\w+)\.([^<]+)', '\\1:\\2', html)
     return html
 
 

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -22,7 +22,7 @@ module Chunker
       while (parent = parent.parent)
         extra = parent.context == :document ? parent.attr('title-extra') : ''
         result << <<~HTML.strip
-          <span class="breadcrumb-link"><a #{link_href parent}>#{link_text parent}#{extra}</a></span>
+          <span class="breadcrumb-link"><a #{link_href parent}>#{parent.title}#{extra}</a></span>
           »
         HTML
       end

--- a/resources/asciidoctor/lib/chunker/link.rb
+++ b/resources/asciidoctor/lib/chunker/link.rb
@@ -18,7 +18,7 @@ module Chunker
     def link_text(target)
       case target.context
       when :section
-        target.title
+        target.captioned_title
       when :document
         target.doctitle(partition: true).main.strip
       else

--- a/resources/asciidoctor/lib/chunker/nav.rb
+++ b/resources/asciidoctor/lib/chunker/nav.rb
@@ -43,7 +43,7 @@ module Chunker
       # section could be the document itself which shouldn't render.
       return unless section.context == :section
 
-      %(<a #{link_href section}>#{lmarker}#{section.title}#{rmarker}</a>)
+      %(<a #{link_href section}>#{lmarker}#{link_text section}#{rmarker}</a>)
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -36,7 +36,7 @@ module DocbookCompat
       <<~HTML
         <div class="#{wrapper_class_for node}#{node.role ? " #{node.role}" : ''}">
         <div class="titlepage"><div><div>
-        <h#{node.level} class="title"><a id="#{node.id}"></a>#{node.title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{node.level}>
+        <h#{node.level} class="title"><a id="#{node.id}"></a>#{node.captioned_title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{node.level}>
         </div></div></div>
         #{node.content}
         </div>

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -561,6 +561,28 @@ RSpec.describe DocbookCompat do
         include_examples 'section basics', 'preface xpack', 1, '_p', 'P'
       end
     end
+
+    context 'an appendix' do
+      let(:input) do
+        <<~ASCIIDOC
+          [appendix]
+          == Foo
+          Words.
+        ASCIIDOC
+      end
+      include_examples 'section basics', 'appendix', 1, '_foo',
+                       'Appendix A: Foo'
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [appendix.xpack]
+            == Foo
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'appendix xpack', 1, '_foo',
+                         'Appendix A: Foo'
+      end
+    end
   end
 
   context 'a paragraph' do

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -119,15 +119,11 @@ RSpec.describe EditMe do
         shared_examples 'has standard edit links' do
           it "adds a link to #{type} 1" do
             link = spec_dir_link "#{type}1.adoc"
-            expect(converted).to include(
-              ">#{type.capitalize} 1#{link}</"
-            )
+            expect(converted).to include("#{type.capitalize} 1#{link}</")
           end
           it "adds a link to #{type} 2" do
             link = spec_dir_link "#{type}2.adoc"
-            expect(converted).to include(
-              ">#{type.capitalize} 2#{link}</"
-            )
+            expect(converted).to include("#{type.capitalize} 2#{link}</")
           end
         end
         context "that doesn't override edit_url" do
@@ -169,15 +165,11 @@ RSpec.describe EditMe do
             end
             it "adds a link to #{type} 1" do
               link = edit_link 'foo'
-              expect(converted).to include(
-                ">#{type.capitalize} 1#{link}</"
-              )
+              expect(converted).to include("#{type.capitalize} 1#{link}</")
             end
             it "adds a link to #{type} 2" do
               link = edit_link 'bar'
-              expect(converted).to include(
-                ">#{type.capitalize} 2#{link}</"
-              )
+              expect(converted).to include("#{type.capitalize} 2#{link}</")
             end
             context 'when overriding to an empty string' do
               let(:input) do
@@ -189,14 +181,10 @@ RSpec.describe EditMe do
                 ASCIIDOC
               end
               it "doesn't add edit links to #{type} 1" do
-                expect(converted).to include(
-                  ">#{type.capitalize} 1</"
-                )
+                expect(converted).to include("#{type.capitalize} 1</")
               end
               it "doesn't add edit links to #{type} 2" do
-                expect(converted).to include(
-                  ">#{type.capitalize} 2</"
-                )
+                expect(converted).to include("#{type.capitalize} 2</")
               end
             end
           end
@@ -270,14 +258,10 @@ RSpec.describe EditMe do
           ASCIIDOC
         end
         it "doesn't add a link to #{type} 1" do
-          expect(converted).to include(
-            ">#{type.capitalize} 1</"
-          )
+          expect(converted).to include("#{type.capitalize} 1</")
         end
         it "doesn't add a link to #{type} 2" do
-          expect(converted).to include(
-            ">#{type.capitalize} 2</"
-          )
+          expect(converted).to include("#{type.capitalize} 2</")
         end
       end
     end


### PR DESCRIPTION
Docbook adds "Appendix A." to the front of the title for and appendix.
And references to that apendix. We should do the same. Except we can't
*quite* get it. We do, instead "Appendix A:". This is close enough.
