### PR TITLE
[WIP] Add Observability docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -905,6 +905,25 @@ contents:
 
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
+          - title:      Observability
+            prefix:     en/observability
+            current:    *stackcurrent
+            branches:   [ master ]
+            live:       *stacklive
+            index:      docs/en/observability/index.asciidoc
+            chunk:      1
+            tags:       Observability/Guide
+            subject:    Observability
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc          
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -34,6 +34,7 @@ repos:
     kibana-cn:            https://github.com/elasticsearch-cn/kibana.git
     logstash:             https://github.com/elastic/logstash.git
     logstash-docs:        https://github.com/elastic/logstash-docs.git
+    observability-docs:   https://github.com/elastic/observability-docs.git
     security-docs:        https://github.com/elastic/security-docs.git
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
@@ -907,7 +908,7 @@ contents:
         sections:
           - title:      Observability
             prefix:     en/observability
-            current:    *stackcurrent
+            current:    master
             branches:   [ master ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
@@ -916,7 +917,7 @@ contents:
             subject:    Observability
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs
@@ -1095,7 +1096,7 @@ contents:
             subject:    Logs
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs
@@ -1114,7 +1115,7 @@ contents:
             subject:    Metrics
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs
@@ -1706,7 +1707,7 @@ contents:
             subject:    Ingest Management
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   beats

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -59,6 +59,8 @@ alias docbldsoold=docbldso
 alias docbldaz='$GIT_HOME/docs/build_docs --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
+alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/observability/index.asciidoc --chunk 1'
+
 alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/metrics/index.asciidoc --chunk 1'
 
 alias docbldlog='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/logs/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -59,11 +59,11 @@ alias docbldsoold=docbldso
 alias docbldaz='$GIT_HOME/docs/build_docs --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/observability/index.asciidoc --chunk 1'
+alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 1'
 
-alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/metrics/index.asciidoc --chunk 1'
+alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/metrics/index.asciidoc --chunk 1'
 
-alias docbldlog='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/logs/index.asciidoc --chunk 1'
+alias docbldlog='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/logs/index.asciidoc --chunk 1'
 
 alias docbldup='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
 
@@ -119,7 +119,7 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
 # Ingest management
-alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
+alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -77,6 +77,7 @@ endif::[]
 :logs-ref:             https://www.elastic.co/guide/en/logs/{branch}
 :logs-guide:           https://www.elastic.co/guide/en/logs/guide/{branch}
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
+:observability-guide:  https://www.elastic.co/guide/en/observability/{branch}
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
@@ -296,6 +297,7 @@ Common words and phrases
 
 :default-dist:             default distribution
 :oss-dist:                 OSS-only distribution
+:observability:            Observability
 
 :api-request-title:        Request
 :api-prereq-title:         Prerequisites


### PR DESCRIPTION
This PR is to add the forthcoming Observability docs. The PR includes:

- Observability docs added to config file
- Doc build alias for Observability docs
- Observability docs added to shared attributes file

Related Issue: 

- [x] Add Observability docs to the stack-docs repo. https://github.com/elastic/stack-docs/pull/1216
