### PR TITLE
docs: add ecs-logging

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -17,6 +17,7 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
+    ecs-logging:          https://github.com/elastic/ecs-logging.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
@@ -1167,6 +1168,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+              -
+                repo:   ecs-logging
+                path:   docs
+                map_branches: &mapEcsLoggingJavaToEcsLogging
+                  1.x: master
+                  0.x: master
 
     -   title:      Elastic Security
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1150,31 +1150,53 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-          - title:      ECS Logging Java Reference
-            prefix:     en/ecs-logging/java
-            current:    1.x
-            branches:   [ master, 1.x, 0.x ]
-            live:       [ master, 1.x ]
-            index:      docs/index.asciidoc
-            chunk:      1
-            tags:       ECS-logging/java/Guide
-            subject:    ECS Logging Java Reference
-            sources:
-              -
-                repo:   ecs-logging-java
-                path:   docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   ecs-logging
-                path:   docs
-                map_branches: &mapEcsLoggingJavaToEcsLogging
-                  1.x: master
-                  0.x: master
+          - title:      ECS logging
+            base_dir:   en/ecs-logging
+            sections:
+              - title:      ECS Logging Overview
+                prefix:     overview
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/Guide
+                subject:    ECS Logging Overview
+                sources:
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+              - title:      ECS Logging Java Reference
+                prefix:     java
+                current:    1.x
+                branches:   [ master, 1.x, 0.x ]
+                live:       [ master, 1.x ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/java/Guide
+                subject:    ECS Logging Java Reference
+                sources:
+                  -
+                    repo:   ecs-logging-java
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+                    map_branches: &mapEcsLoggingJavaToEcsLogging
+                      1.x: master
+                      0.x: master
 
     -   title:      Elastic Security
         sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -194,7 +194,7 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 # ECS logging
 
-alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --chunk 1'
+alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -194,6 +194,8 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 # ECS logging
 
+alias docbldecslg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging/docs/index.asciidoc --chunk 1'
+
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 # GKE

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,7 +87,7 @@ endif::[]
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
-:ecs-logging-ref:          https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
+:ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,7 +87,7 @@ endif::[]
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
-:ecs-logging:          https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
+:ecs-logging-ref:          https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,6 +87,7 @@ endif::[]
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
+:ecs-logging:          https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      0.x
+:ecs-logging-java:      1.x

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -35,4 +35,5 @@ APM Agent versions
 ////
 ECS Logging
 ////
+:ecs-logging:           master
 :ecs-logging-java:      1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      0.x
+:ecs-logging-java:      1.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -35,4 +35,5 @@ APM Agent versions
 ////
 ECS Logging
 ////
+:ecs-logging:           master
 :ecs-logging-java:      1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -35,4 +35,4 @@ APM Agent versions
 ////
 ECS Logging
 ////
-:ecs-logging-java:      0.x
+:ecs-logging-java:      1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -35,4 +35,5 @@ APM Agent versions
 ////
 ECS Logging
 ////
+:ecs-logging:           master
 :ecs-logging-java:      1.x


### PR DESCRIPTION
This PR adds the `ecs-logging` repository as a source repo for the `ecs-logging-java` documentation. It also maps the `master` branch of `ecs-logging` to both the `1.x` and `0.x` branches of `ecs-logging-java`.

Blocked by:
- [x] https://github.com/elastic/ecs-logging/pull/40
~https://github.com/elastic/ecs-logging-java/pull/117.~