### PR TITLE
  [7.7 Release] Adding an Enterprise Search Book to the Elastic Documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1454,28 +1454,28 @@ contents:
             branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
-            tags:       Workplace Search/Reference
+            tags:       Workplace Search
             subject:    Workplace Search
             sources:
               -
                 repo:   enterprise-search-pubs
                 path:   workplace-search-docs
           -
-            title:      App Search Reference
+            title:      App Search Guide
             prefix:     en/app-search
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    7.7
             branches:   [ 7.7 ]
             chunk:     1
-            tags:       App Search/Reference
-            subject:    Swiftype
+            tags:       App Search
+            subject:    App Search
             sources:
               -
-                repo:   swiftype
-                path:   docs
+                repo:   enterprise-search-pubs
+                path:   app-search-docs
           -
-            title:      Site Search Reference
+            title:      Site Search
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -1431,6 +1431,21 @@ contents:
         title:      Enterprise Search
         sections:
           -
+            title:      Enterprise Search Guide
+            prefix:     en/enterprise-search
+            index:      workplace-search-docs/index.asciidoc
+            private:    1
+            current:    master
+            branches:   [ master ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Enterprise Search/Reference
+            subject:    Enterprise Search
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   enterprise-search-docs
+          -
             title:      Workplace Search Guide
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -544,7 +544,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/python
-                    
+
               -
                 title:      eland Client
                 prefix:     eland
@@ -1431,12 +1431,12 @@ contents:
         title:      Enterprise Search
         sections:
           -
-            title:      Enterprise Search Guide
+            title:      Enterprise Search
             prefix:     en/enterprise-search
             index:      enterprise-search-docs/index.asciidoc
             private:    1
-            current:    master
-            branches:   [ master ]
+            current:    7.7
+            branches:   [ 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Reference
@@ -1450,8 +1450,8 @@ contents:
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc
             private:    1
-            current:    7.6
-            branches:   [ 7.6 ]
+            current:    7.7
+            branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Reference
@@ -1462,12 +1462,12 @@ contents:
                 path:   workplace-search-docs
           -
             title:      App Search Reference
-            prefix:     en/swiftype/appsearch
-            index:      docs/appsearch/index.asciidoc
+            prefix:     en/app-search
+            index:      app-search-docs/index.asciidoc
             private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
+            current:    7.7
+            branches:   [ 7.7 ]
+            chunk:     1
             tags:       App Search/Reference
             subject:    Swiftype
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1435,7 +1435,7 @@ contents:
             prefix:     en/enterprise-search
             index:      enterprise-search-docs/index.asciidoc
             private:    1
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ 7.7 ]
             live:       *stacklive
             chunk:      1
@@ -1450,7 +1450,7 @@ contents:
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc
             private:    1
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
@@ -1465,7 +1465,7 @@ contents:
             prefix:     en/app-search
             index:      app-search-docs/index.asciidoc
             private:    1
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ 7.7 ]
             chunk:     1
             tags:       App Search/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1433,7 +1433,7 @@ contents:
           -
             title:      Enterprise Search Guide
             prefix:     en/enterprise-search
-            index:      workplace-search-docs/index.asciidoc
+            index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    master
             branches:   [ master ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -1431,7 +1431,7 @@ contents:
         title:      Enterprise Search
         sections:
           -
-            title:      Enterprise Search
+            title:      Enterprise Search Guide
             prefix:     en/enterprise-search
             index:      enterprise-search-docs/index.asciidoc
             private:    1
@@ -1439,7 +1439,7 @@ contents:
             branches:   [ 7.7 ]
             live:       *stacklive
             chunk:      1
-            tags:       Enterprise Search/Reference
+            tags:       Enterprise Search/Guide
             subject:    Enterprise Search
             sources:
               -
@@ -1454,7 +1454,7 @@ contents:
             branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
-            tags:       Workplace Search
+            tags:       Workplace Search/Guide
             subject:    Workplace Search
             sources:
               -
@@ -1468,14 +1468,14 @@ contents:
             current:    7.7
             branches:   [ 7.7 ]
             chunk:     1
-            tags:       App Search
+            tags:       App Search/Guide
             subject:    App Search
             sources:
               -
                 repo:   enterprise-search-pubs
                 path:   app-search-docs
           -
-            title:      Site Search
+            title:      Site Search Reference
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -73,6 +73,8 @@ alias docbldees='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-doc
 
 alias docbldews='$GIT_HOME/docs/build_docs --doc $GIT_HOME/workplace-search-docs/index.asciidoc --chunk=1'
 
+alias docbldas='$GIT_HOME/docs/build_docs --doc $GIT_HOME/app-search-docs/index.asciidoc --chunk=1'
+
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -69,6 +69,10 @@ alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/si
 
 alias docbldepd='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/endpoint/index.asciidoc --chunk 1'
 
+alias docbldees='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-docs/index.asciidoc --chunk=1'
+
+alias docbldews='$GIT_HOME/docs/build_docs --doc $GIT_HOME/workplace-search-docs/index.asciidoc --chunk=1'
+
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 


### PR DESCRIPTION
With the combination of App Search and Workplace Search into an Enterprise Search binary comes 7.7, our team need a solution-level book that allows us to communicate solution level documentation, such as the Enterprise Search Home experience, as well as common installation procedures. 

This book only applies to version 7.7 and above, so I wasn't sure what to put in the config for `version` and `current`. @debadair: you may be able to guide me here.

@zumwalt @chriscressman @goodroot This adds the book to the `docs` repo. 