### PR TITLE
Only build with `--direct_html`

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -354,10 +354,7 @@ Words.
 ----
 --
 
-. If the doc is built with DocBook then you *must* use
-a pass block with `<titleabbrev>`. If the doc is built
-with `--direct_html` then you *may* use the pass block
-but it isn't recommended:
+. You *may* use the pass block but it isn't recommended:
 +
 --
 [source,asciidoc]

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -69,6 +69,12 @@ The Asciidoctor migration is complete! --asciidoctor will emit this message
 forever in honor of our success but otherwise doesn't do anything.
 MSG
 }
+if ( $Opts->{direct_html} ) {
+   say <<MSG
+The direct_html migration is complete! --direct_html will emit this message
+forever in honor of our success but otherwise doesn't do anything.
+MSG
+}
 
 init_env();
 
@@ -887,7 +893,6 @@ sub command_line_opts {
         # Options only compatible with --doc
         'doc=s',
         'alternatives=s@',
-        'direct_html',
         'chunk=i',
         'lang=s',
         'lenient',
@@ -917,6 +922,7 @@ sub command_line_opts {
         # Options that do *something* for either --doc or --all or --preview
         'asciidoctor',
         'conf=s',
+        'direct_html',
         'in_standard_docker',
         'open',
         'procs=i',
@@ -937,8 +943,6 @@ sub usage {
           --chunk 1         Also chunk sections into separate files
           --alternatives <source_lang>:<alternative_lang>:<dir>
                             Examples in alternative languages.
-          --direct_html     Generate html directly from Asciidoctor without
-                            using docbook.
           --lang            Defaults to 'en'
           --lenient         Ignore linking errors
           --out dest/dir/   Defaults to ./html_docs.
@@ -981,6 +985,7 @@ sub usage {
           --asciidoctor     Emit a happy message.
           --conf <ymlfile>  Use your own configuration file, defaults to the
                             bundled conf.yaml
+          --direct_html     Emit a happy message.
           --in_standard_docker
                             Specified by build_docs when running in
                             its container
@@ -988,23 +993,6 @@ sub usage {
           --procs           Number of processes to run in parallel, defaults
                             to 3
           --verbose         Output more logs
-
-    Self Test:
-
-        build_docs --self-test <args to pass to make>
-
-    `--self-test` is a wrapper around `make` which is used exclusively for
-    testing. Like `make`, the current directory selects the `Makefile` and
-    you can make specific targets. Some examples:
-
-    Execute all tests:
-        build_docs --self-test
-
-    Execute all of the tests for our extensions to Asciidoctor:
-        build_docs --self-test -C resources/asciidoctor
-
-    Run rubocop on our extensions to Asciidoctor:
-        build_docs --self-test -C resources/asciidoctor rubocop
 USAGE
 }
 
@@ -1015,7 +1003,6 @@ sub check_opts {
         die('--alternatives only compatible with --doc') if $Opts->{alternatives};
         die('--chunk only compatible with --doc') if $Opts->{chunk};
         # Lang will be 'en' even if it isn't specified so we don't check it.
-        die('--direct_html only compatible with --doc') if $Opts->{direct_html};
         die('--lenient only compatible with --doc') if $Opts->{lenient};
         die('--out only compatible with --doc') if $Opts->{out};
         die('--resource only compatible with --doc') if $Opts->{resource};

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -444,34 +444,6 @@ RSpec.describe 'building all books' do
           include_examples 'second build is not a noop'
           include_examples 'second build only changes chapter2'
         end
-        context 'because the book changes from docbook to direct_html' do
-          build_one_book_out_of_one_repo_twice(
-            before_first_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.single = true
-              book.direct_html = false
-            end,
-            before_second_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.direct_html = true
-            end
-          )
-          include_examples 'second build is not a noop'
-        end
-        context 'because the book changes from direct_html to docbook' do
-          build_one_book_out_of_one_repo_twice(
-            before_first_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.direct_html = true
-              book.single = true
-            end,
-            before_second_build: lambda do |src, _config|
-              book = src.book 'Test'
-              book.direct_html = false
-            end
-          )
-          include_examples 'second build is not a noop'
-        end
         context 'because there is a target_branch and we have changes' do
           # We always fork the target_branch from master so if the target
           # branch contains any changes from master we rebuild them every time.

--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -37,9 +37,6 @@ module ConsoleExamples
 end
 
 RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
-  # NOTE: this class has lots of `if direct_html ... else ... end` going on.
-  # That is because direct_html outputs classes in a different order than
-  # docbook and adds many extra newlines.
   page_context "#{path}/chapter.html" do
     let(:has_classes) { 'has-js has-csharp' }
     let(:console_widget) do
@@ -48,112 +45,65 @@ RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
       HTML
     end
     it 'contains the js listing followed by the csharp listing' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper lang-js alternative">
-          <pre class="programlisting prettyprint lang-js alternative">const result = await client.search({
-            body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
-          })</pre>
-          </div>
-          <div class="pre_wrapper lang-csharp alternative">
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper alternative lang-js"><pre class="alternative programlisting prettyprint lang-js">const result = await client.search({
-            body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
-          })</pre></div><div class="pre_wrapper alternative lang-csharp">
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        <div class="pre_wrapper lang-js alternative">
+        <pre class="programlisting prettyprint lang-js alternative">const result = await client.search({
+          body: { query: 'foo bar' } <a id="A0-CO1-1"></a><i class="conum" data-value="1"></i>
+        })</pre>
+        </div>
+        <div class="pre_wrapper lang-csharp alternative">
+      HTML
     end
     it 'contains the csharp listing followed by the default listing' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper lang-csharp alternative">
-          <pre class="programlisting prettyprint lang-csharp alternative">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
-              .Query(q =&gt; q
-                  .QueryString(m =&gt; m
-                      .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
-                  )
-              )
-          );</pre>
-          </div>
-          <div class="pre_wrapper lang-console default #{has_classes}">
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper alternative lang-csharp"><pre class="alternative programlisting prettyprint lang-csharp">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
-              .Query(q =&gt; q
-                  .QueryString(m =&gt; m
-                      .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
-                  )
-              )
-          );</pre></div><div class="pre_wrapper default #{has_classes} lang-console">
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        <div class="pre_wrapper lang-csharp alternative">
+        <pre class="programlisting prettyprint lang-csharp alternative">var searchResponse = _client.Search&lt;Project&gt;(s =&gt; s
+            .Query(q =&gt; q
+                .QueryString(m =&gt; m
+                    .Query("foo bar") <a id="A1-CO1-1"></a><i class="conum" data-value="1"></i>
+                )
+            )
+        );</pre>
+        </div>
+        <div class="pre_wrapper lang-console default #{has_classes}">
+      HTML
     end
     it 'contains the default listing followed by the console widget' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper lang-console default #{has_classes}">
-          <pre class="programlisting prettyprint lang-console default #{has_classes}">GET /_search
-          {
-              "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
-          }</pre>
-          </div>
-          #{console_widget}
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          <div class="pre_wrapper default #{has_classes} lang-console"><pre class="default #{has_classes} programlisting prettyprint lang-console">GET /_search
-          {
-              "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
-          }</pre></div>#{console_widget}
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        <div class="pre_wrapper lang-console default #{has_classes}">
+        <pre class="programlisting prettyprint lang-console default #{has_classes}">GET /_search
+        {
+            "query": "foo bar" <a id="CO1-1"></a><i class="conum" data-value="1"></i>
+        }</pre>
+        </div>
+        #{console_widget}
+      HTML
     end
     it 'contains the console widget followed by the js calloutlist' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          #{console_widget}
-          <div class="calloutlist alternative lang-js">
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          #{console_widget}<div class="alternative lang-js calloutlist">
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        #{console_widget}
+        <div class="calloutlist alternative lang-js">
+      HTML
     end
     it 'contains the js calloutlist followed by the csharp calloutlist' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          js</p>
-          </td>
-          </tr>
-          </table>
-          </div>
-          <div class="calloutlist alternative lang-csharp">
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          js</p></td></tr></table></div><div class="alternative lang-csharp calloutlist">
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        js</p>
+        </td>
+        </tr>
+        </table>
+        </div>
+        <div class="calloutlist alternative lang-csharp">
+      HTML
     end
     it 'contains the csharp calloutlist followed by the default calloutlist' do
-      if direct_html
-        expect(body).to include(<<~HTML.strip)
-          csharp</p>
-          </td>
-          </tr>
-          </table>
-          </div>
-          <div class="calloutlist default #{has_classes} lang-console">
-        HTML
-      else
-        expect(body).to include(<<~HTML.strip)
-          csharp</p></td></tr></table></div><div class="default #{has_classes} lang-console calloutlist">
-        HTML
-      end
+      expect(body).to include(<<~HTML.strip)
+        csharp</p>
+        </td>
+        </tr>
+        </table>
+        </div>
+        <div class="calloutlist default #{has_classes} lang-console">
+      HTML
     end
     context 'the initial js state' do
       it 'contains the available alternatives' do

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -279,7 +279,6 @@ sub _build_book {
                 branch => $branch,
                 roots => $roots,
                 relativize => 1,
-                direct_html => $self->{direct_html},
             );
         }
         else {
@@ -304,7 +303,6 @@ sub _build_book {
                 branch => $branch,
                 roots => $roots,
                 relativize => 1,
-                direct_html => $self->{direct_html},
             );
         }
         $checkout->rmtree;

--- a/lib/ES/Toc.pm
+++ b/lib/ES/Toc.pm
@@ -45,7 +45,6 @@ sub write {
             branch => '', # TOCs don't have a branch but it is a required arg
             relativize => 1,
             extra => $extra,
-            direct_html => 1,
     );
     $adoc_file->remove;
 }

--- a/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
+++ b/resources/asciidoctor/lib/docbook_compat/titleabbrev_handler.rb
@@ -7,8 +7,7 @@ module DocbookCompat
   # Looks for pass blocks with `<titleabbrev>` and adds an attributes to their
   # parent section. This attribute is an abbreviated title used when rendering
   # the table of contents. This exists entirely for backwards compatibility with
-  # docbook. It is simpler and recommended to set the `reftext` attribute
-  # directly on the section when the document is built with `--direct_html`.
+  # docbook. It is simpler and recommended to set the `reftext` attribute.
   class TitleabbrevHandler < TreeProcessorScaffold
     def process_block(block)
       return unless block.context == :pass


### PR DESCRIPTION
This removes support for building docs without direct_html. You no
longer need to specify `--direct_html` on the command line or
`direct_html` in conf.yaml for it ot build with direct_html.

This doesn't drop the configuration from conf.yaml or the change
tracker or all of the files that we need to build with docbook. We'll do
that in a followup.
