### PR TITLE
Clean up direct_html's inline change admonitions

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -153,6 +153,10 @@ def normalize_html(html):
         e['class'].remove('blockquote')
     for e in soup.select('.quoteblock'):
         e['class'].remove('quoteblock')
+    # Docbook doesn't add `Admonishment--change` but Asciidoctor does to keep
+    # it consistent with the care admonitions.
+    for e in soup.select('.Admonishment--change'):
+        e['class'].remove('Admonishment--change')
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):

--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -20,7 +20,7 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
   MACRO_CONF = [
     [:added, 'added', 'note', 'Added in', nil],
     [:coming, 'changed', 'note', 'Coming in', nil],
-    [:deprecated, 'deleted', 'warning', 'Deprecated in', 'u-strikethrough'],
+    [:deprecated, 'deleted', 'warning', 'Deprecated in', ' u-strikethrough'],
   ].freeze
   def activate(registry)
     MACRO_CONF.each do |(name, revisionflag, tag, message, title_class)|
@@ -118,9 +118,10 @@ class ChangeAdmonition < Asciidoctor::Extensions::Group
     end
 
     def process_html(parent, version, text)
-      text ||= "#{@message} #{version}."
+      message = "#{@message} #{version}."
+      message += ' ' + text if text
       Asciidoctor::Inline.new(
-        parent, :admonition, text, type: 'change', attributes: {
+        parent, :admonition, message, type: 'change', attributes: {
           'title_type' => 'version',
           'title_class' => "u-mono#{@extra_title_class}",
           'title' => version,

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1766,7 +1766,9 @@ RSpec.describe DocbookCompat do
                 ASCIIDOC
               end
               it "renders with Elastic's custom template" do
-                expect_inline_admonition '7.0.0-beta1', 'admon words'
+                expect_inline_admonition(
+                  '7.0.0-beta1', "#{message} in 7.0.0-beta1. admon words"
+                )
               end
             end
             context 'without text' do
@@ -1801,7 +1803,7 @@ RSpec.describe DocbookCompat do
           let(:key) { 'deprecated' }
           let(:admon_class) { 'warning' }
           let(:message) { 'Deprecated' }
-          let(:extra_class) { 'u-strikethrough' }
+          let(:extra_class) { ' u-strikethrough' }
           include_examples 'change admonition'
         end
       end


### PR DESCRIPTION
This fixes some small errors with direct_html's handling of inline
change admonitions that came up because I didn't have a great example to
compare against when I wrote them. I found an example though! This adds
a missing space between some classes, adds some more text to the
message, and fixes up the diff tool to ignore a small diff that isn't
visible.
