### PR TITLE
Stops publishing master version of Java REST Client book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -462,7 +462,7 @@ contents:
                 prefix:     java-rest
                 current:    *stackcurrent
                 branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                live:       *stacklive
+                live:       [ 7.x, 7.15, 6.8 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -461,7 +461,7 @@ contents:
               - title:      Java REST Client
                 prefix:     java-rest
                 current:    *stackcurrent
-                branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       *stacklive
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST


### PR DESCRIPTION
## Overview

This PR stops publishing the `master` version of the Java REST Client book by updating the conf.yml file.

**Do NOT merge before the following PRs that provide redirects:**
* https://github.com/elastic/stack-docs/pull/1844
* https://github.com/elastic/elasticsearch-java/pull/29
* https://github.com/elastic/elasticsearch/pull/78613