### PR TITLE
Reformat conf.yaml titles.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -48,11 +48,9 @@ contents_title:     Elastic Stack and Product Documentation
 
 toc_extra: extra/docs_landing.html
 contents:
-    -
-        title:      Elastic Stack
+    -   title:      Elastic Stack
         sections:
-          -
-            title:      Installation and Upgrade Guide
+          - title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
             current:    7.6
             index:      docs/en/install-upgrade/index.asciidoc
@@ -100,8 +98,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-          -
-            title:      Getting Started
+          - title:      Getting Started
             prefix:     en/elastic-stack-get-started
             current:    7.6
             index:      docs/en/getting-started/index.asciidoc
@@ -120,8 +117,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Glossary
+          - title:      Glossary
             prefix:     en/elastic-stack-glossary
             current:    master
             index:      docs/en/glossary/index.asciidoc
@@ -141,8 +137,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Machine Learning
+          - title:      Machine Learning
             prefix:     en/machine-learning
             current:    7.6
             index:      docs/en/stack/ml/index.asciidoc
@@ -167,8 +162,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/settings.asciidoc
-          -
-            title:      Elastic Common Schema (ECS) Reference
+          - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.5
             branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
@@ -180,8 +174,7 @@ contents:
               -
                 repo:   ecs
                 path:   docs/
-          -
-            title:      Azure Marketplace and Resource Manager (ARM) template
+          - title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
             current:    7.6
             index:      docs/index.asciidoc
@@ -193,11 +186,10 @@ contents:
               -
                 repo:   azure-marketplace
                 path:   docs
-    -
-        title:      "Elasticsearch: Store, Search, and Analyze"
+
+    -   title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
-          -
-            title:      Elasticsearch Reference
+          - title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
@@ -294,8 +286,7 @@ contents:
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
                 exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          -
-            title:      Elasticsearch Resiliency Status
+          - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1
             branches:   [master]
@@ -319,8 +310,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          -
-            title:      Painless Scripting Language
+          - title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
@@ -344,8 +334,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          -
-            title:      Plugins and Integrations
+          - title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
             current:    7.6
@@ -375,12 +364,10 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          -
-            title:      Elasticsearch Clients
+          - title:      Elasticsearch Clients
             base_dir:   en/elasticsearch/client
             sections:
-              -
-                title:      Java REST Client
+              - title:      Java REST Client
                 prefix:     java-rest
                 current:    7.6
                 branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -408,9 +395,7 @@ contents:
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
-              -
-                title:      Java API
+              - title:      Java API
                 prefix:     java-api
                 current:    7.6
                 branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
@@ -452,9 +437,7 @@ contents:
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
-              -
-                title:      JavaScript API
+              - title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 16.x ]
@@ -465,8 +448,7 @@ contents:
                   -
                     repo:   elasticsearch-js
                     path:   docs/
-              -
-                title:      Ruby API
+              - title:      Ruby API
                 prefix:     ruby-api
                 current:    7.x
                 branches:   [ master, 7.x ]
@@ -477,8 +459,7 @@ contents:
                   -
                     repo:   elasticsearch-ruby
                     path:   docs/
-              -
-                title:      Go API
+              - title:      Go API
                 prefix:     go-api
                 current:    master
                 branches:   [ master ]
@@ -490,8 +471,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/go
-              -
-                title:      .NET API
+              - title:      .NET API
                 prefix:     net-api
                 # The elasticsearch-net repo only keeps .x branches. Do not
                 # bump these with the rest of the stack.
@@ -505,9 +485,7 @@ contents:
                   -
                     repo:   elasticsearch-net
                     path:   docs/
-
-              -
-                title:      PHP API
+              - title:      PHP API
                 prefix:     php-api
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
@@ -521,9 +499,7 @@ contents:
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
-
-              -
-                title:      Perl API
+              - title:      Perl API
                 prefix:     perl-api
                 current:    master
                 branches:   [ master ]
@@ -535,9 +511,7 @@ contents:
                   -
                     repo:   elasticsearch-perl
                     path:   docs/
-
-              -
-                title:      Python API
+              - title:      Python API
                 prefix:     python-api
                 current:    master
                 branches:   [ master ]
@@ -549,9 +523,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/python
-
-              -
-                title:      eland Client
+              - title:      eland Client
                 prefix:     eland
                 current:    7.x
                 branches:   [ 7.x ]
@@ -566,9 +538,7 @@ contents:
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
-
-              -
-                title:      Rust API
+              - title:      Rust API
                 prefix:     rust-api
                 current:    master
                 branches:   [ master ]
@@ -580,9 +550,7 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
-
-              -
-                title:      Community Contributed Clients
+              - title:      Community Contributed Clients
                 prefix:     community
                 branches:   [master]
                 current:    master
@@ -594,8 +562,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/community-clients
-          -
-            title:      Elasticsearch for Apache Hadoop and Spark
+          - title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
@@ -607,9 +574,7 @@ contents:
               -
                 repo:   elasticsearch-hadoop
                 path:   docs/src/reference/asciidoc
-
-          -
-            title:      Curator Index Management
+          - title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
             current:    5.8
             branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
@@ -621,11 +586,9 @@ contents:
                 repo:   curator
                 path:   docs/asciidoc
 
-    -
-        title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
+    -   title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
         sections:
-          -
-            title:      Elasticsearch Service - Hosted Elastic Stack
+          - title:      Elasticsearch Service - Hosted Elastic Stack
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
@@ -677,9 +640,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudSaasToClientsTeam
-
-          -
-            title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
+          - title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
@@ -734,9 +695,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudSaasToClientsTeam
-
-          -
-            title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
+          - title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
@@ -808,9 +767,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/csharp
                 map_branches: *mapCloudEceToClientsTeam
-
-          -
-            title:      Elastic Cloud on Kubernetes
+          - title:      Elastic Cloud on Kubernetes
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
@@ -833,8 +790,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Elastic Cloud Control - The Command-Line Interface for ECE
+          - title:      Elastic Cloud Control - The Command-Line Interface for ECE
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
@@ -846,11 +802,10 @@ contents:
               -
                 repo:   ecctl
                 path:   docs/
-    -
-        title:      "Kibana: Explore, Visualize, and Share"
+
+    -   title:      "Kibana: Explore, Visualize, and Share"
         sections:
-          -
-            title:      Kibana Guide
+          - title:      Kibana Guide
             prefix:     en/kibana
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
@@ -881,11 +836,10 @@ contents:
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-    -
-        title:      "Logstash: Collect, Enrich, and Transport"
+
+    -   title:      "Logstash: Collect, Enrich, and Transport"
         sections:
-          -
-            title:      Logstash Reference
+          - title:      Logstash Reference
             prefix:     en/logstash
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
@@ -920,8 +874,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-          -
-            title:      Logstash Versioned Plugin Reference
+          - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
             branches:   [ versioned_plugin_docs ]
@@ -939,11 +892,9 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
-    -
-        title:      "Beats: Collect, Parse, and Ship"
+    -   title:      "Beats: Collect, Parse, and Ship"
         sections:
-          -
-            title:      Beats Platform Reference
+          - title:      Beats Platform Reference
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    7.6
@@ -968,8 +919,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Beats Developer Guide
+          - title:      Beats Developer Guide
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
@@ -1000,8 +950,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Packetbeat Reference
+          - title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    7.6
@@ -1044,8 +993,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Filebeat Reference
+          - title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    7.6
@@ -1100,8 +1048,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Winlogbeat Reference
+          - title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    7.6
@@ -1144,8 +1091,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Metricbeat Reference
+          - title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    7.6
@@ -1202,8 +1148,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Heartbeat Reference
+          - title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
             current:    7.6
             index:      heartbeat/docs/index.asciidoc
@@ -1250,8 +1195,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Auditbeat Reference
+          - title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    7.6
@@ -1304,8 +1248,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          -
-            title:      Functionbeat Reference
+          - title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
             current:    7.6
             index:      x-pack/functionbeat/docs/index.asciidoc
@@ -1346,8 +1289,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Journalbeat Reference
+          - title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
             current:    7.6
             index:      journalbeat/docs/index.asciidoc
@@ -1388,8 +1330,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Elastic Logging Plugin for Docker
+          - title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
             current:    7.6
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
@@ -1411,8 +1352,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Legacy Topbeat Reference
+          - title:      Legacy Topbeat Reference
             prefix:     en/beats/topbeat
             index:      topbeat/docs/index.asciidoc
             current:    1.3
@@ -1433,11 +1373,9 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
 
-    -
-        title:      Enterprise Search
+    -   title:      Enterprise Search
         sections:
-          -
-            title:      Workplace Search Guide
+          - title:      Workplace Search Guide
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc
             private:    1
@@ -1451,8 +1389,7 @@ contents:
               -
                 repo:   enterprise-search-pubs
                 path:   workplace-search-docs
-          -
-            title:      App Search Reference
+          - title:      App Search Reference
             prefix:     en/swiftype/appsearch
             index:      docs/appsearch/index.asciidoc
             private:    1
@@ -1465,8 +1402,7 @@ contents:
               -
                 repo:   swiftype
                 path:   docs
-          -
-            title:      Site Search Reference
+          - title:      Site Search Reference
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1
@@ -1479,11 +1415,10 @@ contents:
               -
                 repo:   swiftype
                 path:   docs
-    -
-        title:      Elastic Security
+
+    -   title:      Elastic Security
         sections:
-          -
-            title:      Elastic Endpoint Security
+          - title:      Elastic Endpoint Security
             prefix:     en/endpoint
             current:    master
             branches:   [ master ]
@@ -1502,8 +1437,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      SIEM Guide
+          - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
@@ -1522,15 +1456,13 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-    -
-        title:      "Observability: APM, Logs, Metrics, and Uptime"
+
+    -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
-          -
-            title:      Application Performance Monitoring (APM)
+          - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
-              -
-                title:      APM Overview
+              - title:      APM Overview
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
                 current:    7.6
@@ -1546,8 +1478,7 @@ contents:
                   -
                     repo:   apm-server
                     path:   docs
-              -
-                title:      APM Server Reference
+              - title:      APM Server Reference
                 prefix:     server
                 index:      docs/index.asciidoc
                 current:    7.6
@@ -1567,12 +1498,10 @@ contents:
                   -
                     repo:   apm-server
                     path:   CHANGELOG.asciidoc
-              -
-                title:      APM Agents
+              - title:      APM Agents
                 base_dir:   agent
                 sections:
-                  -
-                    title:      APM Go Agent
+                  - title:      APM Go Agent
                     prefix:     go
                     current:    1.x
                     branches:   [ master, 1.x, 0.5 ]
@@ -1589,8 +1518,7 @@ contents:
                         repo:   apm-agent-go
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 0.5 ]
-                  -
-                    title:      APM Java Agent
+                  - title:      APM Java Agent
                     prefix:     java
                     current:    1.x
                     branches:   [ master, 1.x, 0.7, 0.6 ]
@@ -1607,8 +1535,7 @@ contents:
                         repo:   apm-agent-java
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 0.7, 0.6]
-                  -
-                    title:      APM .NET Agent
+                  - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.x
                     branches:   [ master, 1.x ]
@@ -1624,8 +1551,7 @@ contents:
                       -
                         repo:   apm-agent-dotnet
                         path:   CHANGELOG.asciidoc
-                  -
-                    title:      APM Node.js Agent
+                  - title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    3.x
                     branches:   [ master, 3.x, 2.x, 1.x, 0.x ]
@@ -1642,8 +1568,7 @@ contents:
                         repo:   apm-agent-nodejs
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 1.x, 0.x ]
-                  -
-                    title:      APM Python Agent
+                  - title:      APM Python Agent
                     prefix:     python
                     current:    5.x
                     branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x ]
@@ -1660,8 +1585,7 @@ contents:
                         repo:   apm-agent-python
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 4.x, 3.x, 2.x, 1.x ]
-                  -
-                    title:      APM Ruby Agent
+                  - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    3.x
                     branches:   [ master, 3.x, 2.x, 1.x ]
@@ -1678,8 +1602,7 @@ contents:
                         repo:   apm-agent-ruby
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 1.x, 0.x ]
-                  -
-                    title:      APM Real User Monitoring JavaScript Agent
+                  - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
                     branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
@@ -1696,8 +1619,7 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-          -
-            title:      Logs Monitoring Guide
+          - title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
@@ -1716,8 +1638,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Metrics Monitoring Guide
+          - title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
@@ -1736,8 +1657,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Uptime Monitoring Guide
+          - title:      Uptime Monitoring Guide
             prefix:     en/uptime
             current:    7.6
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
@@ -1750,16 +1670,14 @@ contents:
               -
                 repo:   kibana
                 path:   docs/
-    -
-      title:     Docs in Your Native Tongue
+
+    - title:     Docs in Your Native Tongue
       sections:
-        -
-          title:      简体中文
+        - title:      简体中文
           base_dir:   cn
           lang:       zh_cn
           sections:
-            -
-              title:      《Elasticsearch 权威指南》中文版
+            - title:      《Elasticsearch 权威指南》中文版
               prefix:     elasticsearch/guide
               index:      book.asciidoc
               current:    cn
@@ -1774,8 +1692,7 @@ contents:
                 -
                   repo: guide-cn
                   path: /
-            -
-              title:      PHP API
+            - title:      PHP API
               prefix:     elasticsearch/php
               index:      index.asciidoc
               current:    cn
@@ -1787,8 +1704,7 @@ contents:
                 -
                   repo: elasticsearch-php-cn
                   path: /
-            -
-              title:      Kibana 用户手册
+            - title:      Kibana 用户手册
               prefix:     kibana
               index:      docs/index.asciidoc
               current:    cn
@@ -1802,13 +1718,11 @@ contents:
                 -
                   repo: kibana-cn
                   path: /docs
-        -
-          title:      日本語
+        - title:      日本語
           base_dir:   jp
           lang:       ja
           sections:
-            -
-              title:      Elasticsearchリファレンス
+            - title:      Elasticsearchリファレンス
               prefix:     elasticsearch/reference
               index:      docs/jp/reference/gs-index.asciidoc
               current:    5.4
@@ -1825,8 +1739,7 @@ contents:
                 -
                   repo: elasticsearch
                   path: /docs
-            -
-              title:      Logstashリファレンス
+            - title:      Logstashリファレンス
               prefix:     logstash
               index:      docs/jp/gs-index.asciidoc
               current:    5.4
@@ -1840,8 +1753,7 @@ contents:
                 -
                   repo: logstash
                   path: /docs/jp
-            -
-              title:      Kibanaユーザーガイド
+            - title:      Kibanaユーザーガイド
               prefix:     kibana
               index:      docs/jp/gs-index.asciidoc
               current:    5.4
@@ -1855,8 +1767,7 @@ contents:
                 -
                   repo: kibana
                   path: /docs/jp
-            -
-              title:      X-Packリファレンス
+            - title:      X-Packリファレンス
               prefix:     x-pack
               index:      docs/jp/gs-index.asciidoc
               current:    5.4
@@ -1878,13 +1789,11 @@ contents:
                   repo: x-pack-elasticsearch
                   path: /docs/jp
                   prefix: elasticsearch-extra/x-pack-elasticsearch
-        -
-          title:      한국어
+        - title:      한국어
           base_dir:   kr
           lang:       ko
           sections:
-            -
-              title:      Elasticsearch 참조
+            - title:      Elasticsearch 참조
               prefix:     elasticsearch/reference
               index:      docs/kr/reference/gs-index.asciidoc
               current:    5.4
@@ -1901,8 +1810,7 @@ contents:
                 -
                   repo: elasticsearch
                   path: /docs
-            -
-              title:      Logstash 참조
+            - title:      Logstash 참조
               prefix:     logstash
               index:      docs/kr/gs-index.asciidoc
               current:    5.4
@@ -1916,8 +1824,7 @@ contents:
                 -
                   repo: logstash
                   path: /docs/kr
-            -
-              title:      Kibana 사용자 가이드
+            - title:      Kibana 사용자 가이드
               prefix:     kibana
               index:      docs/kr/gs-index.asciidoc
               current:    5.4
@@ -1931,8 +1838,7 @@ contents:
                 -
                   repo: kibana
                   path: /docs/kr
-            -
-              title:      X-Pack 참조
+            - title:      X-Pack 참조
               prefix:     x-pack
               index:      docs/kr/gs-index.asciidoc
               current:    5.4
@@ -1955,11 +1861,9 @@ contents:
                   path: /docs/kr
                   prefix: elasticsearch-extra/x-pack-elasticsearch
 
-    -
-        title:      Legacy Documentation
+    -   title:      Legacy Documentation
         sections:
-          -
-            title:      Elastic Stack and Google Cloud's Anthos
+          - title:      Elastic Stack and Google Cloud's Anthos
             prefix:     en/elastic-stack-gke
             current:    master
             index:      docs/en/gke-on-prem/index.asciidoc
@@ -1979,8 +1883,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Infrastructure Monitoring Guide for 6.5-7.4
+          - title:      Infrastructure Monitoring Guide for 6.5-7.4
             prefix:     en/infrastructure/guide
             current:    7.4
             branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
@@ -1999,8 +1902,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          -
-            title:      Stack Overview
+          - title:      Stack Overview
             prefix:     en/elastic-stack-overview
             current:    7.6
             index:      docs/en/stack/index.asciidoc
@@ -2023,8 +1925,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/settings.asciidoc
-          -
-            title:      X-Pack Reference for 6.0-6.2 and 5.x
+          - title:      X-Pack Reference for 6.0-6.2 and 5.x
             prefix:     en/x-pack
             chunk:      1
             private:    1
@@ -2053,8 +1954,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
-          -
-            title:      Elasticsearch - The Definitive Guide
+          - title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide
             current:    2.x
             branches:   [ master, 2.x, 1.x ]
@@ -2069,9 +1969,7 @@ contents:
               -
                 repo:   guide
                 path:   /
-
-          -
-            title:      Sense Editor for 4.x
+          - title:      Sense Editor for 4.x
             prefix:     en/sense
             current:    master
             branches:   [ master ]
@@ -2084,8 +1982,7 @@ contents:
               -
                 repo:   sense
                 path:   docs
-          -
-            title:      Marvel Reference for 2.x and 1.x
+          - title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1
             private:    1
@@ -2100,8 +1997,7 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/marvel
-          -
-            title:      Shield Reference for 2.x and 1.x
+          - title:      Shield Reference for 2.x and 1.x
             prefix:     en/shield
             chunk:      1
             private:    1
@@ -2116,8 +2012,7 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/shield
-          -
-            title:      Watcher Reference for 2.x and 1.x
+          - title:      Watcher Reference for 2.x and 1.x
             prefix:     en/watcher
             chunk:      1
             private:    1
@@ -2132,8 +2027,7 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/watcher
-          -
-            title:      Reporting Reference for 2.x
+          - title:      Reporting Reference for 2.x
             prefix:     en/reporting
             chunk:      1
             private:    1
@@ -2148,8 +2042,7 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/reporting
-          -
-            title:      Graph Reference for 2.x
+          - title:      Graph Reference for 2.x
             prefix:     en/graph
             repo:       x-pack
             chunk:      1
@@ -2165,8 +2058,7 @@ contents:
               -
                 repo:   x-pack
                 path:   docs/public/graph
-          -
-            title:      Groovy API
+          - title:      Groovy API
             prefix:     en/elasticsearch/client/groovy-api
             current:    2.4
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]


### PR DESCRIPTION
Move the "title" key onto the line with the '-' to make it easier to
browse through the sections and books in editors which support code
folding.

<img width="982" alt="image" src="https://user-images.githubusercontent.com/1045796/81331502-b1fae180-906f-11ea-9924-cc34b31a0c5b.png">
