### PR TITLE
Switch cloud-on-k8s docs to direct_html

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -792,6 +792,7 @@ contents:
             branches:   [ master, 1.0, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
+            direct_html: true
             sources:
               -
                 repo:   cloud-on-k8s

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -84,7 +84,7 @@ alias docbldech='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/heroku/ind
 alias docbldecctl='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/ecctl/docs/index.asciidoc --chunk 1'
 
 # Cloud - Elastic Cloud for K8s
-alias docbldk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
+alias docbldk8s='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
 # Beats
 alias docbldbpr='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
direct_html is faster and more customizable. We're switching all of our
docs to it.
