### PR TITLE
Update `details` style for stacked collapsible sections

### DIFF
--- a/resources/web/style/base_styles.pcss
+++ b/resources/web/style/base_styles.pcss
@@ -26,4 +26,8 @@
   p {
     margin-bottom: 1.15em;
   }
+
+  details {
+    margin-bottom: 1.15em;
+  }
 }


### PR DESCRIPTION
Adds a bottom margin for the `<details>` tag.

Otherwise, collapsible sections are too close when stacked.

### Examples

*Before*
<img width="601" alt="before" src="https://user-images.githubusercontent.com/40268737/79485575-71b1c180-7fe3-11ea-8be8-106e0bc2b3ea.png">


*After*
<img width="610" alt="after" src="https://user-images.githubusercontent.com/40268737/79485610-855d2800-7fe3-11ea-99fb-754a1367d7f0.png">
