### PR TITLE
Doc version bumps for 7.5.2

### DIFF
--- a/shared/versions/stack/7.5.asciidoc
+++ b/shared/versions/stack/7.5.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.5.1
+:version:                7.5.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.5.1
-:logstash_version:       7.5.1
-:elasticsearch_version:  7.5.1
-:kibana_version:         7.5.1
-:apm_server_version:     7.5.1
+:bare_version:           7.5.2
+:logstash_version:       7.5.2
+:elasticsearch_version:  7.5.2
+:kibana_version:         7.5.2
+:apm_server_version:     7.5.2
 :branch:                 7.5
 :major-version:          7.x
 :prev-major-version:     6.x


### PR DESCRIPTION
Related to https://github.com/elastic/dev/issues/1353

#DO NOT MERGE UNTIL RELEASE DAY#