### PR TITLE
[DOCS] Update attributes for multi arg footnotes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -277,7 +277,8 @@ Common words and phrases
 :api-examples-title:       Examples
 :api-definitions-title:    Properties
 
-:multi-arg: †footnote:multi-arg[This parameter accepts multiple arguments.]
+:multi-arg:     †footnoteref:[multi-arg,This parameter accepts multiple arguments.]
+:multi-arg-ref: †footnoteref:[multi-arg]
 
 //////////
 Legacy definitions

--- a/shared/fn-ref-ex.asciidoc
+++ b/shared/fn-ref-ex.asciidoc
@@ -49,7 +49,8 @@ Guidelines for parameter documentation
 * Use a definition list.
 * End each definition with a period.
 * Include whether the parameter is Optional or Required and the data type.
-* Add `{multi-arg}` to parameters that accept multiple arguments.
+* For parameters that accept multiple arguments, add `{multi-arg}` to the first
+  occurrence. Use `{multi-arg-ref}` in subsequent occurrences.
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
 * If the parameter requires a specific delimiter for multiple values, say so.


### PR DESCRIPTION
The `{multi-arg}` attribute is used in the function reference template
to add footnotes for parameters can be passed multiple times.

However, using this attribute multiple times on the same page results
in duplicated footnotes:

<img width="468" alt="Screen Shot 2020-04-28 at 10 12 39 AM" src="https://user-images.githubusercontent.com/40268737/80497702-d0a6fd00-8938-11ea-9009-4ffd441fab40.png">


This updates the `{multi-arg}` attribute to use the `footnoteref`
syntax. This gives the footnote a single, reusable ID. This means only one
footnote is generated:

<img width="517" alt="Screen Shot 2020-04-28 at 10 12 24 AM" src="https://user-images.githubusercontent.com/40268737/80497774-e3b9cd00-8938-11ea-9177-6abd679d224b.png">


This also adds a new attribute, `{multi-arg-ref}`, which can be used for
the subsequent occurrences of the footnote.

This also updates guidance on usage of the `{multi-arg}` attribute
in the function reference template.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
