### PR TITLE
Removes elasticsearch repo from Stack Overview dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1880,9 +1880,6 @@ contents:
                 repo:   stack-docs
                 path:   docs/en/stack
               -
-                repo:   elasticsearch
-                path:   docs
-              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -


### PR DESCRIPTION
This PR updates the conf.yaml since the Stack Overview no longer pulls content from the elasticsearch repo.