### PR TITLE
docs: update child_attributes background color

### DIFF
--- a/resources/web/style/child_attributes.pcss
+++ b/resources/web/style/child_attributes.pcss
@@ -3,7 +3,6 @@
   details > div {
     border: 1px solid #A9A9A9;
     border-radius: 10px;
-    background: #ebf7fa;
     padding: 15px 10px 0;
     margin: 10px 5px 20px;
   }

--- a/resources/web/style/child_attributes.pcss
+++ b/resources/web/style/child_attributes.pcss
@@ -1,9 +1,9 @@
 #guide .child_attributes {
-  
+
   details > div {
     border: 1px solid #A9A9A9;
     border-radius: 10px;
-    background: #fbfbfb;
+    background: #ebf7fa;
     padding: 15px 10px 0;
     margin: 10px 5px 20px;
   }


### PR DESCRIPTION
## Summary
IMO, the background color for `child_attributes` makes it difficult to differentiate between inline code and regular text inside of collapsed sections. @lcawl also pointed out that admonition blocks don't seem to be showing up, as they probably use the same grey. **This PR explores some alternative background colors.**

Here's an example of the current background color:
<img width="748" alt="Screen Shot 2020-04-01 at 11 16 07 AM" src="https://user-images.githubusercontent.com/5618806/78172097-543cff00-740a-11ea-8580-60a02cfee01f.png">

And here's an enlarged comparison:
<img width="991" alt="Screen Shot 2020-04-01 at 11 15 13 AM" src="https://user-images.githubusercontent.com/5618806/78171936-15a74480-740a-11ea-80cb-bb82f3c66df0.png">

## Alternatives

Some of these are just terrible, but I took screenshots, so I might as well share them. I like `#ebf7fa` the best, but I'm also not in love with it. Open to any and all suggestions.

### `#f1f8ff`
<img width="591" alt="Screen Shot 2020-04-03 at 12 53 15 PM" src="https://user-images.githubusercontent.com/5618806/78399989-c6e4e080-75aa-11ea-85b2-8a9fed04a526.png">

### `#b7c9e2`
<img width="594" alt="Screen Shot 2020-04-03 at 12 54 32 PM" src="https://user-images.githubusercontent.com/5618806/78399995-c9473a80-75aa-11ea-8d31-0184ee0322c7.png">

### `#cafffb`
<img width="592" alt="Screen Shot 2020-04-03 at 1 03 12 PM" src="https://user-images.githubusercontent.com/5618806/78400402-7de15c00-75ab-11ea-9f9d-8c9682633a24.png">

### `#ebf7fa`
<img width="588" alt="Screen Shot 2020-04-03 at 1 02 08 PM" src="https://user-images.githubusercontent.com/5618806/78400334-57bbbc00-75ab-11ea-9a10-bc00171cbc88.png">

### `#e0f9ff`
<img width="589" alt="Screen Shot 2020-04-03 at 12 57 34 PM" src="https://user-images.githubusercontent.com/5618806/78400024-d19f7580-75aa-11ea-9e71-0aa6a91f983a.png">

---
cc @jrodewig / @KOTungseth 