### PR TITLE
Change current to MS 51

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -621,8 +621,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-49
-            branches:   [ ms-49 ]
+            current:    ms-51
+            branches:   [ ms-51 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -638,7 +638,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-49: master
+                  ms-51: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -673,8 +673,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-49
-            branches:   [ ms-49 ]
+            current:    ms-51
+            branches:   [ ms-51 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
This PR updates our docs to use MS 51 as `current` for ESS and the Heroku docs built partially off the same source. 