### PR TITLE
Make ECS 1.7 the current release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -173,7 +173,7 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    1.6
+            current:    1.7
             branches:   [ master, 1.x, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :major-version-only:     8
-:ecs_version:            1.6
+:ecs_version:            1.7
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
Do not merge. Please let the ECS team merge this at the appropriate time.