### PR TITLE
Support ids on tables in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -20,13 +20,16 @@ module DocbookCompat
     end
 
     def convert_table_intro(node)
-      return '<div class="informaltable">' unless node.title
+      return '<div class="informaltable">' unless node.title || node.id
 
-      [
-        '<div class="table">',
-        %(<p class="title"><strong>#{node.captioned_title}</strong></p>),
-        '<div class="table-contents">',
-      ]
+      result = ['<div class="table">']
+      result << %(<a id="#{node.id}"></a>) if node.id
+      if node.title
+        title = node.captioned_title
+        result << %(<p class="title"><strong>#{title}</strong></p>)
+      end
+      result << '<div class="table-contents">'
+      result
     end
 
     def convert_table_outro(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1980,6 +1980,24 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with an id' do
+      let(:input) do
+        <<~ASCIIDOC
+          [[id]]
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'is wrapped in table' do
+        expect(converted).to include <<~HTML
+          <div class="table">
+          <a id="id"></a>
+          <div class="table-contents">
+          <table border="1" cellpadding="4px">
+        HTML
+      end
+    end
     context 'with width' do
       let(:input) do
         <<~ASCIIDOC


### PR DESCRIPTION
Adds support for specifying he id on a table in a docbook compatible way
to direct_html. Required by the painless reference (#1562).
