### PR TITLE
Adds main branch to eland repo to docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -580,7 +580,7 @@ contents:
                     path:   docs/guide/
               - title:      eland
                 prefix:     eland
-                current:    master
+                current:    main
                 branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/guide/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -582,7 +582,7 @@ contents:
                 prefix:     eland
                 current:    master
                 branches:   [ {main: master} ]
-                live:       [ master ]
+                live:       [ main ]
                 index:      docs/guide/index.asciidoc
                 chunk:     1
                 tags:       Clients/eland

--- a/conf.yaml
+++ b/conf.yaml
@@ -581,7 +581,7 @@ contents:
               - title:      eland
                 prefix:     eland
                 current:    master
-                branches:   [ master ]
+                branches:   [ {main: master} ]
                 live:       [ master ]
                 index:      docs/guide/index.asciidoc
                 chunk:     1


### PR DESCRIPTION
## Overview

This PR adds a main branch to the `eland` repo in the conf.yml file of the docs build system.

### Note

**It cannot be merged until _after_ a "main" branch is created in the eland repo.**
