### PR TITLE
[DOCS] Correct `minor-version` attribute for 5.5 and 5.6

### DIFF
--- a/shared/versions/stack/5.5.asciidoc
+++ b/shared/versions/stack/5.5.asciidoc
@@ -3,7 +3,7 @@
 :elasticsearch_version:  5.5.3
 :kibana_version:         5.5.3
 :branch:                 5.5
-:major-version:          5.5
+:minor-version:          5.5
 :major-version:          5.x
 :prev-major-version:     2.x
 

--- a/shared/versions/stack/5.6.asciidoc
+++ b/shared/versions/stack/5.6.asciidoc
@@ -3,7 +3,7 @@
 :elasticsearch_version:  5.6.16
 :kibana_version:         5.6.16
 :branch:                 5.6
-:major-version:          5.6
+:minor-version:          5.6
 :major-version:          5.x
 :prev-major-version:     2.x
 


### PR DESCRIPTION
Fixes a copy/paste error from #1797. Thanks for spotting @gtback!