### PR TITLE
Add .NET APM agent 1.10 branch as current 

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1118,9 +1118,9 @@ contents:
                         exclude_branches:   [ 0.7, 0.6]
                   - title:      APM .NET Agent
                     prefix:     dotnet
-                    current:    1.9
-                    branches:   [ master, 1.9, 1.8 ]
-                    live:       [ master, 1.9 ]
+                    current:    1.10
+                    branches:   [ master, 1.10, 1.9, 1.8 ]
+                    live:       [ master, 1.10 ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/7.13.asciidoc
+++ b/shared/versions/stack/7.13.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x
-:apm-dotnet-branch:     1.9
+:apm-dotnet-branch:     1.10
 
 ////
 ECS Logging

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x
-:apm-dotnet-branch:     1.9
+:apm-dotnet-branch:     1.10
 
 ////
 ECS Logging

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -34,7 +34,7 @@ APM Agent versions
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x
-:apm-dotnet-branch:     1.9
+:apm-dotnet-branch:     1.10
 
 ////
 ECS Logging


### PR DESCRIPTION
We released v.1.10 of the .NET APM Agent.

This PR sets this version as current for the docs.

Full disclosure: I'm not 100% sure which files under `shared/versions/stack` we need to update - let me know if I need to change other files or revert some of the changes there. 