### PR TITLE
Strip html from titles in direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -2,6 +2,7 @@
 
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
+require_relative '../strip_tags'
 require_relative 'breadcrumbs'
 require_relative 'convert_outline'
 require_relative 'extra_docinfo'
@@ -34,6 +35,7 @@ module Chunker
     include ConvertOutline
     include FindRelated
     include Footnotes
+    include StripTags
 
     def initialize(delegate, chunk_level)
       super(delegate)
@@ -117,7 +119,7 @@ module Chunker
     def subdoc_attrs(doc, section)
       attrs = doc.attributes.dup
       maintitle = doc.doctitle partition: true
-      attrs['doctitle'] = "#{section.captioned_title} | #{maintitle.main}"
+      attrs['doctitle'] = subdoc_title section, maintitle
       # Asciidoctor defaults these attribute to empty string if they aren't
       # specified and setting them to `nil` clears them. Since we want to
       # preserve the configuration from the parent into the child, we clear
@@ -130,6 +132,10 @@ module Chunker
       attrs['title-separator'] = ''
       attrs.merge! find_related(section)
       attrs
+    end
+
+    def subdoc_title(section, maintitle)
+      strip_tags "#{section.captioned_title} | #{maintitle.main}"
     end
 
     def write(doc, file, html)

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../strip_tags'
 require_relative 'link'
 
 module Chunker
@@ -7,6 +8,7 @@ module Chunker
   # Adds extra tags <link> tags to the <head> to emulate docbook.
   module ExtraDocinfo
     include Link
+    include StripTags
 
     def docinfo(location = :head, suffix = nil)
       info = super
@@ -29,7 +31,7 @@ module Chunker
       return unless related
 
       extra = related.context == :document ? related.attr('title-extra') : ''
-      title = %(title="#{link_text related}#{extra}")
+      title = %(title="#{strip_tags(link_text(related))}#{extra}")
       %(<link rel="#{rel}" #{link_href related} #{title}/>)
     end
   end

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -39,7 +39,7 @@ module DocbookCompat
     def munge_head(title_extra, title, html)
       html.gsub!(
         %r{<title>.+</title>},
-        "<title>#{title.main}#{title_extra} | Elastic</title>"
+        "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_links.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_links.rb
@@ -53,11 +53,7 @@ module DocbookCompat
       # References to inline text don't have a title.
       return unless ref.respond_to?(:title)
 
-      # Strip the html if there is any becaue this is inside a tag. It'd be
-      # nice if there was a cleaner way to do this but there really isn't.
-      # Luckily this html all comes from asciidoctor so we at least know it is
-      # valid.
-      ref.title&.gsub %r{</?[^>]*>}, ''
+      strip_tags ref.title
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -2,6 +2,7 @@
 
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
+require_relative '../strip_tags'
 require_relative 'convert_admonition'
 require_relative 'convert_document'
 require_relative 'convert_dlist'
@@ -39,6 +40,7 @@ module DocbookCompat
     include ConvertParagraph
     include ConvertQuote
     include ConvertTable
+    include StripTags
 
     def convert_section(node)
       <<~HTML

--- a/resources/asciidoctor/lib/strip_tags.rb
+++ b/resources/asciidoctor/lib/strip_tags.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+##
+# Strips tags from html.
+module StripTags
+  def strip_tags(html)
+    return unless html
+
+    html.gsub(/<[^>]*>/, '').squeeze(' ').strip
+  end
+end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Chunker do
 
   shared_examples 'standard page' \
     do |prev_page, prev_title, next_page, next_title|
+    # TODO: replace these parameters with `let` to be more flexible
     context 'the <head>' do
       it 'contains the charset' do
         expect(contents).to include(<<~HTML)
@@ -44,8 +45,9 @@ RSpec.describe Chunker do
       end
       if next_page
         it 'contains the next link' do
+          # TODO: replace gsub with a better `let`
           expect(contents).to include(<<~HTML)
-            <link rel="next" href="#{next_page}.html" title="#{next_title}"/>
+            <link rel="next" href="#{next_page}.html" title="#{next_title.gsub(/<[^<]+>/, '')}"/>
           HTML
         end
       else
@@ -134,7 +136,7 @@ RSpec.describe Chunker do
             <<s2>>
 
             [[s2]]
-            == Section 2
+            == Section `2`
 
             Words again.
 
@@ -155,7 +157,7 @@ RSpec.describe Chunker do
           end
           it 'contains a link to the second section' do
             expect(converted).to include(<<~HTML.strip)
-              <li><a href="s2.html">Section 2</a></li>
+              <li><a href="s2.html">Section <code>2</code></a></li>
             HTML
           end
           it "doesn't contain breadcrumbs" do
@@ -166,7 +168,9 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's1.html' do
-          include_examples 'standard page', 'index', 'Title', 's2', 'Section 2'
+          include_examples 'standard page', 'index', 'Title',
+                           's2', 'Section <code>2</code>'
+          let(:next_link_title) { 'Section 2' }
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 1 | Title</title>')
@@ -189,7 +193,9 @@ RSpec.describe Chunker do
             HTML
           end
           it 'contains a link to the second section' do
-            expect(contents).to include('<a href="s2.html">Section 2</a>')
+            expect(contents).to include(
+              '<a href="s2.html">Section <code>2</code></a>'
+            )
           end
           it 'contains the footnote' do
             expect(contents).to include <<~HTML
@@ -208,7 +214,9 @@ RSpec.describe Chunker do
             expect(contents).to include('<title>Section 2 | Title</title>')
           end
           it 'contains the heading' do
-            expect(contents).to include('<h2 id="s2">Section 2</h2>')
+            expect(contents).to include(
+              '<h2 id="s2">Section <code>2</code></h2>'
+            )
           end
           it 'contains the contents' do
             expect(contents).to include '<p>Words again.</p>'
@@ -218,7 +226,7 @@ RSpec.describe Chunker do
               <div class="breadcrumbs">
               <span class="breadcrumb-link"><a href="index.html">Title</a></span>
               »
-              <span class="breadcrumb-node">Section 2</span>
+              <span class="breadcrumb-node">Section <code>2</code></span>
               </div>
             HTML
           end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -363,6 +363,32 @@ RSpec.describe DocbookCompat do
         end
       end
     end
+    context 'when there is markup in the title' do
+      let(:input) do
+        <<~ASCIIDOC
+          = `foo`
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the title' do
+        it 'only includes the text of the title' do
+          expect(converted).to include('<title>foo | Elastic</title>')
+        end
+      end
+      context 'the header' do
+        it 'includes the title and subtitle' do
+          expect(converted).to include(<<~HTML)
+            <div class="titlepage">
+            <div>
+            <div><h1 class="title"><a id="id-1"></a><code class="literal">foo</code></h1></div>
+            </div>
+            <hr>
+            </div>
+          HTML
+        end
+      end
+    end
     context 'contains a navheader' do
       # Emulates the chunker without trying to include it.
       let(:input) do


### PR DESCRIPTION
If a page has extra html in the title we shouldn't add it to a
`title=""` tag because it'd be invalid. This stips it.
