### PR TITLE
Add libbeat/docs to Functionbeat reference

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1559,6 +1559,10 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
           - title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
             current:    *stackcurrent


### PR DESCRIPTION
Add `x-pack/libbeat/docs` as a dependency to the Functionbeat reference.

For https://github.com/elastic/beats/pull/23344