### PR TITLE
ecctl: Remove beta suffixed branches from listing

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -818,7 +818,7 @@ contents:
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    1.0
-            branches:   [ master, 1.0, 1.0.0-beta3, 1.0.0-beta2 ]
+            branches:   [ master, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Removes the `beta` suffixed branches from the doc building.
