### PR TITLE
[DOCS] Add short-version attribute

### DIFF
--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -12,6 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4
+:short-version:          8
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -11,8 +11,8 @@ bare_version never includes -alpha or -beta
 :minor-version:          7.8
 :major-version:          7.x
 :prev-major-version:     6.x
+:major-version-only:     8
 :ecs_version:            1.4
-:short-version:          7
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4
-:short-version:          8
+:short-version:          7
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -11,7 +11,7 @@ bare_version never includes -alpha or -beta
 :minor-version:          7.8
 :major-version:          7.x
 :prev-major-version:     6.x
-:major-version-only:     8
+:major-version-only:     7
 :ecs_version:            1.4
 
 //////////

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,6 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4
+:short-version:          8
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :ecs_version:            1.4
-:short-version:          8
+:short-version:          7
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -11,7 +11,7 @@ bare_version never includes -alpha or -beta
 :minor-version:          7.9
 :major-version:          7.x
 :prev-major-version:     6.x
-:major-version-only:     8
+:major-version-only:     7
 :ecs_version:            1.4
 
 //////////

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -11,8 +11,8 @@ bare_version never includes -alpha or -beta
 :minor-version:          7.9
 :major-version:          7.x
 :prev-major-version:     6.x
+:major-version-only:     8
 :ecs_version:            1.4
-:short-version:          7
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -11,8 +11,8 @@ bare_version never includes -alpha or -beta
 :minor-version:          8.0
 :major-version:          8.x
 :prev-major-version:     7.x
+:major-version-only:     8
 :ecs_version:            1.4
-:short-version:          8
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,6 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :ecs_version:            1.4
+:short-version:          8
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
This PR adds a `short-version` attribute to the `versions/stack` attribute files for `master`, `7.x`, and `7.8` .