### PR TITLE
Adds chunk attribute to Perl API book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -475,7 +475,7 @@ contents:
                 branches:   [ master ]
                 live:       [ master ]
                 index:      docs/index.asciidoc
-                single:     1
+                chunk:      1
                 tags:       Clients/Perl
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -170,7 +170,7 @@ alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/doc
 
 alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
 
-alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
+alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --chunk 1'
 
 alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the attribute list of the Perl API book in the conf.yml and adds `--chunk 1` to the Perl API book alias in `doc_build_aliases.sh`.

These changes are required because of upcoming structural changes in the Perl client book.

### Note

**Do not merge before https://github.com/elastic/elasticsearch-perl/pull/195!**