### PR TITLE
docs: Update ECS logging current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1150,9 +1150,9 @@ contents:
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
           - title:      ECS Logging Java Reference
             prefix:     en/ecs-logging/java
-            current:    master
-            branches:   [ master ]
-            live:       [ master ]
+            current:    0.x
+            branches:   [ master, 0.x ]
+            live:       [ master, 0.x ]
             index:      docs/index.asciidoc
             chunk:      1
             tags:       ECS-logging/java/Guide

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      master
+:ecs-logging-java:      0.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      master
+:ecs-logging-java:      0.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      master
+:ecs-logging-java:      0.x


### PR DESCRIPTION
## Summary

This PR updates `current` to `0.x` for `ecs-logging-java`. This PR should only be merged after the `0.x` branch has been added to the repository.

cc @felixbarny 

## Related issues

This is a follow-up PR to https://github.com/elastic/docs/pull/2010.