### PR TITLE
Build logging driver docs for 7.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1389,7 +1389,7 @@ contents:
             prefix:     en/beats/loggingplugin
             current:    7.6
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.6 ]
+            branches:   [ master, 7.x, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true


### PR DESCRIPTION
We missed the docker logging driver docs when the conf.yaml was updated to include 7.7 branches.