### PR TITLE
Ignore some defaults in direct_html comparison

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -74,8 +74,6 @@ def normalize_html(html):
     for e in soup.select('.figure'):
         e['class'].remove('figure')
         e['class'].append('imageblock')
-        for i in e.select('img[align=middle]'):
-            del i['align']
         for a in e.select('a'):
             if a['id'].startswith('id-'):
                 a.extract()
@@ -93,6 +91,11 @@ def normalize_html(html):
     for e in soup.select('.content'):
         e['class'].remove('content')
         e['class'].append('mediaobject')
+    # Blast some "defaults" that docbook renders and asciidoctor doesn't.
+    for e in soup.select('.imageblock .mediaobject[align=center]'):
+        del e['align']
+    for e in soup.select('.imageblock img[align=middle]'):
+        del e['align']
     # Asciidoctor emits examples as "exampleblock" instead of "informalexample"
     # but these don't make any visual difference.
     for e in soup.select('.exampleblock'):


### PR DESCRIPTION
Docbook outputs `align=middle` and `align=center` for images but that is
how images look for us by default anyway and asciidoctor doesn't produce
those attributes. So this ignores them.
