### PR TITLE
Add Cloud Terraform provider docs to builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -824,7 +824,7 @@ contents:
             subject:    TPEC
             current:    master
             branches:   [ master ]
-            index:      docs/index.asciidoc
+            index:      docs-elastic/index.asciidoc
             chunk:      1
             sources:
               -

--- a/conf.yaml
+++ b/conf.yaml
@@ -818,6 +818,18 @@ contents:
               -
                 repo:   ecctl
                 path:   docs/
+          - title:      Elastic Cloud Terraform Provider
+            prefix:     en/tpec
+            tags:       CloudTerraform/Reference
+            subject:    TPEC
+            current:    master
+            branches:   [ master ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            sources:
+              -
+                repo:   terraform-provider-ec
+                path:   docs/
 
     -   title:      "Kibana: Explore, Visualize, and Share"
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -829,7 +829,7 @@ contents:
             sources:
               -
                 repo:   terraform-provider-ec
-                path:   docs/
+                path:   docs-elastic/
 
     -   title:      "Kibana: Explore, Visualize, and Share"
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -823,7 +823,7 @@ contents:
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
             subject:    TPEC
-            current:    master
+            current:    v0.1.0-beta
             branches:   [ master, v0.1.0-beta ]
             index:      docs-elastic/index.asciidoc
             single:     1

--- a/conf.yaml
+++ b/conf.yaml
@@ -825,6 +825,7 @@ contents:
             current:    master
             branches:   [ master ]
             index:      docs-elastic/index.asciidoc
+            single:     1
             chunk:      1
             sources:
               -

--- a/conf.yaml
+++ b/conf.yaml
@@ -40,6 +40,7 @@ repos:
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
     swiftype:             https://github.com/elastic/swiftype-doc-placeholder.git
+    terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
     enterprise-search-pubs:  https://github.com/elastic/enterprise-search-pubs.git
     x-pack:               https://github.com/elastic/x-pack.git
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git

--- a/conf.yaml
+++ b/conf.yaml
@@ -824,7 +824,7 @@ contents:
             tags:       CloudTerraform/Reference
             subject:    TPEC
             current:    master
-            branches:   [ master ]
+            branches:   [ master, v0.1.0-beta ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -97,7 +97,7 @@ alias docbldecctl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecctl/docs/index.as
 alias docbldk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
 # Cloud - Terraform provider
-alias docbldtpec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/terraform-provider-ec/docs-elastic/index.asciidoc --chunk 1'
+alias docbldtpec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/terraform-provider-ec/docs-elastic/index.asciidoc --chunk 1 --single'
 
 # Beats
 alias docbldbpr='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -96,6 +96,9 @@ alias docbldecctl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecctl/docs/index.as
 # Cloud - Elastic Cloud for K8s
 alias docbldk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
+# Cloud - Terraform provider
+alias docbldtpec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/terraform-provider-ec/docs/index.asciidoc --chunk 1'
+
 # Beats
 alias docbldbpr='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -97,7 +97,7 @@ alias docbldecctl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecctl/docs/index.as
 alias docbldk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/cloud-on-k8s/docs/index.asciidoc --chunk 1'
 
 # Cloud - Terraform provider
-alias docbldtpec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/terraform-provider-ec/docs/index.asciidoc --chunk 1'
+alias docbldtpec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/terraform-provider-ec/docs-elastic/index.asciidoc --chunk 1'
 
 # Beats
 alias docbldbpr='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/libbeat/docs/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR adds:

* A new `tpec` entry in conf.yaml for the Elastic Cloud Terraform provider book
* A new build alias for building the docs locally (try `docbldtpec --open` once you have the PR mentioned below locally)

Depends on the new docs content in https://github.com/elastic/terraform-provider-ec/pull/163. 

In terms of placement, this is where the new docs will appear:

![image](https://user-images.githubusercontent.com/15148011/97934984-1b606200-1d2c-11eb-87e5-6ecaa5da44fa.png)
