### PR TITLE
Change current to MS 52 for ESS

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -631,8 +631,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-51
-            branches:   [ ms-51 ]
+            current:    ms-52
+            branches:   [ ms-52 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -648,7 +648,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-51: master
+                  ms-52: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -683,8 +683,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-51
-            branches:   [ ms-51 ]
+            current:    ms-52
+            branches:   [ ms-52 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
This PR updates our docs to use MS 52 as `current` for ESS and the Heroku docs.