### PR TITLE
Update Cloud to MS47

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -613,8 +613,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-46
-            branches:   [ ms-46 ]
+            current:    ms-47
+            branches:   [ ms-47 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -630,7 +630,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-46: master
+                  ms-47: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -665,8 +665,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-46
-            branches:   [ ms-46 ]
+            current:    ms-47
+            branches:   [ ms-47 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
Updates `current` and branches to point to MS-47 Cloud docs.