### PR TITLE
Add docker logging attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -53,6 +53,7 @@ endif::[]
 :apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
+:docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         https://www.elastic.co/guide/en/elastic-stack/6.7
@@ -171,7 +172,8 @@ Common words and phrases
 :functionbeat:    Functionbeat
 :journalbeat:     Journalbeat
 :es-sql:          {es} SQL
-:elastic-agent:           Elastic Agent
+:elastic-agent:   {agent}
+:log-driver-long: Elastic Logging Plugin for Docker
 
 :security:                X-Pack security
 :security-features:       security features


### PR DESCRIPTION
Elastic Agent is defined twice. I'll fix the duplication later. This PR is mainly to get the logging attribute added.