### PR TITLE
[DOCS] Adds child_attributes CSS role

### DIFF
--- a/resources/web/style/child_attributes.pcss
+++ b/resources/web/style/child_attributes.pcss
@@ -4,7 +4,7 @@
     border: 1px solid #A9A9A9;
     border-radius: 10px;
     background: #fbfbfb;
-    padding: 15px 20px 0;
-    margin: 10px 15px 20px;
+    padding: 15px 10px 0;
+    margin: 10px 5px 20px;
   }
 }

--- a/resources/web/style/child_attributes.pcss
+++ b/resources/web/style/child_attributes.pcss
@@ -1,0 +1,10 @@
+#guide .child_attributes {
+  
+  details > div {
+    border: 1px solid #00a9e5;
+    border-radius: 10px;
+    background: #fbfbfb;
+    padding: 15px 20px 0;
+    margin: 10px 15px 20px;
+  }
+}

--- a/resources/web/style/child_attributes.pcss
+++ b/resources/web/style/child_attributes.pcss
@@ -1,7 +1,7 @@
 #guide .child_attributes {
   
   details > div {
-    border: 1px solid #00a9e5;
+    border: 1px solid #A9A9A9;
     border-radius: 10px;
     background: #fbfbfb;
     padding: 15px 20px 0;

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -7,6 +7,7 @@
 @import './style/alternative_picker.pcss';
 @import './style/admonishment.pcss';
 @import './style/calloutlist.pcss';
+@import './style/child_attributes.pcss';
 @import './style/conum.pcss';
 @import './style/code.pcss';
 @import './style/console_widget.pcss';


### PR DESCRIPTION
This PR creates a stylesheet with a border around collapsed sections (detail/summary objects). It's intended for use in nested objects on API reference pages. 