### PR TITLE
Adds FLEET_DOCS to Kibana link checker

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -355,11 +355,12 @@ sub check_kibana_links {
 # ${ELASTICSEARCH_DOCS}update-transform.html
 # ${KIBANA_DOCS}canvas.html
 # ${PLUGIN_DOCS}repository-s3.html
+# ${FLEET_DOCS}fleet-overview.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -369,6 +370,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{ELASTICSEARCH_DOCS\}!en/elasticsearch/reference/$branch/!;
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
+                $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -150,6 +150,12 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links in kibana',
                        'en/elasticsearch/plugins/master/not-a-valid-plugin.html'
     end
+    describe 'when there is a broken Fleet link' do
+      include_context 'there is a kibana link', true,
+                      '${FLEET_DOCS}not-a-fleet-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/fleet/master/not-a-fleet-page.html'
+    end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do
         convert_before do |src, dest|


### PR DESCRIPTION
https://github.com/elastic/kibana/pull/102660 added a FLEET_DOCS variable to the documentation link service.

This PR makes changes similar to https://github.com/elastic/docs/pull/2132 so that this variable is handled properly in the doc build checks.