### PR TITLE
Support default admonition text in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert admonitions.
+  module ConvertAdmonition
+    def convert_admonition(node)
+      content = admonition_content node
+      [
+        %(<div class="#{node.attr 'name'} admon">),
+        %(<div class="icon"></div>),
+        %(<div class="admon_content">),
+        node.title? ? "<h3>#{node.title}</h3>" : nil,
+        node.blocks.empty? ? "<p>#{content}</p>" : content,
+        '</div>',
+        '</div>',
+      ].compact.join "\n"
+    end
+
+    private
+
+    ADMONITION_DEFAULT_MESSAGE = {
+      'beta' => <<~TEXT.strip,
+        This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+      TEXT
+      'experimental' => <<~TEXT.strip,
+        This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
+      TEXT
+    }.freeze
+    def admonition_content(node)
+      content = node.content
+      return content unless content == ''
+
+      ADMONITION_DEFAULT_MESSAGE[node.role]
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -2,6 +2,7 @@
 
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
+require_relative 'convert_admonition'
 require_relative 'convert_document'
 require_relative 'convert_dlist'
 require_relative 'convert_links'
@@ -25,6 +26,7 @@ module DocbookCompat
   ##
   # A Converter implementation that emulates Elastic's docbook generated html.
   class Converter < DelegatingConverter
+    include ConvertAdmonition
     include ConvertDocument
     include ConvertDList
     include ConvertLinks
@@ -79,18 +81,6 @@ module DocbookCompat
       else
         yield
       end
-    end
-
-    def convert_admonition(node)
-      [
-        %(<div class="#{node.attr 'name'} admon">),
-        %(<div class="icon"></div>),
-        %(<div class="admon_content">),
-        node.title? ? "<h3>#{node.title}</h3>" : nil,
-        node.blocks.empty? ? "<p>#{node.content}</p>" : node.content,
-        '</div>',
-        '</div>',
-      ].compact.join "\n"
     end
 
     def convert_literal(node)


### PR DESCRIPTION
Our custom "experimental" and "beta" admonitions have default text if
you don't supply any. This adds that default text to direct_html and
cleans up the tests around admonitions a bit, including adding tests for
our custom admonitions.
