### PR TITLE
Adds shared attribute for Elastic Maps Server

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -162,6 +162,7 @@ Kibana app and UI names
 :user-experience:    User Experience
 :ems:                Elastic Maps Service
 :ems-init:           EMS
+:hosted-ems:         Elastic Maps Server
 
 //////////
 Ingest terms


### PR DESCRIPTION
This PR copies the attribute hosted-ems from https://github.com/elastic/kibana/blob/master/docs/maps/index.asciidoc so that it can be used elsewhere too.