### PR TITLE
Remove `v` branches from ecctl docs — DO NOT MERGE YET

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -795,7 +795,7 @@ contents:
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    1.0.0-beta3
-            branches:   [ master, 1.0.0-beta3, 1.0.0-beta2, v1.0.0-beta3, v1.0.0-beta2 ]
+            branches:   [ master, 1.0.0-beta3, 1.0.0-beta2 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR removes the branches with `v` in the name from our ecctl doc builds. These branches match tags in the ecctl repo and we'd like to remove to simplify life. 

Relates to https://github.com/elastic/docs/pull/1840

Depends on https://github.com/elastic/website-www.elastic.co/issues/6128.