### PR TITLE
Vanish ugly grey bars unless needed

### DIFF
--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -4,7 +4,7 @@
      * their containing width, and end up under the nav bar. With this they
      * are harmlessly "contained". They might look ugly this way, but the
      * damage is minimized. */
-    overflow: scroll;
+    overflow: auto;
   }
   table {
     margin-bottom:1em;


### PR DESCRIPTION
Switches the overflow strategy for tables from "always scroll" to
"scroll if needed".
