### PR TITLE
Support alternative examples in direct_html

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -434,6 +434,7 @@ RSpec.describe 'building all books' do
       java_alts = { source_lang: 'console', alternative_lang: 'java' }
       book.source(java_repo, 'examples', alternatives: java_alts)
     end
+    let(:direct_html) { false }
     include_examples 'README-like console alternatives',
                      'raw/test/master', 'html/test/master'
   end

--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -37,6 +37,9 @@ module ConsoleExamples
 end
 
 RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
+  # NOTE: this class has lots of `if direct_html ... else ... end` going on.
+  # That is because direct_html outputs classes in a different order than
+  # docbook and adds many extra newlines.
   page_context "#{path}/chapter.html" do
     let(:has_classes) { 'has-js has-csharp' }
     let(:console_widget) do
@@ -45,45 +48,112 @@ RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
       HTML
     end
     it 'contains the js listing followed by the csharp listing' do
-      expect(body).to include(<<~HTML.strip)
-        <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
-          body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
-        })</pre></div><div class="pre_wrapper alternative lang-csharp">
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper lang-js alternative">
+          <pre class="programlisting prettyprint lang-js alternative">const result = await client.search({
+            body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
+          })</pre>
+          </div>
+          <div class="pre_wrapper lang-csharp alternative">
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
+            body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
+          })</pre></div><div class="pre_wrapper alternative lang-csharp">
+        HTML
+      end
     end
     it 'contains the csharp listing followed by the default listing' do
-      expect(body).to include(<<~HTML.strip)
-        <div class="pre_wrapper alternative lang-csharp"><pre class="alternative programlisting prettyprint lang-csharp">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
-            .Query(q =&gt; q
-                .QueryString(m =&gt; m
-                    .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
-                )
-            )
-        );</pre></div><div class="pre_wrapper default #{has_classes} lang-console">
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper lang-csharp alternative">
+          <pre class="programlisting prettyprint lang-csharp alternative">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
+              .Query(q =&gt; q
+                  .QueryString(m =&gt; m
+                      .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
+                  )
+              )
+          );</pre>
+          </div>
+          <div class="pre_wrapper lang-console default #{has_classes}">
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper alternative lang-csharp"><pre class="alternative programlisting prettyprint lang-csharp">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
+              .Query(q =&gt; q
+                  .QueryString(m =&gt; m
+                      .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
+                  )
+              )
+          );</pre></div><div class="pre_wrapper default #{has_classes} lang-console">
+        HTML
+      end
     end
     it 'contains the default listing followed by the console widget' do
-      expect(body).to include(<<~HTML.strip)
-        <div class="pre_wrapper default #{has_classes} lang-console"><pre class="default #{has_classes} programlisting prettyprint lang-console">GET /_search
-        {
-            "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
-        }</pre></div>#{console_widget}
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper lang-console default #{has_classes}">
+          <pre class="programlisting prettyprint lang-console default #{has_classes}">GET /_search
+          {
+              "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+          }</pre>
+          </div>
+          #{console_widget}
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          <div class="pre_wrapper default #{has_classes} lang-console"><pre class="default #{has_classes} programlisting prettyprint lang-console">GET /_search
+          {
+              "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+          }</pre></div>#{console_widget}
+        HTML
+      end
     end
     it 'contains the console widget followed by the js calloutlist' do
-      expect(body).to include(<<~HTML.strip)
-        #{console_widget}<div class="alternative lang-js calloutlist">
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          #{console_widget}
+          <div class="calloutlist alternative lang-js">
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          #{console_widget}<div class="alternative lang-js calloutlist">
+        HTML
+      end
     end
     it 'contains the js calloutlist followed by the csharp calloutlist' do
-      expect(body).to include(<<~HTML.strip)
-        js</p></td></tr></table></div><div class="alternative lang-csharp calloutlist">
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          js</p>
+          </td>
+          </tr>
+          </table>
+          </div>
+          <div class="calloutlist alternative lang-csharp">
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          js</p></td></tr></table></div><div class="alternative lang-csharp calloutlist">
+        HTML
+      end
     end
     it 'contains the csharp calloutlist followed by the default calloutlist' do
-      expect(body).to include(<<~HTML.strip)
-        csharp</p></td></tr></table></div><div class="default #{has_classes} lang-console calloutlist">
-      HTML
+      if direct_html
+        expect(body).to include(<<~HTML.strip)
+          csharp</p>
+          </td>
+          </tr>
+          </table>
+          </div>
+          <div class="calloutlist default #{has_classes} lang-console">
+        HTML
+      else
+        expect(body).to include(<<~HTML.strip)
+          csharp</p></td></tr></table></div><div class="default #{has_classes} lang-console calloutlist">
+        HTML
+      end
     end
     context 'the initial js state' do
       it 'contains the available alternatives' do

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -510,20 +510,35 @@ RSpec.describe 'building a single book' do
         #{ConsoleExamples::README_LIKE}
       ASCIIDOC
     end
-    convert_before do |src, dest|
-      repo = src.repo 'src'
-      from = repo.write 'index.asciidoc', index
-      repo.commit 'commit outstanding'
-      # Points java to a directory without any examples so we can report that.
-      dest.prepare_convert_single(from, '.')
-          .alternatives('console', 'js', "#{__dir__}/../readme_examples/js")
-          .alternatives(
-            'console', 'csharp', "#{__dir__}/../readme_examples/csharp"
-          )
-          .alternatives('console', 'java', "#{__dir__}/helper")
-          .convert
+    shared_context 'console alternatives' do |direct_html|
+      convert_before do |src, dest|
+        repo = src.repo 'src'
+        from = repo.write 'index.asciidoc', index
+        repo.commit 'commit outstanding'
+        # Points java to a directory without any examples so we can report that.
+        convert = dest.prepare_convert_single(from, '.')
+                      .alternatives(
+                        'console', 'js', "#{__dir__}/../readme_examples/js"
+                      )
+                      .alternatives(
+                        'console', 'csharp',
+                        "#{__dir__}/../readme_examples/csharp"
+                      )
+                      .alternatives('console', 'java', "#{__dir__}/helper")
+        convert.direct_html if direct_html
+        convert.convert
+      end
     end
-    include_examples 'README-like console alternatives', 'raw', '.'
+    context 'with direct_html' do
+      include_context 'console alternatives', true
+      let(:direct_html) { true }
+      include_examples 'README-like console alternatives', 'raw', '.'
+    end
+    context 'without direct_html' do
+      include_context 'console alternatives', false
+      let(:direct_html) { false }
+      include_examples 'README-like console alternatives', 'raw', '.'
+    end
   end
 
   context 'for a book with en -extra-title-page.html file' do

--- a/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_listing.rb
@@ -18,8 +18,9 @@ module DocbookCompat
     end
 
     def convert_colist(node)
+      extra_classes = node.roles.empty? ? '' : " #{node.roles.join ' '}"
       [
-        '<div class="calloutlist">',
+        %(<div class="calloutlist#{extra_classes}">),
         '<table border="0" summary="Callout list">',
         node.items.each_with_index.map do |item, index|
           convert_colist_item item, index
@@ -40,15 +41,20 @@ module DocbookCompat
 
     def convert_listing_body(node)
       if (lang = node.attr 'language')
-        pre_classes = "programlisting prettyprint lang-#{lang}"
-        [
-          %(<div class="pre_wrapper lang-#{lang}">),
-          %(<pre class="#{pre_classes}">#{node.content || ''}</pre>),
-          %(</div>),
-        ].join "\n"
+        convert_listing_body_with_language node, lang
       else
         %(<pre class="screen">#{node.content || ''}</pre>)
       end
+    end
+
+    def convert_listing_body_with_language(node, lang)
+      extra_classes = node.roles.empty? ? '' : " #{node.roles.join ' '}"
+      pre_classes = "programlisting prettyprint lang-#{lang}#{extra_classes}"
+      [
+        %(<div class="pre_wrapper lang-#{lang}#{extra_classes}">),
+        %(<pre class="#{pre_classes}">#{node.content || ''}</pre>),
+        %(</div>),
+      ].join "\n"
     end
 
     def convert_colist_item(item, index)

--- a/resources/asciidoctor/lib/open_in_widget/extension.rb
+++ b/resources/asciidoctor/lib/open_in_widget/extension.rb
@@ -65,16 +65,23 @@ module OpenInWidget
 
     def convert_listing_with_widget(node, lang, snippet_path, original)
       if node.document.basebackend? 'html'
-        <<~HTML.strip
-          #{original}
-          <div class="#{lang}_widget" data-snippet="#{snippet_path}"></div>
-        HTML
+        convert_listing_with_widget_html node, lang, snippet_path, original
       else
         original.gsub(
           '</programlisting>',
           "<ulink type=\"snippet\" url=\"#{snippet_path}\"/></programlisting>"
         )
       end
+    end
+
+    def convert_listing_with_widget_html(node, lang, snippet_path, original)
+      roles = node.roles
+      roles.delete 'default'
+      extra_classes = roles.empty? ? '' : " #{roles.join ' '}"
+      <<~HTML.strip
+        #{original}
+        <div class="#{lang}_widget#{extra_classes}" data-snippet="#{snippet_path}"></div>
+      HTML
     end
 
     def snippet_path(block, lang, snippet)

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1063,6 +1063,23 @@ RSpec.describe DocbookCompat do
         end
       end
 
+      context 'that has a role' do
+        let(:input) do
+          <<~ASCIIDOC
+            [source,sh]
+            ----
+            cpanm Search::Elasticsearch <1>
+            ----
+            [.foo]
+            <1> Foo
+          ASCIIDOC
+        end
+        context 'the callout list' do
+          it 'includes the role' do
+            expect(converted).to include '<div class="calloutlist foo">'
+          end
+        end
+      end
       context 'that has duplicates' do
         let(:input) do
           <<~ASCIIDOC
@@ -1171,6 +1188,23 @@ RSpec.describe DocbookCompat do
         expect(converted).to include(<<~HTML)
           <p><a id="foo"></a><strong>Title.</strong></p>
           <div class="pre_wrapper lang-sh">
+        HTML
+      end
+    end
+    context 'with a role' do
+      let(:input) do
+        <<~ASCIIDOC
+          [source,sh,role=foo]
+          ----
+          cpanm Search::Elasticsearch
+          ----
+        ASCIIDOC
+      end
+      it 'the role is included as a class' do
+        expect(converted).to include(<<~HTML)
+          <div class="pre_wrapper lang-sh foo">
+          <pre class="programlisting prettyprint lang-sh foo">cpanm Search::Elasticsearch</pre>
+          </div>
         HTML
       end
     end

--- a/resources/asciidoctor/spec/open_in_widget_spec.rb
+++ b/resources/asciidoctor/spec/open_in_widget_spec.rb
@@ -117,6 +117,39 @@ RSpec.describe OpenInWidget do
           expect(copied).to include(["snippets/1.#{lang}", "GET /\n"])
         end
       end
+      context 'with a role' do
+        let(:input) do
+          <<~ASCIIDOC
+            == Example
+            [source,#{lang},role=foo]
+            ----
+            GET / <1>
+            ----
+            <1> words
+          ASCIIDOC
+        end
+        let(:expected_link) do
+          if backend == :html5
+            <<~HTML
+              <div class="#{lang}_widget foo" data-snippet="#{relative_path}"></div>
+            HTML
+          else
+            <<~ASCIIDOC.strip
+              <ulink type="snippet" url="#{relative_path}"/>
+            ASCIIDOC
+          end
+        end
+        it 'adds a link to extracted snippet' do
+          expect(converted).to include(expected_link)
+        end
+        let(:text) { 'GET /' }
+        let(:copied_snippet) { "GET /\n" }
+        let(:index) { 1 }
+        let(:line) { 3 }
+        it 'writes the snippet without the callout' do
+          expect(copied).to include(["snippets/1.#{lang}", "GET /\n"])
+        end
+      end
     end
     context 'when there are many blocks with the language' do
       let(:input) do


### PR DESCRIPTION
This adds support for examples in alternative languages to direct_html.
The alternative examples plugin works by adding a bunch of extra
listings and callout lists to the parse tree. This makes sure that they
are all converted properly, including updating the integration test for
them to work with `--direct_html`.
