### PR TITLE
Handle titles on paragraphs in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_paragraph.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_paragraph.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert paragraphs.
+  module ConvertParagraph
+    def convert_paragraph(node)
+      # Asciidoctor adds a \n at the end of the paragraph so we don't.
+      [
+        '<p>',
+        paragraph_id_part(node),
+        paragraph_title_part(node),
+        node.content,
+        '</p>',
+      ].compact.join
+    end
+
+    def paragraph_id_part(node)
+      return if node.id.nil? || node.id.empty?
+
+      %(<a id="#{node.id}"></a>)
+    end
+
+    def paragraph_title_part(node)
+      return unless node.title
+
+      "<strong>#{node.title}</strong>"
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -10,11 +10,8 @@ require_relative 'convert_listing'
 require_relative 'convert_lists'
 require_relative 'convert_open'
 require_relative 'convert_outline'
-<<<<<<< HEAD
 require_relative 'convert_paragraph'
-=======
 require_relative 'convert_quote'
->>>>>>> master
 require_relative 'convert_table'
 require_relative 'titleabbrev_handler'
 
@@ -39,11 +36,8 @@ module DocbookCompat
     include ConvertLists
     include ConvertOpen
     include ConvertOutline
-<<<<<<< HEAD
     include ConvertParagraph
-=======
     include ConvertQuote
->>>>>>> master
     include ConvertTable
 
     def convert_section(node)

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -10,6 +10,7 @@ require_relative 'convert_listing'
 require_relative 'convert_lists'
 require_relative 'convert_open'
 require_relative 'convert_outline'
+require_relative 'convert_paragraph'
 require_relative 'convert_table'
 require_relative 'titleabbrev_handler'
 
@@ -34,6 +35,7 @@ module DocbookCompat
     include ConvertLists
     include ConvertOpen
     include ConvertOutline
+    include ConvertParagraph
     include ConvertTable
 
     def convert_section(node)
@@ -57,17 +59,6 @@ module DocbookCompat
       <<~HTML
         <#{tag_name}#{classes_html}>#{anchor}#{node.title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</#{tag_name}>
       HTML
-    end
-
-    def convert_paragraph(node)
-      # Asciidoctor adds a \n at the end of the paragraph so we don't.
-      %(<p>#{paragraph_id_part node}#{node.content}</p>)
-    end
-
-    def paragraph_id_part(node)
-      return if node.id.nil? || node.id.empty?
-
-      %(<a id="#{node.id}"></a>)
     end
 
     def convert_inline_quoted(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -758,6 +758,17 @@ RSpec.describe DocbookCompat do
         expect(converted).to include '<p><a id="foo"></a>Words.</p>'
       end
     end
+    context 'with a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          Words.
+        ASCIIDOC
+      end
+      it 'contains a paragraph for each anchor' do
+        expect(converted).to include '<p><strong>Title</strong>Words.</p>'
+      end
+    end
   end
 
   context 'a link' do


### PR DESCRIPTION
Adds support for titles on paragraphs to direct_html. These are written
like:
```
.Title
Paragraph body.
```
