### PR TITLE
Promote ECK 1.3 branch to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -791,7 +791,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.2
+            current:    1.3
             branches:   [ master, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR sets the ECK 1.3 branch as the current version.
I am submitting this early to get approval. It should only be merged on November 10th after https://github.com/elastic/docs/pull/1996 is merged and ECK 1.3 is released.