### PR TITLE
Add ECK 1.3

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -792,7 +792,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.2
-            branches:   [ master, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This adds the ECK 1.3 branch to the build list. ECK 1.3.0 is planned for release on November 10th.
