### PR TITLE
Drop admonitions from generated ids in direct_html

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/clear_cached_titles.rb
+++ b/resources/asciidoctor/lib/docbook_compat/clear_cached_titles.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require_relative '../scaffold'
+
+module DocbookCompat
+  ##
+  # Clears the internal cache of the title's conversion on sections that look
+  # like they have generated ids. This is because when we generate ids we
+  # convert titles differently.
+  class ClearCachedTitles < TreeProcessorScaffold
+    def process_block(block)
+      return unless %i[section floating_title].include? block.context
+      return unless block.id&.start_with?(block.attr('idprefix') || '_')
+
+      block.instance_variable_set :@converted_title, nil
+    end
+  end
+end

--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -28,6 +28,25 @@ module DocbookCompat
     end
 
     def convert_inline_admonition(node)
+      return '' if skip_inline_admonition node
+
+      convert_inline_admonition_for_real node
+    end
+
+    ##
+    # If the parent is a section and it doesn't yet have an id then we're
+    # being invoked during the parse phase to generate an id for that section.
+    # We don't want to include the admonition in the id so we convert as
+    # empty string. ClearCachedTitles will make sure we get reconverted
+    # when we're rendered.
+    def skip_inline_admonition(node)
+      return false unless node.parent
+      return false if node.parent.id
+
+      %i[section floating_title].include? node.parent.context
+    end
+
+    def convert_inline_admonition_for_real(node)
       title_classes =
         "Admonishment-#{node.attr 'title_type'} #{node.attr 'title_class'}"
       [

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -3,6 +3,7 @@
 require 'asciidoctor/extensions'
 require_relative '../delegating_converter'
 require_relative '../strip_tags'
+require_relative 'clear_cached_titles'
 require_relative 'convert_admonition'
 require_relative 'convert_dlist'
 require_relative 'convert_document'
@@ -26,6 +27,7 @@ module DocbookCompat
   def self.activate(registry)
     return unless registry.document.basebackend? 'html'
 
+    registry.treeprocessor ClearCachedTitles
     registry.treeprocessor TitleabbrevHandler
     DelegatingConverter.setup(registry.document) { |d| Converter.new d }
   end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1953,6 +1953,33 @@ RSpec.describe DocbookCompat do
                 expect_inline_admonition default_text
               end
             end
+            context 'inside a title' do
+              let(:input) do
+                <<~ASCIIDOC
+                  == Foo #{key}:[]
+                ASCIIDOC
+              end
+              it 'has default text' do
+                expect_inline_admonition default_text
+              end
+              it "doesn't modify the id" do
+                expect(converted).to include 'id="_foo"'
+              end
+            end
+            context 'inside a floating title' do
+              let(:input) do
+                <<~ASCIIDOC
+                  [float]
+                  == Foo #{key}:[]
+                ASCIIDOC
+              end
+              it 'has default text' do
+                expect_inline_admonition default_text
+              end
+              it "doesn't modify the id" do
+                expect(converted).to include 'id="_foo"'
+              end
+            end
           end
         end
         context 'beta' do
@@ -2036,6 +2063,37 @@ RSpec.describe DocbookCompat do
                 expect_inline_admonition(
                   '7.0.0-beta1', "#{message} in 7.0.0-beta1."
                 )
+              end
+            end
+            context 'inside a title' do
+              let(:input) do
+                <<~ASCIIDOC
+                  == Foo #{key}:[7.0.0-beta1]
+                ASCIIDOC
+              end
+              it 'has default text' do
+                expect_inline_admonition(
+                  '7.0.0-beta1', "#{message} in 7.0.0-beta1."
+                )
+              end
+              it "doesn't modify the id" do
+                expect(converted).to include 'id="_foo"'
+              end
+            end
+            context 'inside a floating title' do
+              let(:input) do
+                <<~ASCIIDOC
+                  [float]
+                  == Foo #{key}:[7.0.0-beta1]
+                ASCIIDOC
+              end
+              it 'has default text' do
+                expect_inline_admonition(
+                  '7.0.0-beta1', "#{message} in 7.0.0-beta1."
+                )
+              end
+              it "doesn't modify the id" do
+                expect(converted).to include 'id="_foo"'
               end
             end
           end


### PR DESCRIPTION
When a section or a floating title doesn't have an id asciidoctor
generates one. When that section includes an admonition it *was*
included in the generated id. Docbook also generates ids but doesn't
include the admonition, which makes a ton of sense. So this modifies
direct_html not to generate the admonition into the id. *how* we do that
is a little complex because of the extension points that asciidoctor
gives us:

1. If we're generating an admonition inside of a section that doesn't
yet have an id then return an empty string. This should make the
admonition a noop when generating the title used to generate the
automatic id and *only* then. All other times the section has an id.
2. Before actually converting the document to html we clear that cached
copy of the generated title. Now that the section has an id the next
time we regenerate its title it'll get generated correctly.
