### PR TITLE
Migrate Eland documentation to elastic/eland

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -17,7 +17,7 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
-    eland-docs:           https://github.com/elastic/elasticsearch-eland-docs.git
+    eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
     elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
@@ -495,22 +495,19 @@ contents:
                   -
                     repo:   elasticsearch-py
                     path:   docs/guide/
-              - title:      eland Client
+              - title:      eland
                 prefix:     eland
                 current:    7.x
-                branches:   [ 7.x ]
-                live:       [ 7.x ]
-                index:      docs/en/index.asciidoc
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/guide/index.asciidoc
                 chunk:     1
                 tags:       Clients/eland
                 subject:    Clients
                 sources:
                   -
-                    repo:   eland-docs
-                    path:   docs/en
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
+                    repo:   eland
+                    path:   docs/guide
               - title:      Rust API
                 prefix:     rust-api
                 current:    master

--- a/conf.yaml
+++ b/conf.yaml
@@ -497,7 +497,7 @@ contents:
                     path:   docs/guide/
               - title:      eland
                 prefix:     eland
-                current:    7.x
+                current:    master
                 branches:   [ master ]
                 live:       [ master ]
                 index:      docs/guide/index.asciidoc


### PR DESCRIPTION
This PR depends on https://github.com/elastic/eland/pull/304
After this is merged can delete the repository at: https://github.com/elastic/elasticsearch-eland-docs