### PR TITLE
Ignore missing px in direct_html diff

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -197,7 +197,7 @@ def normalize_html(html):
     # Asciidoctor adds 'px' to the end of raw pixel values but docbook doesn't.
     # We're quite happy to have the new px.
     for e in soup.select('img[width]'):
-        if re.match('^\d+$', e['width']):
+        if re.match('^\\d+$', e['width']):
             e['width'] += 'px'
 
     # Remove empty "class" attributes and sort the listed classes.

--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -194,6 +194,11 @@ def normalize_html(html):
     # doesn't which is fine because it doesn't make a visual difference.
     for e in soup.select('.exclude'):
         e['class'].remove('exclude')
+    # Asciidoctor adds 'px' to the end of raw pixel values but docbook doesn't.
+    # We're quite happy to have the new px.
+    for e in soup.select('img[width]'):
+        if re.match('^\d+$', e['width']):
+            e['width'] += 'px'
 
     # Remove empty "class" attributes and sort the listed classes.
     for e in soup.select('*'):


### PR DESCRIPTION
Docbook doesn't add a `px` that direct_html does add. We're quite happy
to have the `px` but we don't need to see it on every time that gets it.
Thus, we ignore it in `html_diff`.
