### PR TITLE
Add stacklive to conf.yaml for Ingest Management Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1769,7 +1769,7 @@ contents:
             prefix:     en/ingest-management
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.9, 7.8 ]
-            live:       [ master, 7.x, 7.9, 7.8 ]
+            live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1
             tags:       Ingest Management/Guide


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1972#discussion_r500628265

This PR uses the "stacklive" attribute in the conf.yaml for the Ingest Management content.