### PR TITLE
Adds chunk attribute to PHP book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -471,6 +471,7 @@ contents:
                 branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       [ master, 7.x ]
                 index:      docs/index.asciidoc
+                chunk:      1
                 tags:       Clients/PHP
                 subject:    Clients
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -174,7 +174,7 @@ alias docbldego='$GIT_HOME/docs/build_docs --doc $GIT_HOME/go-elasticsearch/.doc
 
 alias docbldnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-net/docs/index.asciidoc --chunk 1'
 
-alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc'
+alias docbldphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-php/docs/index.asciidoc --chunk 1'
 
 alias docbldepl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/perl/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
## Overview

This PR adds the `chunk: 1` attribute to the PHP book attribute list in the conf.yml and adds `--chunk 1` to the PHP book alias in `doc_buil_aliases.sh`.

These changes are required because of upcoming structural changes in the PHP client book.

### Notes

Do not merge until https://github.com/elastic/elasticsearch-php/pull/1099 is not merged.