### PR TITLE
Add main branch to elasticsearch-perl repo to docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -512,8 +512,8 @@ contents:
               - title:      Perl API
                 prefix:     perl-api
                 current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                branches:   [ {main: master} ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl


### PR DESCRIPTION
## Overview

This PR adds a main branch to the `elasticsearch-perl` repo in the conf.yml file of the docs build system.

### Note

**It cannot be merged until _after_ a "main" branch is created in the elasticsearch-perl repo.**