### PR TITLE
Add anchor with hash of example

### DIFF
--- a/integtest/spec/helper/console_alternative_examples.rb
+++ b/integtest/spec/helper/console_alternative_examples.rb
@@ -65,6 +65,7 @@ RSpec.shared_examples 'README-like console alternatives' do |raw_path, path|
             )
         );</pre>
         </div>
+        <a id="8a7e0a79b1743d5fd94d79a7106ee930"></a>
         <div class="pre_wrapper lang-console default #{has_classes}">
       HTML
     end

--- a/resources/asciidoctor/lib/alternative_language_lookup/converter.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/converter.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative '../delegating_converter'
+
+module AlternativeLanguageLookup
+  ##
+  # A Converter that adds an anchor above each listing with its digest.
+  class Converter < DelegatingConverter
+    def convert_listing(node)
+      return yield unless (digest = node.attr 'digest')
+
+      %(<a id="#{digest}"></a>\n) + yield
+    end
+  end
+end

--- a/resources/asciidoctor/lib/alternative_language_lookup/extension.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/extension.rb
@@ -5,12 +5,20 @@ require 'csv'
 require 'digest/murmurhash'
 require_relative '../log_util'
 require_relative '../scaffold'
+require_relative 'converter'
 require_relative 'listing'
 require_relative 'lookup'
 require_relative 'report'
 require_relative 'summary'
 
+##
+# Extension to add "alternative" languages to language examples.
 module AlternativeLanguageLookup
+  def self.activate(registry)
+    registry.treeprocessor AlternativeLanguageLookup
+    DelegatingConverter.setup(registry.document) { |d| Converter.new d }
+  end
+
   ##
   # TreeProcessor extension find alternative languages for snippets.
   class AlternativeLanguageLookup < TreeProcessorScaffold

--- a/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
+++ b/resources/asciidoctor/lib/alternative_language_lookup/listing.rb
@@ -32,6 +32,7 @@ module AlternativeLanguageLookup
     def process
       return unless alternatives
 
+      block.attributes['digest'] = digest
       found_langs = []
 
       alternatives.each do |lookup|

--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -35,8 +35,8 @@ Asciidoctor::Extensions.register do
   preprocessor CrampedInclude
   preprocessor ElasticCompatPreprocessor
   treeprocessor ElasticCompatTreeProcessor
-  # The tree processors after this must come after ElasticComptTreeProcessor
+  # Everything after this must come after ElasticCompatTreeProcessor
   # or they won't see the right tree.
-  treeprocessor AlternativeLanguageLookup::AlternativeLanguageLookup
   include_processor ElasticIncludeTagged
 end
+Asciidoctor::Extensions.register AlternativeLanguageLookup

--- a/resources/asciidoctor/spec/alternative_language_lookup_spec.rb
+++ b/resources/asciidoctor/spec/alternative_language_lookup_spec.rb
@@ -6,9 +6,7 @@ require 'alternative_language_lookup/extension'
 
 RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
   before(:each) do
-    Asciidoctor::Extensions.register do
-      treeprocessor AlternativeLanguageLookup::AlternativeLanguageLookup
-    end
+    Asciidoctor::Extensions.register AlternativeLanguageLookup
   end
 
   after(:each) do
@@ -125,7 +123,20 @@ RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
       include_context 'convert without logs'
       let(:input) { one_snippet }
       let(:snippet_contents) { 'GET /no_alternatives' }
-      include_examples "doesn't modify the output"
+      it 'only adds the digest' do
+        expect(converted).to eq <<~HTML.strip
+          <div id="preamble">
+          <div class="sectionbody">
+          <a id="3fcdfa6097c68c04f3e175dcf3934af6"></a>
+          <div class="listingblock">
+          <div class="content">
+          <pre class="highlight"><code class="language-console" data-lang="console">#{snippet_contents}</code></pre>
+          </div>
+          </div>
+          </div>
+          </div>
+        HTML
+      end
       context 'the alternatives report' do
         it 'contains an entry for the snippet' do
           expect(report).to eq(
@@ -413,6 +424,7 @@ RSpec.describe AlternativeLanguageLookup::AlternativeLanguageLookup do
           <pre class="highlight"><code class="language-csharp" data-lang="csharp">Console.WriteLine("there are callouts"); <b class="conum">(1)</b> <b class="conum">(2)</b></code></pre>
           </div>
           </div>
+          <a id="9e01493a85c06a5100ff712f6b3eead4"></a>
           <div class="listingblock default has-csharp">
           <div class="content">
           <pre class="highlight"><code class="language-console" data-lang="console">GET /there_are_callouts <b class="conum">(1)</b> <b class="conum">(2)</b></code></pre>


### PR DESCRIPTION
This adds an `<a>` tag above every example listing that could
potentially have alternative languages with `id` set to the hash of the
example. This is useful for the folks writing the alternative language
examples so they can easily see the examples in context.

Closes #1709
