### PR TITLE
Implement strange h level bumping in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -38,7 +38,7 @@ module DocbookCompat
       <<~HTML
         <div class="#{wrapper_class_for node}#{node.role ? " #{node.role}" : ''}">
         <div class="titlepage"><div><div>
-        <h#{node.level} class="title"><a id="#{node.id}"></a>#{node.captioned_title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{node.level}>
+        <h#{hlevel node} class="title"><a id="#{node.id}"></a>#{node.captioned_title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{hlevel node}>
         </div></div></div>
         #{node.content}
         </div>
@@ -114,6 +114,22 @@ module DocbookCompat
       return unless node.roles.include? 'xpack'
 
       '<a class="xpack_tag" href="/subscriptions"></a>'
+    end
+
+    def hlevel(section)
+      # Walk up the ancestry until the ancestor's parent is the document. The
+      # ancestor that we end up with is the "biggest" section containing this
+      # section. Except don't walk *all* the way. Because docbook doesn't.
+      # See that `unless` below? If we were walking it should be `until` but
+      # docbook *doesn't* walk. It just does this. Why? Ghosts maybe. I dunno.
+      # But we're trying to emulate docbook. So here we are.
+      ancestor = section
+      ancestor = ancestor.parent unless ancestor.parent.context == :document
+      # If *that* section is level 0 then we have to bump the hlevel of our
+      # section by one. The argument for this goes: we have to bump the level 0
+      # section's hlevel by one anyway because there *isn't* an h0 tag. So we
+      # have to bump all of its children.
+      section.level + (ancestor.level.zero? ? 1 : 0)
     end
 
     SECTION_WRAPPER_CLASSES = %w[part chapter].freeze

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -606,6 +606,41 @@ RSpec.describe DocbookCompat do
       end
     end
 
+    context 'level 0' do
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          = Section
+
+          == L1
+
+          === L2
+        ASCIIDOC
+      end
+      include_examples 'section basics', 'part', 1, '_section', 'Section'
+      it "bumps the h tag of it's children" do
+        expect(converted).to include 'L1</h2>'
+      end
+      it "doesn't bump the h tag of it's children's children" do
+        # Docbook doesn't seem to do this
+        expect(converted).to include 'L2</h2>'
+      end
+      context 'with the xpack role' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [.xpack]
+            = S1
+
+            == Chapter
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'part xpack', 1, '_s1', 'S1'
+      end
+    end
+
     context 'a preface' do
       let(:input) do
         <<~ASCIIDOC
@@ -645,6 +680,23 @@ RSpec.describe DocbookCompat do
         end
         include_examples 'section basics', 'appendix xpack', 1, '_foo',
                          'Appendix A: Foo'
+      end
+      context 'with level 0' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [appendix]
+            = Foo
+
+            == Bar
+          ASCIIDOC
+        end
+        include_examples 'section basics', 'appendix', 1, '_foo',
+                         'Appendix A: Foo'
+        it "doesn't bump the h tags of sections within it" do
+          expect(converted).to include 'Bar</h1>'
+        end
       end
     end
   end


### PR DESCRIPTION
Docbook bumps the `<h` tag levels in level 0 section and their children.
But *not* the their grand children. Which is strange. But we're
emulating docbook. So this does that too. Oh yeah, and only "bar" level
0 sections count. If you make a level 0 section an appendix then no bumping.
