### PR TITLE
Add new Observability attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -81,6 +81,7 @@ endif::[]
 :logs-guide:           https://www.elastic.co/guide/en/logs/guide/{branch}
 :uptime-guide:         https://www.elastic.co/guide/en/uptime/{branch}
 :observability-guide:  https://www.elastic.co/guide/en/observability/{branch}
+:observability-guide-all:   https://www.elastic.co/guide/en/observability
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :security-guide:       https://www.elastic.co/guide/en/security/{branch}
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
@@ -140,6 +141,7 @@ Kibana app and UI names
 :stack-manage-app:   Stack Management
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
+:user-experience:    User Experience
 
 //////////
 Ingest terms


### PR DESCRIPTION
Adds `:observability-guide-all:` and `:user-experience:`

For https://github.com/elastic/observability-docs/pull/187.