### PR TITLE
Handle change admonitions in direct_html

### DIFF
--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -17,14 +17,17 @@ require_relative '../delegating_converter.rb'
 #   Foo deprecated:[6.0.0-beta1]
 #
 class ChangeAdmonition < Asciidoctor::Extensions::Group
+  MACRO_CONF = [
+    [:added, 'added', 'note', 'Added in', nil],
+    [:coming, 'changed', 'note', 'Coming in', nil],
+    [:deprecated, 'deleted', 'warning', 'Deprecated in', 'u-strikethrough'],
+  ].freeze
   def activate(registry)
-    [
-      [:added, 'added', 'note'],
-      [:coming, 'changed', 'note'],
-      [:deprecated, 'deleted', 'warning'],
-    ].each do |(name, revisionflag, tag)|
-      registry.block_macro ChangeAdmonitionBlock.new(revisionflag, tag), name
-      registry.inline_macro ChangeAdmonitionInline.new(revisionflag), name
+    MACRO_CONF.each do |(name, revisionflag, tag, message, title_class)|
+      block = ChangeAdmonitionBlock.new revisionflag, tag, message
+      inline = ChangeAdmonitionInline.new revisionflag, message, title_class
+      registry.block_macro block, name
+      registry.inline_macro inline, name
     end
     DelegatingConverter.setup(registry.document) { |doc| Converter.new doc }
   end
@@ -33,6 +36,7 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
   # Properly renders change admonitions.
   class Converter < DelegatingConverter
     def convert_admonition(node)
+      return yield if node.document.basebackend? 'html'
       return yield unless (flag = node.attr 'revisionflag')
 
       <<~DOCBOOK.strip
@@ -49,22 +53,42 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
     use_dsl
     name_positional_attributes :version, :passtext
 
-    def initialize(revisionflag, tag)
+    def initialize(revisionflag, tag, message)
       super(nil)
       @revisionflag = revisionflag
       @tag = tag
+      @message = message
     end
 
     def process(parent, _target, attrs)
       version = attrs[:version]
+      passtext = attrs[:passtext]
+      if parent.document.basebackend? 'html'
+        process_html parent, version, passtext
+      else
+        process_docbook parent, version, passtext
+      end
+    end
+
+    def process_html(parent, version, passtext)
+      text = "#{@message} #{version}."
+      source = passtext || text
+      title = passtext ? text : nil
+      Asciidoctor::Block.new parent, :admonition, source: source, attributes: {
+        'name' => @tag,
+        'revisionflag' => @revisionflag,
+        'version' => version,
+        'title' => title,
+      }
+    end
+
+    def process_docbook(parent, version, passtext)
       Asciidoctor::Block.new(
-        parent, :admonition,
-        attributes: {
+        parent, :admonition, source: passtext, attributes: {
           'name' => @tag,
           'revisionflag' => @revisionflag,
           'version' => version,
-        },
-        source: attrs[:passtext]
+        }
       )
     end
   end
@@ -76,25 +100,48 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
     name_positional_attributes :version, :text
     format :short
 
-    def initialize(revisionflag)
+    def initialize(revisionflag, message, extra_title_class)
       super(nil)
       @revisionflag = revisionflag
+      @message = message
+      @extra_title_class = extra_title_class
     end
 
     def process(parent, _target, attrs)
-      Asciidoctor::Inline.new(parent, :quoted, text(attrs))
+      version = attrs[:version]
+      text = attrs[:text]
+      if parent.document.basebackend? 'html'
+        process_html parent, version, text
+      else
+        process_docbook parent, version, text
+      end
     end
 
-    def text(attrs)
-      if attrs[:text]
+    def process_html(parent, version, text)
+      text ||= "#{@message} #{version}."
+      Asciidoctor::Inline.new(
+        parent, :admonition, text, type: 'change', attributes: {
+          'title_type' => 'version',
+          'title_class' => "u-mono#{@extra_title_class}",
+          'title' => version,
+        }
+      )
+    end
+
+    def process_docbook(parent, version, text)
+      Asciidoctor::Inline.new parent, :quoted, docbook_text(version, text)
+    end
+
+    def docbook_text(version, text)
+      if text
         <<~DOCBOOK
-          <phrase revisionflag="#{@revisionflag}" revision="#{attrs[:version]}">
-            #{attrs[:text]}
+          <phrase revisionflag="#{@revisionflag}" revision="#{version}">
+            #{text}
           </phrase>
         DOCBOOK
       else
         <<~DOCBOOK
-          <phrase revisionflag="#{@revisionflag}" revision="#{attrs[:version]}"/>
+          <phrase revisionflag="#{@revisionflag}" revision="#{version}"/>
         DOCBOOK
       end
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -5,52 +5,28 @@ module DocbookCompat
   # Methods to convert admonitions.
   module ConvertAdmonition
     def convert_admonition(node)
-      content = block_admonition_content node
       [
         %(<div class="#{node.attr 'name'} admon">),
         %(<div class="icon"></div>),
         %(<div class="admon_content">),
         node.title? ? "<h3>#{node.title}</h3>" : nil,
-        node.blocks.empty? ? "<p>#{content}</p>" : content,
+        node.blocks.empty? ? "<p>#{node.content}</p>" : node.content,
         '</div>',
         '</div>',
       ].compact.join "\n"
     end
 
     def convert_inline_admonition(node)
+      title_classes =
+        "Admonishment-#{node.attr 'title_type'} #{node.attr 'title_class'}"
       [
         %(<span class="Admonishment Admonishment--#{node.type}">),
-        %([<span class="Admonishment-title u-mono">#{node.type}</span>]),
+        %([<span class="#{title_classes}">#{node.attr 'title'}</span>]),
         '<span class="Admonishment-detail">',
-        inline_admonition_text(node),
+        node.text,
         '</span>',
         '</span>',
       ].join "\n"
-    end
-
-    private
-
-    ADMONITION_DEFAULT_MESSAGE = {
-      'beta' => <<~TEXT.strip,
-        This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
-      TEXT
-      'experimental' => <<~TEXT.strip,
-        This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
-      TEXT
-    }.freeze
-
-    def block_admonition_content(node)
-      content = node.content
-      return content unless content == ''
-
-      ADMONITION_DEFAULT_MESSAGE[node.role]
-    end
-
-    def inline_admonition_text(node)
-      text = node.text
-      return text if text
-
-      ADMONITION_DEFAULT_MESSAGE[node.type]
     end
   end
 end

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -20,15 +20,12 @@ RSpec.describe CareAdmonition do
           #{name}::[]
         ASCIIDOC
       end
-      let(:expected) do
-        <<~DOCBOOK
+      it 'creates a warning' do
+        expect(converted).to include <<~DOCBOOK
           <warning role="#{name}">
-          <simpara></simpara>
+          <simpara>#{default_text}</simpara>
           </warning>
         DOCBOOK
-      end
-      it 'creates a warning' do
-        expect(converted).to include(expected)
       end
       context 'when there is asciidoc in the passtext' do
         let(:input) do
@@ -108,10 +105,20 @@ RSpec.describe CareAdmonition do
 
   context 'for beta' do
     let(:name) { 'beta' }
+    let(:default_text) do
+      <<~TEXT.strip
+        This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+      TEXT
+    end
     include_context 'care admonition'
   end
   context 'for experimental' do
     let(:name) { 'experimental' }
+    let(:default_text) do
+      <<~TEXT.strip
+        This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
+      TEXT
+    end
     include_context 'care admonition'
   end
 end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -35,15 +35,11 @@ RSpec.describe ElasticCompatPreprocessor do
       include_context 'convert without logs'
 
       shared_examples 'invokes the block macro' do
-        let(:expected) do
-          <<~DOCBOOK
-            <#{tag_start}>
-            <simpara></simpara>
-            </#{tag_end}>
-          DOCBOOK
-        end
         it 'invokes the block macro' do
-          expect(converted).to include(expected)
+          expect(converted).to include <<~DOCBOOK.strip
+            <#{tag_start}>
+            <simpara>
+          DOCBOOK
         end
       end
       context 'when the admonition is alone on a line' do


### PR DESCRIPTION
This handles change admonitions and cleans up the care admonitions to
look like the change admonitions. For the most part that means moving
the "default text" of the care admonitions into the care admonition
extension itself. This will change the generated docbook xml but it
*shouldn't* change the resulting html.
