### PR TITLE
Fix a bug in direct_html' floating titles

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
@@ -7,8 +7,7 @@ module DocbookCompat
     def convert_floating_title(node)
       tag_name = %(h#{node.level + 1})
       [
-        '<', tag_name, '>',
-        node.role ? %( class="#{node.role}") : nil,
+        '<', tag_name, node.role ? %( class="#{node.role}") : nil, '>',
         node.id ? %(<a id="#{node.id}"></a>) : nil,
         node.title,
         node.attr('edit_me_link', ''),

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -981,6 +981,9 @@ RSpec.describe DocbookCompat do
           ==== Foo
         ASCIIDOC
       end
+      it 'has the xpack class' do
+        expect(converted).to include '<h4 class="xpack">'
+      end
       it 'has the xpack tag' do
         expect(converted).to include(
           '<a class="xpack_tag" href="/subscriptions"></a></h4>'


### PR DESCRIPTION
direct_html's floating titles were rendering classes *outside* of the
tag. Oops. This fixes that.
