### PR TITLE
7.9.3 release

### DIFF
--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.9.2
+:version:                7.9.3
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.9.2
-:logstash_version:       7.9.2
-:elasticsearch_version:  7.9.2
-:kibana_version:         7.9.2
-:apm_server_version:     7.9.2
+:bare_version:           7.9.3
+:logstash_version:       7.9.3
+:elasticsearch_version:  7.9.3
+:kibana_version:         7.9.3
+:apm_server_version:     7.9.3
 :branch:                 7.9
 :minor-version:          7.9
 :major-version:          7.x


### PR DESCRIPTION
Updates the shared version attributes to 7.9.3.

NOTE: Do not merge until release day.