### PR TITLE
[DOCS] Update snippets in API Reference template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -13,11 +13,10 @@ While optional, we recommend including the example request when possible.
 
 Creates a cool thing.
 
-[source,js]
+[source,console]
 --------------------------------------------------
 PUT twitter
 --------------------------------------------------
-// CONSOLE
 
 ////
 ***********************************************************
@@ -153,7 +152,7 @@ Optional additional examples.
 DO NOT repeat the basic example used earlier.
 
 
-[source,js]
+[source,console]
 ----
 PUT /follower_index/_ccr/follow?wait_for_active_shards=1
 {
@@ -171,12 +170,11 @@ PUT /follower_index/_ccr/follow?wait_for_active_shards=1
   "read_poll_timeout" : "30s"
 }
 ----
-// CONSOLE
 // TEST[setup:remote_cluster_and_leader_index]
 
 The API returns the following result:
 
-[source,js]
+[source,console-result]
 ----
 {
   "follow_index_created" : true,
@@ -184,5 +182,4 @@ The API returns the following result:
   "index_following_started" : true
 }
 ----
-// TESTRESPONSE
 ////


### PR DESCRIPTION
elastic/elasticsearch#46180 added support for `[source,console]` and `[source,console-result]`, replacing several older 'magic comments' for snippets.

This updates the API Reference template for the new code block attributes.