### PR TITLE
Add shared attribute for Rules and Connectors

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -159,6 +159,7 @@ Kibana app and UI names
 :stack-manage-app:   Stack Management
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
+:rules-ui:           Rules and Connectors
 :user-experience:    User Experience
 :ems:                Elastic Maps Service
 :ems-init:           EMS


### PR DESCRIPTION
Per https://github.com/elastic/kibana/pull/93597, in 7.13.0 and later releases, the Stack Management > "Alerts and Actions" app in Kibana is renamed to "Rules and Connectors". Since we cannot change the shared attribute "alerts-ui" across all the versions that use this file, I've added a new "rules-ui".