### PR TITLE
Update conf.yml for go-elasticsearch documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -425,16 +425,16 @@ contents:
                     path:   docs/
               - title:      Go API
                 prefix:     go-api
-                current:    master
-                branches:   [ master ]
-                index:      docs/go/index.asciidoc
+                current:    7.x
+                branches:   [ master, 7.x ]
+                index:      .doc/index.asciidoc
                 single:     1
                 tags:       Clients/Go
                 subject:    Clients
                 sources:
                   -
-                    repo:   elasticsearch
-                    path:   docs/go
+                    repo:   go-elasticsearch
+                    path:   .doc/
               - title:      .NET API
                 prefix:     net-api
                 # The elasticsearch-net repo only keeps .x branches. Do not


### PR DESCRIPTION
This patch updates the `conf.yml` file for the new location of go-elasticsearch documentation.

Related: https://github.com/elastic/elasticsearch/pull/62634