### PR TITLE
Add list of live branches that includes main

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,7 +70,7 @@ contents:
             current:    &stackcurrent 7.14
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklive [ master, 7.x, 7.15, 7.14, 6.8 ]
+            live:       &stacklivemain[ main, 7.x, 7.15, 7.14, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -131,7 +131,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklive
+            live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
@@ -167,7 +167,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklive
+            live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Machine Learning
             subject:    Machine Learning
@@ -219,7 +219,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            live:       *stacklive
+            live:       &stacklive [ master, 7.x, 7.15, 7.14, 6.8 ]
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -1462,7 +1462,7 @@ contents:
             prefix:     en/security
             current:    *stackcurrent
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklive
+            live:       *stacklivemain
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Security/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -70,7 +70,7 @@ contents:
             current:    &stackcurrent 7.14
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklivemain[ main, 7.x, 7.15, 7.14, 6.8 ]
+            live:       &stacklivemain [ main, 7.x, 7.15, 7.14, 6.8 ]
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack


### PR DESCRIPTION
The books that currently map "main" branches to a "master" output are currently still using "master" in their list of "live" branches, which causes that branch to disappear from the drop-down:

![image](https://user-images.githubusercontent.com/26471269/129987341-a2a077d5-015f-4c63-b381-a6026797dcd8.png)

This PR updates the conf.yaml to include a "stacklivemain" attribute to address this problem.