### PR TITLE
[WIP] Update uptime sources and build alias

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1139,14 +1139,20 @@ contents:
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
-            index:      docs/uptime-guide/index.asciidoc
+            index:      docs/en/uptime/index.asciidoc
             chunk:      1
             tags:       Uptime/Guide
             subject:    Uptime
             sources:
               -
-                repo:   kibana
-                path:   docs/
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc                
 
     -   title:      Elastic Security
         sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -65,7 +65,7 @@ alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/do
 
 alias docbldlog='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/logs/index.asciidoc --chunk 1'
 
-alias docbldup='$GIT_HOME/docs/build_docs --doc $GIT_HOME/kibana/docs/uptime-guide/index.asciidoc --chunk 1'
+alias docbldup='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/uptime/index.asciidoc --chunk 1'
 
 alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/siem/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
This PR updates the source and doc build alias for the Uptime Monitoring Guide.

The Uptime monitoring content is in the process of being moved from the Kibana repo to the [Observability docs repo](https://github.com/elastic/observability-docs). 

