### PR TITLE
Handle inline admonitions in direct_html

### DIFF
--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -60,7 +60,11 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     end
 
     def process(parent, _target, attrs)
-      Asciidoctor::Inline.new(parent, :quoted, text(attrs))
+      if parent.document.basebackend? 'html'
+        Asciidoctor::Inline.new parent, :admonition, attrs[:text], type: @role
+      else
+        Asciidoctor::Inline.new parent, :quoted, text(attrs)
+      end
     end
 
     def text(attrs)

--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -5,7 +5,7 @@ module DocbookCompat
   # Methods to convert admonitions.
   module ConvertAdmonition
     def convert_admonition(node)
-      content = admonition_content node
+      content = block_admonition_content node
       [
         %(<div class="#{node.attr 'name'} admon">),
         %(<div class="icon"></div>),
@@ -15,6 +15,17 @@ module DocbookCompat
         '</div>',
         '</div>',
       ].compact.join "\n"
+    end
+
+    def convert_inline_admonition(node)
+      [
+        %(<span class="Admonishment Admonishment--#{node.type}">),
+        %([<span class="Admonishment-title u-mono">#{node.type}</span>]),
+        '<span class="Admonishment-detail">',
+        inline_admonition_text(node),
+        '</span>',
+        '</span>',
+      ].join "\n"
     end
 
     private
@@ -27,11 +38,19 @@ module DocbookCompat
         This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
       TEXT
     }.freeze
-    def admonition_content(node)
+
+    def block_admonition_content(node)
       content = node.content
       return content unless content == ''
 
       ADMONITION_DEFAULT_MESSAGE[node.role]
+    end
+
+    def inline_admonition_text(node)
+      text = node.text
+      return text if text
+
+      ADMONITION_DEFAULT_MESSAGE[node.type]
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1422,7 +1422,7 @@ RSpec.describe DocbookCompat do
   end
 
   context 'admonitions' do
-    def expect_admonition(body)
+    def expect_block_admonition(body)
       expect(converted).to include <<~HTML
         <div class="#{admon_class} admon">
         <div class="icon"></div>
@@ -1441,7 +1441,7 @@ RSpec.describe DocbookCompat do
             ASCIIDOC
           end
           it "renders with Elastic's custom template" do
-            expect_admonition '<p>words</p>'
+            expect_block_admonition '<p>words</p>'
           end
         end
         context 'with complex content' do
@@ -1454,7 +1454,7 @@ RSpec.describe DocbookCompat do
             ASCIIDOC
           end
           it 'contains the complex content' do
-            expect_admonition <<~HTML.strip
+            expect_block_admonition <<~HTML.strip
               <div class="olist orderedlist">
               <ol class="orderedlist">
               <li class="listitem">
@@ -1474,7 +1474,7 @@ RSpec.describe DocbookCompat do
             ASCIIDOC
           end
           it "doesn't have default text" do
-            expect_admonition '<p></p>'
+            expect_block_admonition '<p></p>'
           end
         end
         context 'with a title' do
@@ -1524,24 +1524,58 @@ RSpec.describe DocbookCompat do
     end
     context 'elastic custom admonitions' do
       shared_examples 'custom admonition' do
-        context 'with text' do
-          let(:input) do
-            <<~ASCIIDOC
-              #{key}::[words]
-            ASCIIDOC
+        context 'block form' do
+          context 'with text' do
+            let(:input) do
+              <<~ASCIIDOC
+                #{key}::[words]
+              ASCIIDOC
+            end
+            it "renders with Elastic's custom template" do
+              expect_block_admonition '<p>words</p>'
+            end
           end
-          it "renders with Elastic's custom template" do
-            expect_admonition '<p>words</p>'
+          context 'without content' do
+            let(:input) do
+              <<~ASCIIDOC
+                #{key}::[]
+              ASCIIDOC
+            end
+            it 'has default text' do
+              expect_block_admonition "<p>#{default_text}</p>"
+            end
           end
         end
-        context 'without content' do
-          let(:input) do
-            <<~ASCIIDOC
-              #{key}::[]
-            ASCIIDOC
+        context 'inline form' do
+          def expect_inline_admonition(text)
+            expect(converted).to include <<~HTML.strip
+              <span class="Admonishment Admonishment--#{key}">
+              [<span class="Admonishment-title u-mono">#{key}</span>]
+              <span class="Admonishment-detail">
+              #{text}
+              </span>
+              </span>
+            HTML
           end
-          it 'has default text' do
-            expect_admonition "<p>#{default_text}</p>"
+          context 'with text' do
+            let(:input) do
+              <<~ASCIIDOC
+                Words #{key}:[admon words] words.
+              ASCIIDOC
+            end
+            it "renders with Elastic's custom template" do
+              expect_inline_admonition 'admon words'
+            end
+          end
+          context 'without text' do
+            let(:input) do
+              <<~ASCIIDOC
+                Words #{key}:[] words.
+              ASCIIDOC
+            end
+            it 'has default text' do
+              expect_inline_admonition default_text
+            end
           end
         end
       end


### PR DESCRIPTION
Elastic's admonition extensions can be used inline with something like:
```
The foo is experimental::[some warning text].
```

This adds support for that to direct_html.
