### PR TITLE
Make ECE 2.6 doc build changes

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -703,7 +703,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    release-ms-41
+            current:    2.5
             branches:   [ {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      2

--- a/conf.yaml
+++ b/conf.yaml
@@ -703,7 +703,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    2.5
+            current:    release-ms-41
             branches:   [ {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      2

--- a/conf.yaml
+++ b/conf.yaml
@@ -703,8 +703,8 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    2.5
-            branches:   [ 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
+            current:    release-ms-41
+            branches:   [ {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      2
             private:    1
@@ -720,6 +720,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches: &mapCloudEceToCloudAssets
+                  release-ms-41: master
                   2.5: master
                   2.4: master
                   2.3: master
@@ -733,6 +734,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
+                  release-ms-41: master
                   2.5: master
                   2.4: master
                   2.3: master


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR adds the conf.yaml doc build changes required for ECE 2.6. 

Depends on https://github.com/elastic/docs/pull/1918 to be able to build versions rather than branches. 

Ran a docbld --all and it looks like we have a broken doc link:

```
INFO:build_docs:Bad cross-document links:
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-enterprise/2.6/ece-add-capacity.html:
INFO:build_docs:   - en/cloud-enterprise/current//Platform_-_Allocators.html#set-allocator-settings
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-enterprise/current/ece-add-capacity.html:
INFO:build_docs:   - en/cloud-enterprise/current//Platform_-_Allocators.html#set-allocator-settings
```

@elastic/cloud-writers can one of you help Aran by tracking down and fixing this broken doc link for tomorrow? 