### PR TITLE
Adding ESS MS 41 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -597,7 +597,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    release-ms-39
-            branches:   [ release-ms-39 ]
+            branches:   [ release-ms-39, release-ms-41 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -613,7 +613,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-39: master
+                  release-ms-41: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -648,8 +648,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-39
-            branches:   [ release-ms-39 ]
+            current:    release-ms-41
+            branches:   [ release-ms-41 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -596,8 +596,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-39
-            branches:   [ release-ms-39, release-ms-41 ]
+            current:    release-ms-41
+            branches:   [ release-ms-41 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
Adding the `release-ms-41` branch to the ESS build, per the [release CSR](https://github.com/elastic/cloud/issues/60156).
