### PR TITLE
Don't add . to title ending in : in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -8,22 +8,9 @@ module DocbookCompat
       [
         node.title ? '<p>' : nil,
         node.id ? %(<a id="#{node.id}"></a>) : nil,
-        node.title ? %(<strong>#{node.title}.</strong></p>\n) : nil,
+        node.title ? convert_listing_title(node) : nil,
         convert_listing_body(node),
       ].compact.join
-    end
-
-    def convert_listing_body(node)
-      if (lang = node.attr 'language')
-        pre_classes = "programlisting prettyprint lang-#{lang}"
-        [
-          %(<div class="pre_wrapper lang-#{lang}">),
-          %(<pre class="#{pre_classes}">#{node.content || ''}</pre>),
-          %(</div>),
-        ].join "\n"
-      else
-        %(<pre class="screen">#{node.content || ''}</pre>)
-      end
     end
 
     def convert_inline_callout(node)
@@ -38,6 +25,28 @@ module DocbookCompat
         '</table>',
         '</div>',
       ].flatten.compact.join "\n"
+    end
+
+    private
+
+    def convert_listing_title(node)
+      title = '<strong>' + node.title
+      title += '.' unless [':', '.'].include? node.title[-1]
+      title += "</strong></p>\n"
+      title
+    end
+
+    def convert_listing_body(node)
+      if (lang = node.attr 'language')
+        pre_classes = "programlisting prettyprint lang-#{lang}"
+        [
+          %(<div class="pre_wrapper lang-#{lang}">),
+          %(<pre class="#{pre_classes}">#{node.content || ''}</pre>),
+          %(</div>),
+        ].join "\n"
+      else
+        %(<pre class="screen">#{node.content || ''}</pre>)
+      end
     end
 
     def convert_colist_item(item)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -995,6 +995,24 @@ RSpec.describe DocbookCompat do
           <div class="pre_wrapper lang-sh">
         HTML
       end
+
+      context 'that ends in a :' do
+        let(:input) do
+          <<~ASCIIDOC
+            .Title:
+            [source,sh]
+            ----
+            cpanm Search::Elasticsearch
+            ----
+          ASCIIDOC
+        end
+        it "the title is before in docbook's funny wrapper" do
+          expect(converted).to include(<<~HTML)
+            <p><strong>Title:</strong></p>
+            <div class="pre_wrapper lang-sh">
+          HTML
+        end
+      end
     end
     context 'with an id' do
       let(:input) do


### PR DESCRIPTION
When the title of a listing ends in a `:` we shouldn't add a `.` to it
because docbook doesn't and because it looks silly.
