### PR TITLE
Promote ECK 1.5

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -818,7 +818,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.4
-            branches:   [ master, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -817,7 +817,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.4
+            current:    1.5
             branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Based off of #2082. This promotes the ECK 1.5 release branch to current.

I am submitting this early to get approval. It should only be merged on March 23 after ECK 1.5 is released.