### PR TITLE
[DOCS] Add `minor-version` attribute

### DIFF
--- a/shared/versions/stack/5.5.asciidoc
+++ b/shared/versions/stack/5.5.asciidoc
@@ -3,6 +3,7 @@
 :elasticsearch_version:  5.5.3
 :kibana_version:         5.5.3
 :branch:                 5.5
+:major-version:          5.5
 :major-version:          5.x
 :prev-major-version:     2.x
 

--- a/shared/versions/stack/5.6.asciidoc
+++ b/shared/versions/stack/5.6.asciidoc
@@ -3,6 +3,7 @@
 :elasticsearch_version:  5.6.16
 :kibana_version:         5.6.16
 :branch:                 5.6
+:major-version:          5.6
 :major-version:          5.x
 :prev-major-version:     2.x
 

--- a/shared/versions/stack/6.0.asciidoc
+++ b/shared/versions/stack/6.0.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.0.1
 :apm_server_version:     6.0.1
 :branch:                 6.0
+:minor-version:          6.0
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.1.asciidoc
+++ b/shared/versions/stack/6.1.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.1.4
 :apm_server_version:     6.1.4
 :branch:                 6.1
+:minor-version:          6.1
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.2.asciidoc
+++ b/shared/versions/stack/6.2.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.2.4
 :apm_server_version:     6.2.4
 :branch:                 6.2
+:minor-version:          6.2
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.3.asciidoc
+++ b/shared/versions/stack/6.3.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.3.2
 :apm_server_version:     6.3.2
 :branch:                 6.3
+:minor-version:          6.3
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.4.asciidoc
+++ b/shared/versions/stack/6.4.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.4.3
 :apm_server_version:     6.4.3
 :branch:                 6.4
+:minor-version:          6.4
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.5.4
 :apm_server_version:     6.5.4
 :branch:                 6.5
+:minor-version:          6.5
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.6.2
 :apm_server_version:     6.6.2
 :branch:                 6.6
+:minor-version:          6.6
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -4,6 +4,7 @@
 :kibana_version:         6.7.2
 :apm_server_version:     6.7.2
 :branch:                 6.7
+:minor-version:          6.7
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         6.8.8
 :apm_server_version:     6.8.8
 :branch:                 6.8
+:minor-version:          6.8
 :major-version:          6.x
 :prev-major-version:     5.x
 

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.0.1
 :apm_server_version:     7.0.1
 :branch:                 7.0
+:minor-version:          7.0
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.0

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.1.1
 :apm_server_version:     7.1.1
 :branch:                 7.1
+:minor-version:          7.1
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.0

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.2.1
 :apm_server_version:     7.2.1
 :branch:                 7.2
+:minor-version:          7.2
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.0

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.3.2
 :apm_server_version:     7.3.2
 :branch:                 7.3
+:minor-version:          7.3
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.0

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.4.2
 :apm_server_version:     7.4.2
 :branch:                 7.4
+:minor-version:          7.4
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.1

--- a/shared/versions/stack/7.5.asciidoc
+++ b/shared/versions/stack/7.5.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.5.2
 :apm_server_version:     7.5.2
 :branch:                 7.5
+:minor-version:          7.5
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.2

--- a/shared/versions/stack/7.6.asciidoc
+++ b/shared/versions/stack/7.6.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.6.2
 :apm_server_version:     7.6.2
 :branch:                 7.6
+:minor-version:          7.6
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4

--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.7.0
 :apm_server_version:     7.7.0
 :branch:                 7.7
+:minor-version:          7.7
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         7.8.0
 :apm_server_version:     7.8.0
 :branch:                 7.x
+:minor-version:          7.8
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -8,6 +8,7 @@ bare_version never includes -alpha or -beta
 :kibana_version:         8.0.0
 :apm_server_version:     8.0.0
 :branch:                 master
+:minor-version:          8.0
 :major-version:          8.x
 :prev-major-version:     7.x
 :ecs_version:            1.4


### PR DESCRIPTION
Adds a `minor-version` attribute to the `versions/stack` attribute
files.

Writers can use this attribute to reference the minor version of a
release _without_ the bug release. In many cases, this is the same as
the branch, but not always (e.g. `master`, `7.x`).