### PR TITLE
Publish the 7.x branch for all Enterprise Search books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -916,7 +916,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -933,7 +933,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -950,7 +950,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       App Search/Guide


### PR DESCRIPTION
Publish our 7.x docs, since we now have 7.x UIs within Kibana that link to those docs.