### PR TITLE
Remove alternatives for Heroku and ECE

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -685,42 +685,6 @@ contents:
               -
                 repo:   cloud
                 path:   docs/heroku
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   examples/elastic-cloud/php
-                map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-31: master
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   examples/elastic-cloud/go
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   examples/elastic-cloud/ruby
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   examples/elastic-cloud/java
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   examples/elastic-cloud/javascript
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   examples/elastic-cloud/python
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
 
           -
             title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
@@ -751,48 +715,6 @@ contents:
                   2.0: master
                   1.1: master
                   1.0: master
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   examples/elastic-cloud/php
-                map_branches: &mapCloudEceToClientsTeam
-                  2.4: master
-                  2.3: master
-                  2.2: master
-                  2.1: master
-                  2.0: master
-                  1.1: master
-                  1.0: master
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   examples/elastic-cloud/go
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   examples/elastic-cloud/ruby
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   examples/elastic-cloud/java
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   examples/elastic-cloud/javascript
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   examples/elastic-cloud/python
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   examples/elastic-cloud/csharp
-                map_branches: *mapCloudEceToClientsTeam
 
           -
             title:      Elastic Cloud on Kubernetes


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

We now have new client docs for ESS, Heroku, and ECE. Just one gotcha that @philkra pointed out: The examples rely on the Cloud ID, which is not currently supported for Heroku and ECE.

I looked at reverting at the old docs we had for connecting, but they are just not that great. So, I came up with an idea that involves a couple of PRs:

* This PR removes the alternatives from conf.yaml for Heroku and ECE. This removes the selector, but leaves the default console example that should work just fine.
* In a second PR, provide an alternate lead-in text for the "Work with language clients" section that doesn't mention the alternative languages that we just removed.
 
Relates to https://github.com/elastic/docs/pull/1725
