### PR TITLE
Removed master from the list of ecctl branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -738,7 +738,7 @@ contents:
             subject:    ECE
             current:    2.5
             branches:   [ 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
-            index:      docs/cloud-enterprise/new-install-doc/index.asciidoc
+            index:      docs/cloud-enterprise/index.asciidoc
             chunk:      1
             private:    1
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -738,7 +738,7 @@ contents:
             subject:    ECE
             current:    2.5
             branches:   [ 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
-            index:      docs/cloud-enterprise/index.asciidoc
+            index:      docs/cloud-enterprise/new-install-doc/index.asciidoc
             chunk:      1
             private:    1
             sources:
@@ -835,7 +835,7 @@ contents:
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    v1.0.0-beta2
-            branches:   [ master, v1.0.0-beta2 ]
+            branches:   [ v1.0.0-beta2 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This PR removes `master` from the list of ecctl branches.