### PR TITLE
Doc build changes for ECE 2.5 - MERGE ON APRIL 14, 2020

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -741,8 +741,8 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    2.4
-            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
+            current:    2.5
+            branches:   [ 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1
@@ -758,6 +758,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches: &mapCloudEceToCloudAssets
+                  2.5: master
                   2.4: master
                   2.3: master
                   2.2: master
@@ -770,6 +771,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
+                  2.5: master
                   2.4: master
                   2.3: master
                   2.2: master


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

We need to add the `2.5` branch to our doc builds and switch `current` in time for the March 31 GA date.

@elastic/cloud-delivery or @elastic/cloud-writers could I get an LGTM for this PR, please?
