### PR TITLE
Update current version for 7.12

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -66,10 +66,10 @@ contents:
         sections:
           - title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    &stackcurrent 7.11
+            current:    &stackcurrent 7.12
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.12, 7.11, 6.8 ]
+            live:       &stacklive [ master, 7.x, 7.12, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -22,7 +22,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 ////
 APM Agent versions

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -17,12 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 ////
 APM Agent versions

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::7.11.asciidoc[]
+include::7.12.asciidoc[]


### PR DESCRIPTION
--DO NOT MERGE THIS PR UNTIL RELEASE DAY --

Updates "current" from 7.11 to 7.12
Updates release state from "unreleased" to "released".
Removes 7.11 from live releases (branches displayed by default)
Sets is-current-version to false for 7.11 and true for 7.12