### PR TITLE
Fix error in diff tool

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -134,7 +134,7 @@ def normalize_html(html):
         e['title'] = e['title'].replace('\xa0', ' ')
     # Docbook adds a generated id to tables with ids. They aren't used and we
     # have no change of generating it properly so we just ignore it.
-    for a in soup.select('.table a'):
+    for a in soup.select('.table a[id]'):
         if a['id'].startswith('id-'):
             a.extract()
     # Docbook renders partintro's slightly differently but the difference isn't


### PR DESCRIPTION
Fixes a bug in the diff tool that causes it to crash when there is an
anchor tag inside a table without an id. Ooops.
