### PR TITLE
ece: Update branches for upcoming 2.12.0 release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -824,21 +824,6 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches: &mapCloudEceToCloudAssets
-                  ms-62: master
-                  ms-59: master
-                  ms-57: master
-                  ms-53: master
-                  ms-49: master
-                  ms-47: master
-                  release-ms-41: master
-                  2.5: master
-                  2.4: master
-                  2.3: master
-                  2.2: master
-                  2.1: master
-                  2.0: master
-                  1.1: master
-                  1.0: master
               -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team

--- a/conf.yaml
+++ b/conf.yaml
@@ -77,6 +77,7 @@ variables:
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-62: master
     ms-59: master
     ms-57: master
     ms-53: master
@@ -823,12 +824,7 @@ contents:
               -
                 repo:   cloud-assets
                 path:   docs
-                map_branches: &mapCloudEceToCloudAssets
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: &mapCloudEceToClientsTeam
+                map_branches:
                   ms-62: master
                   ms-59: master
                   ms-57: master
@@ -844,6 +840,11 @@ contents:
                   2.0: master
                   1.1: master
                   1.0: master
+              -
+                alternatives: { source_lang: console, alternative_lang: php }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/php
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team

--- a/conf.yaml
+++ b/conf.yaml
@@ -757,8 +757,8 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-59
-            branches:   [ {'ms-59': 2.11}, {'ms-57': 2.10}, {'ms-53': 2.9}, {'ms-49': 2.8}, {'ms-47': 2.7}, {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
+            current:    ms-62
+            branches:   [ {'ms-62': 2.12}, {'ms-59': 2.11}, {'ms-57': 2.10}, {'ms-53': 2.9}, {'ms-49': 2.8}, {'ms-47': 2.7}, {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      2
             private:    1
@@ -774,6 +774,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches: &mapCloudEceToCloudAssets
+                  ms-62: master
                   ms-59: master
                   ms-57: master
                   ms-53: master
@@ -793,6 +794,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudEceToClientsTeam
+                  ms-62: master
                   ms-59: master
                   ms-57: master
                   ms-53: master
@@ -860,8 +862,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.5
-            branches:   [ master, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            current:    1.6
+            branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
@@ -872,8 +874,8 @@ contents:
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
             subject:    TPEC
-            current:    0.1
-            branches:   [ master, 0.1 ]
+            current:    0.2
+            branches:   [ master, 0.2, 0.1 ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1


### PR DESCRIPTION
## Description
**DO NOT MERGE BEFORE SEPTEMBER 21**

Updates the branches for: ECE, ecctl and the Terraform Provider for the
upcoming ECE 2.12.0 release.

**DO NOT MERGE BEFORE SEPTEMBER 21**