### PR TITLE
Add missing resource to filebeat build alias

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -106,7 +106,7 @@ alias docbldbdg='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldpb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/packetbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldfb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --chunk 1'
+alias docbldfb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/filebeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/filebeat/docs --chunk 1'
 
 alias docbldwb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/winlogbeat/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
Fixes doc build alias for Filebeat so that local build does not fail.

@gtback The Beats aliases were defined before we made the file structure of the books more complex. Should we try to sync up the aliases with all potential resource paths defined in the conf.yaml, or just deal with them when they break? I'm inclined to wait until they break.