### PR TITLE
Remove Beats repo dependency

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1377,9 +1377,6 @@ contents:
                 repo:   observability-docs
                 path:   docs/en
               -
-                repo:   beats
-                path:   x-pack/elastic-agent/docs
-              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -


### PR DESCRIPTION
We're currently moving all source for the Elastic Agent + Fleet documentation to a single location in the observability-docs repo. 

When that work is complete, the x-pack/elastic-agent/docs directory will no longer exist.

DO NOT MERGE until the work is complete and all open PRs are merged.