### PR TITLE
Clean html from the table summary in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../strip_tags'
 require_relative 'convert_table_cell'
 
 module DocbookCompat
@@ -7,6 +8,7 @@ module DocbookCompat
   # Methods to convert tables.
   module ConvertTable
     include ConvertTableCell
+    include StripTags
 
     def convert_table(node)
       [
@@ -42,7 +44,7 @@ module DocbookCompat
       [
         '<table',
         %( border="#{border}" cellpadding="4px"),
-        node.title ? %( summary="#{node.title}") : nil,
+        node.title ? %( summary="#{strip_tags node.title}") : nil,
         (width = node.attr 'width') ? %( width="#{width}") : nil,
         '>',
       ].compact.join

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1453,6 +1453,30 @@ RSpec.describe DocbookCompat do
             <table border="0" cellpadding="4px" summary="Title">
           HTML
         end
+
+        context 'when the title has markup in it' do
+          let(:input) do
+            <<~ASCIIDOC
+              .`foo`
+              [horizontal]
+              Foo:: The foo.
+              Bar:: The bar.
+            ASCIIDOC
+          end
+          it 'has the title in a strong with the html' do
+            expect(converted).to include <<~HTML
+              <div class="table">
+              <p class="title"><strong>Table 1. <code class="literal">foo</code></strong></p>
+              <div class="table-contents">
+            HTML
+          end
+          it 'has the title as the summary without the html' do
+            expect(converted).to include <<~HTML
+              <div class="table-contents">
+              <table border="0" cellpadding="4px" summary="foo">
+            HTML
+          end
+        end
       end
     end
     context 'question and anwer styled' do


### PR DESCRIPTION
We add the title of a table to the table's `summary` tag to line up with
docbook. Docbook also strips the html out of the summary because if you
don't do that you can generate invalid html. This makes direct_html
strip the html as well.
