### PR TITLE
Support more table formatting in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -95,10 +95,10 @@ module DocbookCompat
       ].flatten
     end
 
-    def convert_row(row, data_tag, wrap_text)
+    def convert_row(row, data_tag, allow_formatting)
       [
         '<tr>',
-        row.map { |cell| convert_table_cell cell, data_tag, wrap_text },
+        row.map { |cell| convert_table_cell cell, data_tag, allow_formatting },
         '</tr>',
       ].flatten
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_table_cell.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table_cell.rb
@@ -2,17 +2,11 @@
 
 module DocbookCompat
   ##
-  # Methods to convert tables.
+  # Methods to convert table cells.
   module ConvertTableCell
-    def convert_table_cell(cell, data_tag, wrap_text)
+    def convert_table_cell(cell, data_tag, allow_formatting)
       result = [convert_cell_open(cell, data_tag)]
-      if cell.inner_document
-        result << "\n" << cell.content << "\n"
-      else
-        result << '<p>' if wrap_text
-        result << cell.text
-        result << '</p>' if wrap_text
-      end
+      result += convert_cell_content(cell, allow_formatting)
       result << '</' << data_tag << '>'
       result.join
     end
@@ -29,11 +23,66 @@ module DocbookCompat
 
     def cell_open_attrs(cell)
       {
-        align: 'left',
+        align: cell.attr('halign'),
         colspan: cell.colspan == 1 ? nil : cell.colspan,
         rowspan: cell.rowspan == 1 ? nil : cell.rowspan,
-        valign: 'top',
+        valign: cell.attr('valign'),
       }.compact
+    end
+
+    def convert_cell_content(cell, allow_formatting)
+      if cell.inner_document
+        ["\n", cell.content, "\n"]
+      elsif allow_formatting
+        ['<p>', cell_text(cell), '</p>']
+      else
+        [cell.text]
+      end
+    end
+
+    def cell_text(cell)
+      return cell.text unless (style = cell.attr 'style')
+
+      cell.document.converter.convert cell, "cell_text_#{style}"
+    rescue NoMethodError
+      warn block: cell, message: "Unknown style for cell [#{style}]."
+      convert_cell_text_none cell
+    end
+
+    def convert_cell_text_emphasis(cell)
+      delegate_cell_text cell, :emphasis
+    end
+
+    def convert_cell_text_header(cell)
+      convert_cell_text_strong cell
+    end
+
+    def convert_cell_text_literal(cell)
+      delegate_cell_text cell, :literal
+    end
+
+    def convert_cell_text_monospaced(cell)
+      delegate_cell_text cell, :monospaced
+    end
+
+    def convert_cell_text_none(cell)
+      cell.text
+    end
+
+    def convert_cell_text_strong(cell)
+      delegate_cell_text cell, :strong
+    end
+
+    def convert_cell_text_verse(cell)
+      delegate_cell_text cell, :verse
+    end
+
+    private
+
+    def delegate_cell_text(cell, type)
+      Asciidoctor::Inline.new(
+        cell.parent, :quoted, cell.text, type: type
+      ).convert
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1935,6 +1935,96 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with horizontal alignment' do
+      let(:input) do
+        <<~ASCIIDOC
+          [cols="<,^,>"]
+          |===
+          |1 |2 |3
+          |===
+        ASCIIDOC
+      end
+      it 'aligns the cells' do
+        expect(converted).to include <<~HTML
+          <td align="left" valign="top"><p>1</p></td>
+          <td align="center" valign="top"><p>2</p></td>
+          <td align="right" valign="top"><p>3</p></td>
+        HTML
+      end
+    end
+    context 'with vertical alignment' do
+      let(:input) do
+        <<~ASCIIDOC
+          [cols=".<,.^,.>"]
+          |===
+          |1 |2 |3
+          |===
+        ASCIIDOC
+      end
+      it 'aligns the cells' do
+        expect(converted).to include <<~HTML
+          <td align="left" valign="top"><p>1</p></td>
+          <td align="left" valign="middle"><p>2</p></td>
+          <td align="left" valign="bottom"><p>3</p></td>
+        HTML
+      end
+    end
+    context 'with cell formatting' do
+      shared_examples 'with formatting' do
+        let(:input) do
+          <<~ASCIIDOC
+            [cols="#{code}"]
+            |===
+            |Cell
+            |===
+          ASCIIDOC
+        end
+        it 'includes the formatting' do
+          expect(converted).to include <<~HTML.strip
+            <td align="left" valign="top"><p>#{cell}</p></td>
+          HTML
+        end
+      end
+      context 'emphasis' do
+        let(:code) { 'e' }
+        let(:cell) { '<em>Cell</em>' }
+        include_examples 'with formatting'
+      end
+      context 'header' do
+        let(:code) { 'h' }
+        let(:cell) do
+          '<span class="strong strong"><strong>Cell</strong></span>'
+        end
+        include_examples 'with formatting'
+      end
+      context 'literal' do
+        let(:code) { 'l' }
+        let(:cell) { 'Cell' }
+        include_examples 'with formatting'
+      end
+      context 'monospaced' do
+        let(:code) { 'm' }
+        let(:cell) { '<code class="literal">Cell</code>' }
+        include_examples 'with formatting'
+      end
+      context 'explicit "none"' do
+        let(:code) { 'd' } # "d" stands for default, apparently
+        let(:cell) { 'Cell' }
+        include_examples 'with formatting'
+      end
+      context 'strong' do
+        let(:code) { 's' }
+        let(:cell) do
+          '<span class="strong strong"><strong>Cell</strong></span>'
+        end
+        include_examples 'with formatting'
+      end
+      context 'verse' do
+        let(:code) { 'v' }
+        let(:cell) { 'Cell' }
+        include_examples 'with formatting'
+      end
+    end
   end
 
   context 'a quote' do


### PR DESCRIPTION
Asciidoctor supports explicitly setting the format on table cell so we
should respect that in direct_html. This sets up direct_html to mimic
how it all turns out in docbook.
