### PR TITLE
Add attribute for index pattern management

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -169,6 +169,7 @@ Kibana app and UI names
 :ems:                Elastic Maps Service
 :ems-init:           EMS
 :hosted-ems:         Elastic Maps Server
+:ipm-app:            Index Pattern Management
 
 //////////
 Ingest terms
@@ -248,7 +249,7 @@ Common words and phrases
 :slm-init:                SLM
 :rollup-features:         data rollup features
 :ipm:                     index pattern management
-:ipm-cap:                 Index pattern management
+:ipm-cap:                 Index pattern 
 
 :rollup:                     rollup
 :rollup-cap:                 Rollup

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -247,6 +247,8 @@ Common words and phrases
 :slm-cap:                 Snapshot lifecycle management
 :slm-init:                SLM
 :rollup-features:         data rollup features
+:ipm:                     index pattern management
+:ipm-cap:                 Index pattern management
 
 :rollup:                     rollup
 :rollup-cap:                 Rollup


### PR DESCRIPTION
The "index pattern management" feature is referenced from places like https://www.elastic.co/guide/en/kibana/master/index-patterns.html and https://www.elastic.co/guide/en/machine-learning/master/setup.html, so this pr adds an attribute as a shortcut