### PR TITLE
Switch to MS 36

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -624,8 +624,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-34
-            branches:   [ release-ms-34 ]
+            current:    release-ms-36
+            branches:   [ release-ms-36 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -641,7 +641,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-34: master
+                  release-ms-36: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -678,8 +678,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-34
-            branches:   [ release-ms-34 ]
+            current:    release-ms-36
+            branches:   [ release-ms-36 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1
@@ -699,7 +699,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-34: master
+                  release-ms-36: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team


### PR DESCRIPTION
For the Milestone 36 release, we need to switch our ESS and Heroku doc builds over. 

@elastic/cloud-writers, can I get an LGTM for this PR, please?