### PR TITLE
Add ecs-logging-php to the build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -23,6 +23,7 @@ repos:
     ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
     ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
     ecs-logging-nodejs:   https://github.com/elastic/ecs-logging-nodejs.git
+    ecs-logging-php:      https://github.com/elastic/ecs-logging-php.git
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
@@ -1321,6 +1322,28 @@ contents:
                 sources:
                   -
                     repo:   ecs-logging-ruby
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging PHP Reference
+                prefix:     php
+                current:    master
+                branches:   [ master ]
+                live:       [ master ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/php/Guide
+                subject:    ECS Logging PHP Reference
+                sources:
+                  -
+                    repo:   ecs-logging-php
                     path:   docs
                   -
                     repo:   docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -209,6 +209,8 @@ alias docbldecsnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-dotnet/docs/in
 
 alias docbldecsnodejs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-nodejs/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
+alias docbldecsphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-php/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
+
 alias docbldecspy='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-python/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'
 
 alias docbldecsrb='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ecs-logging-ruby/docs/index.asciidoc --resource=$GIT_HOME/ecs-logging/docs/ --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -94,6 +94,7 @@ endif::[]
 :ecs-logging-java-ref: https://www.elastic.co/guide/en/ecs-logging/java/{ecs-logging-java}
 :ecs-logging-dotnet-ref:  https://www.elastic.co/guide/en/ecs-logging/dotnet/{ecs-logging-dotnet}
 :ecs-logging-nodejs-ref:  https://www.elastic.co/guide/en/ecs-logging/nodejs/{ecs-logging-nodejs}
+:ecs-logging-php-ref:     https://www.elastic.co/guide/en/ecs-logging/php/{ecs-logging-php}
 :ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -45,5 +45,6 @@ ECS Logging
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-nodejs:    master
+:ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -45,5 +45,6 @@ ECS Logging
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-nodejs:    master
+:ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -45,5 +45,6 @@ ECS Logging
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-nodejs:    master
+:ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -45,5 +45,6 @@ ECS Logging
 :ecs-logging-java:      1.x
 :ecs-logging-dotnet:    master
 :ecs-logging-nodejs:    master
+:ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master


### PR DESCRIPTION
Adds [`ecs-logging-php`](https://github.com/elastic/ecs-logging-php) to the doc build.

For https://github.com/elastic/ecs-logging-php/issues/20.
~Blocked by https://github.com/elastic/ecs-logging-php/pull/18.~