### PR TITLE
Add cloud-assets to conf.yaml and build aliases for ECE

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -11,6 +11,7 @@ repos:
     beats:                https://github.com/elastic/beats.git
     clients-team:         https://github.com/elastic/clients-team.git
     cloud:                https://github.com/elastic/cloud.git
+    cloud-assets:         https://github.com/elastic/cloud-assets.git
     cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git

--- a/conf.yaml
+++ b/conf.yaml
@@ -751,6 +751,17 @@ contents:
                 path:   docs/shared
                 exclude_branches: [ 1.0 ]
               -
+                repo:   cloud-assets
+                path:   docs
+                map_branches: &mapCloudEceToCloudAssets
+                  2.4: master
+                  2.3: master
+                  2.2: master
+                  2.1: master
+                  2.0: master
+                  1.1: master
+                  1.0: master
+              -
                 alternatives: { source_lang: csharp, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -76,7 +76,7 @@ alias docbldcr='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/curator/
 alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
 # Cloud - Elastic Cloud Enterprise
-alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud-assets/docs --chunk 1'
 
 alias docbldech='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/heroku/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud/docs/saas --chunk 1'
 


### PR DESCRIPTION
We're moving to a more sustainable way of maintaining current Docker image info for ECE that requires pulling from the `master` branch of the elastic/cloud-assets repo. This PR makes the necessary doc build updates. 