### PR TITLE
Give the single-version cloud books a version name of "current"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -633,7 +633,7 @@ contents:
             tags:       Cloud/Reference
             subject:    Elastic Cloud
             current:    ms-54
-            branches:   [ ms-54 ]
+            branches:   [ {'ms-54': current} ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -685,7 +685,7 @@ contents:
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
             current:    ms-54
-            branches:   [ ms-54 ]
+            branches:   [ {'ms-54': current} ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
This should prevent the milestone name from being used as the
"DC.identifier" used for search facets

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
