### PR TITLE
Remove ECK dependency on 7.x attributes

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -789,10 +789,6 @@ contents:
                 exclude_branches:   [ 0.9, 0.8 ]
               -
                 repo:   docs
-                path:   shared/versions/stack/7.x.asciidoc
-                exclude_branches:   [ master, 1.2, 1.1, 1.0, 1.0-beta ]
-              -
-                repo:   docs
                 path:   shared/attributes.asciidoc
           - title:      Elastic Cloud Control - The Command-Line Interface for ECE
             prefix:     en/ecctl


### PR DESCRIPTION
Removes the dependency on `shared/versions/stack/7.x.asciidoc` from the ECK configuration. 

ECK 0.8 and 0.9 docs have a reference to `shared/versions/stack/7.x.asciidoc` but none of the attributes are used anywhere so we don't require the docs to be rebuilt whenever that file changes. Removing this dependency simplifies adding future versions to the build as they all rely on `shared/versions/stack/current.asciidoc` and don't have to be explicitly added to the `exclude_branches` list of 7.x.

Related to https://github.com/elastic/cloud-on-k8s/issues/3448

