### PR TITLE
Drop admonitions from titles

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -40,10 +40,19 @@ module DocbookCompat
     # empty string. ClearCachedTitles will make sure we get reconverted
     # when we're rendered.
     def skip_inline_admonition(node)
-      return false unless node.parent
-      return false if node.parent.id
+      return false unless (parent = node.parent)
+      return false if parent.id
 
-      %i[section floating_title].include? node.parent.context
+      case parent.context
+      when :section
+        # the first level 0 heading doesn't ever auto-generate an id so we
+        # need to render the docs.
+        parent.level != 0 || parent.index != 0
+      when :floating_title
+        true
+      else
+        false
+      end
     end
 
     def convert_inline_admonition_for_real(node)

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -38,7 +38,7 @@ module DocbookCompat
 
     def munge_head(title_extra, title, html)
       html.gsub!(
-        %r{<title>.+</title>}m,
+        %r{<title>.+?</title>}m,
         "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
@@ -66,7 +66,7 @@ module DocbookCompat
         <div class="titlepage">
         #{docbook_style_title doc, title}
       HTML
-      html.gsub!(%r{<div id="header">\n<h1>.+</h1>\n}m, header_start) ||
+      html.gsub!(%r{<div id="header">\n<h1>.+?</h1>\n}m, header_start) ||
         raise("Couldn't wrap header in #{html}")
     end
 

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -38,7 +38,7 @@ module DocbookCompat
 
     def munge_head(title_extra, title, html)
       html.gsub!(
-        %r{<title>.+</title>},
+        %r{<title>.+</title>}m,
         "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
@@ -66,7 +66,7 @@ module DocbookCompat
         <div class="titlepage">
         #{docbook_style_title doc, title}
       HTML
-      html.gsub!(%r{<div id="header">\n<h1>.+</h1>\n}, header_start) ||
+      html.gsub!(%r{<div id="header">\n<h1>.+</h1>\n}m, header_start) ||
         raise("Couldn't wrap header in #{html}")
     end
 

--- a/resources/asciidoctor/lib/strip_tags.rb
+++ b/resources/asciidoctor/lib/strip_tags.rb
@@ -6,6 +6,16 @@ module StripTags
   def strip_tags(html)
     return unless html
 
+    # Remove inline admonitions. This is kind of a lame way to do it but
+    # Asciidoctor doesn't give us a better way.
+    html = html.gsub(%r{
+      <span\ class="Admonishment.+
+      \[<span\ class.+</span>\].+
+      <span\ class=".+
+      </span>\n
+      </span>
+    }xm, '')
+    # Comment to fix up syntax highlighting "HTML
     html.gsub(/<[^>]*>/, '').squeeze(' ').strip
   end
 end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1992,6 +1992,12 @@ RSpec.describe DocbookCompat do
             end
             context 'inside the document title' do
               let(:standalone) { true }
+              let(:convert_attributes) do
+                {
+                  # Shrink the output slightly so it is easier to read
+                  'stylesheet!' => false,
+                }
+              end
               let(:input) do
                 <<~ASCIIDOC
                   = Title #{key}:[]
@@ -1999,7 +2005,7 @@ RSpec.describe DocbookCompat do
               end
               context 'the title' do
                 it "doesn't include the admonition" do
-                  expect(converted).to include '<title>Title</title>'
+                  expect(converted).to include '<title>Title | Elastic</title>'
                 end
               end
               context 'the heading' do
@@ -2012,6 +2018,8 @@ RSpec.describe DocbookCompat do
                 it 'has default text' do
                   expect_inline_admonition default_text
                 end
+              end
+            end
             context 'inside a title' do
               let(:input) do
                 <<~ASCIIDOC
@@ -2126,6 +2134,12 @@ RSpec.describe DocbookCompat do
             end
             context 'inside the document title' do
               let(:standalone) { true }
+              let(:convert_attributes) do
+                {
+                  # Shrink the output slightly so it is easier to read
+                  'stylesheet!' => false,
+                }
+              end
               let(:input) do
                 <<~ASCIIDOC
                   = Title #{key}:[7.0.0-beta1]
@@ -2133,7 +2147,7 @@ RSpec.describe DocbookCompat do
               end
               context 'the title' do
                 it "doesn't include the admonition" do
-                  expect(converted).to include '<title>Title</title>'
+                  expect(converted).to include '<title>Title | Elastic</title>'
                 end
               end
               context 'the heading' do
@@ -2148,6 +2162,8 @@ RSpec.describe DocbookCompat do
                     '7.0.0-beta1', "#{message} in 7.0.0-beta1."
                   )
                 end
+              end
+            end
             context 'inside a title' do
               let(:input) do
                 <<~ASCIIDOC

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1953,6 +1953,36 @@ RSpec.describe DocbookCompat do
                 expect_inline_admonition default_text
               end
             end
+            context 'is in the title' do
+              let(:standalone) { true }
+              let(:convert_attributes) do
+                {
+                  # Shrink the output slightly so it is easier to read
+                  'stylesheet!' => false,
+                }
+              end
+              let(:input) do
+                <<~ASCIIDOC
+                  = Title #{key}:[]
+                ASCIIDOC
+              end
+              context 'the title' do
+                it "doesn't include the admonition" do
+                  expect(converted).to include '<title>Title</title>'
+                end
+              end
+              context 'the heading' do
+                it 'includes the admonition' do
+                  expect(converted).to include <<~HTML.strip
+                    <h1 class="title"><a id="id-1"></a>Title <span class="Admonishment
+                  HTML
+                  # Comment to fix syntax highlighting: ">HTML
+                end
+                it 'has default text' do
+                  expect_inline_admonition default_text
+                end
+              end
+            end
           end
         end
         context 'beta' do
@@ -2036,6 +2066,38 @@ RSpec.describe DocbookCompat do
                 expect_inline_admonition(
                   '7.0.0-beta1', "#{message} in 7.0.0-beta1."
                 )
+              end
+            end
+            context 'is in the title' do
+              let(:standalone) { true }
+              let(:convert_attributes) do
+                {
+                  # Shrink the output slightly so it is easier to read
+                  'stylesheet!' => false,
+                }
+              end
+              let(:input) do
+                <<~ASCIIDOC
+                  = Title #{key}:[7.0.0-beta1]
+                ASCIIDOC
+              end
+              context 'the title' do
+                it "doesn't include the admonition" do
+                  expect(converted).to include '<title>Title</title>'
+                end
+              end
+              context 'the heading' do
+                it 'includes the admonition' do
+                  expect(converted).to include <<~HTML.strip
+                    <h1 class="title"><a id="id-1"></a>Title <span class="Admonishment
+                  HTML
+                  # Comment to fix syntax highlighting: ">HTML
+                end
+                it 'has default text' do
+                  expect_inline_admonition(
+                    '7.0.0-beta1', "#{message} in 7.0.0-beta1."
+                  )
+                end
               end
             end
           end


### PR DESCRIPTION
This removes admonitions from the `<title>` and `title=""` tags. It does
this by hacking it out with regexes which is pretty lame, but
asciidoctor doesn't give us another extension point.
