### PR TITLE
Clean up the chunker test

### DIFF
--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -18,10 +18,14 @@ RSpec.describe Chunker do
   let(:backend) { :html5 }
   let(:standalone) { true }
   let(:home_title) { 'Title' }
+  let(:prev_title) { prev_page == 'index' ? 'Title' : prev_page.upcase }
+  let(:next_title) { next_page.upcase }
+  let(:prev_link_title) { prev_title }
+  let(:next_link_title) { next_title }
 
-  shared_examples 'standard page' \
-    do |prev_page, prev_title, next_page, next_title|
-    # TODO: replace these parameters with `let` to be more flexible
+  shared_examples 'standard page' do |prev_arg, next_arg|
+    let(:prev_page) { prev_arg }
+    let(:next_page) { next_arg }
     context 'the <head>' do
       it 'contains the charset' do
         expect(contents).to include(<<~HTML)
@@ -33,10 +37,10 @@ RSpec.describe Chunker do
           <link rel="home" href="index.html" title="#{home_title}"/>
         HTML
       end
-      if prev_page
+      if prev_arg
         it 'contains the prev link' do
           expect(contents).to include(<<~HTML)
-            <link rel="prev" href="#{prev_page}.html" title="#{prev_title.gsub(/<[^<]+>/, '').gsub('"', '&quot;')}"/>
+            <link rel="prev" href="#{prev_page}.html" title="#{prev_link_title}"/>
           HTML
         end
       else
@@ -44,11 +48,10 @@ RSpec.describe Chunker do
           expect(contents).not_to include('rel="prev"')
         end
       end
-      if next_page
+      if next_arg
         it 'contains the next link' do
-          # TODO: replace gsub with a better `let`
           expect(contents).to include(<<~HTML)
-            <link rel="next" href="#{next_page}.html" title="#{next_title.gsub(/<[^<]+>/, '').gsub('"', '&quot;')}"/>
+            <link rel="next" href="#{next_page}.html" title="#{next_link_title}"/>
           HTML
         end
       else
@@ -68,7 +71,7 @@ RSpec.describe Chunker do
       it 'contains the navfooter' do
         expect(contents).to include('<div class="navfooter">')
       end
-      if prev_page && prev_page != 'index'
+      if prev_arg && prev_arg != 'index'
         it 'contains the prev nav' do
           expect(contents).to include(<<~HTML)
             <span class="prev">
@@ -84,7 +87,7 @@ RSpec.describe Chunker do
           HTML
         end
       end
-      if next_page
+      if next_arg
         it 'contains the next nav' do
           expect(contents).to include(<<~HTML)
             <span class="next">
@@ -150,7 +153,9 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's1', 'Section "1"'
+          include_examples 'standard page', nil, 's1'
+          let(:next_title) { 'Section "1"' }
+          let(:next_link_title) { 'Section &quot;1&quot;' }
           it 'contains a link to the first section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">Section "1"</a></li>
@@ -169,8 +174,8 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first section', 's1.html' do
-          include_examples 'standard page', 'index', 'Title',
-                           's2', 'Section <code>2</code>'
+          include_examples 'standard page', 'index', 's2'
+          let(:next_title) { 'Section <code>2</code>' }
           let(:next_link_title) { 'Section 2' }
           include_examples 'subpage'
           it 'contains the correct title' do
@@ -209,7 +214,9 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the second section', 's2.html' do
-          include_examples 'standard page', 's1', 'Section "1"', nil, nil
+          include_examples 'standard page', 's1', nil
+          let(:prev_title) { 'Section "1"' }
+          let(:prev_link_title) { 'Section &quot;1&quot;' }
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include('<title>Section 2 | Title</title>')
@@ -268,7 +275,8 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 'l1', 'Level 1'
+          include_examples 'standard page', nil, 'l1'
+          let(:next_title) { 'Level 1' }
           it 'contains a link to the level 1 section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="l1.html">Level 1</a></li>
@@ -281,7 +289,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level one section', 'l1.html' do
-          include_examples 'standard page', 'index', 'Title', nil, nil
+          include_examples 'standard page', 'index', nil
           include_examples 'subpage'
           it 'contains the header of the level 1 section' do
             expect(contents).to include('<h2 id="l1">Level 1</h2>')
@@ -323,7 +331,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 'l0', 'L0'
+          include_examples 'standard page', nil, 'l0'
           it 'contains a link to the level 0 section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="l0.html">L0</a>
@@ -336,7 +344,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level 0 section', 'l0.html' do
-          include_examples 'standard page', 'index', 'Title', 'l1', 'L1'
+          include_examples 'standard page', 'index', 'l1'
           include_examples 'subpage'
           it 'contains the header of the level 0 section' do
             expect(contents).to include('<h1 id="l0" class="sect0">L0</h1>')
@@ -346,7 +354,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the level 1 section', 'l1.html' do
-          include_examples 'standard page', 'l0', 'L0', nil, nil
+          include_examples 'standard page', 'l0', nil
           include_examples 'subpage'
           it 'contains the header of the level 1 section' do
             expect(contents).to include('<h2 id="l1">L1</h2>')
@@ -373,26 +381,27 @@ RSpec.describe Chunker do
             = Title
 
             [[s1]]
-            == Section 1
+            == S1
           ASCIIDOC
         end
         let(:home_title) { 'Title [fooo]' }
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's1', 'Section 1'
+          include_examples 'standard page', nil, 's1'
           it 'contains the correct title' do
             expect(contents).to include('<title>Title</title>')
           end
         end
         file_context 'the section', 's1.html' do
-          include_examples 'standard page', 'index', 'Title [fooo]', nil, nil
+          include_examples 'standard page', 'index', nil
+          let(:prev_title) { 'Title [fooo]' }
           include_examples 'subpage'
           it 'contains the breadcrumbs' do
             expect(contents).to include <<~HTML
               <div class="breadcrumbs">
               <span class="breadcrumb-link"><a href="index.html">Title [fooo]</a></span>
               »
-              <span class="breadcrumb-node">Section 1</span>
+              <span class="breadcrumb-node">S1</span>
               </div>
             HTML
           end
@@ -404,7 +413,7 @@ RSpec.describe Chunker do
             = Title    With   Spaces
 
             [[s]]
-            == Section
+            == S
 
             Words.
           ASCIIDOC
@@ -412,11 +421,11 @@ RSpec.describe Chunker do
         let(:home_title) { 'Title With Spaces' }
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's', 'Section'
+          include_examples 'standard page', nil, 's'
         end
         file_context 'the section', 's.html' do
-          include_examples 'standard page', 'index', 'Title With Spaces',
-                           nil, nil
+          include_examples 'standard page', 'index', nil
+          let(:prev_title) { 'Title With Spaces' }
           include_examples 'subpage'
         end
       end
@@ -433,8 +442,9 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil,
-                           's', 'Section <code>foo</code>'
+          include_examples 'standard page', nil, 's'
+          let(:next_title) { 'Section <code>foo</code>' }
+          let(:next_link_title) { 'Section foo' }
           it 'contains a link to the section' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s.html">Section <code>foo</code></a></li>
@@ -442,7 +452,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the section', 's.html' do
-          include_examples 'standard page', 'index', 'Title', nil, nil
+          include_examples 'standard page', 'index', nil
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include(
@@ -473,8 +483,8 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil,
-                           's', 'Section: With subtitle'
+          include_examples 'standard page', nil, 's'
+          let(:next_title) { 'Section: With subtitle' }
           it 'contains a link to the section' do
             expect(converted).to include(<<~HTML.strip)
               <li><span class="chapter"><a href="s.html">Section: With subtitle</a></span>
@@ -483,7 +493,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the section', 's.html' do
-          include_examples 'standard page', 'index', 'Title', nil, nil
+          include_examples 'standard page', 'index', nil
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include(
@@ -551,7 +561,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's1', 'S1'
+          include_examples 'standard page', nil, 's1'
           it 'contains a link to the level 1 sections' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">S1</a>
@@ -576,7 +586,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first level 1 section', 's1.html' do
-          include_examples 'standard page', 'index', 'Title', 's1_1', 'S1_1'
+          include_examples 'standard page', 'index', 's1_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
@@ -595,7 +605,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first level 2 section', 's1_1.html' do
-          include_examples 'standard page', 's1', 'S1', 's2', 'S2'
+          include_examples 'standard page', 's1', 's2'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
@@ -613,7 +623,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the second level 1 section', 's2.html' do
-          include_examples 'standard page', 's1_1', 'S1_1', 's2_1', 'S2_1'
+          include_examples 'standard page', 's1_1', 's2_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
@@ -629,7 +639,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
-          include_examples 'standard page', 's2', 'S2', 's2_2', 'S2_2'
+          include_examples 'standard page', 's2', 's2_2'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_1">S2_1</h3>')
@@ -650,7 +660,7 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the last level 2 section', 's2_2.html' do
-          include_examples 'standard page', 's2_1', 'S2_1', nil, nil
+          include_examples 'standard page', 's2_1', nil
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')
@@ -688,7 +698,7 @@ RSpec.describe Chunker do
         end
         context 'the main output' do
           let(:contents) { converted }
-          include_examples 'standard page', nil, nil, 's1', 'S1'
+          include_examples 'standard page', nil, 's1'
           it 'contains a link to the level 1 sections' do
             expect(converted).to include(<<~HTML.strip)
               <li><a href="s1.html">S1</a>
@@ -707,12 +717,13 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the section', 's1.html' do
-          include_examples 'standard page', 'index', 'Title',
-                           'app', 'Appendix A: Foo'
+          include_examples 'standard page', 'index', 'app'
+          let(:next_title) { 'Appendix A: Foo' }
           include_examples 'subpage'
         end
         file_context 'the appendix', 'app.html' do
-          include_examples 'standard page', 's1', 'S1', 'app_1', 'Foo 1'
+          include_examples 'standard page', 's1', 'app_1'
+          let(:next_title) { 'Foo 1' }
           include_examples 'subpage'
           it 'contains the correct title' do
             expect(contents).to include(
@@ -733,8 +744,9 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first page in the appendix', 'app_1.html' do
-          include_examples 'standard page', 'app', 'Appendix A: Foo',
-                           'app_2', 'Foo 2'
+          include_examples 'standard page', 'app', 'app_2'
+          let(:prev_title) { 'Appendix A: Foo' }
+          let(:next_title) { 'Foo 2' }
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="app_1">Foo 1</h3>')
@@ -752,7 +764,8 @@ RSpec.describe Chunker do
           end
         end
         file_context 'the first page in the appendix', 'app_2.html' do
-          include_examples 'standard page', 'app_1', 'Foo 1', nil, nil
+          include_examples 'standard page', 'app_1', nil
+          let(:prev_title) { 'Foo 1' }
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h3 id="app_2">Foo 2</h3>')


### PR DESCRIPTION
Drops some "funny" `gsub` calls from the chunker test in favor of being
more explicit.
