### PR TITLE
Adds language identification related attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -216,6 +216,8 @@ Common words and phrases
 :classanalysis-cap:          Classification analysis
 :infer-cap:                  Inference
 :infer:                      inference
+:lang-ident-cap:             Language identification
+:lang-ident:                 language identification
 
 :pwd:             YOUR_PASSWORD
 


### PR DESCRIPTION
This PR adds two new attributes to `attributes.asciidoc`.

:lang-ident-cap: --> Language identification
:lang-ident:         --> language identification