### PR TITLE
Add ecs-logging-go-zap to the build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -19,6 +19,7 @@ repos:
     ecs:                  https://github.com/elastic/ecs.git
     ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     ecs-logging:          https://github.com/elastic/ecs-logging.git
+    ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
@@ -1187,6 +1188,28 @@ contents:
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+              - title:      ECS Logging Go Zap Reference
+                prefix:     go-zap
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/go-zap/Guide
+                subject:    ECS Logging Go Zap Reference
+                sources:
+                  -
+                    repo:   ecs-logging-go-zap
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -199,6 +199,8 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 alias docbldecslg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging/docs/index.asciidoc --chunk 1'
 
+alias docbldecszap='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-go-zap/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -89,6 +89,7 @@ endif::[]
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
+:ecs-logging-go-zap-ref:  https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-go-zap}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -89,7 +89,7 @@ endif::[]
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
-:ecs-logging-go-zap-ref:  https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-go-zap}
+:ecs-logging-go-zap-ref:  https://www.elastic.co/guide/en/ecs-logging/go-zap/{ecs-logging-go-zap}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -36,6 +36,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -36,6 +36,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -36,6 +36,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -36,6 +36,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-ruby:      master


### PR DESCRIPTION
Adds `ecs-logging-go-zap` to the build.

For https://github.com/elastic/ecs-logging-go-zap/issues/20.