### PR TITLE
Show better error when Docker missing.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -7,10 +7,10 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 This documentation build process is provided to the public purely for the
 purpose of testing documentation changes before submitting pull requests to
-the appropriate Elasticsearch repository.
+the appropriate Elastic repository.
 
 The documents produced by this build process may be published only on
-http://www.elastic.co. They may not be published in any other form or
+https://www.elastic.co. They may not be published in any other form or
 on any other website without explicit permission.
 
 [[setup]]
@@ -19,7 +19,10 @@ on any other website without explicit permission.
 [float]
 == Requirements
 
-You'll need `bash` and `docker`.
+You'll need the following installed:
+
+* Python (Python 3 preferred, but Python 2 will probably be fine)
+* Docker
 
 [float]
 == Cloning the repository
@@ -1549,7 +1552,7 @@ a new parameter that's in beta:
 `established_param`::
 This param has been around for ages and won't change.
 
-`beta_param`:: 
+`beta_param`::
 beta:[]
 This param is in beta and may change in the future.
 

--- a/build_docs
+++ b/build_docs
@@ -28,6 +28,7 @@
 
 from __future__ import print_function
 
+import errno
 import logging
 from os import environ, getgid, getuid
 from os.path import basename, dirname, exists, expanduser, isdir
@@ -645,6 +646,10 @@ if __name__ == '__main__':
         if e.output:
             print(e.output)
         exit(e.returncode)
+    except OSError as e:
+        print(e)
+        if e.errno == errno.ENOENT:
+            print("Are you sure Docker is installed?")
     except KeyboardInterrupt:
         # Just quit if we get ctrl-c
         exit(1)


### PR DESCRIPTION
Python 2 (annoyingly) doesn't include the name of the missing file, but
we assume that it's `docker`, since other files passed as arguments
should get logged by Perl in the Docker container, not by Python on the
host.

See https://github.com/elastic/docs/issues/1379.

Python 2:
```
$ ./build_docs --doc README.asciidoc --open
[Errno 2] No such file or directory
Are you sure Docker is installed?
```

Python 3:
```
$ ./build_docs --doc README.asciidoc --open
[Errno 2] No such file or directory: 'docker'
Are you sure Docker is installed?
```