### PR TITLE
Add Fleet Server to shared attributes list

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -166,6 +166,7 @@ Ingest terms
 
 :agent: Elastic Agent
 :fleet: Fleet
+:fleet-server: Fleet Server
 :ingest-manager: Ingest Manager
 :ingest-management: ingest management
 :package-manager: Elastic Package Manager


### PR DESCRIPTION
Updated for new Fleet Server that will be added in 7.13.