### PR TITLE
Sets apm branches for 7.x to master

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -32,6 +32,14 @@
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
+///////
+APM does not build n.x documentation. Links from .x branches should point to master instead
+///////
+ifeval::["{source_branch}"=="7.x"]
+:apm-server-ref:       {apm-server-ref-m}
+:apm-server-ref-v:     {apm-server-ref-m}
+:apm-overview-ref-v:   {apm-overview-ref-m}
+endif::[]
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x


### PR DESCRIPTION
APM doesn't build the 7.x branch, so we need to set the URL to master to avoid breaking the build.