### PR TITLE
Ignore difference between examples in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -93,6 +93,13 @@ def normalize_html(html):
     for e in soup.select('.content'):
         e['class'].remove('content')
         e['class'].append('mediaobject')
+    # Asciidoctor emits examples as "exampleblock" instead of "informalexample"
+    # but these don't make any visual difference.
+    for e in soup.select('.exampleblock'):
+        e['class'].remove('exampleblock')
+        e['class'].append('informalexample')
+        for c in e.select('.mediaobject'):
+            c.unwrap()
     # Docbook links with `<a class="link"` when linking from one page of a book
     # to another. Asciidoctor emits `<a class="link"`. Both look fine.
     for e in soup.select('a.xref'):


### PR DESCRIPTION
direct_html renders examples slightly differently than docbook but they
don't make any visual difference. So we ignore the difference.
