### PR TITLE
Add main branch to elasticsearch-php repo to docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -283,6 +283,7 @@ contents:
                 repo:   elasticsearch-php
                 path:   docs/examples
                 exclude_branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMainToMaster
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   elasticsearch-net
@@ -496,8 +497,8 @@ contents:
               - title:      PHP API
                 prefix:     php-api
                 current:    7.x
-                branches:   [ master, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 7.x ]
+                branches:   [ {main: master}, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       [ main, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP


### PR DESCRIPTION
## Overview

This PR adds a main branch to the `elasticsearch-php` repo in the conf.yml file of the docs build system.

### Note

**It cannot be merged until _after_ a "main" branch is created in the elasticsearch-php repo.**
