### PR TITLE
Change chunk level for Fleet User Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1530,7 +1530,7 @@ contents:
             branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
-            chunk:      1
+            chunk:      2
             tags:       Fleet/Guide
             subject:    Fleet
             sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -139,7 +139,7 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
 # Fleet user guide
-alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --resource=$GIT_HOME/apm-server/docs --chunk 1'
+alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/beats/x-pack/elastic-agent/docs --resource=$GIT_HOME/apm-server/docs --chunk 2'
 
 # APM
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'


### PR DESCRIPTION
DO NOT MERGE UNTIL ALL VERSIONS OF THE FLEET DOCS HAVE BEEN MODIFIED TO SUPPORT THIS CHANGE

This change is required in the current doc system to accommodate the large number of policy settings that will be documented in the agent docs. 

I know this goes contrary to the new design, but until we have the docs in the new docs system, having a flat structure is too overwhelming.

Incidentally, when we merge changes like this, we should let contributors know so they can pull down the latest aliases. We should also tell them when we add new build dependencies.