### PR TITLE
Describes work-around for deprecation with commas

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1375,6 +1375,15 @@ user hovers over it:
 `foo.bar`::   Does XYZ. coming:[0.90.4,Replaces `foo.baz`]
 `foo.baz`::   Does XYZ. deprecated:[0.90.4,Replaced by `foo.bar`]
 
+[NOTE]
+====
+If the details include a comma, you must use quotation marks. For example:
+[source,asciidoc]
+----------------------------------
+deprecated[1.1.0,"Span started automatically by <<apm-start-span,apm.startSpan()>>"]
+----------------------------------
+====
+
 === Section notifications
 
 Use section notifications to mark an entire chapter or


### PR DESCRIPTION
There is a known problem when addition or deprecation text includes commas.  This PR updates the readme so that the work-around is easy to find.
