### PR TITLE
Remove unused docs constants

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -258,8 +258,6 @@ Common words and phrases
 :fiscore:                    feature influence score
 :evaluatedf-api:             evaluate {dfanalytics} API
 :evaluatedf-api-cap:         Evaluate {dfanalytics} API
-:binarysc:                   binary soft classification
-:binarysc-cap:               Binary soft classification
 :regression:                 regression
 :regression-cap:             Regression
 :reganalysis:                regression analysis


### PR DESCRIPTION
This PR removes constants that are not used anywhere.

Relates https://github.com/elastic/elasticsearch/issues/59947