### PR TITLE
Add new dependency to Fleet User Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1541,6 +1541,10 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+              -
+                repo:   apm-server
+                path:   docs
+                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -128,8 +128,8 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
-# Ingest management
-alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --chunk 1'
+# Fleet user guide
+alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --resource=$GIT_HOME/apm-server/docs --chunk 1'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR adds the `apm-server` repo as a dependency to the Fleet User Guide.

For https://github.com/elastic/observability-docs/pull/426.