### PR TITLE
Drop "out of date" from version drop down

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -656,7 +656,7 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains the deprecated branch' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="master">master (current)</option><option value="nonlive" selected>nonlive (out of date)</option></select>
+            <select id="live_versions"><option value="master">master (current)</option><option value="nonlive" selected>nonlive</option></select>
           HTML
         end
       end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -343,7 +343,6 @@ sub _update_title_and_version_drop_downs {
         $title .= ' selected'  if $branch eq $b;
         $title .= '>' . $self->branch_title($b);
         $title .= ' (current)' if $self->current eq $b;
-        $title .= ' (out of date)' unless $live;
         $title .= '</option>';
     }
     $title .= '<option value="other">other versions</option>' if $removed_any;


### PR DESCRIPTION
I added "out of date" to the version drop down if you are on a page for
a non-live version of the docs but it turns out we're adding a heading
to the docs that says exactly that so this is duplicate information and
it can be confusing.
