### PR TITLE
Add ECK 1.2 

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -776,7 +776,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.1
-            branches:   [ master, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
@@ -790,7 +790,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/7.x.asciidoc
-                exclude_branches:   [ master, 1.1, 1.0, 1.0-beta ]
+                exclude_branches:   [ master, 1.2, 1.1, 1.0, 1.0-beta ]
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc


### PR DESCRIPTION
This adds the ECK 1.2 branch to the build list. ECK 1.2.0 is planned for release on July 21. 

I followed #1799 and added 1.2 to the exclude list for `7.x`. I hope that is still the correct thing to do as 1.2 also uses `current.asciidoc` (https://raw.githubusercontent.com/elastic/cloud-on-k8s/1.2/docs/index.asciidoc)