### PR TITLE
docs: Guide order

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -837,542 +837,6 @@ contents:
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
-    -   title:      "Logstash: Collect, Enrich, and Transport"
-        sections:
-          - title:      Logstash Reference
-            prefix:     en/logstash
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            live:       *stacklive
-            index:      docs/index.x.asciidoc
-            chunk:      1
-            tags:       Logstash/Reference
-            subject:    Logstash
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   logstash
-                path:   docs/
-              -
-                repo:   x-pack-logstash
-                prefix: logstash-extra/x-pack-logstash
-                path:   docs/en
-                private: true
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   logstash-docs
-                path:   docs/
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-          - title:      Logstash Versioned Plugin Reference
-            prefix:     en/logstash-versioned-plugins
-            current:    versioned_plugin_docs
-            branches:   [ versioned_plugin_docs ]
-            index:      docs/versioned-plugins/index.asciidoc
-            private:    1
-            chunk:      1
-            noindex:    1
-            tags:       Logstash/Plugin Reference
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash-docs
-                path:   docs/versioned-plugins
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
-    -   title:      "Beats: Collect, Parse, and Ship"
-        sections:
-          - title:      Beats Platform Reference
-            prefix:     en/beats/libbeat
-            index:      libbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklive
-            chunk:      1
-            tags:       Libbeat/Reference
-            subject:    libbeat
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Beats Developer Guide
-            prefix:     en/beats/devguide
-            index:      docs/devguide/index.asciidoc
-            current:    master
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Devguide/Reference
-            subject:    Beats
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   beats
-                path:   docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   metricbeat/module
-              -
-                repo:   beats
-                path:   metricbeat/scripts
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Packetbeat Reference
-            prefix:     en/beats/packetbeat
-            index:      packetbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklive
-            chunk:      1
-            tags:       Packetbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Packetbeat
-            sources:
-              -
-                repo:   beats
-                path:   packetbeat
-              -
-                repo:   beats
-                path:   packetbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Filebeat Reference
-            prefix:     en/beats/filebeat
-            index:      filebeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklive
-            chunk:      1
-            tags:       Filebeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Filebeat
-            sources:
-              -
-                repo:   beats
-                path:   filebeat
-              -
-                repo:   beats
-                path:   filebeat/docs
-              -
-                repo:   beats
-                path:   x-pack/filebeat/docs
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/filebeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Winlogbeat Reference
-            prefix:     en/beats/winlogbeat
-            index:      winlogbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Winlogbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Winlogbeat
-            sources:
-              -
-                repo:   beats
-                path:   winlogbeat
-              -
-                repo:   beats
-                path:   winlogbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Metricbeat Reference
-            prefix:     en/beats/metricbeat
-            index:      metricbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Metricbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Metricbeat
-            sources:
-              -
-                repo:   beats
-                path:   metricbeat
-              -
-                repo:   beats
-                path:   metricbeat/docs
-              -
-                repo:   beats
-                path:   metricbeat/module
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   x-pack/metricbeat/module
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   beats
-                path:   metricbeat/scripts
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Heartbeat Reference
-            prefix:     en/beats/heartbeat
-            current:    *stackcurrent
-            index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Heartbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Heartbeat
-            sources:
-              -
-                repo:   beats
-                path:   heartbeat
-              -
-                repo:   beats
-                path:   heartbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Auditbeat Reference
-            prefix:     en/beats/auditbeat
-            index:      auditbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Auditbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Auditbeat
-            sources:
-              -
-                repo:   beats
-                path:   auditbeat
-              -
-                repo:   beats
-                path:   auditbeat/docs
-              -
-                repo:   beats
-                path:   x-pack/auditbeat
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-              -
-                repo:   beats
-                path:   auditbeat/module
-              -
-                repo:   beats
-                path:   auditbeat/scripts
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Functionbeat Reference
-            prefix:     en/beats/functionbeat
-            current:    *stackcurrent
-            index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Functionbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Functionbeat
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/functionbeat
-              -
-                repo:   beats
-                path:   x-pack/functionbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Journalbeat Reference
-            prefix:     en/beats/journalbeat
-            current:    *stackcurrent
-            index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Journalbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Journalbeat
-            sources:
-              -
-                repo:   beats
-                path:   journalbeat
-              -
-                repo:   beats
-                path:   journalbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Logging Plugin for Docker
-            prefix:     en/beats/loggingplugin
-            current:    *stackcurrent
-            index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6 ]
-            chunk:      1
-            tags:       Elastic Logging Plugin/Reference
-            respect_edit_url_overrides: true
-            subject:    Elastic Logging Plugin
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/dockerlogbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Legacy Topbeat Reference
-            prefix:     en/beats/topbeat
-            index:      topbeat/docs/index.asciidoc
-            current:    1.3
-            branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
-            chunk:      1
-            noindex:    1
-            tags:       Legacy/Topbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Topbeat
-            sources:
-              -
-                repo:   beats
-                path:   topbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-
     -   title:      Enterprise Search
         sections:
           - title:      Enterprise Search Guide
@@ -1687,6 +1151,522 @@ contents:
               -
                 repo:   kibana
                 path:   docs/
+
+    -   title:      "Logstash: Collect, Enrich, and Transport"
+        sections:
+          - title:      Logstash Reference
+            prefix:     en/logstash
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            live:       *stacklive
+            index:      docs/index.x.asciidoc
+            chunk:      1
+            tags:       Logstash/Reference
+            subject:    Logstash
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   logstash
+                path:   docs/
+              -
+                repo:   x-pack-logstash
+                prefix: logstash-extra/x-pack-logstash
+                path:   docs/en
+                private: true
+                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   logstash-docs
+                path:   docs/
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+          - title:      Logstash Versioned Plugin Reference
+            prefix:     en/logstash-versioned-plugins
+            current:    versioned_plugin_docs
+            branches:   [ versioned_plugin_docs ]
+            index:      docs/versioned-plugins/index.asciidoc
+            private:    1
+            chunk:      1
+            noindex:    1
+            tags:       Logstash/Plugin Reference
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash-docs
+                path:   docs/versioned-plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
+    -   title:      "Beats: Collect, Parse, and Ship"
+        sections:
+          - title:      Beats Platform Reference
+            prefix:     en/beats/libbeat
+            index:      libbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
+            chunk:      1
+            tags:       Libbeat/Reference
+            subject:    libbeat
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Auditbeat Reference
+            prefix:     en/beats/auditbeat
+            index:      auditbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Auditbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Auditbeat
+            sources:
+              -
+                repo:   beats
+                path:   auditbeat
+              -
+                repo:   beats
+                path:   auditbeat/docs
+              -
+                repo:   beats
+                path:   x-pack/auditbeat
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+              -
+                repo:   beats
+                path:   auditbeat/module
+              -
+                repo:   beats
+                path:   auditbeat/scripts
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Filebeat Reference
+            prefix:     en/beats/filebeat
+            index:      filebeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
+            chunk:      1
+            tags:       Filebeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Filebeat
+            sources:
+              -
+                repo:   beats
+                path:   filebeat
+              -
+                repo:   beats
+                path:   filebeat/docs
+              -
+                repo:   beats
+                path:   x-pack/filebeat/docs
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/filebeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Functionbeat Reference
+            prefix:     en/beats/functionbeat
+            current:    *stackcurrent
+            index:      x-pack/functionbeat/docs/index.asciidoc
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Functionbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Functionbeat
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/functionbeat
+              -
+                repo:   beats
+                path:   x-pack/functionbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Journalbeat Reference
+            prefix:     en/beats/journalbeat
+            current:    *stackcurrent
+            index:      journalbeat/docs/index.asciidoc
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Journalbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Journalbeat
+            sources:
+              -
+                repo:   beats
+                path:   journalbeat
+              -
+                repo:   beats
+                path:   journalbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Heartbeat Reference
+            prefix:     en/beats/heartbeat
+            current:    *stackcurrent
+            index:      heartbeat/docs/index.asciidoc
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Heartbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Heartbeat
+            sources:
+              -
+                repo:   beats
+                path:   heartbeat
+              -
+                repo:   beats
+                path:   heartbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Metricbeat Reference
+            prefix:     en/beats/metricbeat
+            index:      metricbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Metricbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Metricbeat
+            sources:
+              -
+                repo:   beats
+                path:   metricbeat
+              -
+                repo:   beats
+                path:   metricbeat/docs
+              -
+                repo:   beats
+                path:   metricbeat/module
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   x-pack/metricbeat/module
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   beats
+                path:   metricbeat/scripts
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Packetbeat Reference
+            prefix:     en/beats/packetbeat
+            index:      packetbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklive
+            chunk:      1
+            tags:       Packetbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Packetbeat
+            sources:
+              -
+                repo:   beats
+                path:   packetbeat
+              -
+                repo:   beats
+                path:   packetbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Winlogbeat Reference
+            prefix:     en/beats/winlogbeat
+            index:      winlogbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Winlogbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Winlogbeat
+            sources:
+              -
+                repo:   beats
+                path:   winlogbeat
+              -
+                repo:   beats
+                path:   winlogbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Beats Developer Guide
+            prefix:     en/beats/devguide
+            index:      docs/devguide/index.asciidoc
+            current:    master
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Devguide/Reference
+            subject:    Beats
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   beats
+                path:   docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   metricbeat/module
+              -
+                repo:   beats
+                path:   metricbeat/scripts
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Elastic Logging Plugin for Docker
+            prefix:     en/beats/loggingplugin
+            current:    *stackcurrent
+            index:      x-pack/dockerlogbeat/docs/index.asciidoc
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6 ]
+            chunk:      1
+            tags:       Elastic Logging Plugin/Reference
+            respect_edit_url_overrides: true
+            subject:    Elastic Logging Plugin
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/dockerlogbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
     - title:     Docs in Your Native Tongue
       sections:
@@ -2092,6 +2072,26 @@ contents:
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Legacy Topbeat Reference
+            prefix:     en/beats/topbeat
+            index:      topbeat/docs/index.asciidoc
+            current:    1.3
+            branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
+            chunk:      1
+            noindex:    1
+            tags:       Legacy/Topbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Topbeat
+            sources:
+              -
+                repo:   beats
+                path:   topbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
 
 redirects:
     -

--- a/conf.yaml
+++ b/conf.yaml
@@ -894,50 +894,6 @@ contents:
                 repo:   swiftype
                 path:   docs
 
-    -   title:      Elastic Security
-        sections:
-          - title:      Elastic Security
-            prefix:     en/security
-            current:    master
-            branches:   [ master, 7.x, 7.8 ]
-            live:       *stacklive
-            index:      docs/index.asciidoc
-            chunk:      1
-            tags:       Security/Guide
-            subject:    Security
-            sources:
-              -
-                repo:   security-docs
-                path:   docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   stack-docs
-                path:   docs/en
-          - title:      SIEM Guide
-            prefix:     en/siem/guide
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            live:       *stacklive
-            index:      docs/en/siem/index.asciidoc
-            chunk:      1
-            tags:       SIEM/Guide
-            subject:    SIEM
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
           - title:      Application Performance Monitoring (APM)
@@ -1151,6 +1107,50 @@ contents:
               -
                 repo:   kibana
                 path:   docs/
+
+    -   title:      Elastic Security
+        sections:
+          - title:      Elastic Security
+            prefix:     en/security
+            current:    master
+            branches:   [ master, 7.x, 7.8 ]
+            live:       *stacklive
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       Security/Guide
+            subject:    Security
+            sources:
+              -
+                repo:   security-docs
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   stack-docs
+                path:   docs/en
+          - title:      SIEM Guide
+            prefix:     en/siem/guide
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            live:       *stacklive
+            index:      docs/en/siem/index.asciidoc
+            chunk:      1
+            tags:       SIEM/Guide
+            subject:    SIEM
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
     -   title:      "Logstash: Collect, Enrich, and Transport"
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -2072,7 +2072,7 @@ contents:
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      Legacy Topbeat Reference
+          - title:      Topbeat Reference
             prefix:     en/beats/topbeat
             index:      topbeat/docs/index.asciidoc
             current:    1.3

--- a/conf.yaml
+++ b/conf.yaml
@@ -1270,7 +1270,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
+                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   beats
                 path:   x-pack/libbeat/processors/*/docs/*
@@ -1278,7 +1278,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
+                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1554,7 +1554,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   x-pack/libbeat/processors/*/docs/*
@@ -1562,7 +1562,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1383,47 +1383,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Journalbeat Reference
-            prefix:     en/beats/journalbeat
-            current:    *stackcurrent
-            index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Journalbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Journalbeat
-            sources:
-              -
-                repo:   beats
-                path:   journalbeat
-              -
-                repo:   beats
-                path:   journalbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
@@ -1471,6 +1430,47 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+          - title:      Journalbeat Reference
+            prefix:     en/beats/journalbeat
+            current:    *stackcurrent
+            index:      journalbeat/docs/index.asciidoc
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Journalbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Journalbeat
+            sources:
+              -
+                repo:   beats
+                path:   journalbeat
+              -
+                repo:   beats
+                path:   journalbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc


### PR DESCRIPTION
## Summary

@KOTungseth pointed out that our solution docs are hidden away at the bottom of our current documentation landing page. To better 3+1ify the page, this PR moves our solution documentation above the Logstash and Beats reference. The page still isn't perfect, but in its current structure, it will never be.

@dedemorton asked if I could also update the order the Beats documentation while I was working with the file. Beats are now sorted alphabetically, with the Beats platform reference at the top of the list, and the Beats developer reference at the bottom.

## Screenshot

![screencapture-docs-1861-docs-preview-app-elstc-co-guide-index-html-2020-06-03-20_38_30](https://user-images.githubusercontent.com/5618806/83712318-57a36100-a5da-11ea-969b-f87c16df8416.png)
