### PR TITLE
Add shared attribute for external integrations documentation

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -119,6 +119,7 @@ endif::[]
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/{branch}
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}
 :elastic-maps-service: https://maps.elastic.co
+:integrations-docs:    https://docs.elastic.co/en/integrations
 :time-units:           {ref}/api-conventions.html#time-units
 :byte-units:           {ref}/api-conventions.html#byte-units
 


### PR DESCRIPTION
Adds a shared attribute to use across docs that need to link to the externally published integrations doc.