### PR TITLE
Remove Ingest Management Guide from Beats section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1738,28 +1738,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Ingest Management Guide
-            prefix:     en/ingest-management
-            current:    *stackcurrent
-            branches:   [ master, 7.x, 7.10, 7.9, 7.8 ]
-            live:       *stacklive
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      1
-            tags:       Ingest Management/Guide
-            subject:    Ingest Management
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   beats
-                path:   x-pack/elastic-agent/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
 
     - title:     Docs in Your Native Tongue
       sections:


### PR DESCRIPTION
The Ingest Management Guide has been renamed to the Fleet User Guide in all versions of the docs. This PR removes the guide permanently from the Beats section.

**Do not merge until after the global redirects are in place**: https://github.com/elastic/website-www.elastic.co/issues/7066 