### PR TITLE
Support roles on paragraphs in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_paragraph.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_paragraph.rb
@@ -7,7 +7,7 @@ module DocbookCompat
     def convert_paragraph(node)
       # Asciidoctor adds a \n at the end of the paragraph so we don't.
       [
-        '<p>',
+        node.role ? %(<p class="#{node.role}">) : '<p>',
         paragraph_id_part(node),
         paragraph_title_part(node),
         node.content,

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -782,7 +782,7 @@ RSpec.describe DocbookCompat do
           Words.
         ASCIIDOC
       end
-      it 'contains a paragraph for each anchor' do
+      it 'contains the id' do
         expect(converted).to include '<p><a id="foo"></a>Words.</p>'
       end
     end
@@ -793,8 +793,21 @@ RSpec.describe DocbookCompat do
           Words.
         ASCIIDOC
       end
-      it 'contains a paragraph for each anchor' do
+      it 'contains the title' do
         expect(converted).to include '<p><strong>Title</strong>Words.</p>'
+      end
+    end
+    context 'with a role' do
+      let(:input) do
+        <<~ASCIIDOC
+          [.screenshot]
+          image:foo[]
+        ASCIIDOC
+      end
+      it 'has the role as a class' do
+        expect(converted).to include <<~HTML
+          <p class="screenshot"><span class="image"><img src="foo" alt="foo"></span></p>
+        HTML
       end
     end
   end


### PR DESCRIPTION
Docbook copies the `role` on paragraphs into the class. This implements
that in direct_html.

Required for beats.
