### PR TITLE
Handle attributes in `titleabbrev` in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -28,6 +28,7 @@ module DocbookCompat
     private
 
     def process_titleabbrev(block, reftext)
+      reftext = block.apply_subs reftext, [:attributes]
       section = block.parent
       section = section.parent until section.context == :section
       # Docbook seems to bold links to sections less than 2 so we should too.

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -297,6 +297,25 @@ RSpec.describe DocbookCompat do
             ASCIIDOC
           end
           include_examples 'reftext'
+          context 'when the titleabbrev contains an attribute' do
+            let(:input) do
+              <<~ASCIIDOC
+                = Title
+
+                :abbrev: S1
+                [[s1]]
+                == Section 1
+                ++++
+                <titleabbrev>{abbrev}</titleabbrev>
+                ++++
+
+                === Section 2
+
+                <<s1>>
+              ASCIIDOC
+            end
+            include_examples 'reftext'
+          end
         end
         context 'using an attribute' do
           let(:input) do


### PR DESCRIPTION
You can use an attribute in a `titleabbrev` like so:
```
++++
<titleabbrev>{security}</titleabbrev>
++++
```

The `{security}` thing *should* get replaced with the attribute value.
This does that in direct_html and solves a *ton* of problems converting
logstash (#1512).

