### PR TITLE
Adds main branch for go-elasticsearch repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -303,7 +303,8 @@ contents:
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
                 exclude_branches:   [ 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
+                map_branches: &mapMasterToMain
+                  master: main
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1477,8 +1478,7 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
-                map_branches: &mapMasterToMain
-                  master: main
+                map_branches: *mapMasterToMain
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8

--- a/conf.yaml
+++ b/conf.yaml
@@ -303,6 +303,7 @@ contents:
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
                 exclude_branches:   [ 7.x, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -466,8 +467,8 @@ contents:
               - title:      Go API
                 prefix:     go-api
                 current:    7.x
-                branches:   [ master, 7.x ]
-                live:       [ master, 7.x ]
+                branches:   [ {main: master}, 7.x ]
+                live:       [ main, 7.x ]
                 index:      .doc/index.asciidoc
                 chunk:      1
                 tags:       Clients/Go


### PR DESCRIPTION
The master branch has been renamed to "main" in https://github.com/elastic/go-elasticsearch, which is resulting in the following docs build error:

> 09:06:59 INFO:build_docs:Error executing: git rev-parse master in GIT_DIR /docs_build/.repos/go-elasticsearch.git
09:06:59 INFO:build_docs

This PR makes the necessary changes to pull from main instead of master.