### PR TITLE
Allow replacing a book's default title page

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe 'building a single book' do
       end
       it 'prints an error about both files existing' do
         expect(outputs[0]).to include(<<~LOG.strip)
-          Cannot have both custom and extra title pages for for the same source file
+          Cannot have both custom and extra title pages for the same source file
         LOG
       end
     end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -646,6 +646,21 @@ RSpec.describe 'building a single book' do
         end
       end
     end
+    context 'and a -extra-title-page.html file' do
+      convert_before do |src, dest|
+        repo = src.repo 'src'
+        from = repo.write 'index.adoc', INDEX_BODY
+        repo.write 'index-custom-title-page.html', '<h1>My Custom Header</h1>'
+        repo.write 'index-extra-title-page.html', '<h1>My Extra Header</h1>'
+        repo.commit 'commit outstanding'
+        dest.prepare_convert_single(from, '.').convert(expect_failure: true)
+      end
+      it 'prints an error about both files existing' do
+        expect(outputs[0]).to include(<<~LOG.strip)
+          Cannot have both custom and extra title pages for for the same source file
+        LOG
+      end
+    end
   end
   context 'for a book with page-header.html' do
     context 'single page' do

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -608,6 +608,21 @@ RSpec.describe 'building a single book' do
       [[section]]
       == Section
     ASCIIDOC
+    context 'built as a single page' do
+      convert_before do |src, dest|
+        repo = src.repo 'src'
+        from = repo.write 'index.asciidoc', INDEX_BODY
+        repo.write 'index-custom-title-page.html', '<h1>My Custom Header</h1>'
+        repo.commit 'commit outstanding'
+        dest.prepare_convert_single(from, '.')
+            .single.convert(expect_failure: true)
+      end
+      it 'prints an error message about being incompatible' do
+        expect(outputs[0]).to include(<<~LOG.strip)
+          Using a custom title page is incompatible with --single
+        LOG
+      end
+    end
     context 'multipage' do
       convert_before do |src, dest|
         repo = src.repo 'src'

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -278,6 +278,7 @@ sub _customize_title_page {
 
     if ( -e $custom_title_page ) {
         die "Using a custom title page is incompatible with --single" if $single;
+        die "Cannot have both custom and extra title pages for for the same source file" if -e $extra_title_page;
 
         my $custom_contents = $custom_title_page->slurp( iomode => '<:encoding(UTF-8)' );
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -278,7 +278,7 @@ sub _customize_title_page {
 
     if ( -e $custom_title_page ) {
         die "Using a custom title page is incompatible with --single" if $single;
-        die "Cannot have both custom and extra title pages for for the same source file" if -e $extra_title_page;
+        die "Cannot have both custom and extra title pages for the same source file" if -e $extra_title_page;
 
         my $custom_contents = $custom_title_page->slurp( iomode => '<:encoding(UTF-8)' );
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -129,7 +129,7 @@ sub build_chunked {
     } or do { $output = $@; $died = 1; };
     _check_build_error( $output, $died, $lenient );
 
-    _add_extra_title_page( $index, $raw_dest->file('index.html') );
+    _customize_title_page( $index, $raw_dest->file('index.html') );
     extract_toc_from_index( $raw_dest );
     finish_build( $index->parent, $raw_dest, $dest, $lang, 0 );
 }
@@ -240,7 +240,7 @@ sub build_single {
             or die "Couldn't rename <$src> to <index.html>: $!";
     }
 
-    _add_extra_title_page( $index, $html_file );
+    _customize_title_page( $index, $html_file );
 
     if ( $extra ) {
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
@@ -253,21 +253,40 @@ sub build_single {
 }
 
 #===================================
-# Emulates how we've been using docbook's -docinfo.xml feature by allowing us
-# to add our own extra html to the title page of books.
+# Customize a book's title page.
+#
+# By default, the title page shows just the table of contents.
+#
+# If a file exists named `<index>-custom-title-page.html`, the table of contents
+# will be replaced by the contents of this file.  Otherwise, if a file named
+# `<index>-extra-title-page.html` exists, its contents will be added above the
+# table of contents. (Note that the `<index>` may be different based on the
+# book's "index" file.
 #===================================
-sub _add_extra_title_page {
+sub _customize_title_page {
 #===================================
     my ( $index, $html_file ) = @_;
-    my $extra_title_page = $index->basename;
-    $extra_title_page =~ s/(\.x)?\.a(scii)?doc$/-extra-title-page.html/ || die;
+    my $index_basename = $index->basename;
+
+    (my $custom_title_page = $index_basename) =~ s/(\.x)?\.a(scii)?doc$/-custom-title-page.html/ || die;
+    $custom_title_page = $index->parent->file( $custom_title_page );
+
+    (my $extra_title_page = $index_basename) =~ s/(\.x)?\.a(scii)?doc$/-extra-title-page.html/ || die;
     $extra_title_page = $index->parent->file( $extra_title_page );
-    if ( -e $extra_title_page ) {
-        $extra_title_page = $extra_title_page->slurp( iomode => '<:encoding(UTF-8)' );
+
+    if ( -e $custom_title_page ) {
+        my $custom_contents = $custom_title_page->slurp( iomode => '<:encoding(UTF-8)' );
+        my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
+        $contents =~ s|<!--START_TOC-->.*<!--END_TOC-->|$custom_contents|sm or
+            die "Couldn't set custom contents in file";
+        $html_file->spew( iomode => '>:utf8', $contents );
+    }
+    elsif ( -e $extra_title_page ) {
+        my $extra_contents = $extra_title_page->slurp( iomode => '<:encoding(UTF-8)' );
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
         # Wrapping the extra in a div is a relic of docbook. But we're trying
         # to emulate docbook so here we are.
-        $contents =~ s|</h1></div>|</h1></div>\n<div>\n$extra_title_page\n</div>| or
+        $contents =~ s|</h1></div>|</h1></div>\n<div>\n$extra_contents\n</div>| or
             die "Couldn't add extra-title-page to $contents";
         $html_file->spew( iomode => '>:utf8', $contents );
     }


### PR DESCRIPTION
Having a file named `<index>-extra-title-page.html` allows adding extra
content to a title page. This allows replacing the content entirely with
`<index>-custom-title-page.html`.

Ref: #1892 