### PR TITLE
Fixup the list titles in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_lists.rb
@@ -34,6 +34,15 @@ module DocbookCompat
     def convert_list(node)
       node.items.each { |item| item.attributes['role'] ||= 'listitem' }
       html = yield
+      html.sub!(
+        %r{<div class="title">#{node.title}</div>},
+        %(<p class="title"><strong>#{node.title}</strong></p>)
+      )
+      munge_list_items node, html
+      html
+    end
+
+    def munge_list_items(node, html)
       node.items.each do |item|
         next unless item.text
         next if item.blocks?
@@ -41,7 +50,6 @@ module DocbookCompat
         html.sub!("<p>#{item.text}</p>", item.text) ||
           raise("Couldn't remove <p> for #{item.text} in #{html}")
       end
-      html
     end
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1165,6 +1165,23 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+
+    context 'when there is a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          * Thing
+        ASCIIDOC
+      end
+      context 'the title' do
+        it 'is wrapped a strong' do
+          expect(converted).to include <<~HTML
+            <div class="ulist itemizedlist">
+            <p class="title"><strong>Title</strong></p>
+          HTML
+        end
+      end
+    end
   end
 
   context 'an ordered list' do
@@ -1209,6 +1226,22 @@ RSpec.describe DocbookCompat do
       end
     end
 
+    context 'when there is a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          . Thing
+        ASCIIDOC
+      end
+      context 'the title' do
+        it 'is wrapped a strong' do
+          expect(converted).to include <<~HTML
+            <div class="olist orderedlist">
+            <p class="title"><strong>Title</strong></p>
+          HTML
+        end
+      end
+    end
     context 'when the list if defined with 1.' do
       let(:input) do
         <<~ASCIIDOC


### PR DESCRIPTION
This makes direct_html's rendering of the titles for ordered and
unordered lists line up with docbook's rendering.
