### PR TITLE
Move id for admonitions in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -9,12 +9,22 @@ module DocbookCompat
         %(<div class="#{node.attr 'name'} admon">),
         %(<div class="icon"></div>),
         %(<div class="admon_content">),
-        node.id ? %(<a id="#{node.id}"></a>) : nil,
-        node.title? ? "<h3>#{node.title}</h3>" : nil,
+        node.converter.convert(node, 'admonition_title_id'),
         node.blocks.empty? ? "<p>#{node.content}</p>" : node.content,
         '</div>',
         '</div>',
       ].compact.join "\n"
+    end
+
+    def convert_admonition_title_id(node)
+      return node.id ? %(<a id="#{node.id}"></a>) : nil unless node.title
+
+      [
+        '<h3>',
+        node.title,
+        node.id ? %(<a id="#{node.id}"></a>) : nil,
+        '</h3>',
+      ].compact.join
     end
 
     def convert_inline_admonition(node)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1782,6 +1782,30 @@ RSpec.describe DocbookCompat do
               </div>
             HTML
           end
+
+          context 'and an id' do
+            let(:input) do
+              <<~ASCIIDOC
+                [[id]]
+                [#{key}]
+                .Title
+                --
+                words
+                --
+              ASCIIDOC
+            end
+            it "renders the title in Elastic's custom template" do
+              expect(converted).to include(<<~HTML)
+                <div class="#{admon_class} admon">
+                <div class="icon"></div>
+                <div class="admon_content">
+                <h3>Title<a id="id"></a></h3>
+                <p>words</p>
+                </div>
+                </div>
+              HTML
+            end
+          end
         end
         context 'with an id' do
           let(:input) do


### PR DESCRIPTION
Docbook puts ids *inside* the title of an admonition if there is a
title. This does that too.
