### PR TITLE
Updates for 7.7 release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -57,7 +57,7 @@ contents:
             current:    &stackcurrent 7.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.8, 7.7, 7.6, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.8, 7.7, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack

--- a/conf.yaml
+++ b/conf.yaml
@@ -1432,34 +1432,49 @@ contents:
         title:      Enterprise Search
         sections:
           -
+            title:      Enterprise Search Guide
+            prefix:     en/enterprise-search
+            index:      enterprise-search-docs/index.asciidoc
+            private:    1
+            current:    *stackcurrent
+            branches:   [ 7.7 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Enterprise Search/Guide
+            subject:    Enterprise Search
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   enterprise-search-docs
+          -
             title:      Workplace Search Guide
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc
             private:    1
-            current:    7.6
-            branches:   [ 7.6 ]
+            current:    *stackcurrent
+            branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
-            tags:       Workplace Search/Reference
+            tags:       Workplace Search/Guide
             subject:    Workplace Search
             sources:
               -
                 repo:   enterprise-search-pubs
                 path:   workplace-search-docs
           -
-            title:      App Search Reference
-            prefix:     en/swiftype/appsearch
-            index:      docs/appsearch/index.asciidoc
+            title:      App Search Guide
+            prefix:     en/app-search
+            index:      app-search-docs/index.asciidoc
             private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
-            tags:       App Search/Reference
-            subject:    Swiftype
+            current:    *stackcurrent
+            branches:   [ 7.7 ]
+            chunk:     1
+            tags:       App Search/Guide
+            subject:    App Search
             sources:
               -
-                repo:   swiftype
-                path:   docs
+                repo:   enterprise-search-pubs
+                path:   app-search-docs
           -
             title:      Site Search Reference
             prefix:     en/swiftype/sitesearch

--- a/conf.yaml
+++ b/conf.yaml
@@ -1442,7 +1442,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7 ]
+            branches:   [ 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -1457,7 +1457,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7, 7.6 ]
+            branches:   [ 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -1472,7 +1472,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7 ]
+            branches:   [ 7.8, 7.7 ]
             chunk:     1
             tags:       App Search/Guide
             subject:    App Search

--- a/conf.yaml
+++ b/conf.yaml
@@ -1442,7 +1442,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7 ]
+            branches:   [ 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -1457,7 +1457,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7, 7.6 ]
+            branches:   [ 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -1472,7 +1472,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7 ]
+            branches:   [ 7.7 ]
             chunk:     1
             tags:       App Search/Guide
             subject:    App Search

--- a/conf.yaml
+++ b/conf.yaml
@@ -54,10 +54,10 @@ contents:
           -
             title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    7.6
+            current:    &stackcurrent 7.7
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.7, 7.6, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.7, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -103,7 +103,7 @@ contents:
           -
             title:      Getting Started
             prefix:     en/elastic-stack-get-started
-            current:    7.6
+            current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -144,7 +144,7 @@ contents:
           -
             title:      Machine Learning
             prefix:     en/machine-learning
-            current:    7.6
+            current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
@@ -199,7 +199,7 @@ contents:
           -
             title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
@@ -322,7 +322,7 @@ contents:
           -
             title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
@@ -348,7 +348,7 @@ contents:
             title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
-            current:    7.6
+            current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
@@ -382,7 +382,7 @@ contents:
               -
                 title:      Java REST Client
                 prefix:     java-rest
-                current:    7.6
+                current:    *stackcurrent
                 branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
@@ -412,7 +412,7 @@ contents:
               -
                 title:      Java API
                 prefix:     java-api
-                current:    7.6
+                current:    *stackcurrent
                 branches:   [ 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 live:       *stacklive
                 index:      docs/java-api/index.asciidoc
@@ -592,7 +592,7 @@ contents:
           -
             title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
@@ -847,7 +847,7 @@ contents:
           -
             title:      Kibana Guide
             prefix:     en/kibana
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -882,7 +882,7 @@ contents:
           -
             title:      Logstash Reference
             prefix:     en/logstash
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
@@ -941,7 +941,7 @@ contents:
             title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -999,7 +999,7 @@ contents:
             title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1043,7 +1043,7 @@ contents:
             title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
@@ -1099,7 +1099,7 @@ contents:
             title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklive
             chunk:      1
@@ -1143,7 +1143,7 @@ contents:
             title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklive
             chunk:      1
@@ -1200,7 +1200,7 @@ contents:
           -
             title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
-            current:    7.6
+            current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklive
@@ -1249,7 +1249,7 @@ contents:
             title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
@@ -1302,7 +1302,7 @@ contents:
           -
             title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    7.6
+            current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1344,7 +1344,7 @@ contents:
           -
             title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    7.6
+            current:    *stackcurrent
             index:      journalbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
@@ -1386,7 +1386,7 @@ contents:
           -
             title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
-            current:    7.6
+            current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6 ]
             chunk:      1
@@ -1500,7 +1500,7 @@ contents:
           -
             title:      SIEM Guide
             prefix:     en/siem/guide
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/en/siem/index.asciidoc
@@ -1528,7 +1528,7 @@ contents:
                 title:      APM Overview
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
-                current:    7.6
+                current:    *stackcurrent
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1545,7 +1545,7 @@ contents:
                 title:      APM Server Reference
                 prefix:     server
                 index:      docs/index.asciidoc
-                current:    7.6
+                current:    *stackcurrent
                 branches:   [ master, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
@@ -1694,7 +1694,7 @@ contents:
           -
             title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/logs/index.asciidoc
@@ -1714,7 +1714,7 @@ contents:
           -
             title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
@@ -1734,7 +1734,7 @@ contents:
           -
             title:      Uptime Monitoring Guide
             prefix:     en/uptime
-            current:    7.6
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/uptime-guide/index.asciidoc
@@ -1997,7 +1997,7 @@ contents:
           -
             title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    7.6
+            current:    *stackcurrent
             index:      docs/en/stack/index.asciidoc
             branches:   [ master, 7.x, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -69,6 +69,12 @@ alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/si
 
 alias docbldepd='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/endpoint/index.asciidoc --chunk 1'
 
+alias docbldees='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-docs/index.asciidoc --chunk=1'
+
+alias docbldews='$GIT_HOME/docs/build_docs --doc $GIT_HOME/workplace-search-docs/index.asciidoc --chunk=1'
+
+alias docbldas='$GIT_HOME/docs/build_docs --doc $GIT_HOME/app-search-docs/index.asciidoc --chunk=1'
+
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'
 

--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -17,7 +17,7 @@ bare_version never includes -alpha or -beta
 release-state can be: released | prerelease | unreleased
 //////////
 
-:release-state:          unreleased
+:release-state:          released
 
 ////
 APM Agent versions

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::7.6.asciidoc[]
+include::7.7.asciidoc[]


### PR DESCRIPTION
DO NOT MERGE THIS PR UNTIL RELEASE DAY

Changes:
* Adds the `Enterprise Search Guide` docbook and makes several Enterprise Search changes from #1790
* Adds `&stackcurrent` variable for the current Stack docs branch
* Sets the `&stackcurrent` variable as `7.7`
* Removes the `7.6` branch from `&stacklive`

Closes #1396

### Preview
http://docs_1822.docs-preview.app.elstc.co/guide/index.html