### PR TITLE
Clean up conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -16,16 +16,16 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
-    eland-docs:           https://github.com/elastic/elasticsearch-eland-docs
+    eland-docs:           https://github.com/elastic/elasticsearch-eland-docs.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
     elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
     elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
-    elasticsearch-php:    https://github.com/elastic/elasticsearch-php
+    elasticsearch-php:    https://github.com/elastic/elasticsearch-php.git
     elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
-    elasticsearch-py:     https://github.com/elastic/elasticsearch-py
-    elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl
-    go-elasticsearch:     https://github.com/elastic/go-elasticsearch
+    elasticsearch-py:     https://github.com/elastic/elasticsearch-py.git
+    elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl.git
+    go-elasticsearch:     https://github.com/elastic/go-elasticsearch.git
     elasticsearch-rs:     https://github.com/elastic/elasticsearch-rs.git
     elasticsearch:        https://github.com/elastic/elasticsearch.git
     guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
@@ -194,7 +194,7 @@ contents:
                 repo:   azure-marketplace
                 path:   docs
     -
-        title:      Elasticsearch: Store, Search, and Analyze
+        title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
           -
             title:      Elasticsearch Reference
@@ -617,7 +617,7 @@ contents:
                 path:   docs/asciidoc
 
     -
-        title:      Cloud: Provision, Manage and Monitor the Elastic Stack
+        title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
         sections:
           -
             title:      Elasticsearch Service - Hosted Elastic Stack
@@ -698,8 +698,7 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
-                map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-34: master
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -843,7 +842,7 @@ contents:
                 repo:   ecctl
                 path:   docs/
     -
-        title:      Kibana: Explore, Visualize, and Share
+        title:      "Kibana: Explore, Visualize, and Share"
         sections:
           -
             title:      Kibana Guide
@@ -878,7 +877,7 @@ contents:
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
     -
-        title:      Logstash: Collect, Enrich, and Transport
+        title:      "Logstash: Collect, Enrich, and Transport"
         sections:
           -
             title:      Logstash Reference
@@ -936,7 +935,7 @@ contents:
                 path:   shared/attributes.asciidoc
 
     -
-        title:      Beats: Collect, Parse, and Ship
+        title:      "Beats: Collect, Parse, and Ship"
         sections:
           -
             title:      Beats Platform Reference
@@ -1519,7 +1518,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
     -
-        title:      Observability: APM, Logs, Metrics, and Uptime
+        title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
           -
             title:      Application Performance Monitoring (APM)


### PR DESCRIPTION
- Add .git suffix to repo URLs for consistency
- Add quotes around section titles that contain colons
- reuse rather than redefine `mapCloudSaasToClientsTeam` variable.

The last two changes are needed to make Python's YAML library able to
load the file.