### PR TITLE
Revised  default notice for older versions.

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -15,8 +15,8 @@ use utf8;
 our %Page_Header = (
     en => {
         old => <<"HEADER",
-<strong>IMPORTANT</strong>: No additional bug fixes will be released for this version 
-and this documentation is no longer being updated. For the latest information, see the 
+<strong>IMPORTANT</strong>: No additional bug fixes or documentation updates 
+will be released for this version. For the latest information, see the 
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -15,8 +15,8 @@ use utf8;
 our %Page_Header = (
     en => {
         old => <<"HEADER",
-You are looking at documentation for an older release.
-Not what you want? See the
+<strong>IMPORTANT</strong>: No additional bug fixes will be released for this version 
+and this documentation is no longer being updated. For the latest information, see the 
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"


### PR DESCRIPTION
This updates the default notice for versions older than current. With this change, we do not have to override the default notice in every OOM version, but we *will* have to override it for the maintenance version of the previous minor (currently 6.8).

![image](https://user-images.githubusercontent.com/362578/70191611-3060eb00-16ae-11ea-8292-38bc81a81151.png)


That's simpler than having to do that for every OOM version, so I think it's a win. At some point, we could automatically apply the correct notice to "live" versions that aren't current and eliminate even  that manual step. 