### PR TITLE
Make it more obvious that the Java API is deprecated.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -400,52 +400,6 @@ contents:
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              - title:      Java API
-                prefix:     java-api
-                current:    *stackcurrent
-                branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                live:       *stacklive
-                index:      docs/java-api/index.asciidoc
-                tags:       Clients/Java
-                subject:    Clients
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-api
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   client/rest-high-level/src/test/java/org/elasticsearch/client
-                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
-                  -
-                   repo:   elasticsearch
-                   path:   server/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                   exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   server/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               - title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x
@@ -560,6 +514,53 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
+              - title:      Java API (deprecated)
+                prefix:     java-api
+                current:    *stackcurrent
+                branches:   [ 7.x, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                live:       *stacklive
+                index:      docs/java-api/index.asciidoc
+                tags:       Clients/Java
+                subject:    Clients
+                chunk:      1
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-api
+                  -
+                    repo:   elasticsearch
+                    path:   docs/Versions.asciidoc
+                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   client/rest-high-level/src/test/java/org/elasticsearch/client
+                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+
+                  -
+                   repo:   elasticsearch
+                   path:   server/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                   exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   server/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]      
+                    
               - title:      Community Contributed Clients
                 prefix:     community
                 branches:   [master]


### PR DESCRIPTION
This adds "(deprecated)" to the title in the doc landing page, and moves the book down to the bottom of the clients list. 