### PR TITLE
Change ECS chunking level

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -172,7 +172,7 @@ contents:
             current:    1.6
             branches:   [ master, 1.x, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
-            chunk:      1
+            chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference
             subject:    Elastic Common Schema (ECS)
             sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -185,7 +185,7 @@ alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-d
 alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'
 
 # ECS
-alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 1'
+alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 2'
 
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'


### PR DESCRIPTION
Updating the ECS book chunking config from `1` to `2`. This change will enable adding additional usage sub-sections per fieldset in the ECS field reference.

Example:

<img width="357" alt="Screen Shot 2020-09-30 at 1 21 20 PM" src="https://user-images.githubusercontent.com/7226265/94738343-e5971a80-0334-11eb-9556-05461e8218a6.png">

The full details of these ECS documentation changes are captured in https://github.com/elastic/ecs/issues/943.