### PR TITLE
Add attributes for ESS login and product pages

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -58,7 +58,7 @@
 :ess-trial:            https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product:          https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
 :ess-console:          https://cloud.elastic.co?baymax=docs-body&elektra=docs
-:ess-baymax:          ?baymax=docs-body&elektra=docs
+:ess-baymax:           ?baymax=docs-body&elektra=docs
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -58,6 +58,7 @@
 :ess-trial:            https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product:          https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
 :ess-console:          https://cloud.elastic.co?baymax=docs-body&elektra=docs
+:ess-baymax:          ?baymax=docs-body&elektra=docs
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -56,6 +56,8 @@
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :cloud:                https://www.elastic.co/guide/en/cloud/current
 :ess-trial:            https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
+:ess-product:          https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
+:ess-console:          https://cloud.elastic.co?baymax=docs-body&elektra=docs
 :ece-ref:              https://www.elastic.co/guide/en/cloud-enterprise/current
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR is in addition to https://github.com/elastic/docs/pull/1737 and adds standard attributes to track logins for:

* links to the ESS product page https://www.elastic.co/cloud/elasticsearch-service
* links to the cloud sign-in page https://cloud.elastic.co
* an ESS baymax-only attribute for variants of these pages (e.g. `https://www.elastic.co/cloud/elasticsearch-service/pricing`)

We discussed whether we want to start tracking these links recently and the consensus was that we should. Ergo, this PR. 