### PR TITLE
Exclude ECK 1.0-beta from shared/versions/stack/7.x.asciidoc

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -809,7 +809,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/7.x.asciidoc
-                exclude_branches:   [ master, 1.0 ]
+                exclude_branches:   [ master, 1.0, 1.0-beta ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc


### PR DESCRIPTION
This PR exclude `1.0-beta` from `shared/versions/stack/7.x.asciidoc`
