### PR TITLE
Add new version of the docs for ecctl

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -835,8 +835,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.1
-            branches:   [ master, 1.1, 1.0 ]
+            current:    1.2
+            branches:   [ master, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Part of the ecctl 1.2 release, accompanying ECE 2.8.0
Relates to https://github.com/elastic/ecctl/issues/436
