### PR TITLE
Remove ECS 1.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -191,7 +191,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.11
-            branches:   [ master, 1.x, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
Remove the ECS `1.x` branch from `conf.yaml` in the docs config.
