### PR TITLE
Add ecs-logging-go-logrus to the build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -19,6 +19,7 @@ repos:
     ecs:                  https://github.com/elastic/ecs.git
     ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
     ecs-logging:          https://github.com/elastic/ecs-logging.git
+    ecs-logging-go-logrus:  https://github.com/elastic/ecs-logging-go-logrus.git
     ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
@@ -1194,7 +1195,29 @@ contents:
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
-              - title:      ECS Logging Go Zap Reference
+              - title:      ECS Logging Go (Logrus) Reference
+                prefix:     go-logrus
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/go-logrus/Guide
+                subject:    ECS Logging Go Logrus Reference
+                sources:
+                  -
+                    repo:   ecs-logging-go-logrus
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Go (Zap) Reference
                 prefix:     go-zap
                 current:    master
                 branches:   [ master ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -1203,7 +1203,7 @@ contents:
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/go-logrus/Guide
-                subject:    ECS Logging Go Logrus Reference
+                subject:    ECS Logging Go (Logrus) Reference
                 sources:
                   -
                     repo:   ecs-logging-go-logrus
@@ -1225,7 +1225,7 @@ contents:
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/go-zap/Guide
-                subject:    ECS Logging Go Zap Reference
+                subject:    ECS Logging Go (Zap) Reference
                 sources:
                   -
                     repo:   ecs-logging-go-zap

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -199,6 +199,8 @@ alias docbldecs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs/docs/index.asciid
 
 alias docbldecslg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging/docs/index.asciidoc --chunk 1'
 
+alias docbldecslrs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-go-logrus/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 alias docbldecszap='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-go-zap/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -89,7 +89,8 @@ endif::[]
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}
 :ecs-logging-ref:      https://www.elastic.co/guide/en/ecs-logging/overview/{ecs-logging}
-:ecs-logging-go-zap-ref:  https://www.elastic.co/guide/en/ecs-logging/go-zap/{ecs-logging-go-zap}
+:ecs-logging-go-logrus-ref:  https://www.elastic.co/guide/en/ecs-logging/go-logrus/{ecs-logging-go-logrus}
+:ecs-logging-go-zap-ref:     https://www.elastic.co/guide/en/ecs-logging/go-zap/{ecs-logging-go-zap}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
 :ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -40,6 +40,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-logrus: master
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -40,6 +40,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-logrus: master
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -40,6 +40,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-logrus: master
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -40,6 +40,7 @@ APM Agent versions
 ECS Logging
 ////
 :ecs-logging:           master
+:ecs-logging-go-logrus: master
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master


### PR DESCRIPTION
This PR adds `ecs-logging-go-logrus` to the build. It also renames the ECS zap book.

For https://github.com/elastic/ecs-logging-go-logrus/issues/5.

~**Merge after https://github.com/elastic/ecs-logging-go-logrus/pull/9.**~