### PR TITLE
Fix console selector for ESS client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -687,7 +687,8 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
-                map_branches: *mapCloudSaasToClientsTeam
+                map_branches: &mapCloudSaasToClientsTeam
+                  release-ms-31: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team

--- a/conf.yaml
+++ b/conf.yaml
@@ -656,6 +656,11 @@ contents:
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
                 map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   examples/elastic-cloud/csharp
+                map_branches: *mapCloudSaasToClientsTeam
 
           -
             title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
@@ -679,34 +684,39 @@ contents:
                 repo:   cloud
                 path:   docs/heroku
               -
-                alternatives: { source_lang: csharp, alternative_lang: php }
+                alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: go }
+                alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: java }
+                alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: python }
+                alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   examples/elastic-cloud/csharp
                 map_branches: *mapCloudSaasToClientsTeam
 
           -
@@ -739,7 +749,7 @@ contents:
                   1.1: master
                   1.0: master
               -
-                alternatives: { source_lang: csharp, alternative_lang: php }
+                alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
@@ -751,30 +761,35 @@ contents:
                   1.1: master
                   1.0: master
               -
-                alternatives: { source_lang: csharp, alternative_lang: go }
+                alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
                 map_branches: *mapCloudEceToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
                 map_branches: *mapCloudEceToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: java }
+                alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
                 map_branches: *mapCloudEceToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
                 map_branches: *mapCloudEceToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: python }
+                alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
                 map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   examples/elastic-cloud/csharp
+                map_branches: *mapCloudSaasToClientsTeam
 
           -
             title:      Elastic Cloud on Kubernetes

--- a/conf.yaml
+++ b/conf.yaml
@@ -789,7 +789,7 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   clients-team
                 path:   examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
+                map_branches: *mapCloudEceToClientsTeam
 
           -
             title:      Elastic Cloud on Kubernetes

--- a/conf.yaml
+++ b/conf.yaml
@@ -614,7 +614,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-31
-            branches:   [ release-ms-31 ]
+            branches:   [ master, release-ms-31 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -626,33 +626,33 @@ contents:
                 repo:   cloud
                 path:   docs/shared
               -
-                alternatives: { source_lang: csharp, alternative_lang: php }
+                alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
                   release-ms-31: master
               -
-                alternatives: { source_lang: csharp, alternative_lang: go }
+                alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
                 path:   examples/elastic-cloud/go
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: ruby }
+                alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
                 path:   examples/elastic-cloud/ruby
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: java }
+                alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
                 path:   examples/elastic-cloud/java
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: javascript }
+                alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
                 path:   examples/elastic-cloud/javascript
                 map_branches: *mapCloudSaasToClientsTeam
               -
-                alternatives: { source_lang: csharp, alternative_lang: python }
+                alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
                 path:   examples/elastic-cloud/python
                 map_branches: *mapCloudSaasToClientsTeam

--- a/conf.yaml
+++ b/conf.yaml
@@ -614,7 +614,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-31
-            branches:   [ master, release-ms-31 ]
+            branches:   [ release-ms-31 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -73,7 +73,9 @@ alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/si
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
 # Cloud
-alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
+alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/clients-team/examples/elastic-cloud/php --chunk 1'
+
+alias docbldess=docbldec
 
 # Cloud - Elastic Cloud Enterprise
 alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud-assets/docs --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -73,7 +73,7 @@ alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/si
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
 # Cloud
-alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/clients-team/examples/elastic-cloud/php --chunk 1'
+alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
 alias docbldess=docbldec
 


### PR DESCRIPTION
This PR fixes the language selector dropdown for the Elasticsearch Service docs. Previously, no selector was shown at all. With a small fix to conf.yaml, the selector now appears as expected:

![image](https://user-images.githubusercontent.com/15148011/73907742-4fb9f700-485c-11ea-8c9c-d6d15ce5407e.png)

Before this is ready for review: 

* With the selector enabled, none of the language examples can be found. Need to investigate further to see what's amiss. ~~Possibly related to us needing to map to the `master` branch in the clients-team repo?~~ EDIT: After investigating further, I think this might be because of how the examples in the elastic/cloud repo are written, which will require a separate PR to fix. 

  ![image](https://user-images.githubusercontent.com/15148011/73963844-e8d12800-48c5-11ea-9e12-2f07d7b60081.png)

* Added the `master` branch to the ESS doc build for testing; need to remove before merging

Also added an alias for `docbldess`. Unrelated but helpful, since `docbldec` is dates back to the pre-renaming days of our SaaS. 



