### PR TITLE
Set Legacy & translated docs to private to remove edit links.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1653,6 +1653,7 @@ contents:
               current:    cn
               branches:   [ {cn: 2.x} ]
               chunk:      1
+              private:    1
               lang:       zh_cn
               tags:       Elasticsearch/Definitive Guide
               subject:    Elasticsearch
@@ -1682,6 +1683,7 @@ contents:
               branches:   [ {cn: 6.0} ]
               lang:       zh_cn
               chunk:      1
+              private:    1
               tags:       Kibana/Reference
               subject:    Kibana
               sources:
@@ -1700,6 +1702,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ja
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
@@ -1717,6 +1720,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ja
               tags:       Logstash/Reference
               subject:    Logstash
@@ -1731,6 +1735,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ja
               tags:       Kibana/Reference
               subject:    Kibana
@@ -1745,6 +1750,7 @@ contents:
               current:    5.4
               branches:   [ 5.4 ]
               chunk:      1
+              private:    1
               lang:       ja
               tags:       X-Pack/Reference
               subject:    X-Pack
@@ -1772,6 +1778,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ko
               tags:       Elasticsearch/Reference
               subject:    Elasticsearch
@@ -1789,6 +1796,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ko
               tags:       Logstash/Reference
               subject:    Logstash
@@ -1803,6 +1811,7 @@ contents:
               current:    5.4
               branches:   [ 5.4, 5.3 ]
               chunk:      1
+              private:    1
               lang:       ko
               tags:       Kibana/Reference
               subject:    Kibana
@@ -1817,6 +1826,7 @@ contents:
               current:    5.4
               branches:   [ 5.4 ]
               chunk:      1
+              private:    1
               lang:       ko
               tags:       X-Pack/Reference
               subject:    X-Pack
@@ -1843,6 +1853,7 @@ contents:
             branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             index:      docs/en/infraops/index.asciidoc
             chunk:      1
+            private:    1
             tags:       Infrastructure/Guide
             subject:    Infrastructure
             sources:
@@ -1859,6 +1870,7 @@ contents:
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack
             chunk:      1
+            private:    1            
             noindex:    1
             tags:       Legacy/XPack/Reference
             current:    6.2
@@ -1888,6 +1900,7 @@ contents:
             index:      book.asciidoc
             chunk:      1
             noindex:    1
+            private:    1            
             tags:       Legacy/Elasticsearch/Definitive Guide
             subject:    Elasticsearch
             suppress_migration_warnings: true
@@ -1903,6 +1916,7 @@ contents:
             branches:   [ master ]
             index:      docs/index.asciidoc
             noindex:    1
+            private:    1
             tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
             direct_html: true
@@ -1914,6 +1928,7 @@ contents:
             title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1
+            private:    1
             noindex:    1
             tags:       Legacy/Marvel/Reference
             subject:    Marvel
@@ -1929,6 +1944,7 @@ contents:
             title:      Shield Reference for 2.x and 1.x
             prefix:     en/shield
             chunk:      1
+            private:    1
             noindex:    1
             tags:       Legacy/Shield/Reference
             subject:    Shield
@@ -1944,6 +1960,7 @@ contents:
             title:      Watcher Reference for 2.x and 1.x
             prefix:     en/watcher
             chunk:      1
+            private:    1
             noindex:    1
             tags:       Legacy/Watcher/Reference
             subject:    Watcher
@@ -1959,6 +1976,7 @@ contents:
             title:      Reporting Reference for 2.x
             prefix:     en/reporting
             chunk:      1
+            private:    1
             noindex:    1
             tags:       Legacy/Reporting/Reference
             subject:    Reporting
@@ -1975,6 +1993,7 @@ contents:
             prefix:     en/graph
             repo:       x-pack
             chunk:      1
+            private:    1
             noindex:    1
             tags:       Legacy/Graph/Reference
             subject:    Graph
@@ -1992,6 +2011,7 @@ contents:
             current:    2.4
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/groovy-api/index.asciidoc
+            private:    1
             noindex:    1
             tags:       Legacy/Clients/Groovy
             subject:    Clients


### PR DESCRIPTION
Since we don't intend to update these docs, we don't want folks to open PRs against them.

Related to: https://github.com/elastic/docs/pull/1533