### PR TITLE
Adds apm PR shared attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -407,6 +407,9 @@ Issue and pull request URLs
 :ml-issue:     {ml-repo}issues/
 :ml-pull:      {ml-repo}pull/
 :ml-commit:    {ml-repo}commit/
+:apm-repo:     https://github.com/elastic/apm-server/
+:apm-issue:    {apm-repo}issues/
+:apm-pull:     {apm-repo}pull/
 
 //////////
 Legacy definitions


### PR DESCRIPTION
Adds shared attributes for APM pull requests and issues.

The list of breaking changes in APM are re-used in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/current/apm-breaking-changes.html), but the generic "pull" attribute is misunderstood in that context.