### PR TITLE
[DOCS] Correct current ECS version for several branches

### DIFF
--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.4
+:ecs_version:            1.5
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.4
+:ecs_version:            1.5
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :major-version-only:     8
-:ecs_version:            1.4
+:ecs_version:            1.5
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
The current ECS version is incorrectly listed as 1.4 on the 7.9, 7.x, and master branches.
This PR fixes that.