### PR TITLE
Add ECK 1.5 branch to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -818,7 +818,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.4
-            branches:   [ master, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This adds the 1.5 release branch for the upcoming [ECK Operator](https://github.com/elastic/cloud-on-k8s) release.