### PR TITLE
Change current for ESS to MS 39

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -592,8 +592,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-36
-            branches:   [ release-ms-36 ]
+            current:    release-ms-39
+            branches:   [ release-ms-39 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -609,7 +609,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-36: master
+                  release-ms-39: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -644,8 +644,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-36
-            branches:   [ release-ms-36 ]
+            current:    release-ms-39
+            branches:   [ release-ms-39 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
With the release of milestone 39﻿to happen soon, we should get a PR ready to change our doc builds to use the new milestone for ESS and Heroku. 

@elastic/cloud-writers could one of you approve this PR, please? 

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
