### PR TITLE
Clean up html in meta links in direct_html

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -44,7 +44,9 @@ module Chunker
 
     def convert_document(doc)
       title = doc.doctitle partition: true
-      doc.attributes['home'] = title.main.strip + doc.attr('title-extra', '')
+      doc.attributes['home'] = strip_tags(
+        title.main.strip + doc.attr('title-extra', '')
+      )
       doc.attributes['next_section'] = find_next_in doc, 0
       add_nav doc
       yield


### PR DESCRIPTION
Strips html from the `<link>` tag in the headings generated by direct
html. *and* squeezes extra spaces out of the titles as a side effect.

Required for .NET client (#1575).
