### PR TITLE
Get Ingest Management docs building

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -896,28 +896,6 @@ contents:
 
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
-          - title:      Ingest Management Guide
-            prefix:     en/ingest-management
-            current:    7.8
-            branches:   [ master, 7.x, 7.8 ]
-            live:       [ master, 7.x, 7.8 ]
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      1
-            tags:       Ingest Management/Guide
-            subject:    Ingest Management
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   beats
-                path:   x-pack/elastic-agent/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
@@ -1683,6 +1661,28 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Ingest Management Guide
+            prefix:     en/ingest-management
+            current:    7.8
+            branches:   [ master, 7.x, 7.8 ]
+            live:       [ master, 7.x, 7.8 ]
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      1
+            tags:       Ingest Management/Guide
+            subject:    Ingest Management
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   beats
+                path:   x-pack/elastic-agent/docs
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -897,7 +897,7 @@ contents:
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
           - title:      Ingest Management Guide
-            prefix:     en/ingest-management/guide
+            prefix:     en/ingest-management
             current:    7.8
             branches:   [ master, 7.x, 7.8 ]
             live:       [ master, 7.x, 7.8 ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -896,6 +896,28 @@ contents:
 
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
+          - title:      Ingest Management Guide
+            prefix:     en/ingest-management/guide
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8 ]
+            live:       [ master, 7.x, 7.8 ]
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      1
+            tags:       Ingest Management/Guide
+            subject:    Ingest Management
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   beats
+                path:   x-pack/elastic-agent/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -898,7 +898,7 @@ contents:
         sections:
           - title:      Ingest Management Guide
             prefix:     en/ingest-management/guide
-            current:    *stackcurrent
+            current:    7.8
             branches:   [ master, 7.x, 7.8 ]
             live:       [ master, 7.x, 7.8 ]
             index:      docs/en/ingest-management/index.asciidoc

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -116,6 +116,9 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
+# Ingest management
+alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
+
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Initial PR to add ingest management docs.

Draft until we get the initial files in place.

Open issues:
- [x] Finalize location of the content. The options are:
  - Put under Elastic Stack
  - Put under Observability: APM, Logs, Metrics, and Uptime
  - Rename "Beats: Collect, Parse, and Ship" to "Collect, Parse, and Ship" and put under there.

UPDATE: Decision was to put under Beats for now because this feature is experimental.