### PR TITLE
Remove ES glossary from Stack glossary dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -148,9 +148,6 @@ contents:
                 repo:   stack-docs
                 path:   docs/en
               -
-                repo:   elasticsearch
-                path:   docs/reference/glossary.asciidoc
-              -
                 repo:   kibana
                 path:   docs/glossary.asciidoc
               -


### PR DESCRIPTION
With https://github.com/elastic/stack-docs/pull/1722, we no longer need to include the ES glossary as a source.

Once this is merged, I'll remove the ES glossary with https://github.com/elastic/elasticsearch/pull/74579.