### PR TITLE
Make extra-title-page ignore `.x` in index

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -260,7 +260,7 @@ sub _add_extra_title_page {
 #===================================
     my ( $index, $html_file ) = @_;
     my $extra_title_page = $index->basename;
-    $extra_title_page =~ s/\.a(scii)?doc$/-extra-title-page.html/ || die;
+    $extra_title_page =~ s/(\.x)?\.a(scii)?doc$/-extra-title-page.html/ || die;
     $extra_title_page = $index->parent->file( $extra_title_page );
     if ( -e $extra_title_page ) {
         $extra_title_page = $extra_title_page->slurp( iomode => '<:encoding(UTF-8)' );


### PR DESCRIPTION
Some of our `index.asciidoc` files are actually `index.x.asciidoc` for
historical reasons. The `.x` filse should always have the same
`-extra-title-page` content so this strips the `.x` from the check for
`-extra-title-page`.

Closes #1689
