### PR TITLE
docs: set 1.x as current for apm-agent-php

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1151,9 +1151,9 @@ contents:
                         exclude_branches:   [ 1.x, 0.x ]
                   - title:      APM PHP Agent
                     prefix:     php
-                    current:    master
-                    branches:   [ master ]
-                    live:       [ master ]
+                    current:    1.x
+                    branches:   [ master, 1.x ]
+                    live:       [ master, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -31,7 +31,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
 :apm-node-branch:       3.x
-:apm-php-branch:        master
+:apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.8

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -31,7 +31,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
 :apm-node-branch:       3.x
-:apm-php-branch:        master
+:apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.8

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -31,7 +31,7 @@ APM Agent versions
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
 :apm-node-branch:       3.x
-:apm-php-branch:        master
+:apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.8


### PR DESCRIPTION
Adds the [apm-agent-php](https://github.com/elastic/apm-agent-php) `1.x` branch to the doc build and sets it as `current`.