### PR TITLE
Clean xref title in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_links.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_links.rb
@@ -24,11 +24,13 @@ module DocbookCompat
       return "#{xref}>#{refid}</a>" unless ref
 
       text = node.text || ref_text_for(ref, node)
-      title = ref.respond_to?(:title) ? ref.title : nil
+      title = ref_title_for ref
       <<~HTML.strip
         #{xref}#{title ? %(title="#{title}") : ''}>#{text}</a>
       HTML
     end
+
+    private
 
     def ref_text_for(ref, node)
       if ref.node_name == 'inline_link'
@@ -47,6 +49,17 @@ module DocbookCompat
       return unless (index = parent.blocks.find_index ref)
 
       parent[index + 1]&.convert
+    end
+
+    def ref_title_for(ref)
+      # References to inline text don't have a title.
+      return unless ref.respond_to?(:title)
+
+      # Strip the html if there is any becaue this is inside a tag. It'd be
+      # nice if there was a cleaner way to do this but there really isn't.
+      # Luckily this html all comes from asciidoctor so we at least know it is
+      # valid.
+      ref.title.gsub %r{</?[^>]*>}, ''
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -808,6 +808,19 @@ RSpec.describe DocbookCompat do
         expect(converted).to include('>override text</a>')
       end
     end
+    context 'when the section title has markup' do
+      let(:input) do
+        <<~ASCIIDOC
+          Words <<foo>>.
+
+          [[foo]]
+          == `foo`
+        ASCIIDOC
+      end
+      it "contains the target's title without the markup" do
+        expect(converted).to include('title="foo"')
+      end
+    end
     context 'when the cross reference is to an inline anchor' do
       let(:input) do
         <<~ASCIIDOC


### PR DESCRIPTION
When you make a cross reference to a section who's title contains html
we were generating invlid html. For example, a link to this:
```
[[foo]]
== `foo`
```

Would come out with `<a title="<code ....>foo</code>"`. That ain't
right. This strips the html which is *super* helpful for converting
logstash (#1512).
