### PR TITLE
Fix remaining rubocop

### DIFF
--- a/resources/asciidoctor/.rubocop.yml
+++ b/resources/asciidoctor/.rubocop.yml
@@ -6,12 +6,3 @@ AllCops:
   Exclude:
     # This file comes from asciidoctor's source and it is *fairly* temporary.
     - lib/docbook45/converter.rb
-
-Metrics/AbcSize:
-  Exclude:
-    - lib/elastic_compat_tree_processor/extension.rb
-
-Metrics/MethodLength:
-  Exclude:
-    - lib/elastic_compat_preprocessor/extension.rb
-    - lib/elastic_include_tagged/extension.rb

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -238,12 +238,14 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
         return
       end
 
-      if line != @code_block_start
-        line.replace @code_block_start
-        migration_warn @document, cursor, 'delimiter-mismatch',
-                       "code block end doesn't match start"
-      end
+      fix_bad_code_block_end line unless line == @code_block_start
       @code_block_start = nil
+    end
+
+    def fix_bad_code_block_end(line)
+      line.replace @code_block_start
+      migration_warn @document, cursor, 'delimiter-mismatch',
+                     "code block end doesn't match start"
     end
   end
 end

--- a/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_tree_processor/extension.rb
@@ -69,13 +69,7 @@ class ElasticCompatTreeProcessor < TreeProcessorScaffold
   }.freeze
 
   def process_lang_override(block)
-    # Check if the next block is a marker for the language
-    # We don't want block.next_adjacent_block because that'll go "too far"
-    # and it has trouble with definition lists.
-    return unless (my_index = block.parent.blocks.find_index block)
-
-    next_block = block.parent.blocks[my_index + 1]
-    return unless next_block && next_block.context == :pass
+    return unless (next_block = candidate_block block)
     return unless (match = LANG_OVERRIDE_RX.match(next_block.source))
     return unless (lang = LANG_MAPPING[match[1]]) # Not a language we handle
 
@@ -84,5 +78,17 @@ class ElasticCompatTreeProcessor < TreeProcessorScaffold
 
     block.parent.blocks.delete next_block
     block.parent.reindex_sections
+  end
+
+  # Check if the next block is a marker for the language
+  # We don't want block.next_adjacent_block because that'll go "too far"
+  # and it has trouble with definition lists.
+  def candidate_block(block)
+    return unless (my_index = block.parent.blocks.find_index block)
+
+    next_block = block.parent.blocks[my_index + 1]
+    return unless next_block && next_block.context == :pass
+
+    next_block
   end
 end


### PR DESCRIPTION
This fixes all of the remaining rubocop warnings in our code and removes
the suppresions. The last suppression is for the docbook45 converter
which mostly comes from Asciidoctor's code base and we're in the process
of removing it.
