### PR TITLE
Capitalize subject for ML Book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -165,8 +165,8 @@ contents:
             branches:   [ master, 7.x, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
-            tags:       Elastic Stack/Machine learning
-            subject:    Machine learning
+            tags:       Elastic Stack/Machine Learning
+            subject:    Machine Learning
             sources:
               -
                 repo:   stack-docs


### PR DESCRIPTION
This value is used as the `DC.subject` meta value for the ML book. The search facets on www.elastic.co use the capitalized version of the name, so we should match that in order for results to appear.

cc: @laurent-qa @brianjolly 