### PR TITLE
Add a robots tag for Elastic Site Search

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -27,6 +27,7 @@
     <meta name="naver-site-verification" content="936882c1853b701b3cef3721758d80535413dbfd" />
     <meta name="yandex-verification" content="d8a47e95d0972434" />
     <meta name="localized" content="true" />
+    <meta name="st:robots" content="follow,index" />
     <meta property="og:image" content="https://www.elastic.co/static/images/elastic-logo-200.png" />
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
     <link rel="icon" href="/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
This adds a `<meta name="robot"` tag specifically for site search so we
*always* crawl the site, even if we've instructed other robots not to.
We'll use site search's customization to downplay the results for old
docs rather than excluding them entirely.

Here are the docs for the robots tag we use:
https://swiftype.com/documentation/site-search/crawler-configuration/meta-tags#swiftbot
