### PR TITLE
Implement glossary style dlists in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_dlist.rb
@@ -50,8 +50,16 @@ module DocbookCompat
       ].flatten
     end
 
+    def convert_glossary_dlist(node)
+      [
+        '<dl>',
+        node.items.map { |terms, dd| Glossary.convert_dlist_item terms, dd },
+        '</dl>',
+      ].flatten.compact.join "\n"
+    end
+
     ##
-    # Creates a "vertical" style (the default) dlists.
+    # Creates "vertical" style (the default) dlists.
     module Vertical
       def self.convert_dlist_item(terms, definition)
         [
@@ -78,7 +86,7 @@ module DocbookCompat
     end
 
     ##
-    # Creates a "horizontal" style dlists.
+    # Creates "horizontal" style dlists.
     module Horizontal
       INTRO = [
         '<colgroup>',
@@ -119,7 +127,7 @@ module DocbookCompat
     end
 
     ##
-    # Creates a "qanda" style dlists.
+    # Creates "qanda" style dlists.
     module QuestionAndAnswer
       INTRO = [
         '<div class="qandaset">',
@@ -175,6 +183,33 @@ module DocbookCompat
           index ? "<p><strong>#{index + 1}.</strong></p>" : nil,
           '</td>',
         ].compact
+      end
+    end
+
+    ##
+    # Creates "glossary" style dlists.
+    module Glossary
+      def self.convert_dlist_item(terms, definition)
+        [
+          terms.map { |term| convert_dlist_term term },
+          convert_dlist_definition(definition),
+        ].flatten
+      end
+
+      def self.convert_dlist_term(term)
+        [
+          '<dt>',
+          '<span class="glossterm">',
+          term.convert,
+          '</span>',
+          '</dt>',
+        ]
+      end
+
+      def self.convert_dlist_definition(definition)
+        return unless definition
+
+        ['<dd class="glossdef">', definition.convert, '</dd>']
       end
     end
   end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1500,6 +1500,43 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'glossary styled' do
+      let(:input) do
+        <<~ASCIIDOC
+          [glossary]
+          Foo:: The foo.
+          Bar:: The bar.
+        ASCIIDOC
+      end
+      it 'is wrapped in a dl' do
+        expect(converted).to include '<dl>'
+        expect(converted).to include '</dl>'
+      end
+      it 'contains a dt/dd pair for the first entry' do
+        expect(converted).to include <<~HTML
+          <dt>
+          <span class="glossterm">
+          Foo
+          </span>
+          </dt>
+          <dd class="glossdef">
+          The foo.
+          </dd>
+        HTML
+      end
+      it 'contains a dt/dd pair for the second entry' do
+        expect(converted).to include <<~HTML
+          <dt>
+          <span class="glossterm">
+          Bar
+          </span>
+          </dt>
+          <dd class="glossdef">
+          The bar.
+          </dd>
+        HTML
+      end
+    end
     context 'an unimplemented dlist style' do
       include_context 'convert with logs'
       let(:input) do


### PR DESCRIPTION
This implements glossary style dlists in direct_html which is required
to convert the Elasticsearch reference (#1566).
