### PR TITLE
Update exclude paths for output docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1009,7 +1009,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   &processorexcludes[ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &processorexcludes [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*

--- a/conf.yaml
+++ b/conf.yaml
@@ -1013,7 +1013,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1065,7 +1065,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1105,7 +1105,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1159,7 +1159,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1203,7 +1203,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1253,7 +1253,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1293,7 +1293,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1331,7 +1331,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -945,11 +945,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   &sharedfileexcludes [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Beats Developer Guide
             prefix:     en/beats/devguide
@@ -977,11 +977,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
@@ -1009,19 +1009,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   &processorexcludes [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   &outputexcludes [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
@@ -1047,7 +1047,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   &xpacklibbeatexcludes [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc
@@ -1057,23 +1057,23 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   x-pack/filebeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
@@ -1101,19 +1101,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
@@ -1138,7 +1138,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   *xpacklibbeatexcludes
+                exclude_branches:   *beatsXpackLibbeatExclude
               -
                 repo:   beats
                 path:   x-pack/metricbeat/module
@@ -1155,19 +1155,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
@@ -1195,23 +1195,23 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   *xpacklibbeatexcludes
+                exclude_branches:   *beatsXpackLibbeatExclude
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
@@ -1249,19 +1249,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   *sharedfileexcludes
+                exclude_branches:   *beatsSharedExclude
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
@@ -1289,11 +1289,11 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1327,11 +1327,11 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *processorexcludes
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *outputexcludes
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -945,11 +945,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &sharedfileexcludes [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Beats Developer Guide
             prefix:     en/beats/devguide
@@ -977,11 +977,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
@@ -1009,19 +1009,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &processorexcludes[ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &outputexcludes [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
@@ -1047,7 +1047,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   &xpacklibbeatexcludes [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc
@@ -1057,23 +1057,23 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   x-pack/filebeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
@@ -1101,19 +1101,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
@@ -1138,7 +1138,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   *xpacklibbeatexcludes
               -
                 repo:   beats
                 path:   x-pack/metricbeat/module
@@ -1155,19 +1155,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
@@ -1195,23 +1195,23 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   *xpacklibbeatexcludes
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
@@ -1249,19 +1249,19 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+                exclude_branches:   *sharedfileexcludes
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0 ]
+                exclude_branches:   *sharedfileexcludes
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
@@ -1289,11 +1289,11 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1327,11 +1327,11 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   *processorexcludes
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+                exclude_branches:   *outputexcludes
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
Updates the Beats documentation to pull output doc source in 7.x and 7.5 from libbeat/outputs