### PR TITLE
Adds API reference attributes to older versions

### DIFF
--- a/shared/attributes62.asciidoc
+++ b/shared/attributes62.asciidoc
@@ -80,3 +80,15 @@
 :dfeeds-cap:              Datafeeds
 
 :pwd:             YOUR_PASSWORD
+
+:api-request-title:        Request
+:api-prereq-title:         Prerequisites
+:api-description-title:    Description
+:api-path-parms-title:     Path parameters
+:api-query-parms-title:    Query parameters
+:api-request-body-title:   Request body
+:api-response-codes-title: Response codes
+:api-response-body-title:  Response body
+:api-example-title:        Example
+:api-examples-title:       Examples
+:api-definitions-title:    Properties


### PR DESCRIPTION
There is at least one page where the API reference shared attributes are failing in 6.2 documentation:
https://www.elastic.co/guide/en/elasticsearch/reference/6.2/ml-close-job.html

This PR copies those attributes from https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc to https://github.com/elastic/docs/blob/master/shared/attributes62.asciidoc