### PR TITLE
Update ECS versions

### DIFF
--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.5
+:ecs_version:            1.6
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.5
+:ecs_version:            1.6
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :major-version-only:     8
-:ecs_version:            1.5
+:ecs_version:            1.6
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
ECS 1.6.0 released today (2020-0825)!  This PR updates our shared version files for 7.10, 7.x, and master. 