### PR TITLE
Moved the Cloud Doc Examples folder

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -625,38 +625,38 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
-                path:   examples/elastic-cloud/php
+                path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
                   release-ms-31: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
-                path:   examples/elastic-cloud/go
+                path:   docs/examples/elastic-cloud/go
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
-                path:   examples/elastic-cloud/ruby
+                path:   docs/examples/elastic-cloud/ruby
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
-                path:   examples/elastic-cloud/java
+                path:   docs/examples/elastic-cloud/java
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
-                path:   examples/elastic-cloud/javascript
+                path:   docs/examples/elastic-cloud/javascript
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
-                path:   examples/elastic-cloud/python
+                path:   docs/examples/elastic-cloud/python
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   clients-team
-                path:   examples/elastic-cloud/csharp
+                path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudSaasToClientsTeam
 
           -
@@ -683,38 +683,38 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
-                path:   examples/elastic-cloud/php
+                path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
                   release-ms-31: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
-                path:   examples/elastic-cloud/go
+                path:   docs/examples/elastic-cloud/go
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
-                path:   examples/elastic-cloud/ruby
+                path:   docs/examples/elastic-cloud/ruby
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
-                path:   examples/elastic-cloud/java
+                path:   docs/examples/elastic-cloud/java
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
-                path:   examples/elastic-cloud/javascript
+                path:   docs/examples/elastic-cloud/javascript
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
-                path:   examples/elastic-cloud/python
+                path:   docs/examples/elastic-cloud/python
                 map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   clients-team
-                path:   examples/elastic-cloud/csharp
+                path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudSaasToClientsTeam
 
           -
@@ -749,7 +749,7 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
-                path:   examples/elastic-cloud/php
+                path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
                   2.4: master
                   2.3: master
@@ -761,32 +761,32 @@ contents:
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
-                path:   examples/elastic-cloud/go
+                path:   docs/examples/elastic-cloud/go
                 map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   clients-team
-                path:   examples/elastic-cloud/ruby
+                path:   docs/examples/elastic-cloud/ruby
                 map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: java }
                 repo:   clients-team
-                path:   examples/elastic-cloud/java
+                path:   docs/examples/elastic-cloud/java
                 map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: javascript }
                 repo:   clients-team
-                path:   examples/elastic-cloud/javascript
+                path:   docs/examples/elastic-cloud/javascript
                 map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   clients-team
-                path:   examples/elastic-cloud/python
+                path:   docs/examples/elastic-cloud/python
                 map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   clients-team
-                path:   examples/elastic-cloud/csharp
+                path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudEceToClientsTeam
 
           -


### PR DESCRIPTION
We want to move the folder containing the doc examples for Elastic Cloud in the [clients-team](https://github.com/elastic/clients-team) from the root level to a semantic more appropriated level under [docs](https://github.com/elastic/clients-team/tree/master/docs/examples).

Once we have this change merged, we will remove the old folder to avoid breaking the docs build.