### PR TITLE
Adds main branch to enterprise-search-ruby repo to docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1020,7 +1020,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby


### PR DESCRIPTION
## Overview

This PR adds a main branch to the `enterprise-search-ruby` repo in the conf.yml file of the docs build system.

### Note

**It cannot be merged until _after_ a "main" branch is created in the enterprise-search-ruby repo.**