### PR TITLE
Don't fail when trying to remove TOC from custom title page

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -861,4 +861,32 @@ RSpec.describe 'building all books' do
       end
     end
   end
+  context 'for a book with a custom index page' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'my-repo', 'placeholder text'
+      repo.write 'index-custom-title-page.html', '<h1>My Custom Header</h1>'
+      repo.commit 'add custom title page'
+      repo.switch_to_new_branch 'second-branch'
+      book = src.book 'Test'
+      book.source repo, '.'
+      book.branches = ['master', 'second-branch']
+    end
+    file_context 'raw/test/master/index.html' do
+      it 'contains the custom header' do
+        expect(contents).to include('<h1>My Custom Header</h1>')
+      end
+      it 'does not contain the table of contents' do
+        expect(contents).not_to include('START_TOC')
+        expect(contents).not_to include('<div class="toc">')
+      end
+    end
+    file_context 'raw/test/master/toc.html' do
+      it 'contains the table of contents' do
+        # extract_toc_from_index() grabs everything *between* START_TOC and
+        # END_TOC.
+        expect(contents).not_to include('START_TOC')
+        expect(contents).to include('<div class="toc">')
+      end
+    end
+  end
 end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -386,6 +386,11 @@ sub _update_title_and_version_drop_downs {
         next unless -e $file;
 
         my $html = $file->slurp( iomode => "<:encoding(UTF-8)" );
+        
+        # If a book uses a custom index page, it may not include the TOC. The 
+        # substitution below will fail, so we abort early in this case.
+        next unless ($_ == 'index.html' && ($html =~ /ul class="toc"/));
+
         my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?\n?<li>/<ul class="toc">${title}<li>/);
         die "couldn't update version" unless $success;
         $file->spew( iomode => '>:utf8', $html );

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -130,8 +130,11 @@ sub build_chunked {
     } or do { $output = $@; $died = 1; };
     _check_build_error( $output, $died, $lenient );
 
-    _customize_title_page( $index, $raw_dest->file('index.html'), $single );
+    # Extract the TOC from the index.html page *before* we (potentially) replace
+    # the TOC on the index.html page with a custom title page.
     extract_toc_from_index( $raw_dest );
+
+    _customize_title_page( $index, $raw_dest->file('index.html'), $single );
     finish_build( $index->parent, $raw_dest, $dest, $lang, 0 );
 }
 


### PR DESCRIPTION
In #1909, we added the ability to replace the title page of a book with
completely custom content. For multi-branch builds, we previously
assumed the index.html file would always contain the TOC, which caused
errors in Kibana builds when removing a non-existant TOC.

Also, we previously customized the title page and then tried to extract the
TOC. Now, we extract the TOC first, since it may not exist if the title
page has been customized.
