### PR TITLE
docs: update shared cloud docs

### DIFF
--- a/shared/cloud/ess-getting-started-obs.asciidoc
+++ b/shared/cloud/ess-getting-started-obs.asciidoc
@@ -6,7 +6,7 @@
 
 . {ess-trial}[Get a free trial].
 
-. Log into {ess-console}[Elastic Cloud].
+. Log into {ess-console}[{ecloud}].
 
 . Click *Create deployment*.
 

--- a/shared/cloud/ess-getting-started-obs.asciidoc
+++ b/shared/cloud/ess-getting-started-obs.asciidoc
@@ -16,7 +16,6 @@ ifdef::include-apm-instructions[]
 . Click *Create deployment* and copy the password for the `elastic` user.
 
 . Select *APM* from the menu on the left and make note of the APM endpoint and APM Server secret token.
-You'll need these in step two.
 endif::include-apm-instructions[]
 
 ifndef::include-apm-instructions[]

--- a/shared/cloud/ess-getting-started-obs.asciidoc
+++ b/shared/cloud/ess-getting-started-obs.asciidoc
@@ -1,0 +1,24 @@
+// Include this file in your docs:
+// include::{docs-root}/shared/cloud/ess-getting-started-obs.asciidoc[]
+
+// To include APM Server instructions, add this attribute:
+// :include-apm-instructions:
+
+. {ess-trial}[Get a free trial].
+
+. Log into {ess-console}[Elastic Cloud].
+
+. Click *Create deployment*.
+
+. Select *Elastic Observability* and give your deployment a name.
+
+ifdef::include-apm-instructions[]
+. Click *Create deployment* and copy the password for the `elastic` user.
+
+. Select *APM* from the menu on the left and make note of the APM endpoint and APM Server secret token.
+You'll need these in step two.
+endif::include-apm-instructions[]
+
+ifndef::include-apm-instructions[]
+. Click *Create deployment* and copy the password for the `elastic` user and Cloud ID information.
+endif::include-apm-instructions[]

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -6,12 +6,14 @@
 
 There's no faster way to get started than with our hosted {ess} on Elastic Cloud:
 
-. {ess-trial}[Get a free trial]. 
+. {ess-trial}[Get a free trial].
 
 . Log into {ess-console}[Elastic Cloud].
 
-. Click *Create deployment* and give your deployment a name.
-. Optional: The default options are great for getting started, but you can add more features by clicking *Customize deployment*.
-. Click *Create deployment* and copy down the password for the `elastic` user and Cloud ID information.
+. Click *Create deployment*.
+
+. Select a deployment type and give your deployment a name.
+
+. Click *Create deployment* and copy the password for the `elastic` user and Cloud ID information.
 
 That’s it! Now that you are up and running, it’s time to get some data into {kib}. Click *Launch Kibana*.

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -12,7 +12,7 @@ There's no faster way to get started than with our hosted {ess} on Elastic Cloud
 
 . Click *Create deployment*.
 
-. Select a deployment type and give your deployment a name.
+. Select a solution and give your deployment a name.
 
 . Click *Create deployment* and copy the password for the `elastic` user and Cloud ID information.
 


### PR DESCRIPTION
@EamonnTP pointed out in https://github.com/elastic/observability-docs/issues/144 that the ESS shared docs content is outdated. This PR updates it.

In addition, this PR adds a new getting started snippet for Observability. I'm not sure if the best approach here is to have two different files, or to pepper a bunch of `ifdef::[]` and `ifndef::[]` statements into one cloud getting started snippet. Thoughts?

Closes https://github.com/elastic/observability-docs/issues/144.