### PR TITLE
added 6.x branch to elastic/apm-agent-python

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1167,9 +1167,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Python Agent
                     prefix:     python
-                    current:    5.x
-                    branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ master, 5.x ]
+                    current:    6.x
+                    branches:   [ master, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ master, 6.x, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM


### PR DESCRIPTION
We started releasing 6.x versions some time ago, but forgot about updating the docs.

I left 5.x as a live branch as it is the last version of the agent to support Python 2.7. 6.x+ only supports Python 3.

We added an item to our release checklist to avoid this from happening going forward. See https://github.com/elastic/apm-agent-python/pull/1109

