### PR TITLE
Adds apm_docs variable to Kibana link checker

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -372,7 +372,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
-                $path =~ s!\$\{APM_DOCS\}!en/apm/!
+                $path =~ s!\$\{APM_DOCS\}!en/apm/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -373,7 +373,6 @@ sub check_kibana_links {
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
                 $path =~ s!\$\{APM_DOCS\}!en/apm/get-started/$branch/!;
-                $path =~ s!\$\{APM_DOCS\}!en/apm/server/$branch/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -356,12 +356,12 @@ sub check_kibana_links {
 # ${KIBANA_DOCS}canvas.html
 # ${PLUGIN_DOCS}repository-s3.html
 # ${FLEET_DOCS}fleet-overview.html
-# ${APM_GET_STARTED_DOCS}overview.html
+# ${APM_DOCS}overview.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_GET_STARTED_DOCS)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -372,7 +372,8 @@ sub check_kibana_links {
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
-                $path =~ s!\$\{APM_GET_STARTED_DOCS\}!en/apm/get-started/$branch/!;
+                $path =~ s!\$\{APM_DOCS\}!en/apm/get-started/$branch/!;
+                $path =~ s!\$\{APM_DOCS\}!en/apm/server/$branch/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -372,7 +372,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
-                $path =~ s!\$\{APM_DOCS\}!en/apm/get-started/$branch/!;
+                $path =~ s!\$\{APM_DOCS\}!en/apm/!
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -356,11 +356,12 @@ sub check_kibana_links {
 # ${KIBANA_DOCS}canvas.html
 # ${PLUGIN_DOCS}repository-s3.html
 # ${FLEET_DOCS}fleet-overview.html
+# ${APM_GET_STARTED_DOCS}overview.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_GET_STARTED_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -371,6 +372,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
+                $path =~ s!\$\{APM_GET_STARTED_DOCS\}!en/apm/get-started/$branch/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe 'building all books' do
       include_context 'there is a kibana link', true,
                       '${APM_DOCS}not-an-apm-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/apm/get-started/master/not-an-apm-page.html'
+                       'en/apm/not-an-apm-page.html'
     end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -156,6 +156,12 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links in kibana',
                        'en/fleet/master/not-a-fleet-page.html'
     end
+    describe 'when there is a broken APM Get Started link' do
+      include_context 'there is a APM Get Started link', true,
+                      '${APM_GET_STARTED}not-an-apm-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/apm/get-started/master/not-an-apm-page.html'
+    end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do
         convert_before do |src, dest|

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -156,9 +156,9 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links in kibana',
                        'en/fleet/master/not-a-fleet-page.html'
     end
-    describe 'when there is a broken APM Get Started link' do
+    describe 'when there is a broken APM link' do
       include_context 'there is a kibana link', true,
-                      '${APM_GET_STARTED}not-an-apm-page.html', true
+                      '${APM_DOCS}not-an-apm-page.html', true
       include_examples 'there are broken links in kibana',
                        'en/apm/get-started/master/not-an-apm-page.html'
     end


### PR DESCRIPTION
## Overview

This PR adds `APM_DOCS` variable to align with https://github.com/elastic/kibana/blob/master/src/core/public/doc_links/doc_links_service.ts

Related to https://github.com/elastic/kibana/pull/110992