### PR TITLE
Change current to MS 53 for ESS

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -632,8 +632,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-52
-            branches:   [ ms-52 ]
+            current:    ms-53
+            branches:   [ ms-53 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -649,7 +649,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-52: master
+                  ms-53: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -684,8 +684,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-52
-            branches:   [ ms-52 ]
+            current:    ms-53
+            branches:   [ ms-53 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
As MS-53 has now been deployed in ESS production, this PR bumps the docs to use MS 53 as current for ESS and the Heroku docs
