### PR TITLE
Update conf.yml for go-elasticsearch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -285,8 +285,6 @@ contents:
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
                 exclude_branches:   [ 7.x, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  master: doc_examples
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
The generator and the generated examples have been merged into the `master` branch of the go-elasticsearch client, so this patch removes the extra branch mapping.
