### PR TITLE
Handle missing titles in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_links.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_links.rb
@@ -59,7 +59,7 @@ module DocbookCompat
       # nice if there was a cleaner way to do this but there really isn't.
       # Luckily this html all comes from asciidoctor so we at least know it is
       # valid.
-      ref.title.gsub %r{</?[^>]*>}, ''
+      ref.title&.gsub %r{</?[^>]*>}, ''
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -840,6 +840,19 @@ RSpec.describe DocbookCompat do
         expect(converted).to include('title="foo"')
       end
     end
+    context 'when the section title is empty' do
+      let(:input) do
+        <<~ASCIIDOC
+          Words <<foo>>.
+
+          [[foo]]
+          ==
+        ASCIIDOC
+      end
+      it "contains the target's title without the markup" do
+        expect(converted).not_to include('title')
+      end
+    end
     context 'when the cross reference is to an inline anchor' do
       let(:input) do
         <<~ASCIIDOC


### PR DESCRIPTION
When you link to a section that doesn't have a title at all we crashed!
Crash bad! No crash! This skips the `title` tag if the section we link
to doesn't have a title.
