### PR TITLE
Support id on sidebar in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_sidebar.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_sidebar.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert lists.
+  module ConvertSidebar
+    def convert_sidebar(node)
+      [
+        %(<div class="sidebar#{node.role ? " #{node.role}" : ''}">),
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+        node.document.converter.convert(node, 'sidebar_title'),
+        node.content,
+        '</div>',
+      ].compact.join "\n"
+    end
+
+    def convert_sidebar_title(node)
+      return '<div class="titlepage"></div>' unless node.title
+
+      [
+        '<div class="titlepage"><div><div>',
+        %(<p class="title"><strong>#{node.title}</strong></p>),
+        %(</div></div></div>),
+      ].join "\n"
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -13,6 +13,7 @@ require_relative 'convert_open'
 require_relative 'convert_outline'
 require_relative 'convert_paragraph'
 require_relative 'convert_quote'
+require_relative 'convert_sidebar'
 require_relative 'convert_table'
 require_relative 'titleabbrev_handler'
 
@@ -39,6 +40,7 @@ module DocbookCompat
     include ConvertOutline
     include ConvertParagraph
     include ConvertQuote
+    include ConvertSidebar
     include ConvertTable
     include StripTags
 
@@ -82,19 +84,6 @@ module DocbookCompat
       <<~HTML
         <pre class="literallayout">#{node.content}</pre>
       HTML
-    end
-
-    def convert_sidebar(node)
-      result = [%(<div class="sidebar#{node.role ? " #{node.role}" : ''}">)]
-      if node.title
-        result << '<div class="titlepage"><div><div>'
-        result << %(<p class="title"><strong>#{node.title}</strong></p>)
-        result << %(</div></div></div>)
-      else
-        result << '<div class="titlepage"></div>'
-      end
-      result += [node.content, '</div>']
-      result.join "\n"
     end
 
     def xpack_tag(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1950,6 +1950,25 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'when there is a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          [[id]]
+          ****
+          Words
+          ****
+        ASCIIDOC
+      end
+      it 'renders like docbook' do
+        expect(converted).to include(<<~HTML)
+          <div class="sidebar">
+          <a id="id"></a>
+          <div class="titlepage"></div>
+          <p>Words</p>
+          </div>
+        HTML
+      end
+    end
   end
 
   context 'an open block' do


### PR DESCRIPTION
Adds support for rendering the id on a sidebar in a docbook-like way to
direct_html.
