### PR TITLE
Add elastic logging plugin docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1339,6 +1339,9 @@ contents:
                 repo:   beats
                 path:   x-pack/dockerlogbeat/docs
               -
+                repo:   beats
+                path:   libbeat/docs
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -

--- a/conf.yaml
+++ b/conf.yaml
@@ -1325,6 +1325,26 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
           -
+            title:      Elastic Logging Plugin for Docker
+            prefix:     en/beats/loggingplugin
+            current:    7.6
+            index:      x-pack/dockerlogbeat/docs/index.asciidoc 
+            branches:   [ master, 7.x, 7.6 ]
+            chunk:      1
+            tags:       Elastic Logging Plugin/Reference
+            respect_edit_url_overrides: true
+            subject:    Elastic Logging Plugin
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/dockerlogbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          -
             title:      Legacy Topbeat Reference
             prefix:     en/beats/topbeat
             index:      topbeat/docs/index.asciidoc


### PR DESCRIPTION
Updating the conf yaml in preparation for adding docs about the Elastic Logging Plugin for Docker.

PR is here: https://github.com/elastic/beats/pull/15799

Do not merge until after the docs are merged and the CI is clean.