### PR TITLE
Add main branch in security-docs repo to doc builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1459,7 +1459,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/index.asciidoc
             chunk:      1
@@ -1478,7 +1478,6 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
-                map_branches: *mapMasterToMain
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8


### PR DESCRIPTION
This PR depends on https://github.com/elastic/docs/pull/2174

It cannot be merged until *after* a "main" branch is created in the stack-docs repo.