### PR TITLE
Use string equality operator for custom index page comparison

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -390,7 +390,7 @@ sub _update_title_and_version_drop_downs {
         
         # If a book uses a custom index page, it may not include the TOC. The 
         # substitution below will fail, so we abort early in this case.
-        next unless ($_ == 'index.html' && ($html =~ /ul class="toc"/));
+        next unless ($_ eq 'index.html' && ($html =~ /ul class="toc"/));
 
         my $success = ($html =~ s/<ul class="toc">(?:<li id="book_title">.+?<\/li>)?\n?<li>/<ul class="toc">${title}<li>/);
         die "couldn't update version" unless $success;


### PR DESCRIPTION
Our recent doc builds include the following warnings:

```
INFO:build_docs:Argument "index.html" isn't numeric in numeric eq (==) at lib/ES/Book.pm line 393.
INFO:build_docs:Argument "toc.html" isn't numeric in numeric eq (==) at lib/ES/Book.pm line 393.
INFO:build_docs:Argument "index.html" isn't numeric in numeric eq (==) at lib/ES/Book.pm line 393.
```

This stops the warnings by replacing the numeric `==` operator with the string
`eq` operator.