### PR TITLE
Add support for colspan and rowspan to direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+require_relative 'convert_table_cell'
+
 module DocbookCompat
   ##
   # Methods to convert tables.
   module ConvertTable
+    include ConvertTableCell
+
     def convert_table(node)
       [
         convert_table_intro(node),
@@ -96,22 +100,9 @@ module DocbookCompat
     def convert_row(row, data_tag, wrap_text)
       [
         '<tr>',
-        row.map { |cell| convert_cell cell, data_tag, wrap_text },
+        row.map { |cell| convert_table_cell cell, data_tag, wrap_text },
         '</tr>',
       ].flatten
-    end
-
-    def convert_cell(cell, data_tag, wrap_text)
-      result = ['<', data_tag, ' align="left" valign="top">']
-      if cell.inner_document
-        result << "\n" << cell.content << "\n"
-      else
-        result << '<p>' if wrap_text
-        result << cell.text
-        result << '</p>' if wrap_text
-      end
-      result << '</' << data_tag << '>'
-      result.join
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/convert_table_cell.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table_cell.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert tables.
+  module ConvertTableCell
+    def convert_table_cell(cell, data_tag, wrap_text)
+      result = [convert_cell_open(cell, data_tag)]
+      if cell.inner_document
+        result << "\n" << cell.content << "\n"
+      else
+        result << '<p>' if wrap_text
+        result << cell.text
+        result << '</p>' if wrap_text
+      end
+      result << '</' << data_tag << '>'
+      result.join
+    end
+
+    def convert_cell_open(cell, data_tag)
+      [
+        '<',
+        data_tag,
+        ' ',
+        cell_open_attrs(cell).map { |k, v| %(#{k}="#{v}") }.join(' '),
+        '>',
+      ].join
+    end
+
+    def cell_open_attrs(cell)
+      {
+        align: 'left',
+        colspan: cell.colspan == 1 ? nil : cell.colspan,
+        rowspan: cell.rowspan == 1 ? nil : cell.rowspan,
+        valign: 'top',
+      }.compact
+    end
+  end
+end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1854,5 +1854,33 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with colspan' do
+      let(:input) do
+        <<~ASCIIDOC
+          |===
+          2+|Col
+          |===
+        ASCIIDOC
+      end
+      it 'has the colspan' do
+        expect(converted).to include <<~HTML.strip
+          <td align="left" colspan="2" valign="top">
+        HTML
+      end
+    end
+    context 'with rowspan' do
+      let(:input) do
+        <<~ASCIIDOC
+          |===
+          .2+|Col
+          |===
+        ASCIIDOC
+      end
+      it 'has the rowspan' do
+        expect(converted).to include <<~HTML.strip
+          <td align="left" rowspan="2" valign="top">
+        HTML
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds support for `colspan` and `rowspan` to direct_html's tables.
