### PR TITLE
Temporarily change the default banner text for old versions.

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -15,8 +15,7 @@ use utf8;
 our %Page_Header = (
     en => {
         old => <<"HEADER",
-<strong>IMPORTANT</strong>: No additional bug fixes or documentation updates 
-will be released for this version. For the latest information, see the 
+A newer version is available. For the latest information, see the 
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"


### PR DESCRIPTION
Changing the default "old version" banner until @nik9000 merges a change to enable a different default for live versions older than current (actively maintained versions).

Once we rebuild, this will replace the erroneous out of maintenance message on the Cloud docs. OOM stack docs will also get the "milder" message until Nik's fix is merged and this is reverted, but we're okay with that.