### PR TITLE
Add shared attribute for Elastic Agents

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -185,6 +185,7 @@ Ingest terms
 //////////
 
 :agent: Elastic Agent
+:agents: Elastic Agents
 :fleet: Fleet
 :fleet-server: Fleet Server
 :ingest-manager: Ingest Manager


### PR DESCRIPTION
This PR adds a shared attribute for the plural form of Elastic Agents, since it's needed for pages like https://www.elastic.co/guide/en/fleet/current/elastic-agent-installation-configuration.html and https://github.com/elastic/kibana/pull/112138