### PR TITLE
Add 7.13 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -68,8 +68,8 @@ contents:
             prefix:     en/elastic-stack
             current:    &stackcurrent 7.12
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.12, 6.8 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       &stacklive [ master, 7.x, 7.13, 7.12, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -115,12 +115,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           - title:      Getting Started
             prefix:     en/elastic-stack-get-started
             current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Getting started
@@ -162,7 +162,7 @@ contents:
             prefix:     en/machine-learning
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine Learning
@@ -213,7 +213,7 @@ contents:
           - title:      Elasticsearch Guide
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -228,13 +228,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
                 private: true
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -265,7 +265,7 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/qa/sql
                 # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/plugin/sql/qa
@@ -274,27 +274,27 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   elasticsearch-php
                 path:   docs/examples
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   elasticsearch-net
                 path:   examples
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   elasticsearch-py
                 path:   docs/examples
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   elasticsearch-ruby
                 path:   docs/examples/guide
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -306,12 +306,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
-                exclude_branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1
@@ -339,7 +339,7 @@ contents:
           - title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -365,7 +365,7 @@ contents:
             repo:       elasticsearch
             current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
             chunk:      2
             tags:       Elasticsearch/Plugins
@@ -396,7 +396,7 @@ contents:
               - title:      Java REST Client
                 prefix:     java-rest
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
@@ -546,7 +546,7 @@ contents:
               - title:      Java API (deprecated)
                 prefix:     java-api
                 current:    *stackcurrent
-                branches:   [ 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                branches:   [ 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 live:       *stacklive
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
@@ -605,7 +605,7 @@ contents:
           - title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -865,7 +865,7 @@ contents:
           - title:      Kibana Guide
             prefix:     en/kibana
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -880,7 +880,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -892,11 +892,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches: [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
+                exclude_branches: [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
               -
                 repo:   kibana
                 # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
@@ -918,7 +918,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -935,7 +935,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -952,7 +952,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       App Search/Guide
@@ -983,7 +983,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.12, 7.11 ]
+                branches:   [ master, 7.x, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -998,7 +998,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.12, 7.11 ]
+                branches:   [ master, 7.x, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1016,7 +1016,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      1
@@ -1047,7 +1047,7 @@ contents:
                 prefix:     get-started
                 index:      docs/guide/index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference
@@ -1063,7 +1063,7 @@ contents:
                 prefix:     server
                 index:      docs/index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                branches:   [ master, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                 live:       *stacklive
                 chunk:      1
                 tags:       APM Server/Reference
@@ -1423,7 +1423,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/index.asciidoc
             chunk:      1
@@ -1468,7 +1468,7 @@ contents:
           - title:      Logstash Reference
             prefix:     en/logstash
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -1484,7 +1484,7 @@ contents:
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -1499,11 +1499,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+                exclude_branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
@@ -1527,7 +1527,7 @@ contents:
           - title:      Fleet User Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
@@ -1554,7 +1554,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Libbeat/Reference
@@ -1579,7 +1579,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Auditbeat/Reference
@@ -1632,7 +1632,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Filebeat/Reference
@@ -1687,7 +1687,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
             chunk:      1
             tags:       Functionbeat/Reference
@@ -1736,7 +1736,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklive
             chunk:      1
             tags:       Heartbeat/Reference
@@ -1783,7 +1783,7 @@ contents:
             prefix:     en/beats/journalbeat
             current:    *stackcurrent
             index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklive
             chunk:      1
             tags:       Journalbeat/Reference
@@ -1824,7 +1824,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Metricbeat/Reference
@@ -1881,7 +1881,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklive
             chunk:      1
             tags:       Packetbeat/Reference
@@ -1924,7 +1924,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklive
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -1967,7 +1967,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    master
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklive
             chunk:      1
             tags:       Devguide/Reference
@@ -1998,7 +1998,7 @@ contents:
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ master, 7.x, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ master, 7.x, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true

--- a/shared/versions/stack/7.13.asciidoc
+++ b/shared/versions/stack/7.13.asciidoc
@@ -1,18 +1,18 @@
-:version:                7.14.0
+:version:                7.13.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.14.0
-:logstash_version:       7.14.0
-:elasticsearch_version:  7.14.0
-:kibana_version:         7.14.0
-:apm_server_version:     7.14.0
-:branch:                 7.x
-:minor-version:          7.14
+:bare_version:           7.13.0
+:logstash_version:       7.13.0
+:elasticsearch_version:  7.13.0
+:kibana_version:         7.13.0
+:apm_server_version:     7.13.0
+:branch:                 7.13
+:minor-version:          7.13
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.9
+:ecs_version:            1.8
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
Won't pass until all books publish a `7.13` branch.

- Adds 7.13 to include/exclude lists in central config file
- Adds shared attributes file for 7.13
- Changes 7.x shared attributes to reference 7.14