### PR TITLE
Improve prettifier for asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -297,15 +297,15 @@ layout for books.  The most basic structure is as follows:
 
 [source,asciidoc]
 ----------------------------------
-= Book title                # level 0
+= Book title                // level 0
 
-== Chapter title            # level 1
+== Chapter title            // level 1
 
-=== Section title           # level 2
+=== Section title           // level 2
 
-==== Section title          # level 3
+==== Section title          // level 3
 
-===== Section title         # level 4
+===== Section title         // level 4
 ----------------------------------
 
 Usually this structure will be sufficient for most of your
@@ -379,13 +379,13 @@ with `level 0` headers:
 
 [source,asciidoc]
 ----------------------------------
-= Book title                # level 0
+= Book title                // level 0
 
-= Part title                # level 0
+= Part title                // level 0
 
-== Chapter title            # level 1
+== Chapter title            // level 1
 
-=== Section title           # level 2
+=== Section title           // level 2
 
 ... etc ...
 ----------------------------------
@@ -399,14 +399,14 @@ it must be marked with `[partintro]` in order to be valid:
 
 [source,asciidoc]
 ----------------------------------
-= Book title                # level 0
+= Book title                // level 0
 
-= Part one                  # level 0
+= Part one                  // level 0
 
 [partintro]
 A paragraph introducing this Part
 
-== Chapter title            # level 1
+== Chapter title            // level 1
 
 ... etc ...
 ----------------------------------
@@ -417,7 +417,7 @@ which starts and ends with two dashes: `--`:
 
 ["source","asciidoc",subs="attributes,callouts,macros"]
 ----------------------------------
-= Part two                  # level 0
+= Part two                  // level 0
 
 [partintro]
 .A partintro title
@@ -431,7 +431,7 @@ Everything up to the closing -- marker
 will be considered part of the partintro.
 pass:[--] <1>
 
-== Chapter title           # level 2
+== Chapter title           // level 2
 
 ... etc ...
 ----------------------------------
@@ -448,7 +448,7 @@ a _glossary_ or _appendices_.
 
 [source,asciidoc]
 ----------------------------------
-= Book title                # level 0
+= Book title                // level 0
 
 .Optional preamble title
 Preamble text...
@@ -460,11 +460,11 @@ Preamble text...
 [source,asciidoc]
 ----------------------------------
 [preface]
-= Preface title             # level 0
+= Preface title             // level 0
 
-=== Preface header          # level 2 <1>
+=== Preface header          // level 2 <1>
 
-= Part one                  # level 0
+= Part one                  // level 0
 ----------------------------------
 
 and
@@ -472,9 +472,9 @@ and
 [source,asciidoc]
 ----------------------------------
 [appendix]
-= Appendix title            # level 0
+= Appendix title            // level 0
 
-=== Appendix header         # level 2 <1>
+=== Appendix header         // level 2 <1>
 ----------------------------------
 
 <1> Any headers in the appendix or in the preface start
@@ -486,7 +486,7 @@ and
 [source,asciidoc]
 ----------------------------------
 [glossary]
-= Glossary title            # level 0
+= Glossary title            // level 0
 
 [glossary]
 Term one::
@@ -1737,13 +1737,13 @@ For instance, in the ES reference docs, we have:
 
 [source,asciidoc]
 ----------------------------------
-= Search APIs               # part
+= Search APIs               // part
 
-== Request body search      # chapter
+== Request body search      // chapter
 
-=== Query                   # section level 1
+=== Query                   // section level 1
 
-=== From/Size               # section level 1
+=== From/Size               // section level 1
 
 ... etc ...
 ----------------------------------
@@ -1792,17 +1792,17 @@ a "real" header:
 [source,asciidoc]
 ----------------------------------
 [[chapter-one]]
-== chapter               # new chunk
+== chapter              // new chunk
 
 [[section-one]]
-=== Section one         # new chunk
+=== Section one         // new chunk
 
 [[section-two]]
 [float]
-=== Section two         # same chunk
+=== Section two         // same chunk
 
 [[section-three]]
-=== Section three       # new chunk
+=== Section three       // new chunk
 ----------------------------------
 
 The above would produce three HTML files,

--- a/resources/web/docs_js/__tests__/prettify/lang-asciidoc.test.js
+++ b/resources/web/docs_js/__tests__/prettify/lang-asciidoc.test.js
@@ -1,0 +1,60 @@
+import PR from "../../../lib/prettify/prettify";
+import "../../prettify/lang-asciidoc";
+import dedent from "../../../../../../node_modules/dedent";
+
+const prettyAsciidoc = str => PR.prettyPrintOne(str, "asciidoc");
+const tag = str => `<span class="tag">${str}</span>`;
+const pln = str => `<span class="pln">${str}</span>`;
+const com = str => `<span class="com">${str}</span>`;
+const str = str => `<span class="str">${str}</span>`;
+const kwd = str => `<span class="kwd">${str}</span>`;
+const pun = str => `<span class="pun">${str}</span>`;
+
+describe("lang-asciidoc", () => {
+  describe("headings", () => {
+    const pretty = prettyAsciidoc(dedent `
+      = Book title                // level 0
+
+      == Chapter title            // level 1
+    `);
+    test("the first heading", () => {
+      expect(pretty).toContain(tag("=") + pln(" Book title                ") + com("// level 0\n"));
+    });
+    test("the second heading", () => {
+      expect(pretty).toContain(tag("==") + pln(" Chapter title            ") + com("// level 1"));
+    });
+  });
+  test("ids", () => {
+    const pretty = prettyAsciidoc(dedent `
+      [[intro-to-xyz]]
+    `);
+    expect(pretty).toContain(tag("[[") + pln("intro-to-xyz") + tag("]]"));
+  });
+  test("passthrough", () => {
+    const pretty = prettyAsciidoc(dedent `
+      ++++
+      foo
+      ++++
+    `);
+    expect(pretty).toContain(tag("++++") + pln("\nfoo\n") + tag("++++"));
+  });
+  describe("attribute list", () => {
+    test("with the id first", () => {
+      const pretty = prettyAsciidoc(dedent `
+        [foo,bar=zoo,baz="bort bort"]
+      `);
+      const id = str("foo") + pun(",");
+      const bar = kwd("bar") + pun("=") + str("zoo") + pun(",");
+      const baz = kwd("baz") + pun("=") + str(`"bort bort"`);
+      expect(pretty).toContain(tag("[") + id + bar + baz + tag("]"));
+    });
+    test("with an attribute first", () => {
+      const pretty = prettyAsciidoc(dedent `
+        [bar=zoo]
+      `);
+      const bar = kwd("bar") + pun("=") + str("zoo");
+      expect(pretty).toContain(tag("[") + bar + tag("]"));
+    });
+
+  })
+});

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -7,6 +7,7 @@ import {lang_strings} from "./localization";
 import store from "./store";
 import * as utils from "./utils.js";
 import PR from "../lib/prettify/prettify";
+import "./prettify/lang-asciidoc";
 import "./prettify/lang-console";
 import "../lib/prettify/lang-sql";
 import "../lib/prettify/lang-yaml";

--- a/resources/web/docs_js/prettify/lang-asciidoc.js
+++ b/resources/web/docs_js/prettify/lang-asciidoc.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import PR from "../../lib/prettify/prettify";
+
+PR.registerLangHandler(PR.createSimpleLexer(
+  [
+  ],
+  [
+    [PR.PR_COMMENT, /\/\/[^\n]*(\n|$)/],
+    [PR.PR_TAG, /\[\[/],
+    ["lang-asciidoc-block-attribute-list", /\[([^\]]+)\]/],
+    [PR.PR_TAG, /=/],
+    [PR.PR_TAG, /\+\+\+\+/],
+    [PR.PR_TAG, /\./],
+    [PR.PR_TAG, /--/],
+    [PR.PR_TAG, /\[|\]/],
+  ]
+), ["asciidoc"]);
+
+const basicAttributeList = PR.createSimpleLexer(
+  [
+  ],
+  [
+    [PR.PR_STRING, /[^=,]+/],
+    [PR.PR_PUNCTUATION, /[,=]/],
+  ]
+);
+const enhancedAttributeList = job => {
+  basicAttributeList(job);
+  /* Switches the "key" part of parameter lists to keywords. */
+  for (var i = 0; i < job.decorations.length; i += 2) {
+    const decoration = job.decorations[i + 1];
+    if (decoration === "str") {
+      const next = job.decorations[i + 2];
+      if (job.sourceCode.charAt(next - 1) === "=") {
+        job.decorations[i + 1] = PR.PR_KEYWORD;
+      }
+    }
+  }
+};
+PR.registerLangHandler(enhancedAttributeList, ["asciidoc-block-attribute-list"]);


### PR DESCRIPTION
The syntax highlighter has been doing a terrible job on asciidoc code
for a long time and it ha bothered me. This teaches it to do a little
better. Not perfect at all, but better.
