### PR TITLE
Add 7.8 branch to Enterprise Search books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -844,7 +844,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7 ]
+            branches:   [ 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -861,7 +861,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7, 7.6 ]
+            branches:   [ 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -878,7 +878,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.7 ]
+            branches:   [ 7.8, 7.7 ]
             chunk:     1
             tags:       App Search/Guide
             subject:    App Search


### PR DESCRIPTION
**To be merged by the docs release manager during the 7.8.0 docs release**

Preview: https://docs_1866.docs-preview.app.elstc.co/guide/index.html