### PR TITLE
Add attributes for units sections

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -117,6 +117,8 @@ endif::[]
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/{branch}
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}
 :elastic-maps-service: https://maps.elastic.co
+:time-units:           {ref}/api-conventions.html
+:byte-units:           {ref}/api-conventions.html
 
 //////////
 Elastic Cloud


### PR DESCRIPTION
Adding attributes for the time units & byte units sections that are cross-linked from outside of the ES guide. 