### PR TITLE
Change current to MS 43 for ESS

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -600,8 +600,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    release-ms-41
-            branches:   [ release-ms-41 ]
+            current:    release-ms-43
+            branches:   [ release-ms-43 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -617,7 +617,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  release-ms-41: master
+                  release-ms-43: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -652,8 +652,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    release-ms-41
-            branches:   [ release-ms-41 ]
+            current:    release-ms-43
+            branches:   [ release-ms-43 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR changes current to MS 43 for ESS for the new release and removed the older MS 41 release. 

@elastic/cloud-writers could I get approval for this please?
