### PR TITLE
Add ECS 1.7 branch in preparation for release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -170,7 +170,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.6
-            branches:   [ master, 1.x, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.x, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.6
+:ecs_version:            1.7
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
This PR:

* adds the new unreleased 1.7 branch to the version selector.
* maps the next stack release (7.x) to this new ECS version

The "current" version is not changing, as the ECS release is in a few weeks.