### PR TITLE
Fix capitalization for 'curl'

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1079,11 +1079,11 @@ footnote to a particular line of code:
 ==================================
 
 [[copy-as-curl]]
-=== Copy as cURL/View in Console
+=== Copy as curl/View in Console
 
-Code blocks can be followed by a "Copy as cURL" link which will convert the
+Code blocks can be followed by a "Copy as curl" link which will convert the
 snippet into a sequence of calls to the ubiquitous
-https://curl.haxx.se/[cURL] tool that work in the bash shell and copy it to
+https://curl.se/[curl] tool that work in the bash shell and copy it to
 the clipboard. Similarly, if the target of the snippet is Elasticsearch we also
 add a "View in Console" link will open the code snippet in Console.
 
@@ -1094,7 +1094,7 @@ for Elastic Cloud Enterprise.
 
 For Elasticsearch do this:
 
-.Code block with "Copy as cURL" and "View in Console" link for Elasticsearch
+.Code block with "Copy as curl" and "View in Console" link for Elasticsearch
 ==================================
 [source,asciidoc]
 --
@@ -1125,7 +1125,7 @@ NOTE: In older branches you'll see `// CONSOLE` after the snippet to trigger
 
 For Kibana do this:
 
-.Code block with "Copy as cURL" link for Kibana
+.Code block with "Copy as curl" link for Kibana
 ==================================
 [source,asciidoc]
 --
@@ -1145,7 +1145,7 @@ GET /
 
 For Elasticsearch Service do this:
 
-.Code block with "Copy as cURL" link for Elasticsearch Service
+.Code block with "Copy as curl" link for Elasticsearch Service
 ==================================
 [source,asciidoc]
 --
@@ -1165,7 +1165,7 @@ GET /
 
 For Elastic Cloud Enterprise do this:
 
-.Code block with "Copy as cURL" link for Elastic Cloud Enterprise
+.Code block with "Copy as curl" link for Elastic Cloud Enterprise
 ==================================
 [source,asciidoc]
 --

--- a/resources/web/docs_js/__tests__/docs.test.js
+++ b/resources/web/docs_js/__tests__/docs.test.js
@@ -70,7 +70,7 @@ function pageWithConsole(name, consoleText, extraTextAssertions) {
 }
 
 describe('console widget', () => {
-  describe('Copy as cURL button', () => {
+  describe('Copy as curl button', () => {
     pageWithConsole('a snippet without a body', 'GET /_cat/health?v', () => {
       test('includes the corrent method', () => {
         expect(document.copied).toMatch(/-X GET/);

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -35,14 +35,14 @@ export class _ConsoleForm extends Component {
       <label for="url">{props.langStrings(props.url_label)}</label>
       <input id="url" type="text" value={getValueFromState("url")} onInput={linkState(this, getFieldName("url"))} />
 
-      <label for="curl_host">cURL {props.langStrings('host')}</label>
+      <label for="curl_host">curl {props.langStrings('host')}</label>
       <input id="curl_host" type="text" value={getValueFromState("curl_host")} onInput={linkState(this, getFieldName("curl_host"))} />
 
-      <label for="curl_username">cURL {props.langStrings('username')}</label>
+      <label for="curl_username">curl {props.langStrings('username')}</label>
       <input id="curl_username" type="text" value={getValueFromState("curl_user")} onInput={linkState(this, getFieldName("curl_user"))} />
 
       {/* TODO
-      <label for="curl_pw" title={props.langStrings("curl_pw_title")}>cURL {props.langStrings('password')}</label>
+      <label for="curl_pw" title={props.langStrings("curl_pw_title")}>curl {props.langStrings('password')}</label>
       <input id="curl_pw" title={props.langStrings("curl_pw_title")} type="text" value={getValueFromState("curl_password")} onInput={linkState(this, getFieldName("curl_password"))} />
        */}
       <button id="save_url" type="button" onClick={e => props.saveSettings(this.state)}>
@@ -83,7 +83,7 @@ export const ConsoleWidget = props => {
           setting: props.setting,
           addPretty: props.addPretty
         })}>
-        {props.langStrings('Copy as cURL')}
+        {props.langStrings('Copy as curl')}
       </a>
       {props.view_in_text &&
         <a className="view_in_link"

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -14,8 +14,8 @@ export const lang_spec = {
   "Configure the Elastic Cloud Enterprise endpoint URL": {
     "zh_cn": "配置 Elastic Cloud Enterprise endpoint URL"
   },
-  "Copy as cURL": {
-    "zh_cn": "拷贝为 cURL"
+  "Copy as curl": {
+    "zh_cn": "拷贝为 curl"
   },
   "Couldn't automatically copy!": {
     "zh_cn": "无法自动拷贝!"


### PR DESCRIPTION
Super minor nit PR:

Per the [official site][0] and its [creator][1], the `curl` command-line tool should not be in camel case. This updates our `copy as curl` button accordingly.

Stumbled upon this when writing https://github.com/elastic/elasticsearch/pull/71331.

### Before
<img width="742" alt="Screen Shot 2021-04-08 at 6 28 56 PM" src="https://user-images.githubusercontent.com/40268737/114104303-9a883200-9898-11eb-9a23-f30a9886365d.PNG">

### After
<img width="751" alt="Screen Shot 2021-04-08 at 6 29 36 PM" src="https://user-images.githubusercontent.com/40268737/114104320-a07e1300-9898-11eb-88fc-256498bddc25.PNG">

[0]: https://curl.se/
[1]: https://daniel.haxx.se/docs/curl-vs-libcurl.html