### PR TITLE
Promote ECK 1.7 to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -830,7 +830,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.6
+            current:    1.7
             branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR promotes the ECK 1.7 release branch to current.

It depends on #2161, which should be merged first, I am submitting this early to get approval. It should only be merged on Tue, Aug 3 after ECK 1.7 is released.