### PR TITLE
Add ECK 1.8 to the list of ECK branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -878,7 +878,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.7
-            branches:   [ master, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
We are about to release ECK 1.8.0, this commit adds the 1.8 branch
to the list of branches to build docs for.

Note this should be merged slightly before the release.
