### PR TITLE
Handle "width" in tables in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -38,6 +38,7 @@ module DocbookCompat
         '<table',
         ' border="1" cellpadding="4px"',
         node.title ? %( summary="#{node.title}") : nil,
+        (width = node.attr 'width') ? %( width="#{width}") : nil,
         '>',
       ].compact.join
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1713,5 +1713,20 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with width' do
+      let(:input) do
+        <<~ASCIIDOC
+          [width=50%]
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'has the width' do
+        expect(converted).to include <<~HTML
+          <table border="1" cellpadding="4px" width="50%">
+        HTML
+      end
+    end
   end
 end


### PR DESCRIPTION
Docbook handles `[width=50%]` on tables by adding the width to the
`<table>` tag. So we should too, just to be even.
