### PR TITLE
Add support for "collapsible" examples

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1274,6 +1274,25 @@ in an error.  To resolve this, add newlines
 between the delimiter and the content
 before and after it.
 
+Examples can be made collapsible:
+
+[source,asciidoc]
+----------------------------------
+[%collapsible]
+.An example
+====
+Lots of text can go in here.
+====
+----------------------------------
+
+Which renders as:
+
+[%collapsible]
+.An example
+====
+Lots of text can go in here.
+====
+
 [[includes]]
 == Including files
 

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -50,6 +50,7 @@ RSpec.describe 'building all books' do
       has_license 'code-prettify', 'The Apache 2.0 License'
       has_license "code-prettify's lang-sql", 'The Apache 2.0 License'
       has_license "code-prettify's lang-yaml", 'The Apache 2.0 License'
+      has_license 'details-polyfill', 'The MIT License (MIT)'
       has_license 'js-cookie', 'The MIT License (MIT)'
       has_license 'linkstate', 'The MIT License (MIT)'
       has_license 'loose-envify', 'The MIT License (MIT)'

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
   },
   "dependencies": {
     "dedent": "^0.7.0",
-    "js-cookie": "^2.1.0",
+    "details-polyfill": "^1.1.0",
     "jquery": "^1.11.3",
+    "js-cookie": "^2.1.0",
     "linkstate": "^1.1.1",
     "parcel": "^1.12.3",
     "postcss-assets": "^5.0.0",

--- a/resources/asciidoctor/lib/docbook_compat/convert_example.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_example.rb
@@ -6,6 +6,7 @@ module DocbookCompat
   module ConvertExample
     def convert_example(node)
       return yield unless node.title
+      return yield if node.option? 'collapsible'
 
       [
         '<div class="example">',

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -2406,5 +2406,25 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'collapsible' do
+      let(:input) do
+        <<~ASCIIDOC
+          [%collapsible]
+          .Title
+          ====
+          Words
+          ====
+        ASCIIDOC
+      end
+      it "uses asciidoctor's default" do
+        expect(converted).to include <<~HTML
+          <details>
+          <summary class="title">Title</summary>
+          <div class="content">
+          <p>Words</p>
+          </div>
+        HTML
+      end
+    end
   end
 end

--- a/resources/web/docs.js.licenses
+++ b/resources/web/docs.js.licenses
@@ -51,6 +51,29 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License. */
+/* details-polyfill
+ * The MIT License (MIT)
+ * 
+ * Copyright (c) 2018 Rico Sta. Cruz
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 /* js-cookie
  * The MIT License (MIT)
  *

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -12,6 +12,9 @@ import "./prettify/lang-console";
 import "../lib/prettify/lang-sql";
 import "../lib/prettify/lang-yaml";
 
+// Add support for <details> in IE and the like
+import "../../../../../node_modules/details-polyfill";
+
 export function init_headers(right_col, lang_strings) {
   // Add on-this-page block
   var this_page = $('<div id="this_page"></div>').prependTo(right_col);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2427,6 +2427,11 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
+details-polyfill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/details-polyfill/-/details-polyfill-1.1.0.tgz#d6d71be0885560e7afca42688b03ff379fd80e56"
+  integrity sha512-YARtvrZ+FobZBMjfAyCxNZ5Cm5riB2tKMsdUQvTFnCvg3OeAkOGCoSxgDZT0uAXV+t5zgJYMGWd/ftVI6v8I0w==
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"


### PR DESCRIPTION
This adds support for collapsible examples to our docs. It turns out
that asciidoctor just uses `<details>` and `<summary>` which isn't
supported by all browsers, but we've got a polyfill.

Closes #1279
