### PR TITLE
Test observability-docs repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1073,7 +1073,7 @@ contents:
             prefix:     en/logs/guide
             current:    master
             branches:   [ master ]
-            live:       master
+            live:       [ master ]
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1092,7 +1092,7 @@ contents:
             prefix:     en/metrics/guide
             current:    master
             branches:   [ master ]
-            live:       master
+            live:       [ master ]
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide
@@ -1684,7 +1684,7 @@ contents:
             prefix:     en/ingest-management
             current:    master
             branches:   [ master ]
-            live:       master
+            live:       [ master ]
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -34,6 +34,7 @@ repos:
     kibana-cn:            https://github.com/elasticsearch-cn/kibana.git
     logstash:             https://github.com/elastic/logstash.git
     logstash-docs:        https://github.com/elastic/logstash-docs.git
+    observability-docs:   https://github.com/elastic/observability-docs.git
     security-docs:        https://github.com/elastic/security-docs.git
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
@@ -1071,7 +1072,7 @@ contents:
           - title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            branches:   [ master ]
             live:       *stacklive
             index:      docs/en/logs/index.asciidoc
             chunk:      1
@@ -1079,7 +1080,7 @@ contents:
             subject:    Logs
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs
@@ -1090,7 +1091,7 @@ contents:
           - title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            branches:   [ master ]
             live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
@@ -1098,7 +1099,7 @@ contents:
             subject:    Metrics
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs
@@ -1690,7 +1691,7 @@ contents:
             subject:    Ingest Management
             sources:
               -
-                repo:   stack-docs
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   beats

--- a/conf.yaml
+++ b/conf.yaml
@@ -1090,7 +1090,7 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    *stackcurrent
+            current:    master
             branches:   [ master ]
             live:       master
             index:      docs/en/metrics/index.asciidoc
@@ -1682,9 +1682,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Ingest Management Guide
             prefix:     en/ingest-management
-            current:    7.8
-            branches:   [ master, 7.x, 7.8 ]
-            live:       [ master, 7.x, 7.8 ]
+            current:    master
+            branches:   [ master ]
+            live:       master
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1071,9 +1071,9 @@ contents:
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
           - title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    master
-            branches:   [ master ]
-            live:       [ master ]
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            live:       *stacklive
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1090,9 +1090,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
-            current:    master
-            branches:   [ master ]
-            live:       [ master ]
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide
@@ -1682,9 +1682,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Ingest Management Guide
             prefix:     en/ingest-management
-            current:    master
-            branches:   [ master ]
-            live:       [ master ]
+            current:    7.8
+            branches:   [ master, 7.x, 7.8 ]
+            live:       [ master, 7.x, 7.8 ]
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1071,9 +1071,9 @@ contents:
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
           - title:      Logs Monitoring Guide
             prefix:     en/logs/guide
-            current:    *stackcurrent
+            current:    master
             branches:   [ master ]
-            live:       *stacklive
+            live:       master
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             tags:       Logs/Guide
@@ -1092,7 +1092,7 @@ contents:
             prefix:     en/metrics/guide
             current:    *stackcurrent
             branches:   [ master ]
-            live:       *stacklive
+            live:       master
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             tags:       Metrics/Guide


### PR DESCRIPTION
This PR tests the `master` branch of the Observability documentation that now lives in the `observability-docs` repo.

DO NOT MERGE.