### PR TITLE
Switch ESS and Heroku docs to MS 31

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -663,8 +663,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-28
-            branches:   [ release-ms-31, release-ms-28  ]
+            current:    release-ms-31
+            branches:   [ release-ms-31  ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -681,7 +681,6 @@ contents:
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-28: master
                   release-ms-31: master
               -
                 alternatives: { source_lang: csharp, alternative_lang: go }
@@ -714,8 +713,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-28
-            branches:   [ release-ms-31, release-ms-28 ]
+            current:    release-ms-31
+            branches:   [ release-ms-31 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -664,7 +664,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-31
-            branches:   [ release-ms-31  ]
+            branches:   [ release-ms-31 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
With `release-ms-31` going out soon, it's time to get ready to switch the docs builds. 

@elastic/cloud-writers can I get an LGTM for this, please?