### PR TITLE
Add `dev` care admonition

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1505,79 +1505,20 @@ deprecated::[0.90.4,Replace by `foo.baz`. See <<new-section>>]
 Text about old functionality...
 
 [[experimental]]
-== Experimental and Beta
+== Beta, Dev, and Experimental
 
-APIs or parameters that are experimental or in beta can be marked as such, using
-markup similar to that used in <<changes>>.
+APIs or parameters that are in beta, in development, or experimental can be
+marked as such, using markup similar to that used in <<changes>>.
 
 In the block format, you have the option of adding a related GitHub issue link.
 If both custom text and a GitHub link are provided, the GitHub link **must** be
 provided second. If it's supported in your repo, you can use the `{issue}`
 attribute in place of the GitHub issue link.
 
-For instance:
+=== Using the `beta` admonition
 
 [source,asciidoc]
-----------------------------------
-[[new-feature]]
-=== New experimental feature
-
-experimental::[]
-
-experimental::[https://github.com/elastic/docs/issues/505]
-
-experimental::[{issue}505]
-
-experimental::[Custom text goes here]
-
-experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
-
-experimental::[Custom text goes here,{issue}505]
-
-Text about new feature...
-
-[[old-feature]]
-=== Established feature
-
-This feature has been around for a while, but we're adding
-a new experimental parameter:
-
-[horizontal]
-`established_param`::  This param has been around for ages and won't change.
-`experimental_param`:: experimental:[] This param is experimental and may change in the future.
-`experimental_param`:: experimental:[Custom text goes here] This param is experimental and may change in the future.
-
-----------------------------------
-
-[[new-feature]]
-=== New experimental feature
-
-experimental::[]
-
-experimental::[https://github.com/elastic/docs/issues/505]
-
-experimental::[{issue}505]
-
-experimental::[Custom text goes here]
-
-experimental::[Custom text goes here,https://github.com/elastic/docs/issues/505]
-
-experimental::[Custom text goes here,{issue}505]
-
-Text about new feature...
-[[old-feature]]
-=== Established feature
-
-This feature has been around for a while, but we're adding
-a new experimental parameter:
-
-[horizontal]
-`established_param`::  This param has been around for ages and won't change.
-`experimental_param`:: experimental:[] This param is experimental and may change in the future.
-`experimental_param`:: experimental:[Custom text goes here] This param is experimental and may change in the future.
-
-[source,asciidoc]
-----------------------------------
+----
 [[new-beta-feature]]
 === New beta feature
 
@@ -1587,41 +1528,11 @@ beta::[https://github.com/elastic/docs/issues/505]
 
 beta::[{issue}505]
 
-beta::[Custom text goes here]
+beta::["Custom text goes here."]
 
-beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
+beta::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
 
-beta::[Custom text goes here,{issue}505]
-
-Text about new feature...
-
-[[old-beta-feature]]
-=== Established feature
-
-This feature has been around for a while, but we're adding
-a new beta parameter:
-
-[horizontal]
-`established_param`::  This param has been around for ages and won't change.
-`beta_param`:: beta:[] This param is beta and may change in the future.
-`beta_param`:: beta:[Custom text goes here] This param is beta and may change in the future.
-
-----------------------------------
-
-[[new-beta-feature]]
-=== New beta feature
-
-beta::[]
-
-beta::[https://github.com/elastic/docs/issues/505]
-
-beta::[{issue}505]
-
-beta::[Custom text goes here]
-
-beta::[Custom text goes here,https://github.com/elastic/docs/issues/505]
-
-beta::[Custom text goes here,{issue}505]
+beta::["Custom text goes here.",{issue}505]
 
 Text about new feature...
 
@@ -1629,12 +1540,97 @@ Text about new feature...
 === Established feature
 
 This feature has been around for a while, but we're adding
-a new beta parameter:
+a new parameter that's in beta:
 
-[horizontal]
-`established_param`::  This param has been around for ages and won't change.
-`beta_param`:: beta:[] This param is experimental and may change in the future.
-`beta_param`:: beta:[Custom text goes here] This param is beta and may change in the future.
+`established_param`::
+This param has been around for ages and won't change.
+
+`beta_param`:: 
+beta:[]
+This param is in beta and may change in the future.
+
+`beta_param`::
+beta:["Custom text goes here."]
+This param is in beta and may change in the future.
+----
+
+=== Using the `dev` admonition
+
+[source,asciidoc]
+----
+[[new-dev-feature]]
+=== New feature in development
+
+dev::[]
+
+dev::[https://github.com/elastic/docs/issues/505]
+
+dev::[{issue}505]
+
+dev::["Custom text goes here."]
+
+dev::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
+
+dev::["Custom text goes here.",{issue}505]
+
+Text about feature in development...
+
+[[old-dev-feature]]
+=== Established feature
+
+This feature has been around for a while, but we're adding
+a new parameter that's in development:
+
+`established_param`::
+This param has been around for ages and won't change.
+
+`dev_param`::
+dev:[]
+This param is in development and may change in the future.
+
+`dev_param`::
+dev:["Custom text goes here."]
+This param is in development and may change in the future.
+----
+
+=== Using the `experimental` admonition
+
+[source,asciidoc]
+----
+[[new-feature]]
+=== New experimental feature
+
+experimental::[]
+
+experimental::[https://github.com/elastic/docs/issues/505]
+
+experimental::[{issue}505]
+
+experimental::["Custom text goes here."]
+
+experimental::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
+
+experimental::["Custom text goes here.",{issue}505]
+
+Text about new feature...
+
+[[old-feature]]
+=== Established feature
+
+This feature has been around for a while, but we're adding
+a new experimental parameter:
+
+`established_param`::
+This param has been around for ages and won't change.
+
+`experimental_param`::
+experimental:[]
+This param is experimental and may change in the future.
+
+`experimental_param`::
+experimental:["Custom text goes here."]
+This param is experimental and may change in the future.
+----
 
 [[images]]
 == Images

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -3,18 +3,23 @@
 require 'asciidoctor/extensions'
 
 ##
-# Extensions for marking when something as `beta` or `experimental`.
+# Extensions for marking when something as `beta`, `dev`, or `experimental`.
 #
 # Usage
 #
 #   beta::[]
+#   dev::[]
 #   experimental::[]
 #   Foo beta:[]
+#   Foo dev:[]
 #   Foo experimental:[]
 #
 class CareAdmonition < Asciidoctor::Extensions::Group
   BETA_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+  TEXT
+  DEV_DEFAULT_TEXT = <<~TEXT.strip
+    This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   EXPERIMENTAL_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
@@ -23,6 +28,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
   def activate(registry)
     [
       [:beta, 'beta', BETA_DEFAULT_TEXT],
+      [:dev, 'dev', DEV_DEFAULT_TEXT],
       [:experimental, 'experimental', EXPERIMENTAL_DEFAULT_TEXT],
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -116,7 +116,7 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
     /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
   CODE_BLOCK_RX = /^-----*$/
   SNIPPET_RX = %r{^//\s*(AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)$}
-  LEGACY_MACROS = 'added|beta|coming|deprecated|experimental'
+  LEGACY_MACROS = 'added|beta|coming|deprecated|dev|experimental'
   LEGACY_BLOCK_MACRO_RX = /^\s*(#{LEGACY_MACROS})\[(.*)\]\s*$/
   LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[(.*)\]/
 

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -232,6 +232,16 @@ RSpec.describe CareAdmonition do
     end
     include_examples 'care admonition'
   end
+  context 'dev' do
+    let(:key) { 'dev' }
+    let(:admon_class) { 'warning' }
+    let(:default_text) do
+      <<~TEXT.strip
+        This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
+      TEXT
+    end
+    include_examples 'care admonition'
+  end
   context 'experimental' do
     let(:key) { 'experimental' }
     let(:admon_class) { 'warning' }

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -140,6 +140,11 @@ RSpec.describe ElasticCompatPreprocessor do
       let(:name) { 'beta' }
       let(:inline_admon_class) { 'beta' }
     end
+    context 'for dev' do
+      include_context 'care admonition'
+      let(:name) { 'dev' }
+      let(:inline_admon_class) { 'dev' }
+    end
     context 'for experimental' do
       include_context 'care admonition'
       let(:name) { 'experimental' }

--- a/resources/web/style/toc.pcss
+++ b/resources/web/style/toc.pcss
@@ -83,11 +83,12 @@
       }
     }
 
-    .experimental,
+    .added,
     .beta,
     .coming,
-    .added,
-    .deprecated {
+    .deprecated,
+    .dev, 
+    .experimental {
         display: none;
     }
   }


### PR DESCRIPTION
Adds a new `dev` care admonition, similar to the existing `beta`
and `experimental` admonitions. Also cleans up some outdated/redundant
docs regarding care admonitions in the README.

The ES team has started developing more features under feature flags.
Previously, we've indicated that in the feature's docs using the
`experimental` care admonition.

However, we also use the `experimental` admonition for experimental
features. Unlike feature flag development, experimental features _are_
released as part of ES distributions.

Reusing the admonition could confuse users and our internal support
team. Creating a new admonition lets us set a reusable default text
that's easy for contributors to use.