### PR TITLE
Add ECS .NET & Ruby documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1211,28 +1211,28 @@ contents:
                     map_branches: &mapEcsLoggingJavaToEcsLogging
                       1.x: master
                       0.x: master
-                - title:      ECS Logging .NET Reference
-                  prefix:     en/ecs-logging/dotnet
-                  current:    master
-                  branches:   [ master ]
-                  live:       [ master ]
-                  index:      docs/index.asciidoc
-                  chunk:      1
-                  tags:       ECS-logging/.NET/Guide
-                  subject:    ECS Logging .NET Reference
-                  sources:
-                    -
-                      repo:   ecs-dotnet
-                      path:   docs
-                    -
-                      repo:   docs
-                      path:   shared/versions/stack/{version}.asciidoc
-                    -
-                      repo:   docs
-                      path:   shared/attributes.asciidoc
-                    -
-                      repo:   ecs-logging
-                      path:   docs
+              - title:      ECS Logging .NET Reference
+                prefix:     en/ecs-logging/dotnet
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/.NET/Guide
+                subject:    ECS Logging .NET Reference
+                sources:
+                  -
+                    repo:   ecs-dotnet
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
 
     -   title:      Elastic Security
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -20,6 +20,7 @@ repos:
     ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     ecs-logging:          https://github.com/elastic/ecs-logging.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
+    ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -1223,6 +1224,28 @@ contents:
                 sources:
                   -
                     repo:   ecs-dotnet
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Ruby Reference
+                prefix:     ruby
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/ruby/Guide
+                subject:    ECS Logging Ruby Reference
+                sources:
+                  -
+                    repo:   ecs-logging-ruby
                     path:   docs
                   -
                     repo:   docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -18,6 +18,7 @@ repos:
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
+    ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -1167,6 +1168,28 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+          - title:      ECS Logging .NET Reference
+            prefix:     en/ecs-logging/dotnet
+            current:    master
+            branches:   [ master ]
+            live:       [ master ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       ECS-logging/.NET/Guide
+            subject:    ECS Logging .NET Reference
+            sources:
+              -
+                repo:   ecs-dotnet
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   ecs-logging
+                path:   docs
 
     -   title:      Elastic Security
         sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -201,7 +201,7 @@ alias docbldecslg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging/docs/in
 
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
-alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -201,7 +201,7 @@ alias docbldecslg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging/docs/in
 
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
-alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -196,6 +196,8 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --chunk 1'
 
+alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -203,6 +203,8 @@ alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/do
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
+alias docbldecsrb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 # GKE
 alias docbldgke='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/gke-on-prem/index.asciidoc --chunk 1'
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -89,7 +89,8 @@ endif::[]
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
-:ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-dotnet}
+:ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
+:ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -88,6 +88,7 @@ endif::[]
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
+:ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-dotnet}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -38,3 +38,4 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-ruby:      master

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -36,3 +36,4 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging-java:      0.x
+:ecs-logging-dotnet:    master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -38,3 +38,4 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-ruby:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -36,3 +36,4 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging-java:      0.x
+:ecs-logging-dotnet:    master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -38,3 +38,4 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-ruby:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -36,3 +36,4 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging-java:      0.x
+:ecs-logging-dotnet:    master


### PR DESCRIPTION
This PR adds ECS Logging .NET documentation to our build system. It sets `master` as the `current` branch and sets up the required include parameters for including content from `ecs-logging`.

Blocked by:
- [x] https://github.com/elastic/ecs-dotnet/pull/120
- [x] elastic/ecs-logging#40
- [x] https://github.com/elastic/docs/pull/2017
- [x] Update ecs-dotnet docs to use shared content elastic/ecs-dotnet#122