### PR TITLE
Add ECS 1.12 branch in prep for release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -191,7 +191,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.11
-            branches:   [ master, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.x, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/conf.yaml
+++ b/conf.yaml
@@ -191,7 +191,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.11
-            branches:   [ master, 1.x, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          7.x
 :prev-major-version:     6.x
 :major-version-only:     7
-:ecs_version:            1.11
+:ecs_version:            1.12
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -12,7 +12,7 @@ bare_version never includes -alpha or -beta
 :major-version:          8.x
 :prev-major-version:     7.x
 :major-version-only:     8
-:ecs_version:            1.11
+:ecs_version:            master
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
* Adds a new unreleased 1.12 branch to the ECS version selector.
* ~Remove 1.x branch; ECS 1.12 is the last planned ECS 1.x version.~ **Update:** Will address in separate PR
* Update the 7.x version mappings to point to ECS 1.12
* Update the master version mappings to point to ECS master

`current` version will be updated later when ECS 1.12 releases.