### PR TITLE
Change current to MS 54 for ESS

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -632,8 +632,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-53
-            branches:   [ ms-53 ]
+            current:    ms-54
+            branches:   [ ms-54 ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -649,7 +649,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-53: master
+                  ms-54: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -684,8 +684,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-53
-            branches:   [ ms-53 ]
+            current:    ms-54
+            branches:   [ ms-54 ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
As MS-54 has now been deployed in ESS production, this PR bumps the docs to use MS 54 as current for ESS and the Heroku docs