### PR TITLE
Add ECS Logging Java Reference to doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1147,7 +1147,22 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-
+          - title:      ECS Logging Java Reference
+            prefix:     en/ecs-logging/java
+            current:    master
+            branches:   [ master ]
+            live:       master
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       ECS-logging/java/Guide
+            subject:    ECS Logging Java Reference
+            sources:
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
     -   title:      Elastic Security
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1151,7 +1151,7 @@ contents:
             prefix:     en/ecs-logging/java
             current:    master
             branches:   [ master ]
-            live:       master
+            live:       [ master ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       ECS-logging/java/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -17,6 +17,7 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
+    ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -1157,6 +1158,9 @@ contents:
             tags:       ECS-logging/java/Guide
             subject:    ECS Logging Java Reference
             sources:
+              -
+                repo:   ecs-logging-java
+                path:   docs
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -194,7 +194,6 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 # ECS logging
 
-# ECS
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --chunk 1'
 
 # GKE

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -192,6 +192,11 @@ alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.as
 # ECS
 alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciidoc --chunk 2'
 
+# ECS logging
+
+# ECS
+alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --chunk 1'
+
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,6 +87,7 @@ endif::[]
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
+:ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -31,3 +31,8 @@ APM Agent versions
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging-java:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -31,3 +31,8 @@ APM Agent versions
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging-java:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -31,3 +31,8 @@ APM Agent versions
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging-java:      master


### PR DESCRIPTION
## Summary

This PR adds the [ECS Logging Java Reference](https://github.com/elastic/ecs-logging-java) to the elastic.co documentation build.


## Related

* For https://github.com/elastic/ecs-logging-java/pull/112