### PR TITLE
Promote ECK 1.6 to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -819,7 +819,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.5
+            current:    1.6
             branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR promotes ECK 1.6 docs as current. Should be merged on May 25 after #2120  is merged and ECK 1.6 is released.