### PR TITLE
docs: remove ruby 2.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1229,7 +1229,7 @@ contents:
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
-                    branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    branches:   [ master, 5.x, 4.x, 3.x, 1.x, 0.x ]
                     live:       [ master, 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
@@ -1242,7 +1242,7 @@ contents:
                       -
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
+                        exclude_branches:   [ 3.x, 1.x, 0.x ]
           - title:      ECS logging
             base_dir:   en/ecs-logging
             sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1212,7 +1212,7 @@ contents:
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x
-                    branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
+                    branches:   [ master, 4.x, 3.x, 1.x ]
                     live:       [ master, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
@@ -1229,7 +1229,7 @@ contents:
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
-                    branches:   [ master, 5.x, 4.x, 3.x, 1.x, 0.x ]
+                    branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
                     live:       [ master, 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
@@ -1242,7 +1242,7 @@ contents:
                       -
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 3.x, 1.x, 0.x ]
+                        exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
           - title:      ECS logging
             base_dir:   en/ecs-logging
             sections:


### PR DESCRIPTION
Removes the 2.x branch of the apm-agent-ruby repo from the doc build.