### PR TITLE
Add attribute for 7.x ES ref docs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,5 +1,6 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.x
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4


### PR DESCRIPTION
Adds an attribute for the 7.x version of the Elasticsearch Reference docs