### PR TITLE
Renamed the elasticsearch-php doc branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -512,8 +512,8 @@ contents:
               -
                 title:      PHP API
                 prefix:     php-api
-                current:    7.4
-                branches:   [ master, 7.4, 7.2, 7.0, 6.7.x, 6.5.x, 5.0, 2.0, 1.0, 0.4 ]
+                current:    7.x
+                branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients


### PR DESCRIPTION
I renamed the version branches of `elasticsearch-php` in `7.x`, `6.x`, `5.x`, `2.x` and `1.x`. This to be compliant with the naming convention used by Elasticsearch client.

I didn't remove the old branch names for backward compatibility (e.g. `7.4`, `7.2`, etc). I'll remove these branches when this PR will be merged.