### PR TITLE
Update ecctl branch to 1.1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -817,8 +817,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.0
-            branches:   [ master, 1.0, 1.0.0-beta3, 1.0.0-beta2 ]
+            current:    1.1
+            branches:   [ master, 1.1, 1.0, 1.0.0-beta3, 1.0.0-beta2 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
__IMPORTANT: Do not merge until ECE 2.7.1 release__
# Description
Updates the current branch to 1.1, adds 1.1 in the branches array,
