### PR TITLE
Updated the title of ESS to "Hosted Elastic Stack"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -618,7 +618,7 @@ contents:
         title:      Cloud: Provision, Manage and Monitor the Elastic Stack
         sections:
           -
-            title:      Elasticsearch Service - Hosted Elasticsearch and Kibana
+            title:      Elasticsearch Service - Hosted Elastic Stack
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud


### PR DESCRIPTION
As we are adding support for more products such as APM, App Search, and in the future Workplace Search as well, a more suitable title seems to be the "Elasticsearch Service - Hosted Elastic Stack"