### PR TITLE
Make direct_html tables a little more docbook

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -22,7 +22,7 @@ module DocbookCompat
     end
 
     def convert_table_intro(node)
-      return '<div class="informaltable">' unless node.title || node.id
+      return convert_table_informal_intro node unless node.title
 
       result = ['<div class="table">']
       result << %(<a id="#{node.id}"></a>) if node.id
@@ -32,6 +32,13 @@ module DocbookCompat
       end
       result << '<div class="table-contents">'
       result
+    end
+
+    def convert_table_informal_intro(node)
+      [
+        '<div class="informaltable">',
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+      ].compact
     end
 
     def convert_table_outro(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -2186,6 +2186,27 @@ RSpec.describe DocbookCompat do
           <table border="1" cellpadding="4px" summary="Title">
         HTML
       end
+
+      context 'and an id' do
+        let(:input) do
+          <<~ASCIIDOC
+            [[id]]
+            .Title
+            |===
+            |Col 1 | Col 2
+            |===
+          ASCIIDOC
+        end
+        it 'is wrapped in table' do
+          expect(converted).to include <<~HTML
+            <div class="table">
+            <a id="id"></a>
+            <p class="title"><strong>Table 1. Title</strong></p>
+            <div class="table-contents">
+            <table border="1" cellpadding="4px" summary="Title">
+          HTML
+        end
+      end
     end
     context 'with an id' do
       let(:input) do
@@ -2196,11 +2217,10 @@ RSpec.describe DocbookCompat do
           |===
         ASCIIDOC
       end
-      it 'is wrapped in table' do
+      it 'is wrapped in informaltable' do
         expect(converted).to include <<~HTML
-          <div class="table">
+          <div class="informaltable">
           <a id="id"></a>
-          <div class="table-contents">
           <table border="1" cellpadding="4px">
         HTML
       end


### PR DESCRIPTION
Apparently docbook only uses the formal "table" wrapper when there is a
title and uses the informal "informaltable" wrapper even when the table
has an id. direct_html was using the formal wrapper when it *either* had
an id or a title. This fixes that.

Required by the Elaticsearch reference (#1566).
