### PR TITLE
GH5984 - Docs default RTP: swap out ES Trial with Getting Started

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -102,7 +102,7 @@
                     <div class="mktg-promo">
                       <h3>Most Popular</h3>
                       <ul class="icons">
-                        <li class="icon-elasticsearch-white"><a href="https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=default&elektra=docs&storm=top-video">Elasticsearch Service: Free Trial</a></li>
+                        <li class="icon-elasticsearch-white"><a href="https://www.elastic.co/webinars/getting-started-elasticsearch?baymax=default&elektra=docs&storm=top-video">Get Started with Elasticsearch: Video</a></li>
                         <li class="icon-kibana-white"><a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">Intro to Kibana: Video</a></li>
                         <li class="icon-logstash-white"><a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">ELK for Logs & Metrics: Video</a></li>
                       </ul>


### PR DESCRIPTION
Updates default RTP content for docs sidebar.

Ref: https://github.com/elastic/website-www.elastic.co/issues/5984