### PR TITLE
Share a test utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,15 @@ include common.mk
 check: unit_test integration_test
 
 .PHONY: unit_test
-unit_test: style asciidoctor_check web_check template_check preview_check
+unit_test: style test_check asciidoctor_check web_check template_check preview_check
 
 .PHONY: style
 style: build_docs
 	$(DOCKER) py_test pycodestyle build_docs
+
+.PHONY: test_check
+test_check:
+	$(MAKE) -C resources/test
 
 .PHONY: asciidoctor_check
 asciidoctor_check:

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'helper/matcher/doc_body'
+require_relative '../../resources/test/matcher/file_exist'
 require_relative 'helper/matcher/have_same_keys'
 require_relative 'helper/matcher/initial_js_state'
 require_relative 'helper/matcher/redirect_to'
@@ -34,15 +35,6 @@ RSpec.configure do |config|
   config.include Sh
 end
 
-##
-# Return a list of the paths of all files in a directory relative to
-# that directory.
-def files_in(dir)
-  Dir.chdir(dir) do
-    Dir.glob('**/*').select { |f| File.file?(f) }
-  end
-end
-
 def indent(str, indentation)
   str.split("\n").map { |s| indentation + s }.join "\n"
 end
@@ -58,24 +50,5 @@ def desymbolize_keys(thing)
     thing.map { |v| desymbolize_keys v }
   else
     thing
-  end
-end
-
-##
-# Match paths that refer to an existing file.
-# Prefer this instead of `expect(File).to exist('path')` because the failure
-# message is worlds better
-RSpec::Matchers.define :file_exist do
-  # TODO: move to helper/matcher/file_exists.rb
-  match do |actual|
-    File.exist? actual
-  end
-  failure_message do |actual|
-    msg = "expected that #{actual} exists"
-    parent = File.expand_path '..', actual
-    parent = File.expand_path '..', parent until Dir.exist? parent
-
-    entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
-    msg + " but only #{parent}/#{entries.sort} exist"
   end
 end

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative '../../test/matcher/file_exist'
 require 'docbook45/converter'
 
 RSpec.configure do |config|
@@ -136,22 +137,5 @@ RSpec.shared_context 'Dsl_file' do |file_name|
 
   it 'is created' do
     expect(file).to file_exist
-  end
-end
-##
-# Match paths that refer to an existing file.
-# Prefer this instead of `expect(File).to exist('path')` because the failure
-# message is worlds better
-RSpec::Matchers.define :file_exist do
-  match do |actual|
-    File.exist? actual
-  end
-  failure_message do |actual|
-    msg = "expected that #{actual} exists"
-    parent = File.expand_path '..', actual
-    parent = File.expand_path '..', parent until Dir.exist? parent
-
-    entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
-    msg + " but only #{parent}/#{entries.sort} exist"
   end
 end

--- a/resources/test/Makefile
+++ b/resources/test/Makefile
@@ -1,0 +1,8 @@
+include ../../common.mk
+
+.PHONY: check
+check: rubocop
+
+.PHONY: rubocop
+rubocop:
+	$(DOCKER) ruby_test rubocop

--- a/resources/test/matcher/file_exist.rb
+++ b/resources/test/matcher/file_exist.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+##
+# Match paths that refer to an existing file.
+# Prefer this instead of `expect(File).to exist('path')` because the failure
+# message is worlds better.
+RSpec::Matchers.define :file_exist do
+  match do |actual|
+    File.exist? actual
+  end
+  failure_message do |actual|
+    msg = "expected that #{actual} exists"
+    parent = File.expand_path '..', actual
+    parent = File.expand_path '..', parent until Dir.exist? parent
+
+    entries = Dir.entries(parent).reject { |e| e.start_with? '.' }
+    msg + " but only #{parent}/#{entries.sort} exist"
+  end
+end


### PR DESCRIPTION
This moves the `file_exist` matcher into a place so the Asciidoctor
plugin unit tests and the integration tests can share it.
