### PR TITLE
Add attribute and new alias for Fleet User Guide

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -121,7 +121,10 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
-# Ingest management
+# Fleet 
+alias docbldfg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
+
+# Ingest management 7.8 - 7.9
 alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
 
 # APM

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -21,6 +21,7 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
+:fleet-guide:          https://www.elastic.co/guide/en/fleet/{branch}
 :ingest-guide:         https://www.elastic.co/guide/en/ingest-management/{branch}
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}


### PR DESCRIPTION
Adds a new attribute for resolving the path to the Fleet User Guide. Also adds the build alias.

Note that I plan to rename the `ingest-management` docs folder to `fleet`, but leaving it as-is for now to get these changes in place first.