### PR TITLE
Adds eland-docs repo to conf.yaml and alias to doc_build_aliases.sh 

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -16,6 +16,7 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
+    eland-docs:           https://github.com/elastic/elasticsearch-eland-docs
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
     elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
@@ -548,6 +549,22 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/python
+                    
+              -
+                title:      eland Client
+                prefix:     eland
+                current:    7.x
+                branches:   [ master, 7.x ]
+                index:      docs/en/index.asciidoc
+                tags:       Clients/eland
+                subject:    Clients
+                sources:
+                  -
+                    repo:   eland-docs
+                    path:   docs/en
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
 
               -
                 title:      Rust API

--- a/conf.yaml
+++ b/conf.yaml
@@ -554,7 +554,7 @@ contents:
                 title:      eland Client
                 prefix:     eland
                 current:    7.x
-                branches:   [ master, 7.x ]
+                branches:   [ 7.x ]
                 index:      docs/en/index.asciidoc
                 single:     1
                 tags:       Clients/eland

--- a/conf.yaml
+++ b/conf.yaml
@@ -556,6 +556,7 @@ contents:
                 current:    7.x
                 branches:   [ master, 7.x ]
                 index:      docs/en/index.asciidoc
+                single:     1
                 tags:       Clients/eland
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -165,6 +165,8 @@ alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/co
 
 alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
+alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc'
+
 # X-Pack Reference 5.4 to 6.2
 
 alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -165,7 +165,7 @@ alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/co
 
 alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
-alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc'
+alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc --single'
 
 # X-Pack Reference 5.4 to 6.2
 


### PR DESCRIPTION
This PR adds a new repository (`eland-docs`) to the conf.yaml file and a build alias to the `doc_build_alias.sh` file.

Depends on https://github.com/elastic/elasticsearch-eland-docs/pull/4. Please merge that PR first