### PR TITLE
Promote ECK 1.0 branch to "current"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -790,7 +790,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.0-beta
+            current:    1.0
             branches:   [ master, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
**Only for review, please do not merge**

This PR makes the 1.0 branch the current one.
