### PR TITLE
Update Azure Marketplace docs version

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -197,9 +197,9 @@ contents:
                 path:   docs/
           - title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
-            current:    7.10
+            current:    7.11
             index:      docs/index.asciidoc
-            branches:   [ master, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template


### PR DESCRIPTION
This commit adds 7.11 to the Azure Marketplace docs and sets as current