### PR TITLE
Adds chunk attribute to JavaScript API book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -405,6 +405,7 @@ contents:
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 16.x ]
                 index:      docs/index.asciidoc
+                chunk:      1
                 tags:       Clients/JavaScript
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -158,7 +158,7 @@ alias docbldjvr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/ja
 
 alias docbldejv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-api/index.asciidoc --chunk 1'
 
-alias docbldejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc'
+alias docbldejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js/docs/index.asciidoc --chunk 1'
 
 alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the attribute list of the JavaScript API book in the conf.yml and adds `--chunk 1` to the JavaScript API book alias in `doc_build_aliases.sh`.

These changes are required because of upcoming structural changes in the JavaScript client book.

### Note

**Do not merge this PR before https://github.com/elastic/elasticsearch-js/pull/1316 and re-generating the API reference docs.**