### PR TITLE
Updated the code examples folder for PHP

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -271,12 +271,7 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   elasticsearch-php
-                path:   examples/docs/asciidoc
-                exclude_branches:   [ 7.x, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                # Used by the php examples but doesn't contain asciidoc files
-                repo:   elasticsearch-php
-                path:   examples/docs/src/Examples
+                path:   docs/examples
                 exclude_branches:   [ 7.x, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }


### PR DESCRIPTION
This PR updates the code examples folder for PHP. Changed in https://github.com/elastic/elasticsearch-php/pull/987.