### PR TITLE
Make Google Cloud's Anthos docs legacy

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1846,6 +1846,8 @@ contents:
             current:    master
             index:      docs/en/gke-on-prem/index.asciidoc
             branches:   [ master ]
+            private:    1            
+            noindex:    1
             chunk:      1
             tags:       Elastic Stack/Google
             subject:    Elastic Stack

--- a/conf.yaml
+++ b/conf.yaml
@@ -190,25 +190,6 @@ contents:
               -
                 repo:   azure-marketplace
                 path:   docs
-          -
-            title:      Elastic Stack and Google Cloud's Anthos
-            prefix:     en/elastic-stack-gke
-            current:    master
-            index:      docs/en/gke-on-prem/index.asciidoc
-            branches:   [ master ]
-            chunk:      1
-            tags:       Elastic Stack/Google
-            subject:    Elastic Stack
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/gke-on-prem
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
     -
         title:      Elasticsearch: Store, Search, and Analyze
         sections:
@@ -1859,6 +1840,25 @@ contents:
     -
         title:      Legacy Documentation
         sections:
+          -
+            title:      Elastic Stack and Google Cloud's Anthos
+            prefix:     en/elastic-stack-gke
+            current:    master
+            index:      docs/en/gke-on-prem/index.asciidoc
+            branches:   [ master ]
+            chunk:      1
+            tags:       Elastic Stack/Google
+            subject:    Elastic Stack
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/gke-on-prem
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           -
             title:      Infrastructure Monitoring Guide for 6.5-7.4
             prefix:     en/infrastructure/guide


### PR DESCRIPTION
Related PR: https://github.com/elastic/stack-docs/pull/807.
Closes https://github.com/elastic/stack-docs/issues/495.