### PR TITLE
[DOCS] Remove branches from Stack Overview

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1932,10 +1932,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    *stackcurrent
+            current:    6.8
             index:      docs/en/stack/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklive
+            branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             noindex:    1
             tags:       Legacy/Elastic Stack/Overview

--- a/conf.yaml
+++ b/conf.yaml
@@ -1932,9 +1932,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Stack Overview
             prefix:     en/elastic-stack-overview
-            current:    6.8
+            current:    7.4
             index:      docs/en/stack/index.asciidoc
-            branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             noindex:    1
             tags:       Legacy/Elastic Stack/Overview


### PR DESCRIPTION
The content in the Stack Overview was moved elsewhere and it doesn't contain any useful information after 6.3. Redirects were created, so there doesn't seem to be any point to having 7.x or later branches in that book.