### PR TITLE
Adds shared attributes section to README

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -685,7 +685,10 @@ build process. They are labelled `<repo>-root`, where `<repo>` is the name
 defined at the top of the
 https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`]. For example,
 there is an `elasticsearch-root` attribute that resolves to the root path of the
-Elasticsearch repo.
+Elasticsearch repo. Please use these root attributes or define `es-repo-dir`,
+for example, rather than relying on intrinsic attributes like `{docdir}` and
+`{asciidoc-dir}`. The instrinsic attributes are problematic when you re-use
+files in different source file paths.
 
 If books don't use shared attributes files, the attributes generally appear at
 the beginning of the book, under the title. For example:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -646,6 +646,64 @@ ifndef::env-github[]
 +&#x28;R)+::  (R)
 endif::[]
 
+[[shared-attributes]]
+== Shared attributes
+
+To facilitate consistency across the documentation, there are shared attributes
+for common terms and URLs: https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc. 
+There are also attributes related to the versions and branches that are used to
+build our books
+(for example: https://github.com/elastic/docs/blob/master/shared/versions/stack/master.asciidoc).
+
+Books that use shared attributes files must declare a dependency on them in
+https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`] like this:
+
+[source,yaml]
+----
+  -
+    repo:   docs
+    path:   shared/versions/stack/{version}.asciidoc
+  -
+    repo:   docs
+    path:   shared/attributes.asciidoc
+----
+
+or
+
+[source,yaml]
+----
+  -
+    repo:   docs
+    path:   shared/versions/stack/current.asciidoc
+  -
+    repo:   docs
+    path:   shared/attributes.asciidoc
+----
+
+There is also a special set of attributes that are automatically created by the
+build process. They are labelled `<repo>-root`, where `<repo>` is the name
+defined at the top of the
+https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`]. For example,
+there is an `elasticsearch-root` attribute that resolves to the root path of the
+Elasticsearch repo.
+
+If books don't use shared attributes files, the attributes generally appear at
+the beginning of the book, under the title. For example:
+
+.Using book-scoped attributes for cross-document linking
+==================================
+
+[source,asciidoc]
+----------------------------------
+= My Book Title
+
+:branch: master
+:ref:    https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
+
+Here is a link to the {ref}/search.html[search page]
+----------------------------------
+==================================
+
 [[linking]]
 == Linking
 
@@ -756,7 +814,7 @@ the build process.
 
 === Cross document links
 
-Links to other Elasticsearch docs are essentially the
+Links to other Elastic books are essentially the
 same as external links. However, for conciseness and
 maintainability, you should use an _attribute_ to
 represent the absolute URL of the docs.
@@ -782,51 +840,6 @@ attributes file] to resolve links:
 
 Here is a link to the {ref}/search.html[search page]
 ----------------------------------
-
-Here is a link to the {ref}/search.html[search page]
-==================================
-
-Books that use the attributes file should declare a dependency on it in
-https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`] like this:
-
-[source,yaml]
-----
-  -
-    repo:   docs
-    path:   shared/versions/stack/{version}.asciidoc
-  -
-    repo:   docs
-    path:   shared/attributes.asciidoc
-----
-
-or
-
-[source,yaml]
-----
-  -
-    repo:   docs
-    path:   shared/versions/stack/current.asciidoc
-  -
-    repo:   docs
-    path:   shared/attributes.asciidoc
-----
-
-For books that don't use the
-https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc[shared
-attributes file], the attributes appear at the beginning of the docs, under the
-book title:
-
-.Using book-scoped attributes for cross-document linking
-==================================
-
-[source,asciidoc]
-----------------------------------
-= My Book Title
-
-Here is a link to the {ref}/search.html[search page]
-----------------------------------
-
-Here is a link to the {ref}/search.html[search page]
 ==================================
 
 The main benefit of using attributes for cross document links is


### PR DESCRIPTION
This PR adds a new "Shared attributes" section to the readme (moving some existing content out of the linking section and augmenting it with details about the special *-root attributes). 