### PR TITLE
Updates 7.9 version atts

### DIFF
--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.9.1
+:version:                7.9.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.9.1
-:logstash_version:       7.9.1
-:elasticsearch_version:  7.9.1
-:kibana_version:         7.9.1
-:apm_server_version:     7.9.1
+:bare_version:           7.9.2
+:logstash_version:       7.9.2
+:elasticsearch_version:  7.9.2
+:kibana_version:         7.9.2
+:apm_server_version:     7.9.2
 :branch:                 7.9
 :minor-version:          7.9
 :major-version:          7.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

This PR updates the shared version attributes for the latest 7.9 documentation release.