### PR TITLE
Improve rendering of callout lists in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -21,7 +21,9 @@ module DocbookCompat
       [
         '<div class="calloutlist">',
         '<table border="0" summary="Callout list">',
-        node.items.map { |item| convert_colist_item item },
+        node.items.each_with_index.map do |item, index|
+          convert_colist_item item, index
+        end,
         '</table>',
         '</div>',
       ].flatten.compact.join "\n"
@@ -49,19 +51,19 @@ module DocbookCompat
       end
     end
 
-    def convert_colist_item(item)
+    def convert_colist_item(item, index)
       [
         '<tr>',
-        convert_colist_item_head(item),
+        convert_colist_item_head(item, index),
         convert_colist_item_body(item),
         '</tr>',
       ]
     end
 
-    def convert_colist_item_head(item)
+    def convert_colist_item_head(item, index)
       [
         '<td align="left" valign="top" width="5%">',
-        "<p>#{convert_colist_item_coids item}</p>",
+        "<p>#{convert_colist_item_coids item, index}</p>",
         '</td>',
       ]
     end
@@ -75,16 +77,17 @@ module DocbookCompat
       ]
     end
 
-    def convert_colist_item_coids(item)
+    def convert_colist_item_coids(item, index)
       return '' unless (coids = item.attr 'coids')
 
-      result = []
-      coids.split(' ').each do |coid|
-        num = coid.split('-')[1]
-        result << '<a href="#' << coid << '">'
-        result << '<i class="conum" data-value="' << num << '"></i></a>'
-      end
-      result.join
+      coids = coids.split(' ')
+      return '' unless (first = coids.shift)
+
+      [
+        %(<a href="##{first}">),
+        %(<i class="conum" data-value="#{index + 1}"></i></a>),
+        coids.map { |coid| %(<a href="##{coid}"></a>) },
+      ].compact.join
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1017,6 +1017,50 @@ RSpec.describe DocbookCompat do
           HTML
         end
       end
+
+      context 'that has duplicates' do
+        let(:input) do
+          <<~ASCIIDOC
+            [source,sh]
+            ----
+            foo <1>
+            bar <1>
+            baz <2>
+            ----
+            <1> Foo
+            <2> Baz
+          ASCIIDOC
+        end
+        context 'the duplicated callouts in the listing' do
+          it 'have the same data-value' do
+            expect(converted).to include <<~HTML
+              foo <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+              bar <a id="CO1-2"></a><i class="conum" data-value="1"></i>
+            HTML
+          end
+        end
+        context 'the unique callout in the listing' do
+          it 'has a number that counts up from the previously shown number' do
+            expect(converted).to include <<~HTML
+              baz <a id="CO1-3"></a><i class="conum" data-value="2"></i></pre>
+            HTML
+          end
+        end
+        context 'the duplicated callouts in the callout list' do
+          it 'only contains a single number' do
+            expect(converted).to include <<~HTML
+              <p><a href="#CO1-1"><i class="conum" data-value="1"></i></a><a href="#CO1-2"></a></p>
+            HTML
+          end
+        end
+        context 'the unique callout in the callout list' do
+          it 'has a number that counts up from the previously shown number' do
+            expect(converted).to include <<~HTML
+              <p><a href="#CO1-3"><i class="conum" data-value="2"></i></a></p>
+            HTML
+          end
+        end
+      end
     end
     context 'with a title' do
       let(:input) do


### PR DESCRIPTION
When you write a callout list with duplicate entries we'd previously
duplicate a bunch of the callouts in strange ways. Both docbook and
direct_html had different, strange renderings. This changes direct_html
to have a fairly sane rendering. Say you write this, like we do in the
Elasticsearch reference:
```
      "tokens" : [ {
        "token" : "detail",
        "start_offset" : 0,
        "end_offset" : 8,
        "type" : "<ALPHANUM>",
        "position" : 0,
        "keyword" : false <1>
      }, {
        "token" : "output",
        "start_offset" : 9,
        "end_offset" : 15,
        "type" : "<ALPHANUM>",
        "position" : 1,
        "keyword" : false <1>
      } ]
```

The duplicate `<1>` elemenets now get a single callout which looks sort
of like:
```
<1> Output only "keyword" attribute, since specify "attributes" in
the request.
```

This is *much* cleaner than how docbook does it and how direct_html used
to do it.
