### PR TITLE
Adds chunk attribute to Ruby API book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -461,6 +461,7 @@ contents:
                 current:    7.x
                 branches:   [ master, 7.x ]
                 index:      docs/index.asciidoc
+                chunk:      1
                 tags:       Clients/Ruby
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -158,7 +158,7 @@ alias docbldejv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/ja
 
 alias docbldejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
 
-alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc'
+alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc --chunk 1'
 
 alias docbldegr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the Ruby API book attribute list in the conf.yml and adds `--chunk 1` to the Ruby book alias in `doc_buil_aliases.sh`.

These changes are required because of upcoming structural changes in the Ruby client book.

### Note

**Do not** merge this PR before https://github.com/elastic/elasticsearch-ruby/pull/998.