### PR TITLE
Ignore funny quote in direct_html diff

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,8 +97,8 @@ RUN rm -rf /var/log/nginx && rm -rf /run/nginx
 FROM base AS py_test
 RUN install_packages python3 python3-pip
 RUN pip3 install \
-  beautifulsoup4==4.7.1 \
-  lxml==4.3.1 \
+  beautifulsoup4==4.8.1 \
+  lxml==4.4.2 \
   pycodestyle==2.5.0
 
 FROM node_deps AS node_test

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -157,6 +157,12 @@ def normalize_html(html):
     # it consistent with the care admonitions.
     for e in soup.select('.Admonishment--change'):
         e['class'].remove('Admonishment--change')
+    # Docbook adds `<span class="quote"` whenever it sees quotes. These don't
+    # change the rendering and Asciidoctor doesns't add them.
+    for e in soup.select('span.quote'):
+        parent = e.parent
+        e.unwrap()
+        parent.smooth()
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):


### PR DESCRIPTION
This ignores `<span class="quote">` in the direct_html diffs. They don't
render differently and Asciidoctor doesn't make them so I don't believe
they are worth looking at.
