### PR TITLE
Move Logs, Metrics, and Uptime docs to legacy docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1144,63 +1144,7 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-          - title:      Logs Monitoring Guide
-            prefix:     en/logs/guide
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            live:       *stacklive
-            index:      docs/en/logs/index.asciidoc
-            chunk:      1
-            tags:       Logs/Guide
-            subject:    Logs
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Metrics Monitoring Guide
-            prefix:     en/metrics/guide
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            live:       *stacklive
-            index:      docs/en/metrics/index.asciidoc
-            chunk:      1
-            tags:       Metrics/Guide
-            subject:    Metrics
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Uptime Monitoring Guide
-            prefix:     en/uptime
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            live:       *stacklive
-            index:      docs/en/uptime/index.asciidoc
-            chunk:      1
-            tags:       Uptime/Guide
-            subject:    Uptime
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
+
 
     -   title:      Elastic Security
         sections:
@@ -1245,6 +1189,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+
 
     -   title:      "Logstash: Collect, Enrich, and Transport"
         sections:
@@ -1994,6 +1939,66 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en/gke-on-prem
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Logs Monitoring Guide for 7.5-7.9
+            prefix:     en/logs/guide
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
+            live:       *stacklive
+            index:      docs/en/logs/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Logs/Guide
+            subject:    Logs
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Metrics Monitoring Guide for 7.5-7.9
+            prefix:     en/metrics/guide
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
+            live:       *stacklive
+            index:      docs/en/metrics/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Metrics/Guide
+            subject:    Metrics
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Uptime Monitoring Guide for 7.2-7.9
+            prefix:     en/uptime
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            live:       *stacklive
+            index:      docs/en/uptime/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Uptime/Guide
+            subject:    Uptime
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1949,7 +1949,6 @@ contents:
             prefix:     en/logs/guide
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            live:       *stacklive
             index:      docs/en/logs/index.asciidoc
             chunk:      1
             private:    1
@@ -1969,7 +1968,6 @@ contents:
             prefix:     en/metrics/guide
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            live:       *stacklive
             index:      docs/en/metrics/index.asciidoc
             chunk:      1
             private:    1
@@ -1989,7 +1987,6 @@ contents:
             prefix:     en/uptime
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            live:       *stacklive
             index:      docs/en/uptime/index.asciidoc
             chunk:      1
             private:    1


### PR DESCRIPTION
**DO NOT MERGE** until **7.10** is released.

This PR moves the content for the Logs, Metrics, and Uptime Monitoring Guides to the Legacy docs section.

From the 7.10 release onwards, the content for the Logs, Metrics, and Uptime apps is in the `docs/en/observability` folder in the [observability-docs](https://github.com/elastic/observability-docs/tree/master/docs/en/observability) repo.

### Related issue:

https://github.com/elastic/observability-docs/issues/189

