### PR TITLE
Fix air-gapped build

### DIFF
--- a/.ci/publish_air_gapped_docs.sh
+++ b/.ci/publish_air_gapped_docs.sh
@@ -2,7 +2,6 @@
 
 set -eo pipefail
 
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)"
 source ./air_gapped/build.sh
-docker tag $AIR_GAPPED push.$AIR_GAPPED
-docker push push.$AIR_GAPPED
+docker push "$AIR_GAPPED"


### PR DESCRIPTION
We don't push to push.docker.elastic.co anymore.
