### PR TITLE
Use branch list to decide if branch is new or old

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -889,4 +889,50 @@ RSpec.describe 'building all books' do
       end
     end
   end
+  context 'when there is an x.10 version' do
+    convert_all_before_context do |src|
+      repo = src.repo_with_index 'src', 'placeholder text'
+      repo.switch_to_new_branch '7.9'
+      repo.switch_to_new_branch '7.10-alpha'
+      repo.switch_to_new_branch '7.10'
+      repo.switch_to_new_branch '7.11'
+      repo.switch_to_new_branch '7.x'
+      book = src.book 'Version Tests'
+      book.source repo, 'index.asciidoc'
+      book.branches = ['master', '7.x', '7.11', '7.10', '7.10-alpha', '7.9']
+      book.current_branch = '7.10'
+    end
+    shared_examples 'future version' do
+      it 'contains a "future" header' do
+        expect(body).to include('<div class="page_header">')
+        expect(body).to include('You are looking at preliminary documentation for a future release.')
+      end
+    end
+    shared_examples 'past version' do
+      it 'contains a "past" header' do
+        expect(body).to include('<div class="page_header">')
+        expect(body).to include('A newer version is available.')
+      end
+    end
+    page_context 'html/version-tests/7.10/index.html' do
+      it 'does not contain a header' do
+        expect(body).not_to include('<div class="page_header">')
+      end
+    end
+    page_context 'html/version-tests/master/index.html' do
+      include_examples 'future version'
+    end
+    page_context 'html/version-tests/7.x/index.html' do
+      include_examples 'future version'
+    end
+    page_context 'html/version-tests/7.11/index.html' do
+      include_examples 'future version'
+    end
+    page_context 'html/version-tests/7.9/index.html' do
+      include_examples 'past version'
+    end
+    page_context 'html/version-tests/7.10-alpha/index.html' do
+      include_examples 'past version'
+    end
+  end
 end

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -905,7 +905,7 @@ RSpec.describe 'building all books' do
     shared_examples 'future version' do
       it 'contains a "future" header' do
         expect(body).to include('<div class="page_header">')
-        expect(body).to include('You are looking at preliminary documentation for a future release.')
+        expect(body).to include('You are looking at preliminary documentation')
       end
     end
     shared_examples 'past version' do

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -390,7 +390,7 @@ sub _update_title_and_version_drop_downs {
         
         # If a book uses a custom index page, it may not include the TOC. The 
         # substitution below will fail, so we abort early in this case.
-        next unless ($_ eq 'index.html' && ($html =~ /ul class="toc"/));
+        next unless ($_ == 'index.html' && ($html =~ /ul class="toc"/));
 
         my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?\n?<li>/<ul class="toc">${title}<li>/);
         die "couldn't update version" unless $success;

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -11,6 +11,7 @@ use ES::Source();
 use File::Copy::Recursive qw(fcopy rcopy);
 use ES::Toc();
 use utf8;
+use List::Util qw(first);
 
 our %Page_Header = (
     en => {
@@ -389,7 +390,7 @@ sub _update_title_and_version_drop_downs {
         
         # If a book uses a custom index page, it may not include the TOC. The 
         # substitution below will fail, so we abort early in this case.
-        next unless ($_ == 'index.html' && ($html =~ /ul class="toc"/));
+        next unless ($_ eq 'index.html' && ($html =~ /ul class="toc"/));
 
         my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?\n?<li>/<ul class="toc">${title}<li>/);
         die "couldn't update version" unless $success;
@@ -425,16 +426,15 @@ sub _page_header {
     my $current = $self->current;
     return '' if $current eq $branch;
 
-    my $orig_branch = $branch;
-    if ( $current !~ /-\w/ ) {
-        $current .= '-zzzzzz';
-    }
-    if ( $branch !~ /-\w/ ) {
-        $branch .= '-zzzzzz';
-    }
+    # Find the positions of the branch being built ($branch) and the current
+    # branch ($current) in the list of branches for this book.
+    my @branches = @{$self->branches};
+    my $branchidx = first { $branches[$_] eq $branch } 0..$#branches;
+    my $currentidx = first { $branches[$_] eq $current } 0..$#branches;
 
-    my $key = $branch lt $current ? 'old' : 'new';
-    $key = 'dead' if $key eq 'old' && !grep( /^$orig_branch$/, @{ $self->{live_branches} } );
+    # Old branches are "later" in the list than the current branch;
+    my $key = $branchidx > $currentidx ? 'old' : 'new';
+    $key = 'dead' if $key eq 'old' && !grep( /^$branch$/, @{ $self->{live_branches} } );
 
     return $self->_page_header_text( $key );
 }

--- a/schema.yaml
+++ b/schema.yaml
@@ -52,6 +52,10 @@ book:
     # List of all versions of the book being published. If only one branch is
     # listed, there won't be a "other versions" link, or a version dropdown in
     # the table of contents.
+    # This list should be in order from "newest" to "oldest". A branch's
+    # position in this list relative to the "current" branch will be used to
+    # determine if a non-current branch is shown as "newer" or "older" than the
+    # "current" branch.
     # TODO: Change this to "versions".
     branches: list(include("branch_spec"))
 


### PR DESCRIPTION
Previously, there was some complex analysis of the string values of each branch. Instead, we just require the "branches" list in conf.yaml to be in the correct order, and use list position to decide which branches are newer or older than the "current" branch.

See #1899

I went through a lot of complex calculations to compare branch versions, but kept running into edge cases, so just decided this approach was easier. conf.yaml already appears to have the right rules (the ones that didn't were the "versions" fixed by #1918, so this fixes that too).

~I also fixed a warning (using `==` rather than `eq`).~ Turns out this is actually related to a separate bug (#1930) so I removed this.