### PR TITLE
docs: fix ecs-logging link

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,7 +87,7 @@ endif::[]
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
-:ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/{ecs-logging}
+:ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}


### PR DESCRIPTION
Fixes ECS logging link

For https://github.com/elastic/ecs-logging-java/pull/117.