### PR TITLE
move location of re-index java-api

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -431,8 +431,8 @@ contents:
                     exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   elasticsearch
-                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -432,7 +432,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -436,7 +436,7 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -434,6 +434,10 @@ contents:
                     path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
                     exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                   -
+                    repo:   elasticsearch
+                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]


### PR DESCRIPTION
related https://github.com/elastic/elasticsearch/pull/60026

----

Note - I am not 100% this is correct, however in https://github.com/elastic/elasticsearch/pull/60026 I am moving this from test to internalClusterTest. The 7.x PR is failing https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request+build-docs/6444/console ... i _think_ this will fix that ? I suppose that I will need to merge these two PRs fairly close to each other to prevent alot of failures. 

```
14:14:54 INFO:build_docs: -                                 Java API: Merging the subbed dir for [elasticsearch][7.x][modules/reindex/src/test/java/org/elasticsearch/client/documentation] into the last successful build.
14:14:56 INFO:build_docs: -                                 Java API: Merged the subbed dir for [elasticsearch][7.x][modules/reindex/src/test/java/org/elasticsearch/client/documentation] into the last successful build.
14:14:56 INFO:build_docs:Error executing: git archive --format=tar -o /tmp/docsbuild/rANET_McuZ/elasticsearch/.temp_git_archive.tar 7a23c6b6ec557ff1498d40118e755c561a333116_fa848406f6e09775677557c55bdc161a56e99a15_modules_reindex_src_test_java_org_elasticsearch_client_documentation modules/reindex/src/test/java/org/elasticsearch/client/documentation in GIT_DIR /docs_build/.repos/elasticsearch.git
14:14:56 INFO:build_docs:---out---
14:14:56 INFO:build_docs:
14:14:56 INFO:build_docs:---err---
14:14:56 INFO:build_docs:fatal: pathspec 'modules/reindex/src/test/java/org/elasticsearch/client/documentation' did not match any files
```
