### PR TITLE
Hide X-Pack tags on versions 7.11 and later

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -370,19 +370,28 @@ RSpec.describe 'building a single book' do
       end
     end
 
-    def self.xpack_tag_context(onpart, onchapter, onfloater, onsection)
+    def self.xpack_tag_context(onpart, onchapter, onfloater, onsection,
+                               hideXPack)
       convert_single_before_context do |src|
-        index = xpack_tag_test_asciidoc onpart, onchapter, onfloater, onsection
+        index = xpack_tag_test_asciidoc onpart, onchapter, onfloater, onsection,
+                                        hideXPack
         src.write 'index.asciidoc', index
       end
 
-      include_examples 'part page titles', onpart
-      include_examples 'chapter page titles', onchapter, onfloater, onsection
+      include_examples 'part page titles',
+                       onpart && !hideXPack
+      include_examples 'chapter page titles',
+                       onchapter && !hideXPack,
+                       onfloater && !hideXPack,
+                       onsection && !hideXPack
     end
 
-    def self.xpack_tag_test_asciidoc(onpart, onchapter, onfloater, onsection)
+    def self.xpack_tag_test_asciidoc(onpart, onchapter, onfloater, onsection,
+                                     hideXPack)
       <<~ASCIIDOC
         = Title
+
+        #{hideXPack ? ':hide-xpack-tags: true' : ''}
 
         #{onpart ? '[role="xpack"]' : ''}
         [[part]]
@@ -408,20 +417,27 @@ RSpec.describe 'building a single book' do
       ASCIIDOC
     end
 
-    context 'when the xpack role is on a part' do
-      xpack_tag_context true, false, false, false
+    context 'when not hiding xpack tags' do
+      context 'when the xpack role is on a part' do
+        xpack_tag_context true, false, false, false, false
+      end
+      context 'when the xpack role is on a chapter' do
+        xpack_tag_context false, true, false, false, false
+      end
+      context 'when the xpack role is on a floating title' do
+        xpack_tag_context false, false, true, false, false
+      end
+      context 'when the xpack role is on a section' do
+        xpack_tag_context false, false, false, true, false
+      end
+      context 'when the xpack role is on everything' do
+        xpack_tag_context true, true, true, true, false
+      end
     end
-    context 'when the xpack role is on a chapter' do
-      xpack_tag_context false, true, false, false
-    end
-    context 'when the xpack role is on a floating title' do
-      xpack_tag_context false, false, true, false
-    end
-    context 'when the xpack role is on a section' do
-      xpack_tag_context false, false, false, true
-    end
-    context 'when the xpack role is on everything' do
-      xpack_tag_context true, true, true, true
+    context 'when hiding xpack tags' do
+      context 'when the xpack role is on everything' do
+        xpack_tag_context true, true, true, true, true
+      end
     end
   end
 

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -371,27 +371,25 @@ RSpec.describe 'building a single book' do
     end
 
     def self.xpack_tag_context(onpart, onchapter, onfloater, onsection,
-                               hideXPack)
+                               hide_xpack)
       convert_single_before_context do |src|
         index = xpack_tag_test_asciidoc onpart, onchapter, onfloater, onsection,
-                                        hideXPack
+                                        hide_xpack
         src.write 'index.asciidoc', index
       end
 
       include_examples 'part page titles',
-                       onpart && !hideXPack
-      include_examples 'chapter page titles',
-                       onchapter && !hideXPack,
-                       onfloater && !hideXPack,
-                       onsection && !hideXPack
+                       onpart && !hide_xpack
+      include_examples 'chapter page titles', onchapter && !hide_xpack,
+                       onfloater && !hide_xpack, onsection && !hide_xpack
     end
 
     def self.xpack_tag_test_asciidoc(onpart, onchapter, onfloater, onsection,
-                                     hideXPack)
+                                     hide_xpack)
       <<~ASCIIDOC
         = Title
 
-        #{hideXPack ? ':hide-xpack-tags: true' : ''}
+        #{hide_xpack ? ':hide-xpack-tags: true' : ''}
 
         #{onpart ? '[role="xpack"]' : ''}
         [[part]]

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -71,6 +71,7 @@ module DocbookCompat
 
     def xpack_tag(node)
       return unless node.roles.include? 'xpack'
+      return if (node.document.attr 'hide-xpack-tags') == 'true'
 
       '<a class="xpack_tag" href="/subscriptions"></a>'
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -592,7 +592,8 @@ RSpec.describe DocbookCompat do
       end
       context 'the header' do
         let(:xpack_tag) do
-          if input.include? '.xpack'
+          if (input.include? '.xpack') &&
+             (!input.include? ':hide-xpack-tags: true')
             '<a class="xpack_tag" href="/subscriptions"></a>'
           else
             ''
@@ -623,6 +624,21 @@ RSpec.describe DocbookCompat do
           ASCIIDOC
         end
         include_examples 'section basics', 'chapter xpack', 1, '_s1', 'S1'
+        context 'with the hide-xpack-tags attribute' do
+          let(:input) do
+            <<~ASCIIDOC
+              :hide-xpack-tags: true
+
+              [.xpack]
+              == Some XPack Feature
+            ASCIIDOC
+          end
+          # Because the block is marked with the `xpack` role, the surrounding
+          # <div> will still have the "xpack" class. But the clickable icon
+          # should be hidden.
+          include_examples 'section basics', 'chapter xpack', 1,
+                           '_some_xpack_feature', 'Some XPack Feature'
+        end
       end
     end
 

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/7.13.asciidoc
+++ b/shared/versions/stack/7.13.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/7.14.asciidoc
+++ b/shared/versions/stack/7.14.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    true
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/7.15.asciidoc
+++ b/shared/versions/stack/7.15.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -24,6 +24,11 @@ is-current-version can be: true | false
 //////////
 :is-current-version:    false
 
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
 ////
 APM Agent versions
 ////


### PR DESCRIPTION
Eventually, we'll want to remove the x-pack role from the Asciidoc for
all sections/headers that include it, but until then this will at least
hide the visual indicator and link. The `xpack` class will be included
on the surrounding divs, since this is the default Asciidoctor behavior
for "role" tags.

Fixes #2207.
