### PR TITLE
Add 7.9 branches to all applicable books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -912,7 +912,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    master
-            branches:   [ master, 7.9 ]
+            branches:   [ master, 7.x, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -1180,9 +1180,9 @@ contents:
                 path:   docs/en
           - title:      SIEM Guide
             prefix:     en/siem/guide
-            current:    *stackcurrent
+            current:    7.8
             branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            live:       *stacklive
+            live:       [ 7.8 ]
             index:      docs/en/siem/index.asciidoc
             chunk:      1
             tags:       SIEM/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1159,7 +1159,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8 ]
+            branches:   [ master, 7.x, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/index.asciidoc
             chunk:      1
@@ -1181,7 +1181,7 @@ contents:
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/en/siem/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -55,8 +55,8 @@ contents:
             prefix:     en/elastic-stack
             current:    &stackcurrent 7.8
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.8, 6.8 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       &stacklive [ master, 7.x, 7.9, 7.8, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -98,12 +98,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           - title:      Getting Started
             prefix:     en/elastic-stack-get-started
             current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Getting started
@@ -812,7 +812,7 @@ contents:
           - title:      Kibana Guide
             prefix:     en/kibana
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -827,7 +827,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -839,7 +839,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
 
     -   title:      Enterprise Search
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -848,7 +848,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7 ]
+            branches:   [ 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -865,7 +865,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7, 7.6 ]
+            branches:   [ 7.9, 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -882,7 +882,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ 7.8, 7.7 ]
+            branches:   [ 7.9, 7.8, 7.7 ]
             chunk:     1
             tags:       App Search/Guide
             subject:    App Search

--- a/conf.yaml
+++ b/conf.yaml
@@ -145,7 +145,7 @@ contents:
             prefix:     en/machine-learning
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine learning

--- a/conf.yaml
+++ b/conf.yaml
@@ -1716,8 +1716,8 @@ contents:
           - title:      Ingest Management Guide
             prefix:     en/ingest-management
             current:    7.8
-            branches:   [ master, 7.x, 7.8, 7.9 ]
-            live:       [ master, 7.x, 7.8, 7.9 ]
+            branches:   [ master, 7.x, 7.9, 7.8 ]
+            live:       [ master, 7.x, 7.9, 7.8 ]
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -912,7 +912,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    master
-            branches:   [ master ]
+            branches:   [ master, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      1
@@ -1099,7 +1099,7 @@ contents:
           - title:      Logs Monitoring Guide
             prefix:     en/logs/guide
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/logs/index.asciidoc
             chunk:      1
@@ -1118,7 +1118,7 @@ contents:
           - title:      Metrics Monitoring Guide
             prefix:     en/metrics/guide
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5 ]
             live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
@@ -1137,7 +1137,7 @@ contents:
           - title:      Uptime Monitoring Guide
             prefix:     en/uptime
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       *stacklive
             index:      docs/en/uptime/index.asciidoc
             chunk:      1
@@ -1259,7 +1259,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Libbeat/Reference
@@ -1284,7 +1284,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Auditbeat/Reference
@@ -1337,7 +1337,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Filebeat/Reference
@@ -1392,7 +1392,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
             chunk:      1
             tags:       Functionbeat/Reference
@@ -1433,7 +1433,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklive
             chunk:      1
             tags:       Heartbeat/Reference
@@ -1480,7 +1480,7 @@ contents:
             prefix:     en/beats/journalbeat
             current:    *stackcurrent
             index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
             chunk:      1
             tags:       Journalbeat/Reference
@@ -1521,7 +1521,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Metricbeat/Reference
@@ -1578,7 +1578,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Packetbeat/Reference
@@ -1621,7 +1621,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklive
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -1664,7 +1664,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Devguide/Reference
@@ -1695,7 +1695,7 @@ contents:
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true
@@ -1716,8 +1716,8 @@ contents:
           - title:      Ingest Management Guide
             prefix:     en/ingest-management
             current:    7.8
-            branches:   [ master, 7.x, 7.8 ]
-            live:       [ master, 7.x, 7.8 ]
+            branches:   [ master, 7.x, 7.8, 7.9 ]
+            live:       [ master, 7.x, 7.8, 7.9 ]
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1181,7 +1181,7 @@ contents:
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8
-            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
             live:       [ 7.8 ]
             index:      docs/en/siem/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -196,7 +196,7 @@ contents:
           - title:      Elasticsearch Reference
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -211,13 +211,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
                 private: true
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -243,7 +243,7 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/qa/sql
                 # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/plugin/sql/qa
@@ -252,27 +252,27 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   elasticsearch-php
                 path:   docs/examples
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   elasticsearch-net
                 path:   examples
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   elasticsearch-py
                 path:   docs/examples
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   elasticsearch-ruby
                 path:   docs/examples/guide
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -284,12 +284,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
-                exclude_branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1
@@ -317,7 +317,7 @@ contents:
           - title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -343,7 +343,7 @@ contents:
             repo:       elasticsearch
             current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
             chunk:      2
             tags:       Elasticsearch/Plugins
@@ -374,7 +374,7 @@ contents:
               - title:      Java REST Client
                 prefix:     java-rest
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
@@ -402,7 +402,7 @@ contents:
               - title:      Java API
                 prefix:     java-api
                 current:    *stackcurrent
-                branches:   [ 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 live:       *stacklive
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -569,7 +569,7 @@ contents:
           - title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop

--- a/conf.yaml
+++ b/conf.yaml
@@ -1203,7 +1203,7 @@ contents:
           - title:      Logstash Reference
             prefix:     en/logstash
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -1219,7 +1219,7 @@ contents:
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 7.x, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/

--- a/conf.yaml
+++ b/conf.yaml
@@ -943,7 +943,7 @@ contents:
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference
@@ -959,7 +959,7 @@ contents:
                 prefix:     server
                 index:      docs/index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference


### PR DESCRIPTION
A place for technical writers to coordinate the docs configuration changes that should be applied shortly after the 7.9.0 feature freeze.