### PR TITLE
Add 2 new branches in the ECS version selector

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -169,7 +169,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.5
-            branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.x, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
This PR adds a few ECS branches to the version selector for ECS. We are not changing the "current" version yet, however, and this is intentional.

* ECS 1.6 release is coming, the branch has been cut
* ECS' main branch will now target ECS 2.0, and we have therefore added
an 1.x branch to track the upcoming minor releases before 2.0.

This can be merged as soon as it's approved.

### Preview

https://docs_1936.docs-preview.app.elstc.co/guide/en/ecs/1.6/index.html
https://docs_1936.docs-preview.app.elstc.co/guide/en/ecs/1.x/index.html
