### PR TITLE
Ignore a few more differences in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -17,9 +17,14 @@ def normalize_html(html):
     """Normalizes html to remove expected differences between AsciiDoc's
     output and Asciidoctor's output.
     """
+    soup = BeautifulSoup(html, 'lxml')
+    # Remove all duplicate classes because that doesn't make any
+    # visual difference.
+    for e in soup.descendants:
+        if hasattr(e, 'attrs') and 'class' in e.attrs:
+            e['class'] = list(set(e['class']))
     # Replace many whitespace characters with a single space in some elements
     # kind of like a browser does.
-    soup = BeautifulSoup(html, 'lxml')
     for e in soup.select(':not(script,pre,code,style)'):
         for part in e:
             if isinstance(part, NavigableString):
@@ -179,6 +184,10 @@ def normalize_html(html):
         parent = e.parent
         e.extract()
         parent.smooth()
+    # Docbook passes the `exclude` class on some paragraphs and asciidoctor
+    # doesn't which is fine because it doesn't make a visual difference.
+    for e in soup.select('.exclude'):
+        e['class'].remove('exclude')
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):


### PR DESCRIPTION
Ignores the difference between `<p class="exclude exclude">` (docbook's
output) and `<p>` (asciidoctor's output). The `exclude` role doesn't
have any visual effect. And duplicate classes *never* have any visual
effect.

Required by the Elasticsearch reference (#1566).
