### PR TITLE
Rewrite README about branches

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -220,19 +220,24 @@ You can add a new repository under the `repos` section, if it
 doesn't already exist, and you can add a new "book" under the
 `contents` section.
 
-The `repos.$NAME.branches[]` key lists all of the branches which
-should be built -- all of these branches will be available on the
-website -- while `repos.$NAME.current` lists the branch which
-should be used as the default version on the site.
+Each book contains a list of `branches` and we build a separate copy of each
+book for each of those `branches`. There is also a `current` branch which gets
+special treatment. When we fork a branch like like 7.x or 7.9 we typically add
+it to the list of `branches` so we immediately start building docs for it while
+we're actively developing against it. When we release a new minor or major
+version we update the `current` branch to point to that branch.
 
-NOTE: The `branches` and `current` settings can be overridden in
-the config for each book.  For instance, the "Community Clients"
-docs are built only from the `master` branch.
+NOTE: At this point changing `current` requires a full "rebuild" which we do
+by logging into the docs
+https://elasticsearch-ci.elastic.co/view/Docs/job/elastic+docs+master+build/[build]
+clicking the "Build with Parameters" link, checking the "rebuild" option, and
+then starting the build.
 
-When you release a new version of your code, you need to add
-a new `branch` to the config and to update the `current` branch
-for your project.  Commit the change to https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`] and push
-to the remote `docs` repo.
+Each book may optionally contain a list of `live` branches. If the list is
+specified only branches that are in it are considered "living" and books that
+are not in the list will get a message at the top of each page saying that we
+don't plan to release any more bug fixes or actively maintain the docs for that
+branch.
 
 [[asciidoc-guide]]
 = Asciidoc Guide


### PR DESCRIPTION
The old docs for branches were quite out of date. This changes them to
reflect how they work now.
