### PR TITLE
Add another location to check for Kibana links

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -386,7 +386,7 @@ sub check_kibana_links {
             $links_file = $legacy_path . ".ts";
             $repo->show_file( $link_check_name, $branch, $links_file );
         } || eval {
-            $links_file = "src/core/public/doc_links/doc_links_service.ts"
+            $links_file = "src/core/public/doc_links/doc_links_service.ts";
             $repo->show_file( $link_check_name, $branch, $links_file );
         };
         die "failed to find kibana links file;\n$@" unless $source;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -385,6 +385,9 @@ sub check_kibana_links {
         } || eval {
             $links_file = $legacy_path . ".ts";
             $repo->show_file( $link_check_name, $branch, $links_file );
+        } || eval {
+            $links_file = "src/core/public/doc_links/doc_links_service.ts"
+            $repo->show_file( $link_check_name, $branch, $links_file );
         };
         die "failed to find kibana links file;\n$@" unless $source;
 
@@ -635,7 +638,7 @@ sub init_repos {
 
     # Setup the docs repo
     # We support configuring the remote for the docs repo for testing
-    ES::DocsRepo->new( 
+    ES::DocsRepo->new(
         tracker => $tracker,
         dir => $conf->{docs} || '/docs_build',
         keep_hash => $Opts->{keep_hash} || 0


### PR DESCRIPTION
In the newest branches of the kibana repo, the file is in a new location.

After merging, it should be fine to undo elastic/kibana#76354.

cc: @pgayvallet 
