### PR TITLE
docs: add APM PHP agent to doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -7,6 +7,7 @@ repos:
     apm-agent-go:         https://github.com/elastic/apm-agent-go.git
     apm-agent-java:       https://github.com/elastic/apm-agent-java.git
     apm-agent-dotnet:     https://github.com/elastic/apm-agent-dotnet.git
+    apm-agent-php:     https://github.com/elastic/apm-agent-php.git
     azure-marketplace:    https://github.com/elastic/azure-marketplace.git
     beats:                https://github.com/elastic/beats.git
     clients-team:         https://github.com/elastic/clients-team.git
@@ -949,13 +950,13 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]                
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -
                 repo:   docs
-                path:   shared/attributes.asciidoc          
+                path:   shared/attributes.asciidoc
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
@@ -1065,6 +1066,22 @@ contents:
                         repo:   apm-agent-nodejs
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 1.x, 0.x ]
+                  - title:      APM PHP Agent
+                    prefix:     php
+                    current:    master
+                    branches:   [ master ]
+                    live:       [ master ]
+                    index:      docs/index.asciidoc
+                    tags:       APM PHP Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-php
+                        path:   docs
+                      -
+                        repo:   apm-agent-php
+                        path:   CHANGELOG.asciidoc
                   - title:      APM Python Agent
                     prefix:     python
                     current:    5.x
@@ -1172,7 +1189,7 @@ contents:
                 path:   shared/versions/stack/{version}.asciidoc
               -
                 repo:   docs
-                path:   shared/attributes.asciidoc                
+                path:   shared/attributes.asciidoc
 
     -   title:      Elastic Security
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -7,7 +7,7 @@ repos:
     apm-agent-go:         https://github.com/elastic/apm-agent-go.git
     apm-agent-java:       https://github.com/elastic/apm-agent-java.git
     apm-agent-dotnet:     https://github.com/elastic/apm-agent-dotnet.git
-    apm-agent-php:     https://github.com/elastic/apm-agent-php.git
+    apm-agent-php:        https://github.com/elastic/apm-agent-php.git
     azure-marketplace:    https://github.com/elastic/azure-marketplace.git
     beats:                https://github.com/elastic/beats.git
     clients-team:         https://github.com/elastic/clients-team.git

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -140,6 +140,8 @@ alias docbldamgo='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-go/docs/in
 
 alias docbldamnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-dotnet/docs/index.asciidoc --chunk 1'
 
+alias docbldamphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-php/docs/index.asciidoc --chunk 1'
+
 
 # Definitive Guide
 alias docblddg='$GIT_HOME/docs/build_docs --suppress_migration_warnings --doc $GIT_HOME/elasticsearch-definitive-guide/book.asciidoc --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -53,6 +53,7 @@ endif::[]
 :apm-java-ref:         https://www.elastic.co/guide/en/apm/agent/java/current
 :apm-go-ref:           https://www.elastic.co/guide/en/apm/agent/go/current
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
+:apm-php-ref:          https://www.elastic.co/guide/en/apm/agent/php/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
@@ -299,6 +300,8 @@ Common words and phrases
 :apm-dotnet-agents:          Elastic APM .NET Agents
 :apm-node-agent:             Elastic APM Node.js Agent
 :apm-node-agents:            Elastic APM Node.js Agents
+:apm-php-agent:              Elastic APM PHP Agent
+:apm-php-agents:             Elastic APM PHP Agents
 :apm-py-agent:               Elastic APM Python Agent
 :apm-py-agents:              Elastic APM Python Agents
 :apm-ruby-agent:             Elastic APM Ruby Agent

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -27,6 +27,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
 :apm-node-branch:       3.x
+:apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -27,6 +27,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
 :apm-node-branch:       3.x
+:apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -27,6 +27,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
 :apm-node-branch:       3.x
+:apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -27,6 +27,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
 :apm-node-branch:       3.x
+:apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x


### PR DESCRIPTION
This PR adds the APM PHP agent to the documentation build.

~Do not merge until https://github.com/elastic/apm-agent-php/pull/167 has been merged.~