### PR TITLE
[DOCS] Modify explanation to use doc_build_aliases.sh file in README.asciidoc.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -70,8 +70,10 @@ cd path/to/your/repo
 ~/path/to/docs/repo/build_docs --doc path/to/index.asciidoc
 ----------------------------
 
-Some documentation books require more complex build commands.
+Each Elastic project may need its own documentation book build command. 
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] provides simplified aliases and the build commands for each book.
+For example, if you want to build Elasticsearch reference document, please refer to
+https://github.com/elastic/docs/blob/master/doc_build_aliases.sh#L12[Elasticsearch section] in https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] file.
 
 === Specifying a different output dir
 


### PR DESCRIPTION
Hello,
I suggest modifying explanation for build_aliases.sh file in `README.asciidoc`.
>Some documentation books require more complex build commands, ...

 this  explanation is too broad and  ambiguous, as in most cases the additional options provided in `doc_build_aliases.sh` file are needed to build document.
 
For the first-time builders like me, we don't know our document build process is whether complex one or not. For example, I tried to build a part of elasticsearch document using the simple command and I encountered this errors:
```
...
INFO:build_docs:Error executing: asciidoctor -v --trace -r /docs_build/resources/asciidoctor/lib/extensions.rb -b html5 -d book -a showcomments=1 -a lang=en -a source_branch=master -a compat-mode=legacy -a edit_urls=/doc/elasticsearch,https://github.com/elastic/elasticsearch/edit/master/ -a asciidoc-dir=/docs_build/resources/asciidoc-8.6.8 -a resources=/docs_build/resources/asciidoc-8.6.8 -a docs-root=/docs_build -a elasticsearch-root=/doc/elasticsearch -a stylesheet! -a icons! -a nofooter -a chunk_level=1 -a toc --out-file index.html -a outdir=/out/html_docs/raw -a dc.type=Learn/Docs/ -a dc.subject= -a dc.identifier= --destination-dir=/out/html_docs/raw /doc/elasticsearch/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc
INFO:build_docs:---out---
INFO:build_docs:
INFO:build_docs:---err---
INFO:build_docs:asciidoctor: WARNING: invalid reference: analysis-keyword-tokenizer
INFO:build_docs:/docs_build/resources/asciidoctor/lib/docbook_compat/convert_document.rb:70:in `munge_title': Couldn't wrap header in <!DOCTYPE html> (RuntimeError)
INFO:build_docs:<html>
INFO:build_docs:<head>
INFO:build_docs:<meta charset="UTF-8">
INFO:build_docs:<title>Keyword Analyzer | Elastic</title>
INFO:build_docs:<link rel="home" href="index.html" title="Keyword Analyzer"/>
INFO:build_docs:<meta name="DC.type" content="Learn/Docs/"/>
INFO:build_docs:<meta name="DC.subject" content=""/>
INFO:build_docs:<meta name="DC.identifier" content=""/>
INFO:build_docs:</head>
INFO:build_docs:<body>
INFO:build_docs:<div class="navheader">
INFO:build_docs:<span class="prev">
INFO:build_docs:</span>
INFO:build_docs:<span class="next">
INFO:build_docs:</span>
INFO:build_docs:</div>
INFO:build_docs:<div class="book" lang="en">
INFO:build_docs:<div id="header">
INFO:build_docs:</div>
INFO:build_docs:<div id="content">
INFO:build_docs:<div class="section">
INFO:build_docs:<div class="titlepage"><div><div>
INFO:build_docs:<h2 class="title"><a id="analysis-keyword-analyzer"></a>Keyword Analyzer<a class="edit_me" rel="nofollow" title="Edit this page on GitHub" href="https://github.com/elastic/elasticsearch/edit/master/docs/reference/analysis/analyzers/keyword-analyzer.asciidoc">edit</a></h2>
...
```
which led me to think there might have been something wrong with a Ruby file and to start to dig in that Ruby file.

I think it would be much better to give more detailed reference to `doc_build_aliases.sh` file  so that newcomers can save time and trials for failing document build. 

### diff:
```diff
diff --git a/README.asciidoc b/README.asciidoc
index 414cd6d..475cd8c 100644
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -70,8 +70,10 @@ cd path/to/your/repo
 ~/path/to/docs/repo/build_docs --doc path/to/index.asciidoc
 ----------------------------

-Some documentation books require more complex build commands.
+Each Elastic project may need its own documentation book build command.
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] provides simplified aliases and the build commands for each book.
+For example, if you want to build Elasticsearch reference document, please refer to
+https://github.com/elastic/docs/blob/master/doc_build_aliases.sh#L12[Elasticsearch section] in https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] file.

 === Specifying a different output dir
```