### PR TITLE
Add zshrc to doc_build_aliases instructions

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -1,6 +1,6 @@
 # Aliases for building the docs.
 
-# Edit your .bash_profile. Copy the following two lines into the file
+# Edit your .bash_profile or .zshrc. Copy the following two lines into the file
 # to set the $GIT_HOME variable to the directory that
 # contains your local copies of the elastic repos and include this file.
 #


### PR DESCRIPTION
On newer machines, it seems the default is zsh not bash, so the instructions in the doc_build_aliases can be misleading as-is. This PR adds a reference to .zshrc.