### PR TITLE
Adds shared URL for EMS

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -115,6 +115,7 @@ endif::[]
 :workplace-search-ref: https://www.elastic.co/guide/en/workplace-search/{branch}
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/{branch}
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}
+:elastic-maps-service: https://maps.elastic.co
 
 //////////
 Elastic Cloud

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -160,6 +160,8 @@ Kibana app and UI names
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
 :user-experience:    User Experience
+:ems:                Elastic Maps Service
+:ems-init:           EMS
 
 //////////
 Ingest terms


### PR DESCRIPTION
This PR adds a shared attribute for terms "Elastic Maps Service" and "EMS" and for its URL https://maps.elastic.co/

Related to https://www.elastic.co/guide/en/kibana/master/maps-connect-to-ems.html