### PR TITLE
Support inline xpack declaration in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -179,6 +179,12 @@ def normalize_html(html):
         parent = e.parent
         e.extract()
         parent.smooth()
+    # Docbook sometimes renders the xpack tag *after* the edit me link but
+    # asciidoctor always renders it before the edit me link. Either way is fine
+    # so we ignore the difference.
+    for e in soup.select("a.edit_me"):
+        parent = e.parent
+        parent.append(e.extract())
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):

--- a/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert floating titles.
+  module ConvertFloatingTitle
+    def convert_floating_title(node)
+      tag_name = %(h#{node.level + 1})
+      [
+        '<', tag_name, '>',
+        node.role ? %( class="#{node.role}") : nil,
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+        node.title,
+        node.attr('edit_me_link', ''),
+        xpack_tag(node),
+        '</', tag_name, '>'
+      ].compact.join
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/convert_inline_quoted.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_inline_quoted.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert "inline quoted" which is mostly markup.
+  module ConvertInlineQuoted
+    def convert_inline_quoted(node, &block)
+      [
+        convert_inline_quoted_main(node, &block),
+        xpack_tag(node),
+      ].compact.join
+    end
+
+    private
+
+    def convert_inline_quoted_main(node)
+      case node.type
+      when :monospaced
+        node.attributes['role'] ||= 'literal'
+        yield
+      when :strong
+        # Docbook's "strong" rendering is comically repetitive.....
+        %(<span class="strong strong"><strong>#{node.text}</strong></span>)
+      else
+        yield
+      end
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/convert_quote.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_quote.rb
@@ -2,7 +2,7 @@
 
 module DocbookCompat
   ##
-  # Methods to convert tables.
+  # Methods to convert quotes.
   module ConvertQuote
     def convert_quote(node)
       return convert_fancy_quote node if node.attr 'attribution'

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -4,8 +4,10 @@ require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative '../strip_tags'
 require_relative 'convert_admonition'
-require_relative 'convert_document'
 require_relative 'convert_dlist'
+require_relative 'convert_document'
+require_relative 'convert_floating_title'
+require_relative 'convert_inline_quoted'
 require_relative 'convert_links'
 require_relative 'convert_listing'
 require_relative 'convert_lists'
@@ -31,8 +33,10 @@ module DocbookCompat
   # A Converter implementation that emulates Elastic's docbook generated html.
   class Converter < DelegatingConverter
     include ConvertAdmonition
-    include ConvertDocument
     include ConvertDList
+    include ConvertDocument
+    include ConvertFloatingTitle
+    include ConvertInlineQuoted
     include ConvertLinks
     include ConvertListing
     include ConvertLists
@@ -53,31 +57,6 @@ module DocbookCompat
         #{node.content}
         </div>
       HTML
-    end
-
-    def convert_floating_title(node)
-      tag_name = %(h#{node.level + 1})
-      # Asciidoctor's standard is to put the id on the header tag but docbook
-      # puts it in its own anchor tag.
-      anchor = node.id ? %(<a id="#{node.id}"></a>) : ''
-      classes = [node.role].compact
-      classes_html = classes.empty? ? '' : " class=#{classes.join ' '}"
-      <<~HTML
-        <#{tag_name}#{classes_html}>#{anchor}#{node.title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</#{tag_name}>
-      HTML
-    end
-
-    def convert_inline_quoted(node)
-      case node.type
-      when :monospaced
-        node.attributes['role'] ||= 'literal'
-        yield
-      when :strong
-        # Docbook's "strong" rendering is comically repetitive.....
-        %(<span class="strong strong"><strong>#{node.text}</strong></span>)
-      else
-        yield
-      end
     end
 
     def convert_literal(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -942,6 +942,7 @@ RSpec.describe DocbookCompat do
     it 'has an inline anchor for docbook compatibility' do
       expect(converted).to include('<a id="_foo"></a>')
     end
+
     context 'with the xpack role' do
       let(:input) do
         <<~ASCIIDOC
@@ -953,6 +954,19 @@ RSpec.describe DocbookCompat do
         expect(converted).to include(
           '<a class="xpack_tag" href="/subscriptions"></a></h4>'
         )
+      end
+    end
+    context 'with the xpack bug is declared inline' do
+      let(:input) do
+        <<~ASCIIDOC
+          [float]
+          ==== [xpack]#Foo#
+        ASCIIDOC
+      end
+      it 'has the xpack tag' do
+        expect(converted).to include <<~HTML
+          <span class="xpack">Foo</span><a class="xpack_tag" href="/subscriptions"></a></h4>
+        HTML
       end
     end
   end


### PR DESCRIPTION
Sometimes we declare the xpack tag inline like so:
```
[float]
=== [xpack]#Foo#
```

This renders the xpack tag in those cases.
