### PR TITLE
Update current branch for 7.7 release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -54,7 +54,7 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    7.6
+            current:    7.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       &stacklive [ master, 7.x, 7.7, 7.6, 6.8 ]
@@ -103,7 +103,7 @@ contents:
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
-            current:    7.6
+            current:    7.7
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -144,7 +144,7 @@ contents:
           -
             title:      Machine Learning
             prefix:     en/machine-learning
-            current:    7.6
+            current:    7.7
             index:      docs/en/stack/ml/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -199,7 +199,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
@@ -322,7 +322,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
@@ -348,7 +348,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    7.6
+            current:    7.7
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
@@ -382,7 +382,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    7.6
+                current:    7.7
                 branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
@@ -412,7 +412,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    7.6
+                current:    7.7
                 branches:   [ 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 live:       *stacklive
                 index:      docs/java-api/index.asciidoc
@@ -592,7 +592,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
@@ -846,7 +846,7 @@ contents:
           -
             title:      Kibana Guide
             prefix:     en/kibana
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -881,7 +881,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -940,7 +940,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -998,7 +998,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1042,7 +1042,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1098,7 +1098,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklive
             chunk:      1
@@ -1142,7 +1142,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklive
             chunk:      1
@@ -1199,7 +1199,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    7.6
+            current:    7.7
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklive
@@ -1248,7 +1248,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
@@ -1301,7 +1301,7 @@ contents:
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    7.6
+            current:    7.7
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1343,7 +1343,7 @@ contents:
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    7.6
+            current:    7.7
             index:      journalbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1385,7 +1385,7 @@ contents:
           -
             title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
-            current:    7.6
+            current:    7.7
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.6 ]
             chunk:      1
@@ -1493,7 +1493,7 @@ contents:
           -
             title:      SIEM Guide
             prefix:     en/siem/guide
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/en/siem/index.asciidoc
@@ -1521,7 +1521,7 @@ contents:
                 title:      APM Overview
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
-                current:    7.6
+                current:    7.7
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1538,7 +1538,7 @@ contents:
                 title:      APM Server Reference
                 prefix:     server
                 index:      docs/index.asciidoc
-                current:    7.6
+                current:    7.7
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1687,7 +1687,7 @@ contents:
           -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/logs/index.asciidoc
@@ -1707,7 +1707,7 @@ contents:
           -
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
@@ -1727,7 +1727,7 @@ contents:
           -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime
-            current:    7.6
+            current:    7.7
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/uptime-guide/index.asciidoc
@@ -1990,7 +1990,7 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    7.6
+            current:    7.7
             index:      docs/en/stack/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive

--- a/conf.yaml
+++ b/conf.yaml
@@ -1385,7 +1385,7 @@ contents:
           -
             title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
-            current:    7.7
+            current:    7.6
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.6 ]
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -1385,9 +1385,9 @@ contents:
           -
             title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
-            current:    7.6
+            current:    *stacklive
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.6 ]
+            branches:   [ master, 7.x, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true

--- a/conf.yaml
+++ b/conf.yaml
@@ -54,10 +54,10 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    7.7
+            current:    &stackcurrent 7.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.7, 7.6, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.7, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -103,7 +103,7 @@ contents:
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
-            current:    7.7
+            current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -144,7 +144,7 @@ contents:
           -
             title:      Machine Learning
             prefix:     en/machine-learning
-            current:    7.7
+            current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -199,7 +199,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
@@ -322,7 +322,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
@@ -348,7 +348,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    7.7
+            current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
@@ -382,7 +382,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    7.7
+                current:    *stackcurrent
                 branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
@@ -412,7 +412,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    7.7
+                current:    *stackcurrent
                 branches:   [ 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 live:       *stacklive
                 index:      docs/java-api/index.asciidoc
@@ -592,7 +592,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
@@ -846,7 +846,7 @@ contents:
           -
             title:      Kibana Guide
             prefix:     en/kibana
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -881,7 +881,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -940,7 +940,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -998,7 +998,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1042,7 +1042,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1098,7 +1098,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklive
             chunk:      1
@@ -1142,7 +1142,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklive
             chunk:      1
@@ -1199,7 +1199,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    7.7
+            current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklive
@@ -1248,7 +1248,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
@@ -1301,7 +1301,7 @@ contents:
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    7.7
+            current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1343,7 +1343,7 @@ contents:
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    7.7
+            current:    *stackcurrent
             index:      journalbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1493,7 +1493,7 @@ contents:
           -
             title:      SIEM Guide
             prefix:     en/siem/guide
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/en/siem/index.asciidoc
@@ -1521,7 +1521,7 @@ contents:
                 title:      APM Overview
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
-                current:    7.7
+                current:    *stackcurrent
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1538,7 +1538,7 @@ contents:
                 title:      APM Server Reference
                 prefix:     server
                 index:      docs/index.asciidoc
-                current:    7.7
+                current:    *stackcurrent
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1687,7 +1687,7 @@ contents:
           -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/logs/index.asciidoc
@@ -1707,7 +1707,7 @@ contents:
           -
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
@@ -1727,7 +1727,7 @@ contents:
           -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime
-            current:    7.7
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/uptime-guide/index.asciidoc
@@ -1990,7 +1990,7 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    7.7
+            current:    *stackcurrent
             index:      docs/en/stack/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive

--- a/conf.yaml
+++ b/conf.yaml
@@ -1385,7 +1385,7 @@ contents:
           -
             title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
-            current:    *stacklive
+            current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6 ]
             chunk:      1

--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -16,7 +16,7 @@ bare_version never includes -alpha or -beta
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released
 
 ////
 APM Agent versions

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::7.6.asciidoc[]
+include::7.7.asciidoc[]


### PR DESCRIPTION
DO NOT MERGE THIS PR UNTIL RELEASE DAY

Changes:

* Adds `&stackcurrent` variable for the current Stack docs branch
* Sets the `&stackcurrent` variable as `7.7`
* Removes the `7.6` branch from `&stacklive`