### PR TITLE
Adds shared attributes for release doc PR URLs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -306,15 +306,18 @@ Common words and phrases
 //////////
 Issue and pull request URLs
 //////////
-:es-repo:   https://github.com/elastic/elasticsearch/
-:es-pull:   {es-repo}pull/
-:es-issue:  {es-repo}issues/
-:kib-repo:  https://github.com/elastic/kibana/
-:kib-issue: {kib-repo}issues/
-:kib-pull:  {kib-repo}pull/
-:ml-repo:   https://github.com/elastic/ml-cpp/
-:ml-issue:  {ml-repo}issues/
-:ml-pull:   {ml-repo}pull/
+:es-repo:    https://github.com/elastic/elasticsearch/
+:es-issue:   {es-repo}issues/
+:es-pull:    {es-repo}pull/
+:es-commit:  {es-repo}commit/
+:kib-repo:   https://github.com/elastic/kibana/
+:kib-issue:  {kib-repo}issues/
+:kib-pull:   {kib-repo}pull/
+:kib-commit: {kib-repo}commit/
+:ml-repo:    https://github.com/elastic/ml-cpp/
+:ml-issue:   {ml-repo}issues/
+:ml-pull:    {ml-repo}pull/
+:ml-commit:  {ml-repo}commit/
 
 //////////
 Legacy definitions

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -304,6 +304,19 @@ Common words and phrases
 :multi-arg-ref: †footnoteref:[multi-arg]
 
 //////////
+Issue and pull request URLs
+//////////
+:es-repo:   https://github.com/elastic/elasticsearch/
+:es-pull:   {es-repo}pull/
+:es-issue:  {es-repo}issues/
+:kib-repo:  https://github.com/elastic/kibana/
+:kib-issue: {kib-repo}issues/
+:kib-pull:  {kib-repo}pull/
+:ml-repo:   https://github.com/elastic/ml-cpp/
+:ml-issue:  {ml-repo}issues/
+:ml-pull:   {ml-repo}pull/
+
+//////////
 Legacy definitions
 //////////
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}


### PR DESCRIPTION
The Kibana and Elasticsearch documentation use "{pull}" and "{issue}" attributes with different values (e.g. https://raw.githubusercontent.com/elastic/kibana/master/docs/index.asciidoc and https://raw.githubusercontent.com/elastic/elasticsearch/master/docs/Versions.asciidoc), which can cause problems when the content is used in a shared context (such as the Installation and Upgrade Guide). 

This PR defines repo-specific attributes in the shared attributes file to solve the problem.