### PR TITLE
add ecs-logging-nodejs to the docs repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -22,7 +22,7 @@ repos:
     ecs-logging-go-logrus:  https://github.com/elastic/ecs-logging-go-logrus.git
     ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
-    ecs-logging-js:       https://github.com/elastic/ecs-logging-js.git
+    ecs-logging-nodejs:   https://github.com/elastic/ecs-logging-nodejs.git
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git

--- a/conf.yaml
+++ b/conf.yaml
@@ -1298,7 +1298,7 @@ contents:
                 subject:    ECS Logging Node.js Reference
                 sources:
                   -
-                    repo:   ecs-logging-js
+                    repo:   ecs-logging-nodejs
                     path:   docs
                   -
                     repo:   docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -22,6 +22,7 @@ repos:
     ecs-logging-go-logrus:  https://github.com/elastic/ecs-logging-go-logrus.git
     ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
+    ecs-logging-js:       https://github.com/elastic/ecs-logging-js.git
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
@@ -1276,6 +1277,28 @@ contents:
                 sources:
                   -
                     repo:   ecs-dotnet
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Node.js Reference
+                prefix:     nodejs
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/nodejs/Guide
+                subject:    ECS Logging Node.js Reference
+                sources:
+                  -
+                    repo:   ecs-logging-js
                     path:   docs
                   -
                     repo:   docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -207,7 +207,7 @@ alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/do
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
-alias docbldecsjs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-js/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+alias docbldecsnodejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-nodejs/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -207,6 +207,8 @@ alias docbldecsjv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-java/do
 
 alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
+alias docbldecsjs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-js/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecsrb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -93,6 +93,7 @@ endif::[]
 :ecs-logging-go-zap-ref:     https://www.elastic.co/guide/en/ecs-logging/go-zap/{ecs-logging-go-zap}
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
+:ecs-logging-nodejs-ref:  https://www.elastic.co/guide/en/ecs-logging/nodejs/{ecs-logging-nodejs}
 :ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.6
+:ecs_version:            1.7
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -44,5 +44,6 @@ ECS Logging
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.7
+:ecs_version:            1.6
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -44,5 +44,6 @@ ECS Logging
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -44,5 +44,6 @@ ECS Logging
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -44,5 +44,6 @@ ECS Logging
 :ecs-logging-go-zap:    master
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master


### PR DESCRIPTION
This PR adds `ecs-logging-js` to the documentation build.

For https://github.com/elastic/ecs-logging-js/issues/20.

Note: CI is expected to fail until https://github.com/elastic/ecs-logging-js/pull/44 is merged.