### PR TITLE
Add naming guideline for topic titles and IDs

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -329,6 +329,10 @@ for more.
 These IDs are also used to link to sections within each
 book.  See <<linking>>.
 
+TIP: For search engine optimization (SEO), make sure the keywords you use in the
+ID match keywords used in the topic title. For example, if the topic is called
+"Install XYZ", use `+[[install-xyz]]+` for the topic ID.
+
 === TOC titles
 
 By default, the link text used in the generated TOC is


### PR DESCRIPTION
Adds a tip to help doc contributors use topic titles and IDs that improve SEO.

@AnneB-SEO I'm trying to keep this guideline simple, but let me know if you think I should say more.