### PR TITLE
Add is-current-version attribute

### DIFF
--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -17,8 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-
 :release-state:          released
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    true
 
 ////
 APM Agent versions

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -17,8 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-
 :release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
 
 ////
 APM Agent versions

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -17,8 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-
 :release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
 
 ////
 APM Agent versions

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -17,8 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-
 :release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
 
 ////
 APM Agent versions


### PR DESCRIPTION
## Summary

This PR proposes the addition of a new shared attribute, `is-current-version`. `is-current-version` will be set to `true` in the currently released stack version, and `false` in all other versions.

## Release

At each minor and major release, a two-line update will be required. The previously current version will need to be set to `false`, and the newly current version will need to be set to `true`.

For example, in the 7.11 release, `shared/versions/stack/7.10.asciidoc` will set `:is-current-version:` to `false` and `shared/versions/stack/7.11.asciidoc:` will set `:is-current-version:` to `true`.

If Greg and Lisa are cool with this, I'll update the release documentation as well.

## Related

Required for https://github.com/elastic/observability-docs/pull/350.