### PR TITLE
Add kibana dependency to Glossary

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -130,10 +130,10 @@ contents:
                 path:   docs/en
               -
                 repo:   elasticsearch
-                path:   docs/reference
+                path:   docs/reference/glossary.asciidoc
               -
                 repo:   kibana
-                path:   docs
+                path:   docs/glossary.asciidoc
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -132,6 +132,9 @@ contents:
                 repo:   elasticsearch
                 path:   docs/reference
               -
+                repo:   kibana
+                path:   docs
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -44,7 +44,7 @@ alias docbldstkold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en
 
 
 # Glossary
-alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs'
+alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs --resource=$GIT_HOME/kibana/docs'
 
 # Getting started
 alias docbldgs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/69721

This PR adds the kibana repo as a resource for the Glossary so that it can pull tagged sections from that repo.