### PR TITLE
Default to "non-live" header on non-live old books

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -608,37 +608,79 @@ RSpec.describe 'building all books' do
   context 'when the book has "live" branches' do
     convert_all_before_context do |src|
       repo = src.repo_with_index 'repo', 'test'
+      repo.switch_to_new_branch '0.9_oldbutlive'
       repo.switch_to_new_branch 'nonlive'
 
       book = src.book 'Test'
       book.source repo, 'index.asciidoc'
-      book.branches << 'nonlive'
-      book.live_branches = ['master']
+      book.branches = ['master', '0.9_oldbutlive', 'nonlive']
+      book.live_branches = ['master', '0.9_oldbutlive']
     end
     let(:repo) { @src.repo 'repo' }
-    page_context 'the live branch', 'html/test/master/index.html' do
+    page_context 'the current branch', 'html/test/master/index.html' do
       it "doesn't contain the noindex flag" do
         expect(contents).not_to include(<<~HTML.strip)
           <meta name="robots" content="noindex,nofollow"/>
         HTML
       end
       context 'the live versions drop down' do
-        it 'contains only the live branch' do
+        it 'contains only the live branches' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="master" selected>master (current)</option><option value="other">other versions</option></select>
+            <select id="live_versions"><option value="master" selected>master (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="other">other versions</option></select>
           HTML
         end
       end
       context 'the other versions drop down' do
         it 'contains all branches' do
           expect(body).to include(<<~HTML.strip)
-            <span id="other_versions">other versions: <select><option value="master" selected>master (current)</option><option value="nonlive">nonlive</option></select>
+            <span id="other_versions">other versions: <select><option value="master" selected>master (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="nonlive">nonlive</option></select>
           HTML
         end
+      end
+      it "doesn't contain a page header" do
+        expect(body).not_to include 'class="page_header"'
       end
     end
     page_context "the live branch's chapter", 'html/test/master/chapter.html' do
       let(:edit_url) { "#{repo.root}/edit/master/index.asciidoc" }
+      it 'contains an edit_me link' do
+        expect(body).to include <<~HTML.strip
+          <a class="edit_me" rel="nofollow" title="Edit this page on GitHub" href="#{edit_url}">edit</a>
+        HTML
+      end
+    end
+    page_context 'the old branch', 'html/test/0.9_oldbutlive/index.html' do
+      it "doesn't contain the noindex flag" do
+        expect(contents).not_to include(<<~HTML.strip)
+          <meta name="robots" content="noindex,nofollow"/>
+        HTML
+      end
+      context 'the live versions drop down' do
+        it 'contains only the live branches' do
+          expect(body).to include(<<~HTML.strip)
+            <select id="live_versions"><option value="master">master (current)</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="other">other versions</option></select>
+          HTML
+        end
+      end
+      context 'the other versions drop down' do
+        it 'contains all branches' do
+          expect(body).to include(<<~HTML.strip)
+            <span id="other_versions">other versions: <select><option value="master">master (current)</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="nonlive">nonlive</option></select>
+          HTML
+        end
+      end
+      it 'includes the "old" version header' do
+        expect(body).to include <<~HTML
+          <div class="page_header">
+          A newer version is available. For the latest information, see the
+          <a href="../current/index.html">current release documentation</a>.
+          </div>
+        HTML
+      end
+    end
+    page_context "the old branch's chapter",
+                 'html/test/0.9_oldbutlive/chapter.html' do
+      let(:edit_url) { "#{repo.root}/edit/0.9_oldbutlive/index.asciidoc" }
       it 'contains an edit_me link' do
         expect(body).to include <<~HTML.strip
           <a class="edit_me" rel="nofollow" title="Edit this page on GitHub" href="#{edit_url}">edit</a>
@@ -654,13 +696,22 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains the deprecated branch' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="master">master (current)</option><option value="nonlive" selected>nonlive</option></select>
+            <select id="live_versions"><option value="master">master (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="nonlive" selected>nonlive</option></select>
           HTML
         end
       end
       it "it doesn't contain the other versions drop down" do
         # *because* there aren't any versions filtered from the list
         expect(body).not_to include 'id="other_versions"'
+      end
+      it 'includes the "dead" version header' do
+        expect(body).to include <<~HTML
+          <div class="page_header">
+          <strong>IMPORTANT</strong>: No additional bug fixes or documentation updates
+          will be released for this version. For the latest information, see the
+          <a href="../current/index.html">current release documentation</a>.
+          </div>
+        HTML
       end
     end
     page_context "the dead branch's chapter",

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -15,7 +15,12 @@ use utf8;
 our %Page_Header = (
     en => {
         old => <<"HEADER",
-A newer version is available. For the latest information, see the 
+A newer version is available. For the latest information, see the
+<a href="../current/index.html">current release documentation</a>.
+HEADER
+        dead => <<"HEADER",
+<strong>IMPORTANT</strong>: No additional bug fixes or documentation updates
+will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
@@ -28,14 +33,21 @@ HEADER
         old => <<"HEADER",
 你当前正在查看的是旧版本的文档。如果不是你要找的，请点击查看 <a href="../current/index.html">当前发布版本的文档</a>。
 HEADER
+        dead => <<"HEADER",
+你当前正在查看的是旧版本的文档。如果不是你要找的，请点击查看 <a href="../current/index.html">当前发布版本的文档</a>。
+HEADER
         new => <<"HEADER"
 你当前正在查看的是未发布版本的预览版文档。如果不是你要找的，请点击查看 <a href="../current/index.html">当前发布版本的文档</a>。
 HEADER
     },
     ja => {
         old => <<"HEADER",
-You are looking at documentation for an older release.
-Not what you want? See the
+A newer version is available. For the latest information, see the
+<a href="../current/index.html">current release documentation</a>.
+HEADER
+        dead => <<"HEADER",
+<strong>IMPORTANT</strong>: No additional bug fixes or documentation updates
+will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
@@ -46,8 +58,12 @@ HEADER
     },
     ko => {
         old => <<"HEADER",
-You are looking at documentation for an older release.
-Not what you want? See the
+A newer version is available. For the latest information, see the
+<a href="../current/index.html">current release documentation</a>.
+HEADER
+        dead => <<"HEADER",
+<strong>IMPORTANT</strong>: No additional bug fixes or documentation updates
+will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
@@ -396,6 +412,7 @@ sub _page_header {
     my $current = $self->current;
     return '' if $current eq $branch;
 
+    my $orig_branch = $branch;
     if ( $current !~ /-\w/ ) {
         $current .= '-zzzzzz';
     }
@@ -403,7 +420,10 @@ sub _page_header {
         $branch .= '-zzzzzz';
     }
 
-    return $self->_page_header_text( $branch lt $current ? 'old' : 'new' );
+    my $key = $branch lt $current ? 'old' : 'new';
+    $key = 'dead' if $key == 'old' && !grep( /^$orig_branch$/, @{ $self->{live_branches} } );
+
+    return $self->_page_header_text( $key );
 }
 
 #===================================


### PR DESCRIPTION
If a book is not `live` and is "older" than the current book this
defaults its header to an "end of life" style message.
