### PR TITLE
Fix locale errors in direct_html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,14 @@ COPY .docker/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/
 RUN install_packages \
   nodejs ruby \
     # Used both to install dependencies and at run time
-  bash less
+  bash less \
     # Just in case you have to shell into the image
+  locales
+    # Deal with utf-8 characters properly
+RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 
 FROM base AS ruby_deps


### PR DESCRIPTION
When attempting to switch some Chinese books we were getting errors that
looked like:
```
cli/options.rb:87:in `encode': "\xE8" from ASCII-8BIT to UTF-8
```

This was caused by ruby thinking that the cli was in ascii instead of
utf8 but perl encoding stuff in utf8. Ruby was doing that, helpfully,
because the shell's locale *was* `POSIX` because that is the default in
minideb if you don't run `locale-gen`.

So, interestingly, the fix for this is in the `Dockerfile`. We have to
enable the `en_US.UTF-8` locale. Now ruby reads the CLI as UTF-8.
