### PR TITLE
Add dependencies to observability docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -923,6 +923,14 @@ contents:
                 repo:   observability-docs
                 path:   docs/en
               -
+                repo:   apm-server
+                path:   docs/guide
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   beats
+                path:   libbeat/docs
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]                
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -


### PR DESCRIPTION
This PR adds the beats and APM server docs as dependencies to the Observability docs. 
