### PR TITLE
[DOCS] Add `child_attributes` attribute to API reference template

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -104,6 +104,7 @@ or using a collapsible section. For example, see the "get node stats" API or the
 "create anomaly detection jobs" API.
 ***************************************
 ////
+[role="child_attributes"]
 [[sample-api-request-body]]
 ==== {api-request-body-title}
 ////
@@ -119,7 +120,7 @@ the leader index.
 
 ////
 
-
+[role="child_attributes"]
 [[sample-api-response-body]]
 ==== {api-response-body-title}
 ////


### PR DESCRIPTION
Adds the `[role="child_attributes"]` role attribute to the API reference
template.

This attribute allows us to nicely display nested parameters.

Since the attribute does nothing if a collapsible section isn't present,
we should include it by default. This'll make things easier for
non-writer contributors.