### PR TITLE
Fix support for imagesdir

### DIFF
--- a/resources/asciidoctor/lib/copy_images/copier.rb
+++ b/resources/asciidoctor/lib/copy_images/copier.rb
@@ -57,7 +57,7 @@ module CopyImages
         to_check += subdirs(dir)
       end
 
-      log_missing(block, checked)
+      log_missing block, checked, uri
       nil
     end
 
@@ -85,7 +85,7 @@ module CopyImages
 
     ##
     # Log a warning for files that we couldn't find.
-    def log_missing(block, checked)
+    def log_missing(block, checked, uri)
       # Sort the list of directories we did check so it is consistent from
       # machine to machine. This is mostly useful for testing, but it nice
       # if you happen to want to compare CI to a local machine.
@@ -97,7 +97,8 @@ module CopyImages
           lhs <=> rhs
         end
       end
-      warn block: block, message: "can't read image at any of #{checked}"
+      warn block: block,
+           message: "can't read image [#{uri}]at any of #{checked}"
     end
   end
 end

--- a/resources/asciidoctor/lib/copy_images/copier.rb
+++ b/resources/asciidoctor/lib/copy_images/copier.rb
@@ -98,7 +98,7 @@ module CopyImages
         end
       end
       warn block: block,
-           message: "can't read image [#{uri}]at any of #{checked}"
+           message: "can't read image [#{uri}] at any of #{checked}"
     end
   end
 end

--- a/resources/asciidoctor/lib/copy_images/extension.rb
+++ b/resources/asciidoctor/lib/copy_images/extension.rb
@@ -35,14 +35,14 @@ module CopyImages
 
     #### "Conversion" methods
     def convert_image(node)
-      copy_image node, node.attr('target')
+      copy_image node, node.image_uri(node.attr('target'))
       yield
     end
 
     def convert_inline_image(node)
       # Inline images aren't "real" and don't have a source_location so we have
       # to get the location from the parent.
-      copy_image node.parent, node.target
+      copy_image node.parent, node.image_uri(node.target)
       yield
     end
 

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -153,7 +153,8 @@ RSpec.describe CopyImages do
     context "when it can't find a file" do
       include_examples "when it can't find a file"
       let(:expected_logs) do
-        %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image\ at\ any\ of\ \[
+        %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image
+          \ \[not_found\.jpg\]\ at\ any\ of\ \[
           "#{spec_dir}/not_found.jpg",\s
           "#{spec_dir}/resources/not_found.jpg",\s
           .+
@@ -216,7 +217,8 @@ RSpec.describe CopyImages do
       context "when it can't find a file" do
         include_examples "when it can't find a file"
         let(:expected_logs) do
-          %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image\ at\ any\ of\ \[
+          %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image
+            \ \[not_found\.jpg\]\ at\ any\ of\ \[
             "#{tmp}/not_found.jpg",\s
             "#{spec_dir}/not_found.jpg",\s
             .+
@@ -231,7 +233,8 @@ RSpec.describe CopyImages do
       context "when it can't find a file" do
         include_examples "when it can't find a file"
         let(:expected_logs) do
-          %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image\ at\ any\ of\ \[
+          %r{WARN:\ <stdin>:\ line\ \d+:\ can't\ read\ image
+            \ \[not_found\.jpg\] \ at\ any\ of\ \[
             "/dummy1/not_found.jpg",\s
             "/dummy2/not_found.jpg",\s
             "#{tmp}/not_found.jpg",\s

--- a/resources/asciidoctor/spec/copy_images_spec.rb
+++ b/resources/asciidoctor/spec/copy_images_spec.rb
@@ -125,6 +125,20 @@ RSpec.describe CopyImages do
         include_examples 'copies example1'
       end
     end
+    context 'when using the imagesdir attribute' do
+      let(:target) { 'example1.png' }
+      let(:resolved) { 'resources/copy_images/example1.png' }
+      let(:input) do
+        <<~ASCIIDOC
+          == Example
+          :imagesdir: resources/copy_images
+
+          #{image_command}
+        ASCIIDOC
+      end
+      let(:include_line) { 4 }
+      include_examples 'copies example1'
+    end
     context 'when referencing an external image' do
       let(:target) do
         'https://f.cloud.github.com/assets/4320215/768165/19d8b1aa-e899-11e2-91bc-6b0553e8d722.png'


### PR DESCRIPTION
This fixes our image copier to properly copy images referenced by
`imagesdir`. We *were* copying the images correctly be we weren't
copying them to the right spot. This is because our image copier does a
`find | grep <path>` to find the image for compatibility with the old
`a2x` utility that we used to build the asciidoc before asciidoctor. We
just weren't getting the paths right.

Here is some documentation for the attribute:
https://asciidoctor.org/docs/user-manual/#setting-the-location-of-images
