### PR TITLE
Get all branches building in Fleet User Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1258,7 +1258,7 @@ contents:
           - title:      Fleet User Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10 ]
+            branches:   [ master, 7.x, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Removes the Ingest Management Guide and updates the shared path attribute to use fleet.