### PR TITLE
Improve styling for multi-paragraph admonitions

### DIFF
--- a/resources/web/style/admonishment.pcss
+++ b/resources/web/style/admonishment.pcss
@@ -88,7 +88,7 @@
     h3 {
       margin: 3px 0;
     }
-    p {
+    p:last-of-type {
       margin-bottom: 0em;
     }
   }


### PR DESCRIPTION
PR #1761 set the bottom margin for paragraphs inside admonitions to
zero. This "squishes" all paragraphs within admonitions into a
semi-paragraph.

This tweak sets a zero bottom margin only on the _last_ paragraph
within an admonition. This eliminates unneeded grey space within the
admin without squishing paragraphs.

### Before
<img width="738" alt="before" src="https://user-images.githubusercontent.com/40268737/76338386-ff0c4280-62ce-11ea-99e7-bc2ece7b6cb9.png">

### After
<img width="746" alt="after" src="https://user-images.githubusercontent.com/40268737/76338401-04698d00-62cf-11ea-9313-d8df2f52f6c6.png">