### PR TITLE
Removes outdated link from doc_build_aliases.sh

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -7,8 +7,6 @@
 #    export GIT_HOME="/<fullPathTYourRepos>"
 #    source $GIT_HOME/docs/doc_build_aliases.sh
 #
-# These aliases assume that you have cloned the elastic repos according to
-# the directory layout described in https://github.com/elastic/x-pack/blob/master/README.md
 
 
 # Elasticsearch


### PR DESCRIPTION
This PR removes a link from the doc_build_aliases.sh to a private repo. The information pertained to the layout of private X-Pack repos and is (1) not pertinent to current releases, and (2) not accessible externally.  Therefore I have removed it.
