### PR TITLE
Add ecs-logging-python to the build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -20,6 +20,7 @@ repos:
     ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     ecs-logging:          https://github.com/elastic/ecs-logging.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
+    ecs-logging-python:   https://github.com/elastic/ecs-logging-ruby.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
@@ -1246,6 +1247,28 @@ contents:
                 sources:
                   -
                     repo:   ecs-logging-ruby
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Python Reference
+                prefix:     python
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/python/Guide
+                subject:    ECS Logging Python Reference
+                sources:
+                  -
+                    repo:   ecs-logging-python
                     path:   docs
                   -
                     repo:   docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -20,7 +20,7 @@ repos:
     ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     ecs-logging:          https://github.com/elastic/ecs-logging.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
-    ecs-logging-python:   https://github.com/elastic/ecs-logging-ruby.git
+    ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -203,6 +203,8 @@ alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/do
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
+alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 alias docbldecsrb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 # GKE

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -203,7 +203,7 @@ alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/do
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
-alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecsrb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -91,6 +91,7 @@ endif::[]
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
+:ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-python-dotnet}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -91,7 +91,7 @@ endif::[]
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
-:ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-python-dotnet}
+:ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
 :eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -38,4 +38,5 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -38,4 +38,5 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -38,4 +38,5 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -38,4 +38,5 @@ ECS Logging
 :ecs-logging:           master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-python:    master
 :ecs-logging-ruby:      master


### PR DESCRIPTION
Adds `ecs-logging-python` to the build.

Blocked by https://github.com/elastic/ecs-logging-python/pull/29.
For https://github.com/elastic/ecs-logging-python/issues/27.