### PR TITLE
Set branch for apm-get-started-ref attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -39,6 +39,7 @@ ifeval::["{source_branch}"=="7.x"]
 :apm-server-ref:       {apm-server-ref-m}
 :apm-server-ref-v:     {apm-server-ref-m}
 :apm-overview-ref-v:   {apm-overview-ref-m}
+:apm-get-started-ref:  {apm-overview-ref-m}
 endif::[]
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current


### PR DESCRIPTION
Missed this one in https://github.com/elastic/docs/pull/1873