### PR TITLE
[DOCS] [WIP] Add Beats root attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -8,6 +8,7 @@
 :xpack-ref:            https://www.elastic.co/guide/en/x-pack/6.2
 :logstash-ref:         https://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}
+:beats-ref-root:       https://www.elastic.co/guide/en/beats
 :beats-ref:            https://www.elastic.co/guide/en/beats/libbeat/{branch}
 :beats-ref-60:         https://www.elastic.co/guide/en/beats/libbeat/6.0
 :beats-ref-63:         https://www.elastic.co/guide/en/beats/libbeat/6.3


### PR DESCRIPTION
This PR adds the root attribute for the Beats URL. This is required for including the tab-widgets, from the Beats repo, into the Observability docs. 

Related PR: https://github.com/elastic/observability-docs/pull/16