### PR TITLE
[DOCS] Revised notices.

### DIFF
--- a/shared/notices/README.txt
+++ b/shared/notices/README.txt
@@ -1,9 +1,23 @@
-This directory contains boilerplate notices for versions that have reached 
-the end of their maintenance period or end of life. 
-For the official Elastic product maintenance/EOL schedule, see https://www.elastic.co/support/eol. 
+This directory contains boilerplate notices for books that are released in sync with the stack
+versioning. 
 
-To use, set the version and product name and save as page_header.html
-alongside the book's index.asciidoc file. 
+page_header-maintenance.html contains the notice for the live "maintenance version" from the
+previous major release stream. (The last minor of the previous major.) 
 
-Note that you can create a custom page header for any version of a book. 
+page_header-EOL.html contains the notice for all versions that have reached their 
+end of life (EOL) date. For the official Elastic product EOL schedule, 
+see https://www.elastic.co/support/eol. 
+
+These notices need to be set explicitly by adding a file named `page_header.html` to the same
+directory as the `index.asciidoc` file used to build each book. Edit the EOL notice to specify
+the appropriate product and version.
+
+If no page_header.html file is specified for a version older than current, the default 
+"out of maintenance" notice is displayed:
+
+IMPORTANT: No additional bug fixes or documentation updates will be released for this version. 
+For the latest information, see the current release documentation.
+
+Note that you can create a custom page header for any version of a book.
+This is useful for beta versions and when books are superseded by entirely new books.
 The header must be valid HTML and cannot contain comments.

--- a/shared/notices/page_header-OOM.html
+++ b/shared/notices/page_header-OOM.html
@@ -1,9 +1,0 @@
-<p>
-  <strong>IMPORTANT</strong>: Version {version} of {product} has passed its 
-  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
-</p>  
-<p>
-  This documentation is no longer being updated. 
-  For the latest information, see the 
-  <a href="../current/index.html">current release documentation</a>. 
-</p>

--- a/shared/notices/page_header-maintenance.html
+++ b/shared/notices/page_header-maintenance.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>  


### PR DESCRIPTION
Updated the boilerplate notices to match with the changes discussed in https://github.com/elastic/docs/issues/1419 and https://github.com/elastic/docs/pull/1528.