### PR TITLE
Correct CSS for h5 headings

### DIFF
--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -36,7 +36,7 @@
     font-weight: 600;
   }
   h5 {
-    font-size: 18x;
+    font-size: 18px;
     font-weight: 600;
   }
   /* h3-h6 are generally inside the page so we space the out a bit more. */


### PR DESCRIPTION
Fixes a typo in the CSS that breaks the font-size for h5 headings.