### PR TITLE
Updated units attributes to point to correct anchors

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -117,8 +117,8 @@ endif::[]
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/{branch}
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}
 :elastic-maps-service: https://maps.elastic.co
-:time-units:           {ref}/api-conventions.html
-:byte-units:           {ref}/api-conventions.html
+:time-units:           {ref}/api-conventions.html#time-units
+:byte-units:           {ref}/api-conventions.html#byte-units
 
 //////////
 Elastic Cloud


### PR DESCRIPTION
Now that the units sections are in the API conventions, these can point to the correct subsections.