### PR TITLE
Set ECK 1.8 as the current docs branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -877,8 +877,8 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.7
-            branches:   [ master, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            current:    1.8
+            branches:   [ master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This sets up ECK 1.8 as the current ECK release.

Note this should not be merged before the release date.
https://github.com/elastic/docs/pull/2218 should be merged first so we have extra time to double-check everything is correct :) 

(I can handle both merges)