### PR TITLE
Consolidate Enterprise Search books within index

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1384,22 +1384,23 @@ contents:
                 path:   libbeat/docs
 
     -
-        title:      Swiftype: Site and App Search
+        title:      Enterprise Search
         sections:
           -
-            title:      Site Search Reference
-            prefix:     en/swiftype/sitesearch
-            index:      docs/sitesearch/index.asciidoc
+            title:      Workplace Search Guide
+            prefix:     en/workplace-search
+            index:      workplace-search-docs/index.asciidoc
             private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
-            tags:       Site Search/Reference
-            subject:    Swiftype
+            current:    7.6
+            branches:   [ 7.6 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Workplace Search/Reference
+            subject:    Workplace Search
             sources:
               -
-                repo:   swiftype
-                path:   docs
+                repo:   enterprise-search-pubs
+                path:   workplace-search-docs
           -
             title:      App Search Reference
             prefix:     en/swiftype/appsearch
@@ -1414,25 +1415,20 @@ contents:
               -
                 repo:   swiftype
                 path:   docs
-    -
-        title:      Enterprise Search
-        sections:
           -
-            title:      Workplace Search
-            prefix:     en/workplace-search
-            index:      workplace-search-docs/index.asciidoc
+            title:      Site Search Reference
+            prefix:     en/swiftype/sitesearch
+            index:      docs/sitesearch/index.asciidoc
             private:    1
-            current:    7.6
-            branches:   [ 7.6 ]            
-            live:       *stacklive          
-            chunk:      1
-            tags:       Workplace Search/Reference
-            subject:    Workplace Search
+            current:    master
+            branches:   [ master ]
+            single:     1
+            tags:       Site Search/Reference
+            subject:    Swiftype
             sources:
               -
-                repo:   enterprise-search-pubs
-                path:   workplace-search-docs
-          -
+                repo:   swiftype
+                path:   docs
 
     -
         title:      SIEM: Security Operations with the Elastic Stack


### PR DESCRIPTION
Within the docs index page, Enterprise Search (formerly Swiftype)
books are presented under two separate headings (Swiftype and
Enterprise Search). This is misaligned with Elastic's marketing of
these products, which all fall under Enterprise Search now.

Consolidate all Enterprise Search books under the "Enterprise Search"
heading.

Also:

* Re-order the (formerly) Swiftype books
* Update the Workplace Search link text to match the book title
* Remove errant dash in config file
* Remove trailing whitespace in config file

Closes #1739

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
