### PR TITLE
Support ids on admonitions in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -9,6 +9,7 @@ module DocbookCompat
         %(<div class="#{node.attr 'name'} admon">),
         %(<div class="icon"></div>),
         %(<div class="admon_content">),
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
         node.title? ? "<h3>#{node.title}</h3>" : nil,
         node.blocks.empty? ? "<p>#{node.content}</p>" : node.content,
         '</div>',

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1682,6 +1682,28 @@ RSpec.describe DocbookCompat do
             HTML
           end
         end
+        context 'with an id' do
+          let(:input) do
+            <<~ASCIIDOC
+              [[id]]
+              [#{key}]
+              --
+              words
+              --
+            ASCIIDOC
+          end
+          it "renders the id in Elastic's custom template" do
+            expect(converted).to include(<<~HTML)
+              <div class="#{admon_class} admon">
+              <div class="icon"></div>
+              <div class="admon_content">
+              <a id="id"></a>
+              <p>words</p>
+              </div>
+              </div>
+            HTML
+          end
+        end
       end
       let(:admon_class) { key.downcase }
       context 'note' do


### PR DESCRIPTION
Adds support for ids on admonitions to direct_html in a way that lines
up with docbook. Required for the plugins and integrations guide
(#1564).
