### PR TITLE
Add ecs-logging and ecs-dotnet repos

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -17,6 +17,8 @@ repos:
     curator:              https://github.com/elastic/curator.git
     ecctl:                https://github.com/elastic/ecctl.git
     ecs:                  https://github.com/elastic/ecs.git
+    ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
+    ecs-logging:          https://github.com/elastic/ecs-logging.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git


### PR DESCRIPTION
These were added to the cached worker images used for CI, and will soon be needed by docs builds. I have a periodic job that keeps these two lists in sync, so I'm adding them in here, even though they aren't used by any published docs yet.