### PR TITLE
Renames deprecated Java API to Java Transport Client

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -612,7 +612,7 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
-              - title:      Java API (deprecated)
+              - title:      Java Transport Client (deprecated)
                 prefix:     java-api
                 current:    *stackcurrent
                 branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]


### PR DESCRIPTION
## Overview

This PR renames the deprecated Java API book to Java Transport Client in `conf.yml`.

Related to https://github.com/elastic/elasticsearch/pull/77852