### PR TITLE
"Re-adds the MS31 build to ESS and Heroku books""

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -623,7 +623,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-28
-            branches:   [ release-ms-28 ]
+            branches:   [ release-ms-31, release-ms-28  ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -640,6 +640,7 @@ contents:
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
                   release-ms-28: master
+                  release-ms-31: master
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }
                 repo:   clients-team
@@ -672,7 +673,7 @@ contents:
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
             current:    release-ms-28
-            branches:   [ release-ms-28 ]
+            branches:   [ release-ms-31, release-ms-28 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
Reverts elastic/docs#1535. It was a mistake.