### PR TITLE
Add new location of transport client documentation examples

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -431,6 +431,11 @@ contents:
                     repo:   elasticsearch
                     path:   client/rest-high-level/src/test/java/org/elasticsearch/client
                     exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+
+                  -
+                   repo:   elasticsearch
+                   path:   server/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                   exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   elasticsearch
                     path:   server/src/test/java/org/elasticsearch/client/documentation


### PR DESCRIPTION
This will apply to the 7.7 and 7.x branches.
