### PR TITLE
Use the "version" rather than "branch" in file paths

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -272,6 +272,12 @@ are not in the list will get a message at the top of each page saying that we
 don't plan to release any more bug fixes or actively maintain the docs for that
 branch.
 
+If you want a branch to have a different "version" name (for instance, if you
+want to build a version called "4.2" but have it build out of a branch called
+"branch-for-4.2"), you can put `{branch-for-4.2: 4.2}` as an entry in the
+`branches` list. Everywhere else in `conf.yaml`, continue to use
+`branch-for-4.2`.
+
 [[asciidoc-guide]]
 = Asciidoc Guide
 

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'spec_helper'
+
 ##
 # Assertions about when books are rebuilt based on changes in source
 # repositories or the book's configuration.
@@ -83,7 +85,7 @@ RSpec.describe 'building all books' do
         end,
         before_second_build: before_second_build
       )
-      include_context 'build one book twice'
+      include_examples 'convert all basics'
     end
 
     def self.build_one_book_out_of_one_repo_and_then_out_of_two(
@@ -97,7 +99,7 @@ RSpec.describe 'building all books' do
         end,
         before_second_build: init_second_book_and_customize(before_second_build)
       )
-      include_context 'build one book twice'
+      include_examples 'convert all basics'
     end
 
     def self.init_second_book_and_customize(before_second_build)
@@ -126,7 +128,7 @@ RSpec.describe 'building all books' do
           before_second_build.call src, config
         end
       )
-      include_context 'build one book twice'
+      include_examples 'convert all basics'
     end
 
     def self.init_include(src)
@@ -174,14 +176,6 @@ RSpec.describe 'building all books' do
         end
       )
       include_examples 'build one book then two books'
-    end
-
-    shared_context 'build one book twice' do
-      context 'the first build' do
-        let(:out) { outputs[0] }
-        include_examples 'builds all books'
-      end
-      include_examples 'convert all basics'
     end
 
     shared_examples 'build one book then two books' do

--- a/integtest/spec/helper/dsl/convert_all.rb
+++ b/integtest/spec/helper/dsl/convert_all.rb
@@ -31,11 +31,18 @@ module Dsl
       it 'prints that it is updating repositories' do
         expect(out).to include('Updating repositories')
       end
-      it 'prints that it is building all branches of every book' do
-        # TODO: read branches from somewhere when we specify them
+      it 'prints that it is building all versions of every book' do
         books.each_value do |book|
-          expect(out).to include("#{book.title}: Building master...")
-          expect(out).to include("#{book.title}: Finished master")
+          book.branches.each do |branch|
+            version = branch
+            if branch.is_a?(Hash)
+              branch.each do |_k, v|
+                version = v
+              end
+            end
+            expect(out).to include("#{book.title}: Building #{version}...")
+            expect(out).to include("#{book.title}: Finished #{version}")
+          end
         end
       end
       include_examples 'commits changes'

--- a/schema.yaml
+++ b/schema.yaml
@@ -43,18 +43,26 @@ subsection:
 book:
     # Title of the book (used in headers, and in lists of books)
     title: str()
+
     # URL prefix of this book (under https://www.elastic.co/guide/<prefix>),
-    # unless this book is part of a subsection which has its own prefix. Then,
+    # unless this book is part of a subsection which has its own base_dir. Then,
     # the URL is https://www.elastic.co/guide/<base_dir>/<prefix>)
     prefix: str()
+
     # List of all versions of the book being published. If only one branch is
     # listed, there won't be a "other versions" link, or a version dropdown in
     # the table of contents.
-    branches: list(include("version"))
-    # The default
-    current: include("version")
+    # TODO: Change this to "versions".
+    branches: list(include("branch_spec"))
 
-    live: list(include("version"), required=False)
+    # The default version of the book that appears.
+    # TODO: Change this to a "version".
+    current: include("branch")
+
+    # List of branches shown by default in the dropdown (and are still receiving updates)
+    # TODO: Change this to be a list of versions.
+    live: list(include("branch"), required=False)
+
     subject: str()
     tags: str()
     sources: list(include("source"))
@@ -71,10 +79,29 @@ book:
     suppress_migration_warnings: bool(required=False)
 
 ---
-# A version of a book. Since branch names are often `x.y` (which is a number in
-# YAML), `str()` isn't sufficient. `map()` is used when the branch name doesn't
-# match the branch title (for version dropdown lists).
-version: any(str(), num(), map())
+# A branch of a git repository used to build a book. In many places, the branch
+# is used as a synonym for a version. Since branch names are often `x.y` (which
+# is a number in YAML), `str()` isn't sufficient.
+
+# TODO: Use "version" in most places to refer to editions of a book, and
+# restrict "branch" to just being used for git operations.
+branch: any(str(), num())
+
+# A version of a book.
+version: any(str(), num())
+
+# An item that can go in the `branches` list. Each item in the list can be a
+# single branch, or a branch_version_map. For example:
+# - master
+# - 7.9
+# - 7.x
+# - { branch-1.0: v1.0 }
+branch_spec: any(include("branch"), include("version_map"))
+
+# A map with a single key, mapping a branch name to a version name.
+# TODO: Swap the order of this mapping, so we can use `versions` as the primary
+# key, and map the version to a branch name when they aren't the same.
+version_map: map(include("version"), key=include("branch"))
 
 ---
 # A source is a collection of files used when building a book.
@@ -87,7 +114,7 @@ source:
     # change.
     path: str()
     # List of branches which don't depend on this source
-    exclude_branches: list(include("version"), required=False)
+    exclude_branches: list(include("branch"), required=False)
     prefix: str(required=False)
     private: bool(required=False)
     alternatives: include("alternative", required=False)

--- a/shared/legacy-attrs.asciidoc
+++ b/shared/legacy-attrs.asciidoc
@@ -1,3 +1,3 @@
-// Legacy URLs to specific versions of books which are getting moved
-:marvel-13:           https://www.elastic.co/guide/en/marvel/marvel-1.3/
-:shield-13:           https://www.elastic.co/guide/en/shield/shield-1.3/
+// Legacy URLs to specific versions of books which have been moved
+:marvel-13:           https://www.elastic.co/guide/en/marvel/1.3/
+:shield-13:           https://www.elastic.co/guide/en/shield/1.3/


### PR DESCRIPTION
There's an existing method to give each "branch" a "title". The title corresponds to the "name" of the version, in cases where it doesn't match the name of the branch itself, and the "title" already appears in the version dropdown. This change extends that to use the version name ("title") in the URL.

Future work will better distinguish between "branches" and "versions" in cases where they aren't the same.

---

To use this, put a `{ branch-name: version-name }` into the `branches` list of a book in conf.yaml. All other places where you would put a branch (like `live` and `current`) should continue to use the branch name (not the version name), but I plan to make further enhancements to make this more straighforward.

---

Related to https://github.com/elastic/docs/issues/1850