### PR TITLE
Update docs for ESS to ms-57 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -651,7 +651,6 @@ contents:
                 map_branches: &mapCloudSaasToClientsTeam
                   ms-57: master
               -
-              
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/go

--- a/conf.yaml
+++ b/conf.yaml
@@ -632,8 +632,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-56
-            branches:   [ {'ms-56': latest} ]
+            current:    ms-57
+            branches:   [ {'ms-57': latest} ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -649,7 +649,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-56: master
+                  ms-57: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -684,8 +684,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-56
-            branches:   [ {'ms-56': latest} ]
+            current:    ms-57
+            branches:   [ {'ms-57': latest} ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -651,6 +651,7 @@ contents:
                 map_branches: &mapCloudSaasToClientsTeam
                   ms-57: master
               -
+              
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/go


### PR DESCRIPTION
This PR changes current to MS 57 for ESS for the new release and removed the older MS 56 release.
