### PR TITLE
Add ECK 1.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -831,7 +831,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.6
-            branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This adds the ECK 1.7 branch to the build list. ECK 1.7.0 is planned for release on Tue, Aug 3 2021