### PR TITLE
Add live branches for client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -404,6 +404,7 @@ contents:
                 prefix:     javascript-api
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 16.x ]
+                live:       [ master, 7.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/JavaScript
                 subject:    Clients
@@ -415,6 +416,7 @@ contents:
                 prefix:     ruby-api
                 current:    7.x
                 branches:   [ master, 7.x ]
+                live:       [ master, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Ruby
@@ -427,6 +429,7 @@ contents:
                 prefix:     go-api
                 current:    7.x
                 branches:   [ master, 7.x ]
+                live:       [ master, 7.x ]
                 index:      .doc/index.asciidoc
                 single:     1
                 tags:       Clients/Go
@@ -441,6 +444,7 @@ contents:
                 # bump these with the rest of the stack.
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ master, 7.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -453,6 +457,7 @@ contents:
                 prefix:     php-api
                 current:    7.x
                 branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       [ master, 7.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/PHP
                 subject:    Clients
@@ -467,6 +472,7 @@ contents:
                 prefix:     perl-api
                 current:    master
                 branches:   [ master ]
+                live:       [ master ]
                 index:      docs/index.asciidoc
                 single:     1
                 tags:       Clients/Perl
@@ -479,6 +485,7 @@ contents:
                 prefix:     python-api
                 current:    7.x
                 branches:   [ master, 7.x ]
+                live:       [ master, 7.x ]
                 index:      docs/guide/index.asciidoc
                 single:     1
                 tags:       Clients/Python
@@ -491,6 +498,7 @@ contents:
                 prefix:     eland
                 current:    7.x
                 branches:   [ 7.x ]
+                live:       [ 7.x ]
                 index:      docs/en/index.asciidoc
                 single:     1
                 tags:       Clients/eland
@@ -506,6 +514,7 @@ contents:
                 prefix:     rust-api
                 current:    master
                 branches:   [ master ]
+                live:       [ master ]
                 index:      docs/index.asciidoc
                 single:     1
                 tags:       Clients/Rust


### PR DESCRIPTION
Some very old client versions are appearing high in the search results. For example:

![image](https://user-images.githubusercontent.com/26471269/94066116-e104bc00-fda0-11ea-927b-670805ab2524.png)


This PR adds the "live" option to the client docs in the conf.yaml so that their active branches are prioritized. In a couple of cases there is only one branch, but I didn't think it hurt to add it there either in case more branches are added in the near future.