### PR TITLE
Add rust client to Elasticsearch clients docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -25,6 +25,7 @@ repos:
     elasticsearch-py:     https://github.com/elastic/elasticsearch-py
     elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl
     go-elasticsearch:     https://github.com/elastic/go-elasticsearch
+    elasticsearch-rs:     https://github.com/elastic/elasticsearch-rs.git       
     elasticsearch:        https://github.com/elastic/elasticsearch.git
     guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
     guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
@@ -573,6 +574,19 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/python
+
+              -
+                title:      Rust API
+                prefix:     rust-api
+                current:    master
+                branches:   [ master ]
+                index:      docs/index.asciidoc
+                tags:       Clients/Rust
+                subject:    Clients
+                sources:
+                  -
+                    repo:   elasticsearch-rs
+                    path:   docs/
 
               -
                 title:      Community Contributed Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -581,6 +581,7 @@ contents:
                 current:    master
                 branches:   [ master ]
                 index:      docs/index.asciidoc
+                single:     1
                 tags:       Clients/Rust
                 subject:    Clients
                 sources:


### PR DESCRIPTION
This PR adds the Rust client to the Elasticsearch Clients documentation.

Per Rust crate idioms, the core documentation is hosted on docs.rs, which for the Rust client package is
at https://docs.rs/elasticsearch. The inclusion of the Rust client in the Clients documentation is to provide representation in the official docs and an overview of the client.