### PR TITLE
Support quotes in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -147,6 +147,12 @@ def normalize_html(html):
         wrapper = soup.new_tag("div")
         wrapper['class'] = ['openblock', 'partintro']
         e.wrap(wrapper)
+    # Asciidoctor adds 'blockquote' and 'quoteblock'. Docbook doesn't and we
+    # don't need them.
+    for e in soup.select('.blockquote'):
+        e['class'].remove('blockquote')
+    for e in soup.select('.quoteblock'):
+        e['class'].remove('quoteblock')
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):

--- a/resources/asciidoctor/lib/docbook_compat/convert_quote.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_quote.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert tables.
+  module ConvertQuote
+    def convert_quote(node)
+      return convert_fancy_quote node if node.attr 'attribution'
+
+      yield
+    end
+
+    def convert_fancy_quote(node)
+      [
+        '<div class="blockquote">',
+        '<table border="0" class="blockquote" summary="Block quote">',
+        convert_quote_row(node),
+        convert_attribution_row(node),
+        '</table>',
+        '</div>',
+      ].compact.join "\n"
+    end
+
+    private
+
+    def convert_quote_row(node)
+      [
+        '<tr>',
+        '<td valign="top" width="10%"></td>',
+        '<td valign="top" width="80%">',
+        node.content,
+        '</td>',
+        '<td valign="top" width="10%"></td>',
+        '</tr>',
+      ]
+    end
+
+    def convert_attribution_row(node)
+      [
+        '<tr>',
+        '<td valign="top" width="10%"></td>',
+        '<td align="right" colspan="2" valign="top">',
+        %(-- <span class="attribution">#{node.attr 'attribution'}</span>),
+        '</td>',
+        '</tr>',
+      ]
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -10,6 +10,7 @@ require_relative 'convert_listing'
 require_relative 'convert_lists'
 require_relative 'convert_open'
 require_relative 'convert_outline'
+require_relative 'convert_quote'
 require_relative 'convert_table'
 require_relative 'titleabbrev_handler'
 
@@ -34,6 +35,7 @@ module DocbookCompat
     include ConvertLists
     include ConvertOpen
     include ConvertOutline
+    include ConvertQuote
     include ConvertTable
 
     def convert_section(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1855,4 +1855,54 @@ RSpec.describe DocbookCompat do
       end
     end
   end
+
+  context 'a quote' do
+    let(:input) do
+      <<~ASCIIDOC
+        [quote]
+        __________________________
+        Baz
+        __________________________
+      ASCIIDOC
+    end
+    it 'is wrapped in a blockquote' do
+      expect(converted).to include <<~HTML
+        <blockquote>
+        <p>Baz</p>
+        </blockquote>
+      HTML
+    end
+
+    context 'with an attribution' do
+      let(:input) do
+        <<~ASCIIDOC
+          [quote, Brendan Francis Behan]
+          __________________________
+          Once we accept our limits, we go beyond them.
+          __________________________
+        ASCIIDOC
+      end
+      it 'looks like docbook' do
+        expect(converted).to include <<~HTML
+          <div class="blockquote">
+          <table border="0" class="blockquote" summary="Block quote">
+          <tr>
+          <td valign="top" width="10%"></td>
+          <td valign="top" width="80%">
+          <p>Once we accept our limits, we go beyond them.</p>
+          </td>
+          <td valign="top" width="10%"></td>
+          </tr>
+          <tr>
+          <td valign="top" width="10%"></td>
+          <td align="right" colspan="2" valign="top">
+          -- <span class="attribution">Brendan Francis Behan</span>
+          </td>
+          </tr>
+          </table>
+          </div>
+        HTML
+      end
+    end
+  end
 end


### PR DESCRIPTION
Docbook renders attributed quotes radically differenly than asciidoctor.
This gets direct_html to look like docbook.
