### PR TITLE
Handle tables with titles in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -125,6 +125,11 @@ def normalize_html(html):
     # links. It doesn't seem like we need that.
     for e in soup.select('link[title]'):
         e['title'] = e['title'].replace('\xa0', ' ')
+    # Docbook adds a generated id to tables with ids. They aren't used and we
+    # have no change of generating it properly so we just ignore it.
+    for a in soup.select('.table a'):
+        if a['id'].startswith('id-'):
+            a.extract()
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):

--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -6,16 +6,41 @@ module DocbookCompat
   module ConvertTable
     def convert_table(node)
       [
-        '<div class="informaltable">',
-        '<table border="1" cellpadding="4px">',
+        convert_table_intro(node),
+        convert_table_tag(node),
         convert_colgroups(node),
         convert_parts(node),
         '</table>',
-        '</div>',
+        convert_table_outro(node),
       ].flatten.join "\n"
     end
 
     private
+
+    def convert_table_intro(node)
+      return '<div class="informaltable">' unless node.title
+
+      [
+        '<div class="table">',
+        %(<p class="title"><strong>#{node.captioned_title}</strong></p>),
+        '<div class="table-contents">',
+      ]
+    end
+
+    def convert_table_outro(node)
+      return '</div>' unless node.title
+
+      ['</div>', '</div>']
+    end
+
+    def convert_table_tag(node)
+      [
+        '<table',
+        ' border="1" cellpadding="4px"',
+        node.title ? %( summary="#{node.title}") : nil,
+        '>',
+      ].compact.join
+    end
 
     def convert_colgroups(node)
       [

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1695,5 +1695,23 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'is wrapped in table' do
+        expect(converted).to include <<~HTML
+          <div class="table">
+          <p class="title"><strong>Table 1. Title</strong></p>
+          <div class="table-contents">
+          <table border="1" cellpadding="4px" summary="Title">
+        HTML
+      end
+    end
   end
 end


### PR DESCRIPTION
Docbook wraps tables with titles differently than tables without. This
adds that wrapping to direct_html.
