### PR TITLE
[DOCS] Drop 7.8 from stack live

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -56,7 +56,7 @@ contents:
             current:    &stackcurrent 7.9
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.9, 7.8, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.9, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack


### PR DESCRIPTION
This removes the 7.8 branch from the list of "live" Stack release branches in our docs.

With the release of 7.9.0, the 7.8.x versions passed their maintenance window: https://www.elastic.co/support/eol