### PR TITLE
Add .NET APM agent 1.8 branch as current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1116,9 +1116,9 @@ contents:
                         exclude_branches:   [ 0.7, 0.6]
                   - title:      APM .NET Agent
                     prefix:     dotnet
-                    current:    1.x
-                    branches:   [ master, 1.x ]
-                    live:       [ master, 1.x ]
+                    current:    1.8
+                    branches:   [ master, 1.x, 1.8 ]
+                    live:       [ master, 1.x, 1.8 ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/6.5.asciidoc
+++ b/shared/versions/stack/6.5.asciidoc
@@ -23,4 +23,4 @@ APM Agent versions
 :apm-node-branch:       2.x
 :apm-py-branch:         4.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -23,4 +23,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -23,4 +23,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -27,4 +27,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8
 
 ////
 ECS Logging

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8
 
 ////
 ECS Logging

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8
 
 ////
 ECS Logging

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.5.asciidoc
+++ b/shared/versions/stack/7.5.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       2.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.6.asciidoc
+++ b/shared/versions/stack/7.6.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -28,4 +28,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -29,4 +29,4 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -30,4 +30,4 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8
 
 ////
 ECS Logging


### PR DESCRIPTION
This commit updates the configuration for the APM
.NET agent to include the 1.8 branch, and set it as
the current branch.