### PR TITLE
docs: add timing note to full build docs

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -206,7 +206,7 @@ To run a full build to mimic the website build, omit the `--sub_dir` and
 ./build_docs --all --target_repo git@github.com:elastic/built-docs.git --open
 ----------------------------
 
-The first time you run a full build is slow as it needs to:
+Running a full build for the first time can be slow (60 mins+) as the build needs to:
 
 * clone each repository
 * build the docs for each branch


### PR DESCRIPTION
Adds a note about what "slow" means to the full build documentation. I didn't realize it meant more than an hour 😅 