### PR TITLE
Adds shared attribute for trial URL

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -86,6 +86,7 @@ endif::[]
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide
 :subscriptions:        https://www.elastic.co/subscriptions
+:extendtrial:          https://www.elastic.co/trialextension
 :wikipedia:            https://en.wikipedia.org/wiki
 :forum:                https://discuss.elastic.co/
 :xpack-forum:          https://discuss.elastic.co/c/50-x-pack


### PR DESCRIPTION
This PR adds a shared attribute for a URL that we reference in several license-related pages.