### PR TITLE
Add kibana observability app names to shared attribute list

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -92,6 +92,15 @@ ifdef::elasticsearch-root[]
 endif::elasticsearch-root[]
 
 //////////
+Kibana app names
+//////////
+
+:uptime-app: Uptime app
+:logs-app: Logs app
+:metrics-app: Metrics app
+:siem-app: SIEM app
+
+//////////
 Common words and phrases
 //////////
 :stack:           Elastic Stack


### PR DESCRIPTION
These attributes are defined in the obs docs, but they need to be defined in the shared file so all projects can use them.

@gchaps Let me know what else you want in this list, or feel free to push commits to my fork, if you want to list other app names. 