### PR TITLE
Switch ESS and Heroku doc builds to MS 34

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -615,8 +615,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-31
-            branches:   [ release-ms-31 ]
+            current:    release-ms-34
+            branches:   [ release-ms-34 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -632,7 +632,7 @@ contents:
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-31: master
+                  release-ms-34: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -669,8 +669,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-31
-            branches:   [ release-ms-31 ]
+            current:    release-ms-34
+            branches:   [ release-ms-34 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1
@@ -690,7 +690,7 @@ contents:
                 repo:   clients-team
                 path:   examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-31: master
+                  release-ms-34: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

With the release of Milestone 34 coming closer, we should be ready to switch `current` to MS 34. 
