### PR TITLE
Add shared attributes for kibana-ref-all and security-guide-all

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -8,6 +8,7 @@
 :xpack-ref:            https://www.elastic.co/guide/en/x-pack/6.2
 :logstash-ref:         https://www.elastic.co/guide/en/logstash/{branch}
 :kibana-ref:           https://www.elastic.co/guide/en/kibana/{branch}
+:kibana-ref-all:       https://www.elastic.co/guide/en/kibana
 :beats-ref-root:       https://www.elastic.co/guide/en/beats
 :beats-ref:            https://www.elastic.co/guide/en/beats/libbeat/{branch}
 :beats-ref-60:         https://www.elastic.co/guide/en/beats/libbeat/6.0

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -87,6 +87,7 @@ endif::[]
 :observability-guide-all:   https://www.elastic.co/guide/en/observability
 :siem-guide:           https://www.elastic.co/guide/en/siem/guide/{branch}
 :security-guide:       https://www.elastic.co/guide/en/security/{branch}
+:security-guide-all:   https://www.elastic.co/guide/en/security
 :endpoint-guide:       https://www.elastic.co/guide/en/endpoint/{branch}
 :sql-odbc:             https://www.elastic.co/guide/en/elasticsearch/sql-odbc/{branch}
 :ecs-ref:              https://www.elastic.co/guide/en/ecs/{ecs_version}


### PR DESCRIPTION
These attributes are useful in the What's New "other versions" links.