### PR TITLE
Move shared variables in conf.yaml to the top

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ node_modules
 
 # The Visual Studio Code Perl extension creates this file
 .vstags
+
+/conf.before.yaml
+/conf.after.yaml

--- a/conf.yaml
+++ b/conf.yaml
@@ -2421,7 +2421,6 @@ contents:
             current:    6.2
             subject:    X-Pack
             index:      docs/en/index.asciidoc
-            private:    1
             branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             sources:
               -
@@ -2482,7 +2481,6 @@ contents:
             subject:    Marvel
             current:    2.4
             index:      docs/public/marvel/index.asciidoc
-            private:    1
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
             sources:
               -
@@ -2501,7 +2499,6 @@ contents:
             subject:    Shield
             current:    2.4
             index:      docs/public/shield/index.asciidoc
-            private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
             sources:
               -
@@ -2520,7 +2517,6 @@ contents:
             subject:    Watcher
             current:    2.4
             index:      docs/public/watcher/index.asciidoc
-            private:    1
             branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
             sources:
               -
@@ -2539,7 +2535,6 @@ contents:
             current:    2.4
             index:      docs/public/reporting/index.asciidoc
             branches:   [ 2.4 ]
-            private:    1
             sources:
               -
                 repo:   x-pack
@@ -2555,7 +2550,6 @@ contents:
             current:    2.4
             index:      docs/public/graph/index.asciidoc
             branches:   [ 2.4, 2.3 ]
-            private:    1
             sources:
               -
                 repo:   x-pack

--- a/conf.yaml
+++ b/conf.yaml
@@ -61,16 +61,57 @@ repos:
 
 contents_title:     Elastic Stack and Product Documentation
 
+# Each item should take the form:
+#   <key>: &<variable> <value>
+# The keys don't really matter, but by convention the are the same as the variable.
+variables:
+  stackcurrent: &stackcurrent 7.14
+  stacklive: &stacklive [ master, 7.x, 7.15, 7.14, 6.8 ]
+
+  stacklivemain: &stacklivemain [ main, 7.x, 7.15, 7.14, 6.8 ]
+
+  mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
+    ms-61: master
+  mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-59: master
+    ms-57: master
+    ms-53: master
+    ms-49: master
+    ms-47: master
+    release-ms-41: master
+    2.5: master
+    2.4: master
+    2.3: master
+    2.2: master
+    2.1: master
+    2.0: master
+    1.1: master
+    1.0: master
+
+  # Use this when you're building a book that uses a "main" branch, but it has a dependency on a repo with a "master" branch
+  mapMainToMaster: &mapMainToMaster
+    main: master
+
+  # Use this when you're building a book that uses a "master" branch, but it has a dependency on a repo with a "main" branch
+  mapMasterToMain: &mapMasterToMain
+    master: main
+
+  beatsSharedExclude: &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsXpackLibbeatExclude: &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsProcessorExclude: &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsOutputExclude: &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+
+
 toc_extra: extra/docs_landing.html
 contents:
     -   title:      Elastic Stack
         sections:
           - title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
-            current:    &stackcurrent 7.14
+            current:    *stackcurrent
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ {main: master}, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       &stacklivemain [ main, 7.x, 7.15, 7.14, 6.8 ]
+            live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -82,8 +123,7 @@ contents:
                 repo:   apm-server
                 path:   docs/guide
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: &mapMainToMaster
-                  main: master
+                map_branches: *mapMainToMaster
               -
                 repo:   beats
                 path:   libbeat/docs
@@ -219,7 +259,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            live:       &stacklive [ master, 7.x, 7.15, 7.14, 6.8 ]
+            live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -293,8 +333,7 @@ contents:
                 repo:   elasticsearch-py
                 path:   docs/examples
                 exclude_branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: &mapMasterToMain
-                  master: main
+                map_branches: *mapMasterToMain
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   elasticsearch-ruby
@@ -669,8 +708,7 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
-                map_branches: &mapCloudSaasToClientsTeam
-                  ms-61: master
+                map_branches: *mapCloudSaasToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -776,7 +814,7 @@ contents:
               -
                 repo:   cloud-assets
                 path:   docs
-                map_branches: &mapCloudEceToCloudAssets
+                map_branches:
                   ms-59: master
                   ms-57: master
                   ms-53: master
@@ -795,21 +833,7 @@ contents:
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   clients-team
                 path:   docs/examples/elastic-cloud/php
-                map_branches: &mapCloudEceToClientsTeam
-                  ms-59: master
-                  ms-57: master
-                  ms-53: master
-                  ms-49: master
-                  ms-47: master
-                  release-ms-41: master
-                  2.5: master
-                  2.4: master
-                  2.3: master
-                  2.2: master
-                  2.1: master
-                  2.0: master
-                  1.1: master
-                  1.0: master
+                map_branches: *mapCloudEceToClientsTeam
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   clients-team
@@ -1345,7 +1369,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
-                    map_branches: &mapEcsLoggingJavaToEcsLogging
+                    map_branches:
                       1.x: master
                       0.x: master
               - title:      ECS Logging .NET Reference
@@ -1631,7 +1655,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsSharedExclude
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
@@ -1672,7 +1696,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/processors/*/docs/*
-                exclude_branches:   &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsProcessorExclude
               -
                 repo:   beats
                 path:   x-pack/libbeat/processors/*/docs/*
@@ -1680,7 +1704,7 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/outputs/*/docs/*
-                exclude_branches:   &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1713,7 +1737,7 @@ contents:
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
-                exclude_branches:   &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+                exclude_branches:   *beatsXpackLibbeatExclude
               -
                 repo:   beats
                 path:   CHANGELOG.asciidoc

--- a/renderconf.py
+++ b/renderconf.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Loads and then dumps conf.yaml, to test that changes to the conf.yaml don't lead to actual functional changes in behavior.
+# Usage:
+#   ./renderconf.py > conf.before.yaml
+#   (Make changes)
+#   ./renderconf.py > conf.after.yaml
+#   diff conf.before.yaml conf.after.yaml
+
+import yaml
+
+yaml.Dumper.ignore_aliases = lambda *args : True
+
+
+def main():
+    data = yaml.load(open("conf.yaml").read(), Loader=yaml.SafeLoader)
+    print(yaml.dump(data))
+
+if __name__ == "__main__":
+    main()

--- a/schema.yaml
+++ b/schema.yaml
@@ -8,6 +8,8 @@ conf:
     # beginning of a build.
     repos: map(str(), str())
 
+    variables: map()
+
     # Used as the top-level title for the Table of Contents, and therefore the
     # entire site.
     contents_title: str()


### PR DESCRIPTION
I also added a script that's used to test changes to ensure YAML refactors don't change the interpreted meaning. I used the script when making this change to ensure that the build would interpret conf.yaml the same way before and after this change.
