### PR TITLE
Fix issue with `:(glob)` in sparse-checkout files

### DIFF
--- a/integtest/spec/all_books_sub_dir_spec.rb
+++ b/integtest/spec/all_books_sub_dir_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'spec_helper'
+
 RSpec.describe 'building all books' do
   describe '--sub_dir' do
     ##
@@ -256,6 +258,20 @@ RSpec.describe 'building all books' do
         include_examples 'log merge', 'docs/index.adoc'
         include_examples 'log merge', 'docs/from_master.adoc'
         include_examples 'log merge', 'docs/from_subbed.adoc'
+        include_examples 'contains the new master and subbed changes'
+      end
+      describe 'when the book uses sources with glob patterns' do
+        def self.setup_book(src, repo)
+          book = src.book 'Test'
+          book.index = 'docs/index.adoc'
+          book.source repo, 'docs/index.adoc'
+          book.source repo, ':(glob)**/from_master.adoc'
+          book.source repo, ':(glob)**/from_subbed.adoc'
+        end
+        convert_with_sub
+        include_examples 'log merge', 'docs/index.adoc'
+        include_examples 'log merge', ':(glob)**/from_master.adoc'
+        include_examples 'log merge', ':(glob)**/from_subbed.adoc'
         include_examples 'contains the new master and subbed changes'
       end
       describe 'when more than one book uses the same source' do

--- a/lib/ES/BaseRepo.pm
+++ b/lib/ES/BaseRepo.pm
@@ -148,6 +148,10 @@ sub _write_sparse_config {
 #===================================
     my ( $self, $root, $config ) = @_;
 
+    # Remove the leading `:(glob)` used to check for matching files from the
+    # sparse-checkout configuration. 
+    $config =~ s|^:\(glob\)||;
+
     my $dest = $root->subdir( '.git' )->subdir( 'info' )->file( 'sparse-checkout' );
     open(my $sparse, '>', $dest) or dir("Couldn't write sparse config");
     print $sparse $config;


### PR DESCRIPTION
These were added in 69e747baa8653201b3589869bb2ab9c9dc2e7b87, and are
necessary to detect all the right files, but we don't want to pass that
flag in the sparse-checkout file.

Related to #1917 