### PR TITLE
Handle horizontal dlist with title in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
@@ -29,10 +29,14 @@ module DocbookCompat
     end
 
     def convert_horizontal_dlist(node)
+      node.assign_caption nil, :table
       [
+        convert_table_intro(node),
+        convert_table_tag(node, 0),
         Horizontal::INTRO,
         node.items.map { |terms, dd| Horizontal.convert_dlist_item terms, dd },
         Horizontal::OUTRO,
+        convert_table_outro(node),
       ].flatten
     end
 
@@ -77,8 +81,6 @@ module DocbookCompat
     # Creates a "horizontal" style dlists.
     module Horizontal
       INTRO = [
-        '<div class="informaltable">',
-        '<table border="0" cellpadding="4px">',
         '<colgroup>',
         '<col/>',
         '<col/>',
@@ -88,7 +90,6 @@ module DocbookCompat
       OUTRO = [
         '</tbody>',
         '</table>',
-        '</div>',
       ].freeze
 
       def self.convert_dlist_item(terms, definition)

--- a/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
@@ -29,7 +29,7 @@ module DocbookCompat
     end
 
     def convert_horizontal_dlist(node)
-      node.assign_caption nil, :table
+      node.assign_caption nil, :table # Caption the dlist like a table
       [
         convert_table_intro(node),
         convert_table_tag(node, 0),

--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -7,15 +7,13 @@ module DocbookCompat
     def convert_table(node)
       [
         convert_table_intro(node),
-        convert_table_tag(node),
+        convert_table_tag(node, 1),
         convert_colgroups(node),
         convert_parts(node),
         '</table>',
         convert_table_outro(node),
       ].flatten.join "\n"
     end
-
-    private
 
     def convert_table_intro(node)
       return '<div class="informaltable">' unless node.title
@@ -33,10 +31,10 @@ module DocbookCompat
       ['</div>', '</div>']
     end
 
-    def convert_table_tag(node)
+    def convert_table_tag(node, border)
       [
         '<table',
-        ' border="1" cellpadding="4px"',
+        %( border="#{border}" cellpadding="4px"),
         node.title ? %( summary="#{node.title}") : nil,
         (width = node.attr 'width') ? %( width="#{width}") : nil,
         '>',

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1373,6 +1373,30 @@ RSpec.describe DocbookCompat do
           </tr>
         HTML
       end
+
+      context 'when it has a title' do
+        let(:input) do
+          <<~ASCIIDOC
+            .Title
+            [horizontal]
+            Foo:: The foo.
+            Bar:: The bar.
+          ASCIIDOC
+        end
+        it 'has the title in a strong' do
+          expect(converted).to include <<~HTML
+            <div class="table">
+            <p class="title"><strong>Table 1. Title</strong></p>
+            <div class="table-contents">
+          HTML
+        end
+        it 'has the title as the summary' do
+          expect(converted).to include <<~HTML
+            <div class="table-contents">
+            <table border="0" cellpadding="4px" summary="Title">
+          HTML
+        end
+      end
     end
     context 'question and anwer styled' do
       let(:input) do


### PR DESCRIPTION
"horizontal" style descriptions lists with a title need to be rendered
*just* like a table with a title. This does that, mostly by leaning on
the table rendering code.

This is required for logstash (#1512).
