### PR TITLE
Add ECK 1.0-beta branch, make it the current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -793,8 +793,8 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.0
-            branches:   [ master, 1.0, 0.9, 0.8 ]
+            current:    1.0-beta
+            branches:   [ master, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             direct_html: true


### PR DESCRIPTION
The ECK project needs to change the "current" version to a new branch.

Thank you