### PR TITLE
Add yamale to enforce (and document) a schema for conf.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,11 +97,14 @@ RUN rm -rf /var/log/nginx && rm -rf /run/nginx
 
 ##### Everything below this run tests
 FROM base AS py_test
-RUN install_packages python3 python3-pip
+# There's not a published wheel for yamale, so we need setuptools and wheel
+RUN install_packages python3 python3-pip python3-setuptools python3-wheel
 RUN pip3 install \
   beautifulsoup4==4.8.1 \
   lxml==4.4.2 \
-  pycodestyle==2.5.0
+  pycodestyle==2.5.0 \
+  yamale==3.0.1 \
+  pyyaml==5.3.1
 
 FROM node_deps AS node_test
 RUN yarn install --frozen-lockfile

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ check: unit_test integration_test
 
 .PHONY: unit_test
 unit_test: style style_check test_check asciidoctor_check \
-           web_check template_check preview_check
+           web_check template_check preview_check conf_check
 
 .PHONY: style
 style: build_docs
@@ -38,3 +38,7 @@ preview_check:
 .PHONY: integration_test
 integration_test:
 	$(MAKE) -C integtest
+
+.PHONY: conf_check
+conf_check: conf.yaml
+	$(DOCKER) py_test yamale -s schema.yaml conf.yaml --no-strict

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -103,6 +103,9 @@ sub new {
     die "<branches> must be an array in book <$title>"
         unless ref $branch_list eq 'ARRAY';
 
+    # Each branch can be either a single value, or a mapping of
+    # {<branch_name>: <title>}. Branch titles are used in the version dropdown
+    # and version lists.
     my ( @branches, %branch_titles );
     for (@$branch_list) {
         my ( $branch, $title ) = ref $_ eq 'HASH' ? (%$_) : ( $_, $_ );

--- a/schema.yaml
+++ b/schema.yaml
@@ -1,0 +1,97 @@
+# Schema for conf.yaml, used by yamale.
+
+include("conf")
+
+---
+conf:
+    # Mapping of repo "slugs" to their URLs. All repos are fetched at the
+    # beginning of a build.
+    repos: map(str(), str())
+
+    # Used as the top-level title for the Table of Contents (and therefore the
+    # entire site)
+    contents_title: str()
+
+    toc_extra: str()
+
+    contents: list(include("section"))
+
+    redirects: list(include("redirect"))
+
+---
+# Top-level section of the guide
+section:
+    title: str()
+    sections: list(any(include("book"), include("subsection")))
+
+---
+subsection:
+    title: str()
+    sections: list(any(include("book"), include("subsection")))
+    prefix: str(required=False)
+    base_dir: str(required=False)
+    lang: str(required=False)  # Just for custom-language sections
+
+---
+book:
+    # Title of the book (used in headers, and in lists of books)
+    title: str()
+    # URL prefix of this book (under https://www.elastic.co/guide/<prefix>),
+    # unless this book is part of a subsection which has its own prefix. Then,
+    # the URL is https://www.elastic.co/guide/<subsection-prefix>/<prefix>)
+    prefix: str()
+    # List of all versions of the book being published. If only one branch is
+    # listed, there won't be a "other versions" link, or a version dropdown in
+    # the table of contents.
+    branches: list(include("version"))
+    # The default
+    current: include("version")
+
+    live: list(include("version"), required=False)
+    subject: str()
+    tags: str()
+    sources: list(include("source"))
+    index: str()
+    chunk: int(required=False)
+    noindex: int(required=False)
+    private: int(required=False)
+    single: int(required=False)
+    toc: int(required=False)
+    toc_extra: str(required=False)
+    repo: str(required=False)  # TODO: Remove?
+    respect_edit_url_overrides: bool(required=False)
+    lang: str(required=False)
+    suppress_migration_warnings: bool(required=False)
+
+---
+# A version of a book. Since branch names are often `x.y` (which is a number in
+# YAML), `str()` isn't sufficient. `map()` is used when the branch name doesn't
+# match the branch title (for version dropdown lists).
+version: any(str(), num(), map())
+
+---
+# A source is a collection of files used when building a book.
+source:
+    # The "slug" for a repo, must be a key in `repos`.
+    repo: str()
+    # Path within the repo for all files used for the build. This is passed to
+    # `git-archive`, so only these files are available. This path is also used
+    # to detect changes, and causes a rebuild when any files on this path
+    # change.
+    path: str()
+    # List of branches which don't depend on this source
+    exclude_branches: list(include("version"), required=False)
+    prefix: str(required=False)
+    private: bool(required=False)
+    alternatives: include("alternative", required=False)
+    map_branches: map(str(), key=include("version"), required=False)
+
+---
+alternative:
+    source_lang: str()
+    alternative_lang: str()
+
+---
+redirect:
+    prefix: str()
+    redirect: str()

--- a/schema.yaml
+++ b/schema.yaml
@@ -8,8 +8,8 @@ conf:
     # beginning of a build.
     repos: map(str(), str())
 
-    # Used as the top-level title for the Table of Contents (and therefore the
-    # entire site)
+    # Used as the top-level title for the Table of Contents, and therefore the
+    # entire site.
     contents_title: str()
 
     toc_extra: str()
@@ -26,11 +26,18 @@ section:
 
 ---
 subsection:
+    # `title` and `sections` are the same as above.
     title: str()
     sections: list(any(include("book"), include("subsection")))
-    prefix: str(required=False)
+
+    # Sections other than the top-level sections have some additional options
+    # that apply to books within that sub-section.
+
+    # URL prefix added to all book URLs within this subsection.
     base_dir: str(required=False)
-    lang: str(required=False)  # Just for custom-language sections
+    # Just for custom-language sections. TODO: Is this redundant with the `lang`
+    # defined in each book?
+    lang: str(required=False)
 
 ---
 book:
@@ -38,7 +45,7 @@ book:
     title: str()
     # URL prefix of this book (under https://www.elastic.co/guide/<prefix>),
     # unless this book is part of a subsection which has its own prefix. Then,
-    # the URL is https://www.elastic.co/guide/<subsection-prefix>/<prefix>)
+    # the URL is https://www.elastic.co/guide/<base_dir>/<prefix>)
     prefix: str()
     # List of all versions of the book being published. If only one branch is
     # listed, there won't be a "other versions" link, or a version dropdown in


### PR DESCRIPTION
schema.yaml lists the keys and their expected values, along with
comments to describe many of the settings in conf.yaml.

This is incorporated into `make check`.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
