### PR TITLE
Adds data view shared attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -170,6 +170,14 @@ Kibana app and UI names
 :ems-init:           EMS
 :hosted-ems:         Elastic Maps Server
 :ipm-app:            Index Pattern Management
+:Data-Sources:       Data Views
+:Data-source:        Data view
+:data-source:        data view
+:Data-sources:       Data views
+:data-sources:       data views
+:A-data-source:      A data view
+:a-data-source:      a data view
+
 
 //////////
 Ingest terms


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/109928 and https://github.com/elastic/kibana/pull/110283

This PR adds shared attributes for data views, so that the terminology can be used appropriately across the library.

This new terminology is specific to 8.0. For earlier branches,  we must either (a) not use the shared attributes, or (b) override them as was done in https://github.com/elastic/kibana/blob/7.x/docs/index.asciidoc