### PR TITLE
Adds elasticsearch-ruby doc examples configuration

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -323,6 +323,12 @@ contents:
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
                 exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: ruby }
+                repo:   elasticsearch-ruby
+                path:   docs/doc_examples
+                exclude_branches:   [ 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+
           -
             title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency


### PR DESCRIPTION
In elastic/elasticsearch-ruby#741, I added the first doc example in `docs/doc_examples`.