### PR TITLE
Change Cloud Terraform provider version

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -850,8 +850,8 @@ contents:
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
             subject:    TPEC
-            current:    v0.1.0-beta
-            branches:   [ master, v0.1.0-beta ]
+            current:    0.1
+            branches:   [ master, 0.1 ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->

This PR updates the version for our Terraform provider docs to be in step with https://github.com/elastic/terraform-provider-ec/blob/master/CHANGELOG.md. Need to do a full rebuild after the PR gets merged. 