### PR TITLE
Add ECK 1.1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -823,7 +823,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/7.x.asciidoc
-                exclude_branches:   [ master, 1.0, 1.0-beta ]
+                exclude_branches:   [ master, 1.1, 1.0, 1.0-beta ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -809,7 +809,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.0
-            branches:   [ master, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Adds ECK 1.1 to the dropdown. Will followup with a PR in the future to make it the current branch.

It wasn't clear to me if I should also add it to the excludes array just below it that includes the 1.0 branch. It was added here https://github.com/elastic/docs/pull/1297