### PR TITLE
Remove extra padding around images

### DIFF
--- a/resources/web/style/img.pcss
+++ b/resources/web/style/img.pcss
@@ -15,10 +15,9 @@
   }
   .imageblock {
     /* Asciidoctor emits the title *after* the image but we want it above. */
-    margin: 32px 0 32px 20px;
+    margin: 32px 0 32px 0;
     display: flex;
     flex-direction: column-reverse;
-    width: 85%;
   }
   .screenshot img {
     box-shadow:  0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);


### PR DESCRIPTION
Link to preview: https://docs_2153.docs-preview.app.elstc.co/guide/index.html

About a year ago, a PR was merged that added padding around images. The change reduced the size of our images to 85% of the original size, resulting in many screen captures that are difficult to read. Most teams did not have an opportunity to review the PR and assess the impact on their published docs.

This PR proposes that we remove the extra padding to maximize the space available for screen captures. (Manipulating the viewport size to get a larger font size in the screen capture is not a good solution to this problem because it forces odd text wraps in the captured screen.)

I've requested a review from @gtback, but I'd like for all the writing teams to weigh in.

Here are some screens that show the difference.

Before:
![image](https://user-images.githubusercontent.com/14206422/125705939-2748b4e1-a157-44e5-aae5-9060f58e8e49.png)

After:
![image](https://user-images.githubusercontent.com/14206422/125705967-cb45023e-444d-4865-bc79-94ec441fac28.png)
