### PR TITLE
Move Ingest Management Guide to legacy section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1738,28 +1738,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Ingest Management Guide
-            prefix:     en/ingest-management
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10, 7.9, 7.8 ]
-            live:       *stacklive
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      1
-            tags:       Ingest Management/Guide
-            subject:    Ingest Management
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   beats
-                path:   x-pack/elastic-agent/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
 
     - title:     Docs in Your Native Tongue
       sections:
@@ -2239,6 +2217,27 @@ contents:
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Ingest Management Guide 7.8-7.9
+            prefix:     en/ingest-management
+            current:    7.9
+            branches:   [ 7.9, 7.8 ]
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      1
+            tags:       Ingest Management/Guide
+            subject:    Ingest Management
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   beats
+                path:   x-pack/elastic-agent/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Topbeat Reference
             prefix:     en/beats/topbeat
             index:      topbeat/docs/index.asciidoc


### PR DESCRIPTION
Moves the Ingest Management Guide to legacy section because it has been replaced by the Fleet User Guide.

This PR will not pass CI until links are fixed.