### PR TITLE
[DOCS] Remove 7.5 from maintained release branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -55,7 +55,7 @@ contents:
             current:    7.6
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.6, 7.5, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.6, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack


### PR DESCRIPTION
This removes the 7.5 branch from the list of "live" Stack release branches in our docs.

With the release of 7.6.0, the 7.5.x versions passed their maintenance date: https://www.elastic.co/support/eol