### PR TITLE
6.8.13 release

### DIFF
--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -1,12 +1,12 @@
-:version:                6.8.12
+:version:                6.8.13
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           6.8.12
-:logstash_version:       6.8.12
-:elasticsearch_version:  6.8.12
-:kibana_version:         6.8.12
-:apm_server_version:     6.8.12
+:bare_version:           6.8.13
+:logstash_version:       6.8.13
+:elasticsearch_version:  6.8.13
+:kibana_version:         6.8.13
+:apm_server_version:     6.8.13
 :branch:                 6.8
 :minor-version:          6.8
 :major-version:          6.x


### PR DESCRIPTION
Updates the shared version attributes to 6.8.13.

NOTE: Do not merge until release day.