### PR TITLE
Fix ref text for inline anchors in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_links.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_links.rb
@@ -31,22 +31,16 @@ module DocbookCompat
     end
 
     def ref_text_for(ref, node)
-      if ref.node_name == 'inline_link'
-        special = ref_text_for_inline_link ref
-        return special if special
-      end
+      text = ref.xreftext node.attr('xrefstyle', 'short', true)
+      return text if text
 
-      ref.xreftext node.attr('xrefstyle', 'short', true)
-    end
+      # The text is empty! Let's grab the parent section's heading.
+      section = ref.parent
+      section = section.parent until section.context == :section
 
-    ##
-    # Inline title's have *boring* text so we instead use the text of the
-    # next element. This is also what docbook does. Because it is better.
-    def ref_text_for_inline_link(ref)
-      return unless (parent = ref.parent)
-      return unless (index = parent.blocks.find_index ref)
-
-      parent[index + 1]&.convert
+      # Docbook doesn't use 'short' as the default here, strangely. So neither
+      # do we.
+      section.xreftext nil
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -838,8 +838,28 @@ RSpec.describe DocbookCompat do
       it 'references the url' do
         expect(converted).to include('href="#target"')
       end
-      it 'has the right title' do
+      it 'has the right text' do
         expect(converted).to include('><code class="literal">target</code></a>')
+      end
+
+      context 'when that inline anchor has empty text' do
+        let(:input) do
+          <<~ASCIIDOC
+            == Section heading
+
+            Words.
+            [[target]]
+            more words.
+
+            <<target>>
+          ASCIIDOC
+        end
+        it 'references the url' do
+          expect(converted).to include('href="#target"')
+        end
+        it 'has the right text' do
+          expect(converted).to include('>Section heading</a>')
+        end
       end
     end
   end


### PR DESCRIPTION
When you reference something like
```
== Section heading
This
[[privileges-list-cluster]]
page has moved.
```

direct_html *was* producting an empty string for the default text while
docbook was using the section heading as the default text. This fixes up
direct_html to match docbook.
