### PR TITLE
Escape quotes in direct_html sibling links

### DIFF
--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -31,8 +31,10 @@ module Chunker
       return unless related
 
       extra = related.context == :document ? related.attr('title-extra') : ''
-      title = %(title="#{strip_tags(link_text(related))}#{extra}")
-      %(<link rel="#{rel}" #{link_href related} #{title}/>)
+      title = "#{strip_tags(link_text(related))}#{extra}"
+      # We're in an attribute so escape quotes too!
+      title = title.gsub '"', '&quot;'
+      %(<link rel="#{rel}" #{link_href related} title="#{title}"/>)
     end
   end
 end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Chunker do
       if prev_page
         it 'contains the prev link' do
           expect(contents).to include(<<~HTML)
-            <link rel="prev" href="#{prev_page}.html" title="#{prev_title}"/>
+            <link rel="prev" href="#{prev_page}.html" title="#{prev_title.gsub(/<[^<]+>/, '').gsub('"', '&quot;')}"/>
           HTML
         end
       else
@@ -48,7 +48,7 @@ RSpec.describe Chunker do
         it 'contains the next link' do
           # TODO: replace gsub with a better `let`
           expect(contents).to include(<<~HTML)
-            <link rel="next" href="#{next_page}.html" title="#{next_title.gsub(/<[^<]+>/, '')}"/>
+            <link rel="next" href="#{next_page}.html" title="#{next_title.gsub(/<[^<]+>/, '').gsub('"', '&quot;')}"/>
           HTML
         end
       else
@@ -129,7 +129,7 @@ RSpec.describe Chunker do
             = Title
 
             [[s1]]
-            == Section 1
+            == Section "1"
 
             [[linkme]]
             Words words.footnote:[foo]
@@ -150,10 +150,10 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's1', 'Section 1'
+          include_examples 'standard page', nil, nil, 's1', 'Section "1"'
           it 'contains a link to the first section' do
             expect(converted).to include(<<~HTML.strip)
-              <li><a href="s1.html">Section 1</a></li>
+              <li><a href="s1.html">Section "1"</a></li>
             HTML
           end
           it 'contains a link to the second section' do
@@ -174,10 +174,10 @@ RSpec.describe Chunker do
           let(:next_link_title) { 'Section 2' }
           include_examples 'subpage'
           it 'contains the correct title' do
-            expect(contents).to include('<title>Section 1 | Title</title>')
+            expect(contents).to include('<title>Section "1" | Title</title>')
           end
           it 'contains the heading' do
-            expect(contents).to include('<h2 id="s1">Section 1</h2>')
+            expect(contents).to include('<h2 id="s1">Section "1"</h2>')
           end
           it 'contains the contents' do
             expect(contents).to include <<~HTML
@@ -189,7 +189,7 @@ RSpec.describe Chunker do
               <div class="breadcrumbs">
               <span class="breadcrumb-link"><a href="index.html">Title</a></span>
               »
-              <span class="breadcrumb-node">Section 1</span>
+              <span class="breadcrumb-node">Section "1"</span>
               </div>
             HTML
           end
@@ -209,7 +209,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the second section', 's2.html' do
-          include_examples 'standard page', 's1', 'Section 1', nil, nil
+          include_examples 'standard page', 's1', 'Section "1"', nil, nil
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 2 | Title</title>')


### PR DESCRIPTION
We have `<link rel="next"` and `prev` and `up`, all of which have the
title of the target section. If the titles of those sections have a
quote in them we were emitting invalid html. This fixes that by escaping
the quotes as `&quot;`.
