### PR TITLE
Add Github link support to beta and experimental macros

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1479,7 +1479,13 @@ Text about old functionality...
 == Experimental and Beta
 
 APIs or parameters that are experimental or in beta can be marked as such, using
-markup similar to that used in <<changes>>.  For instance:
+markup similar to that used in <<changes>>.
+
+In the block format, you have the option of adding a related GitHub issue. If
+both custom text and a GitHub issue are provided, the GitHub issue **must** be
+provided second.
+
+For instance:
 
 [source,asciidoc]
 ----------------------------------
@@ -1488,7 +1494,11 @@ markup similar to that used in <<changes>>.  For instance:
 
 experimental::[]
 
+experimental::[https://github.com/elastic/docs/issues/505]
+
 experimental::[Custom text goes here]
+
+experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
 
 Text about new feature...
 
@@ -1510,10 +1520,13 @@ a new experimental parameter:
 
 experimental::[]
 
+experimental::[https://github.com/elastic/docs/issues/505]
+
 experimental::[Custom text goes here]
 
-Text about new feature...
+experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
 
+Text about new feature...
 [[old-feature]]
 === Established feature
 
@@ -1532,7 +1545,11 @@ a new experimental parameter:
 
 beta::[]
 
+beta::[https://github.com/elastic/docs/issues/505]
+
 beta::[Custom text goes here]
+
+beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
 
 Text about new feature...
 
@@ -1554,7 +1571,11 @@ a new beta parameter:
 
 beta::[]
 
+beta::[https://github.com/elastic/docs/issues/505]
+
 beta::[Custom text goes here]
+
+beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
 
 Text about new feature...
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1481,9 +1481,10 @@ Text about old functionality...
 APIs or parameters that are experimental or in beta can be marked as such, using
 markup similar to that used in <<changes>>.
 
-In the block format, you have the option of adding a related GitHub issue. If
-both custom text and a GitHub issue are provided, the GitHub issue **must** be
-provided second.
+In the block format, you have the option of adding a related GitHub issue link.
+If both custom text and a GitHub link are provided, the GitHub link **must** be
+provided second. If it's supported in your repo, you can use the `{issue}`
+attribute in place of the GitHub issue link.
 
 For instance:
 
@@ -1496,9 +1497,13 @@ experimental::[]
 
 experimental::[https://github.com/elastic/docs/issues/505]
 
+experimental::[{issue}505]
+
 experimental::[Custom text goes here]
 
 experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
+
+experimental::[Custom text goes here,{issue}505]
 
 Text about new feature...
 
@@ -1522,9 +1527,13 @@ experimental::[]
 
 experimental::[https://github.com/elastic/docs/issues/505]
 
+experimental::[{issue}505]
+
 experimental::[Custom text goes here]
 
 experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
+
+experimental::[Custom text goes here,{issue}505]
 
 Text about new feature...
 [[old-feature]]
@@ -1547,9 +1556,13 @@ beta::[]
 
 beta::[https://github.com/elastic/docs/issues/505]
 
+beta::[{issue}505]
+
 beta::[Custom text goes here]
 
 beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
+
+beta::[Custom text goes here,{issue}505]
 
 Text about new feature...
 
@@ -1573,9 +1586,13 @@ beta::[]
 
 beta::[https://github.com/elastic/docs/issues/505]
 
+beta::[{issue}505]
+
 beta::[Custom text goes here]
 
 beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
+
+beta::[Custom text goes here,{issue}505]
 
 Text about new feature...
 

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -42,24 +42,34 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       @default_text = default_text
     end
 
-    def generate_issue_text(text, issue_url)
-      issue_no = issue_url.split('/').last.chomp('/')
-      issue_text = <<~TEXT
-        For feature status, see #{issue_url}[\##{issue_no}].
-      TEXT
-      text + ' ' + issue_text
-    end
-
     def generate_text(text, issue_url)
-      if text&.start_with?('http')
+      if text&.start_with?('http', '{issue}')
         issue_url = text
         text = @default_text
       else
         issue_url = issue_url
         text ||= @default_text
       end
-      text = generate_issue_text(text, issue_url) if issue_url
+      text = add_issue_text(text, issue_url) if issue_url
       text
+    end
+
+    def add_issue_text(text, issue_url)
+      issue_num = get_issue_num(issue_url)
+      issue_text = <<~TEXT
+        For feature status, see #{issue_url}[\##{issue_num}].
+      TEXT
+      text + ' ' + issue_text
+    end
+
+    def get_issue_num(issue_url)
+      if issue_url.start_with?('http')
+        issue_num = issue_url.split('/').last
+        issue_num.chomp!('/')
+      else
+        issue_num = issue_url.sub('{issue}', '')
+      end
+      issue_num
     end
 
     def process(parent, _target, attrs)

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -58,7 +58,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       if github_link
         github_issue = github_link.split('/').last
         github_text = <<~TEXT
-          For feature status,see #{github_link}[\##{github_issue}].
+          For feature status, see #{github_link}[\##{github_issue}].
           TEXT
         text += ' ' + github_text
       end

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -42,10 +42,20 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       @default_text = default_text
     end
 
+    def 
+
+    def generate_github_text(github_link,text)
+      github_issue = github_link.split('/').last.chomp!('/')
+      github_text = <<~TEXT
+        For feature status, see #{github_link}[\##{github_issue}].
+      TEXT
+      text += ' ' + github_text
+      return text
+    end
+
     def process(parent, _target, attrs)
       text = attrs[:passtext]
-      gh_pattern = %r{^https?:\/\/github\.com\/elastic\/\S+[^\/]\/issues\/\d+$}
-      if text&.match(gh_pattern)
+      if text.start_with("http")
         github_link = attrs[:passtext]
         text = @default_text
       else
@@ -53,16 +63,10 @@ class CareAdmonition < Asciidoctor::Extensions::Group
         text ||= @default_text
       end
       if github_link
-        github_issue = github_link.split('/').last
-        github_text = <<~TEXT
-          For feature status, see #{github_link}[\##{github_issue}].
-          TEXT
-        text += ' ' + github_text
+        text = generate_github_text(github_link,text)
       end
       Asciidoctor::Block.new(
-        parent, :admonition,
-        source: text,
-        attributes: {
+        parent, :admonition, source: text, attributes: {
           'role' => @role,
           'name' => 'warning',
           'style' => 'warning',

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -43,12 +43,11 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     end
 
     def process(parent, _target, attrs)
-  
       text = attrs[:passtext]
       link_pattern = /^https?:\/\/github\.com\/elastic\/\S+[^\/]\/issues\/\d+$/
 
       ## If the passtext looks like a Github link, use it.
-      if text && text.match(link_pattern)
+      if text&.match(link_pattern)
         github_link = attrs[:passtext]
         text = @default_text
       else
@@ -58,8 +57,10 @@ class CareAdmonition < Asciidoctor::Extensions::Group
 
       if github_link
         github_issue = github_link.split('/').last
-        github_text = "For feature status, see #{github_link}[\##{github_issue}]."
-        text += " " + github_text
+        github_text = <<~TEXT
+          For feature status,see #{github_link}[\##{github_issue}].
+          TEXT
+        text += ' ' + github_text
       end
 
       Asciidoctor::Block.new(

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -44,17 +44,14 @@ class CareAdmonition < Asciidoctor::Extensions::Group
 
     def process(parent, _target, attrs)
       text = attrs[:passtext]
-      link_pattern = /^https?:\/\/github\.com\/elastic\/\S+[^\/]\/issues\/\d+$/
-
-      ## If the passtext looks like a Github link, use it.
-      if text&.match(link_pattern)
+      gh_pattern = %r{^https?:\/\/github\.com\/elastic\/\S+[^\/]\/issues\/\d+$}
+      if text&.match(gh_pattern)
         github_link = attrs[:passtext]
         text = @default_text
       else
         github_link = attrs[:github]
         text ||= @default_text
       end
-
       if github_link
         github_issue = github_link.split('/').last
         github_text = <<~TEXT
@@ -62,7 +59,6 @@ class CareAdmonition < Asciidoctor::Extensions::Group
           TEXT
         text += ' ' + github_text
       end
-
       Asciidoctor::Block.new(
         parent, :admonition,
         source: text,

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -42,27 +42,28 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       @default_text = default_text
     end
 
-    def generate_github_text(github_link,text)
-      github_issue = github_link.split('/').last.chomp('/')
-      github_text = <<~TEXT
-        For feature status, see #{github_link}[\##{github_issue}].
+    def generate_issue_text(text, issue_url)
+      issue_no = issue_url.split('/').last.chomp('/')
+      issue_text = <<~TEXT
+        For feature status, see #{issue_url}[\##{issue_no}].
       TEXT
-      text += ' ' + github_text
-      return text
+      text += ' ' + issue_text
+    end
+
+    def generate_text(text, issue_url)
+      if text&.start_with?('http')
+        issue_url = text
+        text = @default_text
+      else
+        issue_url = issue_url
+        text ||= @default_text
+      end
+      text = generate_issue_text(text,issue_url) if issue_url
+      text
     end
 
     def process(parent, _target, attrs)
-      text = attrs[:passtext]
-      if text&.start_with?("http")
-        github_link = attrs[:passtext]
-        text = @default_text
-      else
-        github_link = attrs[:issue_url]
-        text ||= @default_text
-      end
-      if github_link
-        text = generate_github_text(github_link,text)
-      end
+      text = generate_text(attrs[:passtext], attrs[:issue_url])
       Asciidoctor::Block.new(
         parent, :admonition, source: text, attributes: {
           'role' => @role,

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -47,7 +47,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       issue_text = <<~TEXT
         For feature status, see #{issue_url}[\##{issue_no}].
       TEXT
-      text += ' ' + issue_text
+      text + ' ' + issue_text
     end
 
     def generate_text(text, issue_url)
@@ -58,7 +58,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
         issue_url = issue_url
         text ||= @default_text
       end
-      text = generate_issue_text(text,issue_url) if issue_url
+      text = generate_issue_text(text, issue_url) if issue_url
       text
     end
 

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -34,7 +34,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
   # Block care admonition.
   class ChangeAdmonitionBlock < Asciidoctor::Extensions::BlockMacroProcessor
     use_dsl
-    name_positional_attributes :passtext, :github
+    name_positional_attributes :passtext, :issue_url
 
     def initialize(role, default_text)
       super(nil)
@@ -57,7 +57,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
         github_link = attrs[:passtext]
         text = @default_text
       else
-        github_link = attrs[:github]
+        github_link = attrs[:issue_url]
         text ||= @default_text
       end
       if github_link

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -42,10 +42,8 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       @default_text = default_text
     end
 
-    def 
-
     def generate_github_text(github_link,text)
-      github_issue = github_link.split('/').last.chomp!('/')
+      github_issue = github_link.split('/').last.chomp('/')
       github_text = <<~TEXT
         For feature status, see #{github_link}[\##{github_issue}].
       TEXT
@@ -55,7 +53,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
 
     def process(parent, _target, attrs)
       text = attrs[:passtext]
-      if text.start_with("http")
+      if text&.start_with?("http")
         github_link = attrs[:passtext]
         text = @default_text
       else

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -62,14 +62,10 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       text + ' ' + issue_text
     end
 
-    def get_issue_num(issue_url)
-      if issue_url.start_with?('http')
-        issue_num = issue_url.split('/').last
-        issue_num.chomp!('/')
-      else
-        issue_num = issue_url.sub('{issue}', '')
-      end
-      issue_num
+    def get_issue_num(url)
+      return url.split('/').last.chomp('/') if url.start_with?('http')
+
+      url.sub('{issue}', '')
     end
 
     def process(parent, _target, attrs)

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -71,6 +71,56 @@ RSpec.describe CareAdmonition do
           expect(converted).to include "<p>#{key}[]</p>"
         end
       end
+      context 'when only a Github issue link is provided' do
+        let(:input) do
+          <<~ASCIIDOC
+            #{key}::[https://github.com/elastic/docs/issues/505]
+          ASCIIDOC
+        end
+        it 'has default text and github text' do
+          expect_block_admonition <<~HTML.strip
+            <p>#{default_text} For feature status, see <a href="https://github.com/elastic/docs/issues/505" class="ulink" target="_top">#505</a>.</p>
+          HTML
+        end
+      end
+      context 'when only an {issue} link is provided' do
+        let(:input) do
+          <<~ASCIIDOC
+            :issue: https://github.com/elastic/docs/issues/
+            #{key}::[{issue}505]
+          ASCIIDOC
+        end
+        it 'has default text and github text' do
+          expect_block_admonition <<~HTML.strip
+            <p>#{default_text} For feature status, see <a href="https://github.com/elastic/docs/issues/505" class="ulink" target="_top">#505</a>.</p>
+          HTML
+        end
+      end
+      context 'when custom text and a Github issue link are provided' do
+        let(:input) do
+          <<~ASCIIDOC
+            #{key}::["Custom text." https://github.com/elastic/docs/issues/505]
+          ASCIIDOC
+        end
+        it 'has custom text and github text' do
+          expect_block_admonition <<~HTML.strip
+            <p>Custom text. For feature status, see <a href="https://github.com/elastic/docs/issues/505" class="ulink" target="_top">#505</a>.</p>
+          HTML
+        end
+      end
+      context 'when custom text and an {issue} link are provided' do
+        let(:input) do
+          <<~ASCIIDOC
+            :issue: https://github.com/elastic/docs/issues/
+            #{key}::["Custom text." {issue}505]
+          ASCIIDOC
+        end
+        it 'has custom text and github text' do
+          expect_block_admonition <<~HTML.strip
+            <p>Custom text. For feature status, see <a href="https://github.com/elastic/docs/issues/505" class="ulink" target="_top">#505</a>.</p>
+          HTML
+        end
+      end
     end
     context 'inline form' do
       def expect_inline_admonition(text)


### PR DESCRIPTION
We add the `experimental::[]` and `beta::[]` macros to document features that are not yet ready for GA. However, these tags don't currently indicate what steps are needed to get a feature to GA.

With these changes, users can include a GitHub issue for the feature in the `experimental::[]` or `beta::[]`. When provided, a concise sentence and link is generated for the issue.

Relates to https://github.com/elastic/elasticsearch/issues/51250

### Examples
http://test__care-admon-links.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/_beta_experimental_macro_examples.html