### PR TITLE
Add Integrations developer guide to build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -49,6 +49,7 @@ repos:
     logstash:             https://github.com/elastic/logstash.git
     logstash-docs:        https://github.com/elastic/logstash-docs.git
     observability-docs:   https://github.com/elastic/observability-docs.git
+    package-spec:         https://github.com/elastic/package-spec.git
     security-docs:        https://github.com/elastic/security-docs.git
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
@@ -1632,6 +1633,29 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+
+          - title:      Integrations Developer Guide
+            prefix:     en/integrations-developer
+            current:    master
+            branches:   [ master ]
+            live:       [ master ]
+            index:      docs/en/integrations/index.asciidoc
+            chunk:      1
+            tags:       Integrations/Developer
+            subject:    Integrations
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   package-spec
+                path:   versions
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
This PR adds the integrations developer guide to the documentation build.

~Blocked by https://github.com/elastic/observability-docs/pull/769.~

<img width="898" alt="Screen Shot 2021-09-03 at 12 56 29 PM" src="https://user-images.githubusercontent.com/5618806/132059450-7cfe12a4-02de-4f01-9e07-aca8fa4dc7cc.png">
