### PR TITLE
[DOCS] Adds chunking to Py, Rust, and eland client books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -488,7 +488,7 @@ contents:
                 branches:   [ master, 7.x ]
                 live:       [ master, 7.x ]
                 index:      docs/guide/index.asciidoc
-                single:     1
+                chunk:     1
                 tags:       Clients/Python
                 subject:    Clients
                 sources:
@@ -501,7 +501,7 @@ contents:
                 branches:   [ 7.x ]
                 live:       [ 7.x ]
                 index:      docs/en/index.asciidoc
-                single:     1
+                chunk:     1
                 tags:       Clients/eland
                 subject:    Clients
                 sources:
@@ -517,7 +517,7 @@ contents:
                 branches:   [ master ]
                 live:       [ master ]
                 index:      docs/index.asciidoc
-                single:     1
+                chunk:     1
                 tags:       Clients/Rust
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -172,13 +172,15 @@ alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/doc
 
 alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --single'
 
-alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/python/index.asciidoc --single'
+alias docbldepy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-py/docs/guide/index.asciidoc --chunk 1'
+
+alias docblders='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-rs/docs/index.asciidoc --chunk 1'
 
 alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/community-clients/index.asciidoc --single'
 
 alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
-alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc --single'
+alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc --chunk 1'
 
 # X-Pack Reference 5.4 to 6.2
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the attribute list of the Python, Rust, and eland client books in the conf.yml and adds `--chunk 1` to the respective book aliases in `doc_build_aliases.sh`.

These changes are required because of upcoming structural changes in the above-mentioned client books. This PR covers the last bits of infrastructural changes required to the Clients docs restructuring.

### Note

**Merge only the following PRs are merged:**

* py: https://github.com/elastic/elasticsearch-py/pull/1393
* eland: https://github.com/elastic/elasticsearch-eland-docs/pull/9
* rust: https://github.com/elastic/elasticsearch-rs/pull/150