### PR TITLE
Moves Stack Overview to legacy documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -134,32 +134,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
-            title:      Stack Overview
-            prefix:     en/elastic-stack-overview
-            current:    7.5
-            index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Elastic Stack/Overview
-            subject:    Elastic Stack
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/stack
-              -
-                repo:   elasticsearch
-                path:   docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   docs
-                path:   shared/settings.asciidoc
-          -
             title:      Machine Learning
             prefix:     en/machine-learning
             current:    7.5
@@ -1882,6 +1856,33 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+          -
+            title:      Stack Overview
+            prefix:     en/elastic-stack-overview
+            current:    7.5
+            index:      docs/en/stack/index.asciidoc
+            branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklive
+            chunk:      1
+            noindex:    1
+            tags:       Legacy/Elastic Stack/Overview
+            subject:    Elastic Stack
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/stack
+              -
+                repo:   elasticsearch
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
           -
             title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/46718 and https://github.com/elastic/docs/pull/1662

This PR moves the Stack Overview to the "legacy documentation" section of the landing page and sets "noindex" to 1.