### PR TITLE
Revert "Add cloud-assets repo to Cloud ESS docs build"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -628,11 +628,6 @@ contents:
                 repo:   cloud
                 path:   docs/shared
               -
-                repo:   cloud-assets
-                path:   docs
-                map_branches: &mapCloudSaasToCloudAssets
-                  release-ms-31: master              
-              -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   examples/elastic-cloud/php

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -75,7 +75,7 @@ alias docbldepd='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/en
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 
 # Cloud
-alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud-assets/docs --chunk 1'
+alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --chunk 1'
 
 alias docbldess=docbldec
 


### PR DESCRIPTION
Reverts elastic/docs#1745
We decided against sourcing the regions list in the cloud-assets repo, so this undoes the changes to make that happen.