### PR TITLE
Update ecctl docs for 1.4 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -846,8 +846,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.3
-            branches:   [ master, 1.3, 1.2, 1.1, 1.0 ]
+            current:    1.4
+            branches:   [ master, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
## Description

Updates the docs to point to the latest branch (`1.4.0`).
