### PR TITLE
Unify some test dsl

### DIFF
--- a/integtest/spec/helper/dsl.rb
+++ b/integtest/spec/helper/dsl.rb
@@ -38,7 +38,7 @@ module Dsl
     let(:statuses) { @dest.convert_statuses }
 
     ##
-    # Build a path to a file in the destination.
+    # Build a path to a file in the destination. Needed by file_context.
     def dest_file(file)
       @dest.path(file)
     end

--- a/integtest/spec/helper/dsl/file_contexts.rb
+++ b/integtest/spec/helper/dsl/file_contexts.rb
@@ -8,33 +8,6 @@ module Dsl
   # their contents.
   module FileContexts
     ##
-    # Create a context to assert things about a file. By default it just
-    # asserts that the file was created but if you pass a block you can add
-    # assertions on `contents`.
-    def file_context(name, file_name = name, &block)
-      context "for #{name}" do
-        include_context 'Dsl_file', file_name
-
-        # Yield to the block to add more tests.
-        class_exec(&block) if block
-      end
-    end
-    shared_context 'Dsl_file' do |file_name|
-      let(:file) do
-        dest_file(file_name)
-      end
-      let(:contents) do
-        return unless File.exist? file
-
-        File.open dest_file(file), 'r:UTF-8', &:read
-      end
-
-      it 'is created' do
-        expect(file).to file_exist
-      end
-    end
-
-    ##
     # Create a context to assert things about an html page. By default it just
     # asserts that the page was created but if you pass a block you can add
     # assertions on `contents, `body`, and `title`.

--- a/integtest/spec/spec_helper.rb
+++ b/integtest/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative 'helper/matcher/doc_body'
+require_relative '../../resources/test/dsl/file_context'
 require_relative '../../resources/test/matcher/file_exist'
 require_relative 'helper/matcher/have_same_keys'
 require_relative 'helper/matcher/initial_js_state'

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative '../../test/dsl/file_context'
+require_relative '../../test/matcher/file_exist'
 require 'chunker/extension'
 require 'docbook_compat/extension'
 require 'fileutils'
@@ -115,6 +117,13 @@ RSpec.describe Chunker do
   context 'when outdir is configured' do
     let(:outdir) { Dir.mktmpdir }
     after(:example) { FileUtils.remove_entry outdir }
+    ##
+    # Build a path to a file in the destination directory.
+    # Needed by file_context.
+    def dest_file(file)
+      converted
+      File.join outdir, file
+    end
     context 'when chunk level is 1' do
       let(:convert_attributes) do
         {

--- a/resources/asciidoctor/spec/spec_helper.rb
+++ b/resources/asciidoctor/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require_relative '../../test/matcher/file_exist'
 require 'docbook45/converter'
 
 RSpec.configure do |config|
@@ -110,32 +109,5 @@ RSpec.shared_context 'convert without logs' do
                           .join("\n")
     end
     converted
-  end
-end
-
-##### TODO: This should be shared with integ tests
-##
-# Create a context to assert things about a file. By default it just
-# asserts that the file was created but if you pass a block you can add
-# assertions on `contents`.
-def file_context(name, file_name = name, &block)
-  context "for #{name}" do
-    include_context 'Dsl_file', file_name
-
-    # Yield to the block to add more tests.
-    class_exec(&block) if block
-  end
-end
-RSpec.shared_context 'Dsl_file' do |file_name|
-  let(:file) do
-    converted # force the conversion so the file will exist
-    File.join outdir, file_name
-  end
-  let(:contents) do
-    File.open file, 'r:UTF-8', &:read if File.exist? file
-  end
-
-  it 'is created' do
-    expect(file).to file_exist
   end
 end

--- a/resources/test/dsl/file_context.rb
+++ b/resources/test/dsl/file_context.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require_relative '../matcher/file_exist'
+
+##
+# Create a context to assert things about a file. By default it just
+# asserts that the file was created but if you pass a block you can add
+# assertions on `contents`.
+# IMPORTANT: This requires a function to be in scope named `dest_file` that
+# resolves the file name into the file's path.
+def file_context(name, file_name = name, &block)
+  context "for #{name}" do
+    include_context 'Dsl_file', file_name
+
+    # Yield to the block to add more tests.
+    class_exec(&block) if block
+  end
+end
+RSpec.shared_context 'Dsl_file' do |file_name|
+  let(:file) do
+    dest_file file_name
+  end
+  let(:contents) do
+    File.open file, 'r:UTF-8', &:read if File.exist? file
+  end
+
+  it 'is created' do
+    expect(file).to file_exist
+  end
+end


### PR DESCRIPTION
Moves `file_context` into a shared space because we use it in both the
unit tests and integration tests.
