### PR TITLE
Get Fleet User Guide building

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1305,7 +1305,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
-    -   title:      "Fleet: Install and manage Elastic Agents"
+    -   title:      "Fleet: Install and Manage Elastic Agents"
         sections:
           - title:      Fleet User Guide
             prefix:     en/fleet

--- a/conf.yaml
+++ b/conf.yaml
@@ -1305,6 +1305,31 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
+    -   title:      "Fleet: Install and manage Elastic Agents"
+        sections:
+          - title:      Fleet User Guide
+            prefix:     en/fleet
+            current:    master
+            branches:   [ master, 7.x, 7.10 ]
+            live:       *stacklive
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      1
+            tags:       Fleet/Guide
+            subject:    Fleet
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   beats
+                path:   x-pack/elastic-agent/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:
           - title:      Beats Platform Reference
@@ -1774,31 +1799,6 @@ contents:
             chunk:      1
             tags:       Ingest Management/Guide
             subject:    Ingest Management
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   beats
-                path:   x-pack/elastic-agent/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
-    -   title:      "Fleet: Install and manage Elastic Agents"
-        sections:
-          - title:      Fleet User Guide
-            prefix:     en/fleet
-            current:    master
-            branches:   [ master, 7.x, 7.10 ]
-            live:       *stacklive
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      1
-            tags:       Fleet/Guide
-            subject:    Fleet
             sources:
               -
                 repo:   observability-docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1792,7 +1792,7 @@ contents:
         sections:
           - title:      Fleet User Guide
             prefix:     en/fleet
-            current:    *stackcurrent
+            current:    master
             branches:   [ master, 7.x, 7.10 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1788,6 +1788,31 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
+    -   title:      "Fleet: Manage Integrations and Elastic Agents"
+        sections:
+          - title:      Fleet User Guide
+            prefix:     en/fleet
+            current:    *stackcurrent
+            branches:   [ master, 7.x, 7.10 ]
+            live:       *stacklive
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      1
+            tags:       Fleet/Guide
+            subject:    Fleet
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   beats
+                path:   x-pack/elastic-agent/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
     - title:     Docs in Your Native Tongue
       sections:
         - title:      简体中文

--- a/conf.yaml
+++ b/conf.yaml
@@ -1309,7 +1309,7 @@ contents:
         sections:
           - title:      Fleet User Guide
             prefix:     en/fleet
-            current:    master
+            current:    *stackcurrent
             branches:   [ master, 7.x, 7.10 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1788,7 +1788,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
-    -   title:      "Fleet: Manage Integrations and Elastic Agents"
+    -   title:      "Fleet: Install and manage Elastic Agents"
         sections:
           - title:      Fleet User Guide
             prefix:     en/fleet


### PR DESCRIPTION
Closes https://github.com/elastic/observability-docs/issues/128

TODO after merging:

- [ ] Move the Ingest Management Guide from Beats section to legacy docs section.
- [ ] Create new path attribute for the Fleet User Guide and update all docs in master, 7.x, and 7.10 (across repos) to use the new attribute.
- [ ] Set up redirects for master, current, and 7.10.
- [ ] Stop building master, 7.x, and 7.10 branches of the Ingest Management Guide

