### PR TITLE
[DOCS] Fix inconsistent deprecated tag in README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1412,7 +1412,7 @@ user hovers over it:
 If the details include a comma, you must use quotation marks. For example:
 [source,asciidoc]
 ----------------------------------
-deprecated[1.1.0,"Span started automatically by <<apm-start-span,apm.startSpan()>>"]
+deprecated::[1.1.0,"Span started automatically by <<apm-start-span,apm.startSpan()>>"]
 ----------------------------------
 ====
 


### PR DESCRIPTION
Updates an example in the README to avoid the `deprecated[...]` syntax.

While it technically works due to some docs build conversions, this syntax
isn't supported in Asciidoctor. We should avoid using it going forward.