### PR TITLE
Add copyright notice to HTML templates

### DIFF
--- a/resources/web/air_gapped_template.html
+++ b/resources/web/air_gapped_template.html
@@ -33,6 +33,8 @@
     <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 
+  <!--© 2015-2021 Elasticsearch B.V. Copying, publishing and/or distributing without written permission is strictly prohibited.-->
+
   <body>
     <!-- TODO air gapped nav -->
     <!-- Subnav -->
@@ -72,7 +74,7 @@
         <div class="container">
           <div class="row u-space-between">
             <div class="col-12 col-md-5">
-              <div>© 2019. Elasticsearch B.V. All Rights Reserved</div>
+              <div>© 2021. Elasticsearch B.V. All Rights Reserved</div>
               <a href="https://www.elastic.co/legal/terms-of-use">Terms of Use</a>
             </div>
             <div class="col-2 col-md-1">

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -43,6 +43,8 @@
     <link rel="stylesheet" type="text/css" href="/guide/static/styles.css" />
   </head>
 
+  <!--© 2015-2021 Elasticsearch B.V. Copying, publishing and/or distributing without written permission is strictly prohibited.-->
+
   <body>
     <!-- Google Tag Manager -->
     <script>dataLayer = [];</script><noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-58RLH5" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>


### PR DESCRIPTION
In the hosted docs, the copyright statement is in a footer injected via
JavaScript. This change makes sure the HTML output itself contains the
copyright statement as well.

cc: @AnneB-SEO @pchang7092 
