### PR TITLE
Migrate Python documentation to elasticsearch-py

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -477,16 +477,16 @@ contents:
                     path:   docs/
               - title:      Python API
                 prefix:     python-api
-                current:    master
-                branches:   [ master ]
-                index:      docs/python/index.asciidoc
+                current:    7.x
+                branches:   [ master, 7.x ]
+                index:      docs/guide/index.asciidoc
                 single:     1
                 tags:       Clients/Python
                 subject:    Clients
                 sources:
                   -
-                    repo:   elasticsearch
-                    path:   docs/python
+                    repo:   elasticsearch-py
+                    path:   docs/guide/
               - title:      eland Client
                 prefix:     eland
                 current:    7.x


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch-py/pull/1380 and the resulting backport to 7.x