### PR TITLE
Support title-less sidebar in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -90,14 +90,16 @@ module DocbookCompat
     end
 
     def convert_sidebar(node)
-      <<~HTML
-        <div class="sidebar#{node.role ? " #{node.role}" : ''}">
-        <div class="titlepage"><div><div>
-        <p class="title"><strong>#{node.title}</strong></p>
-        </div></div></div>
-        #{node.content}
-        </div>
-      HTML
+      result = [%(<div class="sidebar#{node.role ? " #{node.role}" : ''}">)]
+      if node.title
+        result << '<div class="titlepage"><div><div>'
+        result << %(<p class="title"><strong>#{node.title}</strong></p>)
+        result << %(</div></div></div>)
+      else
+        result << '<div class="titlepage"></div>'
+      end
+      result += [node.content, '</div>']
+      result.join "\n"
     end
 
     def xpack_tag(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1643,7 +1643,6 @@ RSpec.describe DocbookCompat do
   context 'a sidebar' do
     let(:input) do
       <<~ASCIIDOC
-        .Title
         ****
         Words
         ****
@@ -1652,12 +1651,30 @@ RSpec.describe DocbookCompat do
     it 'renders like docbook' do
       expect(converted).to include(<<~HTML)
         <div class="sidebar">
-        <div class="titlepage"><div><div>
-        <p class="title"><strong>Title</strong></p>
-        </div></div></div>
+        <div class="titlepage"></div>
         <p>Words</p>
         </div>
       HTML
+    end
+    context 'when there is a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          ****
+          Words
+          ****
+        ASCIIDOC
+      end
+      it 'renders like docbook' do
+        expect(converted).to include(<<~HTML)
+          <div class="sidebar">
+          <div class="titlepage"><div><div>
+          <p class="title"><strong>Title</strong></p>
+          </div></div></div>
+          <p>Words</p>
+          </div>
+        HTML
+      end
     end
   end
 


### PR DESCRIPTION
direct_html's implementation of `[sidebar]` produced an "empty" title if
the sidebar didn't have a title but docbook skipped it. This skips the
title to line up with docbook.
