### PR TITLE
ESS - Change current to MS-62

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,8 +70,10 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 7.x, 7.15, 7.14, 6.8 ]
 
+  cloudSaasCurrent: &cloudSaasCurrent ms-62
+
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
-    ms-62: master
+    *cloudSaasCurrent : master
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-59: master
     ms-57: master
@@ -692,8 +694,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-62
-            branches:   [ {'ms-62': latest} ]
+            current:    *cloudSaasCurrent
+            branches:   [ { *cloudSaasCurrent : latest} ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -743,8 +745,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-62
-            branches:   [ {'ms-62': latest} ]
+            current:    *cloudSaasCurrent
+            branches:   [ { *cloudSaasCurrent : latest} ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -651,8 +651,8 @@ contents:
             prefix:     en/cloud
             tags:       Cloud/Reference
             subject:    Elastic Cloud
-            current:    ms-61
-            branches:   [ {'ms-61': latest} ]
+            current:    ms-62
+            branches:   [ {'ms-62': latest} ]
             index:      docs/saas/index.asciidoc
             chunk:      1
             private:    1
@@ -668,7 +668,7 @@ contents:
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
                 map_branches: &mapCloudSaasToClientsTeam
-                  ms-61: master
+                  ms-62: master
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -703,8 +703,8 @@ contents:
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
             subject:    Elasticsearch Add-On for Heroku
-            current:    ms-61
-            branches:   [ {'ms-61': latest} ]
+            current:    ms-62
+            branches:   [ {'ms-62': latest} ]
             index:      docs/heroku/index.asciidoc
             chunk:      1
             noindex:    1


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-62.