### PR TITLE
Adds eland docs URL to shared/attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -71,6 +71,7 @@
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
+:eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide
 :subscriptions:        https://www.elastic.co/subscriptions
 :wikipedia:            https://en.wikipedia.org/wiki


### PR DESCRIPTION
This PR adds the eland docs URL to the shared/attributes.asciidoc file.