### PR TITLE
Update Observability sources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -956,7 +956,7 @@ contents:
                 path:   docs/en
               -
                 repo:   apm-server
-                path:   docs/guide
+                path:   docs
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   beats


### PR DESCRIPTION
How do sources work for documentation books? We have files in `apm-server`'s `doc` folder that the Observability guide needs to access. Is the fix as simple as removing the `/guide` from the source?

For the failures in https://github.com/elastic/observability-docs/pull/188:

```
08:57:19 INFO:build_docs:
08:57:19 INFO:build_docs:asciidoctor: ERROR: instrument-apps.asciidoc: line 22: include file not found: /tmp/docsbuild/qaSsMmfBdn/apm-server/docs/tab-widgets/install-agents-widget.asciidoc
08:57:19 INFO:build_docs:asciidoctor: ERROR: instrument-apps.asciidoc: line 36: include file not found: /tmp/docsbuild/qaSsMmfBdn/apm-server/docs/tab-widgets/configure-agent-widget.asciidoc
08:57:19 INFO:build_docs:asciidoctor: ERROR: instrument-apps.asciidoc: line 43: include file not found: /tmp/docsbuild/qaSsMmfBdn/apm-server/docs/tab-widgets/configure-server-widget.asciidoc
08:57:19 INFO:build_docs:
```