### PR TITLE
Updates 6.8 version attributes

### DIFF
--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -1,12 +1,12 @@
-:version:                6.8.10
+:version:                6.8.11
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           6.8.10
-:logstash_version:       6.8.10
-:elasticsearch_version:  6.8.10
-:kibana_version:         6.8.10
-:apm_server_version:     6.8.10
+:bare_version:           6.8.11
+:logstash_version:       6.8.11
+:elasticsearch_version:  6.8.11
+:kibana_version:         6.8.11
+:apm_server_version:     6.8.11
 :branch:                 6.8
 :minor-version:          6.8
 :major-version:          6.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

This PR updates the shared version attributes for the latest 6.8 documentation release.