### PR TITLE
Add attributes for ingest management

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -122,7 +122,7 @@ Ingest terms
 :agent: Elastic Agent
 :fleet: Fleet
 :ingest-manager: Ingest Manager
-:package-manager: package manager
+:package-manager: Elastic Package Manager
 :integrations: Integrations
 :package-registry: Elastic Package Registry
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -116,6 +116,17 @@ Kibana app names
 :siem-app: SIEM app
 
 //////////
+Ingest terms
+//////////
+
+:agent: Elastic Agent
+:fleet: Fleet
+:ingest-manager: Ingest Manager
+:package-manager: package manager
+:integrations: Integrations
+:package-registry: Elastic Package Registry
+
+//////////
 Common words and phrases
 //////////
 :stack:           Elastic Stack


### PR DESCRIPTION
Adds attributes (variables) for names related to new ingest management capabilities. 

@mostlyjason Can you verify the names here? Not sure if I got these right, although I did read through 3 different issue.  I couldn't figure out the final decision on a couple names, like the package registry. :-) 

@skh After we merge this PR, please use these attributes in place of names in the ingest management docs. For example, instead of Elastic Agent, use `{agent}`.

The Kibana Reference already includes the file. To include the file in new docs, use:

`include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]`