### PR TITLE
Add main branch in stack-docs repo to doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -69,7 +69,7 @@ contents:
             prefix:     en/elastic-stack
             current:    &stackcurrent 7.14
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ master, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ {main: master}, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       &stacklive [ master, 7.x, 7.14, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
@@ -82,33 +82,42 @@ contents:
                 repo:   apm-server
                 path:   docs/guide
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: &mapMainToMaster
+                  main: master
               -
                 repo:   beats
                 path:   libbeat/docs
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   elasticsearch
                 path:   docs/
+                map_branches: *mapMainToMaster
               -
                 repo:   elasticsearch-hadoop
                 path:   docs/src/reference/asciidoc
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   kibana
                 path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   logstash
                 path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   observability-docs
                 path:   docs/en/observability
                 exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
@@ -116,12 +125,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ main, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           - title:      Getting Started
             prefix:     en/elastic-stack-get-started
             current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ master, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {main: master}, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Getting started
@@ -138,9 +147,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Glossary
             prefix:     en/elastic-stack-glossary
-            current:    master
+            current:    main
             index:      docs/en/glossary/index.asciidoc
-            branches:   [ master ]
+            branches:   [ {main: master} ]
             tags:       Elastic Stack/Glossary
             subject:    Elastic Stack
             sources:
@@ -157,7 +166,7 @@ contents:
             prefix:     en/machine-learning
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ master, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {main: master}, 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine Learning
@@ -169,6 +178,7 @@ contents:
               -
                 repo:   elasticsearch
                 path:   docs
+                map_branches: *mapMainToMaster
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1466,6 +1476,8 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
+                map_branches: &mapMasterToMain
+                  master: main
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8
@@ -2255,9 +2267,9 @@ contents:
         sections:
           - title:      Elastic Stack and Google Cloud's Anthos
             prefix:     en/elastic-stack-gke
-            current:    master
+            current:    main
             index:      docs/en/gke-on-prem/index.asciidoc
-            branches:   [ master ]
+            branches:   [ {main: master} ]
             private:    1
             noindex:    1
             chunk:      1


### PR DESCRIPTION
This PR depends on https://github.com/elastic/docs/pull/2174

It cannot be merged until *after* a "main" branch is created in the stack-docs repo.