### PR TITLE
[DOCS] Add function reference template

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -260,6 +260,8 @@ Common words and phrases
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
 
+:multi-arg: †footnote:multi-arg[This parameter accepts multiple arguments.]
+
 //////////
 Legacy definitions
 //////////

--- a/shared/fn-ref-ex.asciidoc
+++ b/shared/fn-ref-ex.asciidoc
@@ -49,7 +49,7 @@ Guidelines for parameter documentation
 * Use a definition list.
 * End each definition with a period.
 * Include whether the parameter is Optional or Required and the data type.
-* Add `{multi-arg}` to parameters that accept multiple arguments
+* Add `{multi-arg}` to parameters that accept multiple arguments.
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
 * If the parameter requires a specific delimiter for multiple values, say so.

--- a/shared/fn-ref-ex.asciidoc
+++ b/shared/fn-ref-ex.asciidoc
@@ -1,0 +1,83 @@
+////
+Below is a sample function reference listing.
+A heading and short description are visible.
+Other content is hidden in a collapsible block.
+////
+
+[[sample-fn]]
+=== `substring`
+
+////
+A brief 1-2 sentence description.
+////
+Does a cool thing.
+
+[%collapsible]
+====
+
+////
+An example using the function.
+The goal is to show an input and output.
+If needed, you can include the return output in a comment.
+////
+
+*Example*
+[source,txt]
+----
+substring("quick brown fox", 0, 5)      // returns "quick"
+substring("quick brown fox", 6, 11)     // returns "brown"
+substring("quick brown fox", 6)         // returns "b"
+substring("quick brown fox", -3, -1)    // returns "fo"
+substring("quick brown fox", -3)        // returns "f"
+----
+
+////
+A snippet outlining the function syntax.
+Unnamed parameters are included using angle brackets (e.g. `<parm>`).
+Optional parameters are included using square brackets (e.g. [<parm>]).
+////
+
+*Syntax*
+[source,txt]
+----
+substring(<source>, <start_pos>[, <end_pos>])
+----
+
+////
+Guidelines for parameter documentation
+***************************************
+* Use a definition list.
+* End each definition with a period.
+* Include whether the parameter is Optional or Required and the data type.
+* A † denotes a parameter can be passed multiple times.
+* Include default values as the last sentence of the first paragraph.
+* Include a range of valid values, if applicable.
+* If the parameter requires a specific delimiter for multiple values, say so.
+* If the parameter supports wildcards, ditto.
+***************************************
+////
+
+*Parameters*
+`<source>`::
+(Required, string)
+Source string used for extraction.
+
+`<start_pos>`::
+(Required, integer)
+Starting position for extraction.
++
+Positions are zero-indexed. Negative offsets are supported.
+
+`<end_pos>`::
+(Optional†, integer)
+End position for extraction. If this position is not provided, the function only
+extracts the character in the `<start_pos>` position.
++
+Positions are zero-indexed. Negative offsets are supported.
+
+////
+Data type returned by the function.
+////
+
+*Returns:* string
+====

--- a/shared/fn-ref-ex.asciidoc
+++ b/shared/fn-ref-ex.asciidoc
@@ -49,7 +49,7 @@ Guidelines for parameter documentation
 * Use a definition list.
 * End each definition with a period.
 * Include whether the parameter is Optional or Required and the data type.
-* A † denotes a parameter can be passed multiple times.
+* Add `{multi-arg}` to parameters that accept multiple arguments
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
 * If the parameter requires a specific delimiter for multiple values, say so.
@@ -69,7 +69,7 @@ Starting position for extraction.
 Positions are zero-indexed. Negative offsets are supported.
 
 `<end_pos>`::
-(Optional†, integer)
+(Optional{multi-arg}, integer)
 End position for extraction. If this position is not provided, the function only
 extracts the character in the `<start_pos>` position.
 +


### PR DESCRIPTION
Adds a reference template for function documentation.

I ended up needing this while documenting functions for
EQL in the Elasticsearch docs. Even within the Elasticsearch
docs, we have several conventions for documenting functions.

The goal of this template is to standardize the way Elastic
documents functions. Inspiration was taken from the Kibana docs:

https://www.elastic.co/guide/en/kibana/master/canvas-function-reference.html

Any and all feedback welcome!
