### PR TITLE
7.10.1 release

### DIFF
--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.10.0
+:version:                7.10.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.10.0
-:logstash_version:       7.10.0
-:elasticsearch_version:  7.10.0
-:kibana_version:         7.10.0
-:apm_server_version:     7.10.0
+:bare_version:           7.10.1
+:logstash_version:       7.10.1
+:elasticsearch_version:  7.10.1
+:kibana_version:         7.10.1
+:apm_server_version:     7.10.1
 :branch:                 7.10
 :minor-version:          7.10
 :major-version:          7.x


### PR DESCRIPTION
Updates the shared version attributes to 7.10.1.

NOTE: Do not merge until release day.