### PR TITLE
Only publish current and older versions for Workplace search.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1409,7 +1409,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    7.6
-            branches:   [ master, 7.6 ]            
+            branches:   [ 7.6 ]            
             live:       *stacklive          
             chunk:      1
             tags:       Workplace Search/Reference


### PR DESCRIPTION
To be merged after #1704. (Will need to rebase.)