### PR TITLE
Reduce font size of blockquotes

### DIFF
--- a/resources/web/style/base_styles.pcss
+++ b/resources/web/style/base_styles.pcss
@@ -7,6 +7,10 @@
     margin: 1em 0;
   }
 
+  .blockquote {
+    font-size: 1rem;
+  }
+
   dt span {
     font-weight: bold;
 


### PR DESCRIPTION
elastic/docs#1213 added the bootstrap CSS to our built docs. This
inadvertently increased the font size of block quotes by 25%.

This adds a new rule to return the block quote font size to its previous
size.

This was initially raised by @astefan while reviewing https://www.elastic.co/guide/en/elasticsearch/reference/current/sql-client-apps-dbeaver.html

Here's how that page would look after these changes:
http://docs_1735.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/sql-client-apps-dbeaver.html