### PR TITLE
Improve listing blocks in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -5,11 +5,12 @@ module DocbookCompat
   # Methods code listings and their paired callout lists.
   module ConvertListing
     def convert_listing(node)
-      title = convert_listing_title node
-      body = convert_listing_body node
-      return body unless title
-
-      title + body
+      [
+        node.title ? '<p>' : nil,
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+        node.title ? %(<strong>#{node.title}.</strong></p>\n) : nil,
+        convert_listing_body(node),
+      ].compact.join
     end
 
     def convert_listing_body(node)
@@ -23,14 +24,6 @@ module DocbookCompat
       else
         %(<pre class="screen">#{node.content || ''}</pre>)
       end
-    end
-
-    def convert_listing_title(node)
-      return unless node.title
-
-      <<~HTML
-        <p><strong>#{node.title}</strong></p>
-      HTML
     end
 
     def convert_inline_callout(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -776,7 +776,39 @@ RSpec.describe DocbookCompat do
       end
       it "the title is before in docbook's funny wrapper" do
         expect(converted).to include(<<~HTML)
-          <p><strong>Title</strong></p>
+          <p><strong>Title.</strong></p>
+          <div class="pre_wrapper lang-sh">
+        HTML
+      end
+    end
+    context 'with an id' do
+      let(:input) do
+        <<~ASCIIDOC
+          [source,sh,id=foo]
+          ----
+          cpanm Search::Elasticsearch
+          ----
+        ASCIIDOC
+      end
+      it "the title is before in docbook's funny wrapper" do
+        expect(converted).to include(<<~HTML)
+          <a id="foo"></a><div class="pre_wrapper lang-sh">
+        HTML
+      end
+    end
+    context 'with an id and a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          [source,sh,id=foo]
+          ----
+          cpanm Search::Elasticsearch
+          ----
+        ASCIIDOC
+      end
+      it "the title is before in docbook's funny wrapper" do
+        expect(converted).to include(<<~HTML)
+          <p><a id="foo"></a><strong>Title.</strong></p>
           <div class="pre_wrapper lang-sh">
         HTML
       end
@@ -812,7 +844,7 @@ RSpec.describe DocbookCompat do
         end
         it "the title is before in docbook's funny wrapper" do
           expect(converted).to include(<<~HTML)
-            <p><strong>Title</strong></p>
+            <p><strong>Title.</strong></p>
             <pre class="screen">cpanm Search::Elasticsearch</pre>
           HTML
         end


### PR DESCRIPTION
This adds support for `id`s on listing block and adds a missing `.` to
the end of the title.
