### PR TITLE
Update ecctl doc branches and title

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -794,12 +794,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Elastic Cloud Control - The Command-Line Interface for ECE
+          - title:      Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and ECE
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.0.0-beta3
-            branches:   [ master, 1.0.0-beta3, 1.0.0-beta2 ]
+            current:    1.0
+            branches:   [ master, 1.0, 1.0.0-beta3, 1.0.0-beta2 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
## Description

Updates the current branch to `1.0`, adds `1.0` in the branches array,
and updates the title to include Elasticsearch Service.

