### PR TITLE
Fix examples in direct_html

### DIFF
--- a/integtest/html_diff
+++ b/integtest/html_diff
@@ -79,7 +79,7 @@ def normalize_html(html):
     for e in soup.select('.figure'):
         e['class'].remove('figure')
         e['class'].append('imageblock')
-        for a in e.select('a'):
+        for a in e.select('a[id]'):
             if a['id'].startswith('id-'):
                 a.extract()
         for t in e.select('.title'):
@@ -108,6 +108,11 @@ def normalize_html(html):
         e['class'].append('informalexample')
         for c in e.select('.mediaobject'):
             c.unwrap()
+    # Docbook adds ids to all examples and asciidoctor doesn't. We don't need
+    # the ids so we ignore them.
+    for e in soup.select('.example a[id]'):
+        if e['id'].startswith('id-'):
+            e.extract()
     # Docbook links with `<a class="link"` when linking from one page of a book
     # to another. Asciidoctor emits `<a class="link"`. Both look fine.
     for e in soup.select('a.xref'):

--- a/resources/asciidoctor/lib/docbook_compat/convert_example.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_example.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module DocbookCompat
+  ##
+  # Methods to convert example blocks.
+  module ConvertExample
+    def convert_example(node)
+      return yield unless node.title
+
+      [
+        '<div class="example">',
+        %(<p class="title"><strong>#{node.captioned_title}</strong></p>),
+        '<div class="example-contents">',
+        node.content,
+        '</div>',
+        '</div>',
+      ].compact.join "\n"
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -6,6 +6,7 @@ require_relative '../strip_tags'
 require_relative 'convert_admonition'
 require_relative 'convert_dlist'
 require_relative 'convert_document'
+require_relative 'convert_example'
 require_relative 'convert_floating_title'
 require_relative 'convert_inline_quoted'
 require_relative 'convert_links'
@@ -35,6 +36,7 @@ module DocbookCompat
     include ConvertAdmonition
     include ConvertDList
     include ConvertDocument
+    include ConvertExample
     include ConvertFloatingTitle
     include ConvertInlineQuoted
     include ConvertLinks

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -2486,4 +2486,44 @@ RSpec.describe DocbookCompat do
       end
     end
   end
+
+  context 'example' do
+    let(:input) do
+      <<~ASCIIDOC
+        ====
+        Words
+        ====
+      ASCIIDOC
+    end
+    it 'is wrapped in an exampleblock' do
+      expect(converted).to include <<~HTML
+        <div class="exampleblock">
+        <div class="content">
+        <p>Words</p>
+        </div>
+        </div>
+      HTML
+    end
+
+    context 'with a title' do
+      let(:input) do
+        <<~ASCIIDOC
+          .Title
+          ====
+          Words
+          ====
+        ASCIIDOC
+      end
+      it 'is wrapped in an example' do
+        expect(converted).to include <<~HTML
+          <div class="example">
+          <p class="title"><strong>Example 1. Title</strong></p>
+          <div class="example-contents">
+          <p>Words</p>
+          </div>
+          </div>
+        HTML
+      end
+    end
+  end
 end


### PR DESCRIPTION
Formal examples were rendering their titles in a docbook incompatible
way. This fixes that.
