### PR TITLE
Add standard ESS trial attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -54,6 +54,7 @@
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :cloud:                https://www.elastic.co/guide/en/cloud/current
+:ess-trial:            https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

We'd like to start collecting some metrics for ESS trial sign-ups from the docs, for which we need a standard attribute. 

Relates to https://github.com/elastic/marketing-ops/issues/7367.
