### PR TITLE
Rename ES Reference to ES Guide

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -314,7 +314,7 @@ layout for books.  The most basic structure is as follows:
 
 Usually this structure will be sufficient for most of your
 documentation needs. More complicated "books", such
-as the {ref}[Elasticsearch Guide], however,
+as the {ref}[Elasticsearch Guide],
 require a few additional elements, described on the
 following pages.
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -75,7 +75,7 @@ cd path/to/your/repo
 
 Each Elastic project may need its own documentation book build command.
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] provides simplified aliases and the build commands for each book.
-For example, if you want to build Elasticsearch reference document, please refer to
+For example, if you want to build the Elasticsearch Guide, please refer to
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh#L12[Elasticsearch section] in https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] file.
 
 === Specifying a different output dir
@@ -314,7 +314,7 @@ layout for books.  The most basic structure is as follows:
 
 Usually this structure will be sufficient for most of your
 documentation needs. More complicated "books", such
-as the {ref}[Elasticsearch reference docs], however,
+as the {ref}[Elasticsearch Guide], however,
 require a few additional elements, described on the
 following pages.
 
@@ -1848,7 +1848,7 @@ https://github.com/elastic/docs/blob/master/conf.yaml[`conf.yaml`] file in the `
 ----------------------------------
 contents:
     -
-        title:      Elasticsearch reference
+        title:      Elasticsearch Guide
         prefix:     elasticsearch/reference
         repo:       elasticsearch
         index:      docs/reference/index.asciidoc

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -75,7 +75,7 @@ cd path/to/your/repo
 
 Each Elastic project may need its own documentation book build command.
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] provides simplified aliases and the build commands for each book.
-For example, if you want to build the Elasticsearch Guide, please refer to
+For example, if you want to build the Elasticsearch Guide, refer to the
 https://github.com/elastic/docs/blob/master/doc_build_aliases.sh#L12[Elasticsearch section] in https://github.com/elastic/docs/blob/master/doc_build_aliases.sh[`doc_build_aliases.sh`] file.
 
 === Specifying a different output dir

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -360,7 +360,7 @@ sub check_kibana_links {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
-                # the Elasticsearch Reference Guide. In newer branches, the
+                # the Elasticsearch Guide. In newer branches, the
                 # variable is called `${ELASTICSEARCH_DOCS}`
                 $path =~ s!\$\{ELASTIC_DOCS\}!en/elasticsearch/reference/$branch/!;
                 $path =~ s!\$\{ELASTICSEARCH_DOCS\}!en/elasticsearch/reference/$branch/!;

--- a/conf.yaml
+++ b/conf.yaml
@@ -210,7 +210,7 @@ contents:
 
     -   title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
-          - title:      Elasticsearch Reference
+          - title:      Elasticsearch Guide
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -132,7 +132,7 @@ RSpec.describe 'building all books' do
                       '${ELASTIC_WEBSITE_URL}not-part-of-the-guide', false
       include_examples 'all links are ok'
     end
-    describe 'when there is a broken Elasticsearch reference link in Kibana' do
+    describe 'when there is a broken Elasticsearch Guide link in Kibana' do
       include_context 'there is a kibana link', true,
                       '${ELASTICSEARCH_DOCS}missing-page', true
       include_examples 'there are broken links in kibana',


### PR DESCRIPTION
The ES docs team recently agreed to rename the `Elasticsearch Reference` docs to the `Elasticsearch Guide`.

This will help avoid the confusion and highlight that the ES docs contain more than reference material.

! This PR does **not** change the ES docs' URL structure or any links. !

Relates to https://github.com/elastic/elasticsearch/pull/71198