### PR TITLE
Change ECE book chunking level

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -702,7 +702,7 @@ contents:
             current:    2.5
             branches:   [ 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
-            chunk:      1
+            chunk:      2
             private:    1
             sources:
               -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -84,7 +84,7 @@ alias docbldec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/saas/index.
 alias docbldess=docbldec
 
 # Cloud - Elastic Cloud Enterprise
-alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud-assets/docs --chunk 1'
+alias docbldece='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/cloud-enterprise/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud-assets/docs --chunk 2'
 
 alias docbldech='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud/docs/heroku/index.asciidoc --resource=$GIT_HOME/cloud/docs/shared --resource=$GIT_HOME/cloud/docs/saas --chunk 1'
 


### PR DESCRIPTION
This updates the ECE book chunking level from `1` to `2`.  This will enable the structure that Arianna has planned for the ECE install section.  

Also, I notice in at least one spot it improves our existing structure by adding a few new links in our ToC.  Improved navigation is always a win. :-)

Chunk level set to `1`:
![Screen Shot 2020-05-26 at 2 54 36 PM](https://user-images.githubusercontent.com/41695641/82941368-3d2b1100-9f64-11ea-9d26-a14d109e7533.png)

Chunk level set to `2`: 
![Screen Shot 2020-05-26 at 2 53 33 PM](https://user-images.githubusercontent.com/41695641/82941409-4ae09680-9f64-11ea-9852-17deb7dd923b.png)
