### PR TITLE
Remove 7.x from libbeat processor exclude

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1068,7 +1068,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   &beatsXpackLibbeatExclude75 [ 7.x, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*


### PR DESCRIPTION
Removes 7.x from the processor exclude. 