### PR TITLE
Add ECS 1.8 branch in prep for release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -179,7 +179,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.7
-            branches:   [ master, 1.x, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.x, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.7
+:ecs_version:            1.8
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :major-version-only:     8
-:ecs_version:            1.7
+:ecs_version:            1.8
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
* Adds a new unreleased 1.8 branch to the version selector.
* Updates the stack version mappings to this new version.

`current` version will be updated when ECS 1.8 releases.