### PR TITLE
Rework titleabbrev handling in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_outline.rb
@@ -20,15 +20,21 @@ module DocbookCompat
     def convert_outline_section(section, toclevels)
       return if section.roles.include? 'exclude'
 
-      title = section.attr 'titleabbrev'
-      title ||= section.title
-      link = %(<a href="##{section.id}">#{title}</a>)
+      link = %(<a href="##{section.id}">#{section_link_text section}</a>)
       link = %(<span class="#{wrapper_class_for section}">#{link}</span>)
       [
         %(<li>#{link}),
         convert_outline_subsections(section, toclevels),
         '</li>',
       ].compact
+    end
+
+    def section_link_text(section)
+      text = section.xreftext nil
+      # Normally we won't get an <em> wrapping the text *but* if it was set
+      # with something like `reftext=_title_` to make it render properly in
+      # in most places then it will have the <em> and we have to remove it.
+      text.gsub %r{^<em>(.+)</em>$}, '\\1'
     end
 
     def convert_outline_subsections(section, toclevels)

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -7,7 +7,7 @@ module DocbookCompat
   # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
   # parent section. This attribute is an abbreviated title used when rendering
   # the table of contents. This exists entirely for backwards compatibility with
-  # docbook. It is simpler and recommended to set the `titleabbrev` attribute
+  # docbook. It is simpler and recommended to set the `reftext` attribute
   # directly on the section when the document is built with `--direct_html`.
   class TitleabbrevHandler < TreeProcessorScaffold
     def process_block(block)
@@ -22,10 +22,17 @@ module DocbookCompat
 
       text.slice! m.begin(0), m.end(0)
       block.lines = text.split "\n"
+      process_titleabbrev block, m[1]
+    end
 
+    private
+
+    def process_titleabbrev(block, reftext)
       section = block.parent
       section = section.parent until section.context == :section
-      section.attributes['titleabbrev'] = m[1]
+      # Docbook seems to bold links to sections less than 2 so we should too.
+      reftext = "_#{reftext}_" if section.level < 2
+      section.attributes['reftext'] = reftext
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe DocbookCompat do
           end
         end
       end
-      context 'when a section has a titleabbrev' do
+      context 'when a section has reftext' do
         let(:convert_attributes) do
           {
             # Shrink the output slightly so it is easier to read
@@ -253,11 +253,11 @@ RSpec.describe DocbookCompat do
             'toclevels' => 2,
           }
         end
-        shared_examples 'titleabbrev' do
+        shared_examples 'reftext' do
           context 'the table of contents' do
             it 'includes the abbreviated title' do
               expect(converted).to include <<~HTML
-                <li><span class="chapter"><a href="#_section_1">S1</a></span>
+                <li><span class="chapter"><a href="#s1">S1</a></span>
               HTML
             end
             it 'includes the correct title for a subsection' do
@@ -273,35 +273,45 @@ RSpec.describe DocbookCompat do
             it 'includes the unabbreviated title' do
               expect(converted).to include 'Section 1</h1>'
             end
+            it 'includes a link to the abbreviated section' do
+              expect(converted).to include <<~HTML.strip
+                <a class="xref" href="#s1"title="Section 1"><em>S1</em></a>
+              HTML
+            end
           end
         end
-        context 'using a pass block' do
+        context 'using a pass block containing titleabbrev' do
           let(:input) do
             <<~ASCIIDOC
               = Title
 
+              [[s1]]
               == Section 1
               ++++
               <titleabbrev>S1</titleabbrev>
               ++++
 
               === Section 2
+
+              <<s1>>
             ASCIIDOC
           end
-          include_examples 'titleabbrev'
+          include_examples 'reftext'
         end
         context 'using an attribute' do
           let(:input) do
             <<~ASCIIDOC
               = Title
 
-              [titleabbrev=S1]
+              [id=s1,reftext=_S1_]
               == Section 1
 
               === Section 2
+
+              <<s1>>
             ASCIIDOC
           end
-          include_examples 'titleabbrev'
+          include_examples 'reftext'
         end
       end
     end


### PR DESCRIPTION
This reworks `<titleabbrev>` handling in direct_html so it works for
link targets as well. It turns out asciidoctor has a built in thing for
this called `reftext`. So we just use it.
