### PR TITLE
[DOCS] Add tag for generic ESS getting started instructions

### DIFF
--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -6,6 +6,7 @@
 
 There's no faster way to get started than with our hosted {ess} on Elastic Cloud:
 
+// tag::generic[]
 . {ess-trial}[Get a free trial].
 
 . Log into {ess-console}[Elastic Cloud].
@@ -14,6 +15,7 @@ There's no faster way to get started than with our hosted {ess} on Elastic Cloud
 
 . Select a solution and give your deployment a name.
 
-. Click *Create deployment* and copy the password for the `elastic` user and Cloud ID information.
+. Click *Create deployment* and copy the password for the `elastic` user.
+// end::generic[]
 
 That’s it! Now that you are up and running, it’s time to get some data into {kib}. Click *Launch Kibana*.

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -15,7 +15,7 @@ There's no faster way to get started than with our hosted {ess} on Elastic Cloud
 
 . Select a solution and give your deployment a name.
 
-. Click *Create deployment* and copy the password for the `elastic` user.
+. Click *Create deployment* and download the password for the `elastic` user.
 // end::generic[]
 
 That’s it! Now that you are up and running, it’s time to get some data into {kib}. Click *Launch Kibana*.


### PR DESCRIPTION
Tags the generic portion of our ESS getting started instructions for reuse. This lets me avoid Kibana-specific language in the ES docs. Also includes a minor edit.