### PR TITLE
Removes old shared files

### DIFF
--- a/shared/versions55.asciidoc
+++ b/shared/versions55.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/5.5.asciidoc[]

--- a/shared/versions56.asciidoc
+++ b/shared/versions56.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/5.6.asciidoc[]

--- a/shared/versions60.asciidoc
+++ b/shared/versions60.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.0.asciidoc[]

--- a/shared/versions61.asciidoc
+++ b/shared/versions61.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.1.asciidoc[]

--- a/shared/versions62.asciidoc
+++ b/shared/versions62.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.2.asciidoc[]

--- a/shared/versions63.asciidoc
+++ b/shared/versions63.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.3.asciidoc[]

--- a/shared/versions64.asciidoc
+++ b/shared/versions64.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.4.asciidoc[]

--- a/shared/versions65.asciidoc
+++ b/shared/versions65.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.5.asciidoc[]

--- a/shared/versions66.asciidoc
+++ b/shared/versions66.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.6.asciidoc[]

--- a/shared/versions67.asciidoc
+++ b/shared/versions67.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.7.asciidoc[]

--- a/shared/versions68.asciidoc
+++ b/shared/versions68.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/6.8.asciidoc[]

--- a/shared/versions70.asciidoc
+++ b/shared/versions70.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.0.asciidoc[]

--- a/shared/versions71.asciidoc
+++ b/shared/versions71.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.1.asciidoc[]

--- a/shared/versions72.asciidoc
+++ b/shared/versions72.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.2.asciidoc[]

--- a/shared/versions73.asciidoc
+++ b/shared/versions73.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.3.asciidoc[]

--- a/shared/versions74.asciidoc
+++ b/shared/versions74.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.4.asciidoc[]

--- a/shared/versions75.asciidoc
+++ b/shared/versions75.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.5.asciidoc[]

--- a/shared/versions76.asciidoc
+++ b/shared/versions76.asciidoc
@@ -1,1 +1,0 @@
-include::versions/stack/7.x.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/804

This PR removes old shared version attribute files that are no longer required.