### PR TITLE
Correct fallback font for code snippets

### DIFF
--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -1,7 +1,7 @@
 #guide {
   /* Inline code examples */
   code {
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console', monospace;
     padding: 0 3px;
     font-size: 0.9em;
     display: inline;
@@ -29,7 +29,7 @@
 
   /* Code blocks with and without prettyprint. */
   pre {
-    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
+    font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console', monospace;
     font-weight: 400;
     color: #888;
     font-size: 16px;
@@ -52,7 +52,7 @@
     span {
       /* We need to match the element name exactly or the * rule will
        * override here. */
-      font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console';
+      font-family: Consolas, Menlo, 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', 'Lucida Console', monospace;
     }
   }
 


### PR DESCRIPTION
Updates the fallback front for code snippets from `sans-serif` to
`monospace`.

Closes #1802