### PR TITLE
Remove APM .NET agent 1.x branch from the doc build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1117,8 +1117,8 @@ contents:
                   - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.8
-                    branches:   [ master, 1.x, 1.8 ]
-                    live:       [ master, 1.x, 1.8 ]
+                    branches:   [ master, 1.8 ]
+                    live:       [ master, 1.8 ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
-:apm-dotnet-branch:     1.x
+:apm-dotnet-branch:     1.8
 
 ////
 ECS Logging


### PR DESCRIPTION
To simplify their dev process, the APM .NET team wants to remove the `1.x` branch from their repository.

~`current` was swapped from `1.x` to `1.8` in https://github.com/elastic/docs/pull/2066, so I'm optimistic this will pass ci 🤞~ I jinxed myself.