### PR TITLE
Add Observability repo source to stack docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -91,7 +91,7 @@ contents:
               -
                 repo:   observability-docs
                 path:   docs/en/observability
-                exclude_branches:   [ 7.9 ]
+                exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -89,6 +89,10 @@ contents:
                 path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
+                repo:   observability-docs
+                path:   docs/en/observability
+                exclude_branches:   [ 7.9 ]
+              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
@@ -566,8 +570,8 @@ contents:
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]      
-                    
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+
               - title:      Community Contributed Clients
                 prefix:     community
                 branches:   [master]


### PR DESCRIPTION
## Summary

This PR adds observability-docs as a source to the stack-docs repo. This will allow Observability "What's new" content to be included in the installation and upgrade guide.

## Related 

https://github.com/elastic/observability-docs/pull/216