### PR TITLE
Remove Kibana glossary from Stack glossary dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -148,9 +148,6 @@ contents:
                 repo:   stack-docs
                 path:   docs/en
               -
-                repo:   kibana
-                path:   docs/glossary.asciidoc
-              -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
               -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -57,7 +57,7 @@ alias docbldstkold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en
 
 
 # Glossary
-alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs --resource=$GIT_HOME/kibana/docs'
+alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'
 
 # Getting started
 alias docbldgs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/getting-started/index.asciidoc --chunk 1'


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/2141

With https://github.com/elastic/stack-docs/pull/1771, we no longer need to include the Kibana glossary as a source.