### PR TITLE
Add attribute for eck html path

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -108,7 +108,7 @@ Elastic Cloud
 :ess-console: https://cloud.elastic.co?baymax=docs-body&elektra=docs
 :ess-baymax:  ?baymax=docs-body&elektra=docs
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current
-:eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current/
+:eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current
 :ess-leadin: You can run Elasticsearch on your own hardware or use our hosted Elasticsearch Service that is available on AWS, GCP, and Azure. {ess-trial}[Try the Elasticsearch Service for free].
 :ess-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg[link="{ess-trial}", title="Supported on {ess}"]
 :ece-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud_ece.svg[link="{ess-trial}", title="Supported on {ece}"]

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -108,6 +108,7 @@ Elastic Cloud
 :ess-console: https://cloud.elastic.co?baymax=docs-body&elektra=docs
 :ess-baymax:  ?baymax=docs-body&elektra=docs
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current
+:eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current/
 :ess-leadin: You can run Elasticsearch on your own hardware or use our hosted Elasticsearch Service that is available on AWS, GCP, and Azure. {ess-trial}[Try the Elasticsearch Service for free].
 :ess-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg[link="{ess-trial}", title="Supported on {ess}"]
 :ece-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud_ece.svg[link="{ess-trial}", title="Supported on {ece}"]


### PR DESCRIPTION
I need this attribute to resolve links in the Beats documentation that point to the ECK docs.