### PR TITLE
Updates 7.8 version attributes

### DIFF
--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.8.0
+:version:                7.8.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.8.0
-:logstash_version:       7.8.0
-:elasticsearch_version:  7.8.0
-:kibana_version:         7.8.0
-:apm_server_version:     7.8.0
+:bare_version:           7.8.1
+:logstash_version:       7.8.1
+:elasticsearch_version:  7.8.1
+:kibana_version:         7.8.1
+:apm_server_version:     7.8.1
 :branch:                 7.8
 :minor-version:          7.8
 :major-version:          7.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

This PR updates the shared version attributes for the latest 7.8 documentation release.