### PR TITLE
[DOCS] Add multi-parameter footnote attributes

### DIFF
--- a/shared/api-ref-ex.asciidoc
+++ b/shared/api-ref-ex.asciidoc
@@ -67,6 +67,9 @@ Guidelines for parameter documentation
 * Include whether the parameter is Optional or Required and the data type.
 * Include default values as the last sentence of the first paragraph.
 * Include a range of valid values, if applicable.
+* For options that can be specified using a query or request body parameter,
+  add `{multi-param}` to the first occurrence. Use `{multi-param-ref}` in
+  subsequent occurrences.
 * If the parameter requires a specific delimiter for multiple values, say so.
 * If the parameter supports wildcards, ditto.
 ***************************************

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -289,6 +289,9 @@ Common words and phrases
 :multi-arg:     †footnoteref:[multi-arg,This parameter accepts multiple arguments.]
 :multi-arg-ref: †footnoteref:[multi-arg]
 
+:multi-param:     ‡footnoteref:[multi-param,You can specify this option as a query parameter or a request body parameter. If both parameters are specified, only the query parameter is used.]
+:multi-param-ref: ‡footnoteref:[multi-param]
+
 //////////
 Legacy definitions
 //////////


### PR DESCRIPTION
Several Elasticsearch APIs support options that can be specified as a query parameter or a request body parameter.

Currently, this is documented using notes, which can get rather lengthy. This
replaces those multiple notes with a reusable footnote that can be referenced
using the `{multi-param}` and `{multi-param-ref}` attributes.