### PR TITLE
Adds chunk attribute to GO API book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -428,7 +428,7 @@ contents:
                 current:    7.x
                 branches:   [ master, 7.x ]
                 index:      .doc/index.asciidoc
-                single:     1
+                chunk:      1
                 tags:       Clients/Go
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -164,7 +164,7 @@ alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/do
 
 alias docbldegr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
-alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --single'
+alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --chunk 1'
 
 alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -164,7 +164,7 @@ alias docblderb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-ruby/do
 
 alias docbldegr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/groovy-api/index.asciidoc'
 
-alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/go/index.asciidoc --chunk 1'
+alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/go-elasticsearch/.doc/index.asciidoc --chunk 1'
 
 alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the attribute list of the GO API book in the conf.yml and adds `--chunk 1` to the GO API book alias in `doc_build_aliases.sh`.

These changes are required because of upcoming structural changes in the GO client book.