### PR TITLE
docs: update ruby agent current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1184,9 +1184,9 @@ contents:
                         exclude_branches:   [ 4.x, 3.x, 2.x, 1.x ]
                   - title:      APM Ruby Agent
                     prefix:     ruby
-                    current:    3.x
-                    branches:   [ master, 3.x, 2.x, 1.x ]
-                    live:       [ master, 3.x ]
+                    current:    4.x
+                    branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ master, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -33,7 +33,7 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       3.x
+:apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.9
 
 ////

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -33,7 +33,7 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       3.x
+:apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.9
 
 ////

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -33,7 +33,7 @@ APM Agent versions
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
-:apm-ruby-branch:       3.x
+:apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.9
 
 ////


### PR DESCRIPTION
Updates apm-agent-ruby `current` to `4.x`.

For https://github.com/elastic/apm-agent-ruby/issues/991.