### PR TITLE
Adds machine learning book to builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -168,7 +168,7 @@ contents:
             prefix:     en/machine-learning
             current:    7.5
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4 ]
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine learning

--- a/conf.yaml
+++ b/conf.yaml
@@ -137,15 +137,15 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
-            title:      Stack Overview
-            prefix:     en/elastic-stack-overview
+            title:      Machine Learning
+            prefix:     en/machine-learning
             current:    7.5
-            index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            index:      docs/en/stack/ml/index.asciidoc
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8 ]
             live:       *stacklive
             chunk:      1
-            tags:       Elastic Stack/Overview
-            subject:    Elastic Stack
+            tags:       Elastic Stack/Machine learning
+            subject:    Machine learning
             direct_html: true
             sources:
               -
@@ -1925,6 +1925,33 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+          -
+            title:      Stack Overview
+            prefix:     en/elastic-stack-overview
+            current:    7.5
+            index:      docs/en/stack/index.asciidoc
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Legacy/Elastic Stack/Overview
+            subject:    Elastic Stack
+            direct_html: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/stack
+              -
+                repo:   elasticsearch
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
           -
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack

--- a/conf.yaml
+++ b/conf.yaml
@@ -168,7 +168,7 @@ contents:
             prefix:     en/machine-learning
             current:    7.5
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8 ]
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine learning

--- a/conf.yaml
+++ b/conf.yaml
@@ -137,6 +137,33 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
+            title:      Stack Overview
+            prefix:     en/elastic-stack-overview
+            current:    7.5
+            index:      docs/en/stack/index.asciidoc
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Elastic Stack/Overview
+            subject:    Elastic Stack
+            direct_html: true
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/stack
+              -
+                repo:   elasticsearch
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
+          -
             title:      Machine Learning
             prefix:     en/machine-learning
             current:    7.5
@@ -1925,33 +1952,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Stack Overview
-            prefix:     en/elastic-stack-overview
-            current:    7.5
-            index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Legacy/Elastic Stack/Overview
-            subject:    Elastic Stack
-            direct_html: true
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/stack
-              -
-                repo:   elasticsearch
-                path:   docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   docs
-                path:   shared/settings.asciidoc
           -
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -181,3 +181,6 @@ alias docbldall='$GIT_HOME/docs/build_docs --all --target_repo git@github.com:el
 # Do not include the docs repo in this list. The build always uses your local files.
 # For example:
 # --sub_dir elasticsearch:master:./elasticsearch
+
+# Machine learning
+alias docbldml='$GIT_HOME/docs/build_docs --direct_html --doc $GIT_HOME/stack-docs/docs/en/stack/ml/index.asciidoc --resource $GIT_HOME/elasticsearch/docs --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -67,6 +67,7 @@
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
+:ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch} 
 :subscriptions:        https://www.elastic.co/subscriptions
 :wikipedia:            https://en.wikipedia.org/wiki
 :forum:                https://discuss.elastic.co/


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/734

This PR adds a machine learning book to the conf.yaml and adds the "docbldml" build alias.

At this time, the machine learning content also appears in the Stack Overview, since we want to transition gradually to avoid broken links.

Preview:
* http://docs_1662.docs-preview.app.elstc.co/guide/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/master/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.x/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.5/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.4/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.3/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.2/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.1/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/7.0/index.html
* http://docs_1662.docs-preview.app.elstc.co/guide/en/machine-learning/6.8/index.html
...