### PR TITLE
Remove edit links form non-live versions

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -654,7 +654,8 @@ RSpec.describe 'building all books' do
         end
       end
     end
-    page_context "the dead branch's chapter", 'html/test/nonlive/chapter.html' do
+    page_context "the dead branch's chapter",
+                 'html/test/nonlive/chapter.html' do
       let(:edit_url) { "#{repo.root}/edit/master/index.asciidoc" }
       it "doesn't contain an edit_me link" do
         expect(body).not_to include('class="edit_me"')

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -617,6 +617,7 @@ RSpec.describe 'building all books' do
       book.branches << 'nonlive'
       book.live_branches = ['master']
     end
+    let(:repo) { @src.repo 'repo' }
     page_context 'the live branch', 'html/test/master/index.html' do
       it "doesn't contain the noindex flag" do
         expect(contents).not_to include(<<~HTML.strip)
@@ -631,7 +632,15 @@ RSpec.describe 'building all books' do
         end
       end
     end
-    page_context 'the dead branch', 'html/test/nonlive/index.html' do
+    page_context "the live branch's chapter", 'html/test/master/chapter.html' do
+      let(:edit_url) { "#{repo.root}/edit/master/index.asciidoc" }
+      it 'contains an edit_me link' do
+        expect(body).to include <<~HTML.strip
+          <a href="#{edit_url}" class="edit_me" title="Edit this page on GitHub" rel="nofollow">edit</a>
+        HTML
+      end
+    end
+    page_context "the dead branch's index", 'html/test/nonlive/index.html' do
       it 'contains the noindex flag' do
         expect(contents).to include(<<~HTML.strip)
           <meta name="robots" content="noindex,nofollow" />
@@ -643,6 +652,12 @@ RSpec.describe 'building all books' do
             <select><option value="master">master (current)</option><option value="nonlive" selected>nonlive (out of date)</option></select>
           HTML
         end
+      end
+    end
+    page_context "the dead branch's chapter", 'html/test/nonlive/chapter.html' do
+      let(:edit_url) { "#{repo.root}/edit/master/index.asciidoc" }
+      it "doesn't contain an edit_me link" do
+        expect(body).not_to include('class="edit_me"')
       end
     end
   end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -265,8 +265,8 @@ sub _build_book {
                 version       => $branch,
                 lang          => $lang,
                 edit_urls     => $edit_urls,
-                private       => $self->private,
-                noindex       => $self->noindex($branch),
+                private       => $self->private( $branch ),
+                noindex       => $self->noindex( $branch ),
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
                 section_title => $section_title,
@@ -290,8 +290,8 @@ sub _build_book {
                 version       => $branch,
                 lang          => $lang,
                 edit_urls     => $edit_urls,
-                private       => $self->private,
-                noindex       => $self->noindex($branch),
+                private       => $self->private( $branch ),
+                noindex       => $self->noindex( $branch ),
                 chunk         => $self->chunk,
                 multi         => $self->is_multi_version,
                 page_header   => $self->_page_header($branch),
@@ -448,6 +448,15 @@ sub noindex {
     return 1;
 }
 
+#===================================
+sub private {
+#===================================
+    my ( $self, $branch ) = @_;
+    return 1 if $self->{private};
+    return 0 if grep( /^$branch$/, @{ $self->{live_branches} } );
+    return 1;
+}
+
 
 #===================================
 sub title            { shift->{title} }
@@ -461,7 +470,6 @@ sub branches         { shift->{branches} }
 sub branch_title     { shift->{branch_titles}->{ shift() } }
 sub current          { shift->{current} }
 sub is_multi_version { @{ shift->branches } > 1 }
-sub private          { shift->{private} }
 sub tags             { shift->{tags} }
 sub subject          { shift->{subject} }
 sub source           { shift->{source} }


### PR DESCRIPTION
This removes the `edit` links from versions of books that aren't "live"
because, for the most part, we don't want folks opening PRs against
them. I mean, we'd *prefer* folks open PRs against the master branch,
but that isn't really a simple thing to do when fixing docs so we're
pretty happy with whatever. But we'd really prefer PRs to target live
branches.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
