### PR TITLE
Add beta2 doc builds for ecctl and make them current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -834,8 +834,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    master
-            branches:   [ master ]
+            current:    v1.0.0-beta2
+            branches:   [ master, v1.0.0-beta2 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR adds a doc build for beta2 of ecctl and sets that doc build to be the current (default) docs you get. The docs out of `master` remain available but you will have to select them from the version drop-down to see them.

The beta2 build uses the new https://github.com/elastic/ecctl/tree/v1.0.0-beta2 
branch in the ecctl repo that I created off the `v1.0.0-beta2` tag:

![image](https://user-images.githubusercontent.com/15148011/79411865-d8d66400-7f58-11ea-96b2-353fb552bd20.png)
 
