### PR TITLE
[DOCS] Add attribute for EQL guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -67,7 +67,8 @@
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
-:ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch} 
+:ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
+:eql-ref:              https://eql.readthedocs.io/en/latest/query-guide
 :subscriptions:        https://www.elastic.co/subscriptions
 :wikipedia:            https://en.wikipedia.org/wiki
 :forum:                https://discuss.elastic.co/


### PR DESCRIPTION
Adds an attribute for the EQL query guide: https://eql.readthedocs.io/en/latest/index.html

This will be helpful as I add content for https://github.com/elastic/elasticsearch/issues/51057