### PR TITLE
Make ECS 1.10 the current release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -185,7 +185,7 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    1.9
+            current:    1.10
             branches:   [ master, 1.x, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2


### PR DESCRIPTION
Do not merge. Please let the ECS team merge this at the appropriate time.