### PR TITLE
Add attributes62.asciidoc dependency to appropriate books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -314,6 +314,10 @@ contents:
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
                 alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
                 path:   docs/doc_examples

--- a/conf.yaml
+++ b/conf.yaml
@@ -1917,6 +1917,10 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 exclude_branches: [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -92,6 +92,10 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ master, 7.x, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started


### PR DESCRIPTION
This PR updates the conf.yaml such that the Elasticsearch Reference, Installation and Upgrade Guide, and X-Pack Reference are shown as having a dependency on the attributes62.asciidoc file in certain branches.