### PR TITLE
Force updating to a new version of yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ FROM base AS node_deps
 COPY .docker/apt/keys/yarn.gpg /
 RUN apt-key add /yarn.gpg
 COPY .docker/apt/sources.list.d/yarn.list /etc/apt/sources.list.d/
-RUN install_packages yarn
+RUN install_packages yarn=1.21.1-1
 COPY package.json /
 COPY yarn.lock /
 ENV YARN_CACHE_FOLDER=/tmp/.yarn-cache


### PR DESCRIPTION
We need at least 1.21.1 to fix
https://blog.npmjs.org/post/189618601100/binary-planting-with-the-npm-cli
. apt-get doesn't let us say "more than 1.21.1" so we have to pin it
*to* 1.21.1.
