### PR TITLE
Add 7.7 shared versions file

### DIFF
--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -1,13 +1,13 @@
-:version:                7.8.0
+:version:                7.7.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.8.0
-:logstash_version:       7.8.0
-:elasticsearch_version:  7.8.0
-:kibana_version:         7.8.0
-:apm_server_version:     7.8.0
-:branch:                 7.x
+:bare_version:           7.7.0
+:logstash_version:       7.7.0
+:elasticsearch_version:  7.7.0
+:kibana_version:         7.7.0
+:apm_server_version:     7.7.0
+:branch:                 7.7
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4


### PR DESCRIPTION
This PR adds a shared attribute file to reflect version details in the 7.7 and 7.x branches.