### PR TITLE
Switch legacy watcher reference to direct_html

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1975,6 +1975,7 @@ contents:
             index:      docs/public/watcher/index.asciidoc
             private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
+            direct_html: true
             sources:
               -
                 repo:   x-pack


### PR DESCRIPTION
direct_html is the future.
