### PR TITLE
Adds new Java API book to Clients

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -491,6 +491,22 @@ contents:
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              - title:      Java API
+                prefix:     java-api-client
+                current:    7.x
+                branches:   [ {main: master}, 7.x, ]
+                live:       [ main, 7.x ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/Java
+                subject:    Clients
+                sources:
+                  -
+                    repo:   elasticsearch-java
+                    path:   docs/
+                  - 
+                    repo:   elasticsearch
+                    path:   docs/java-rest/low-level
               - title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x


### PR DESCRIPTION
## Overview

This PR creates a new book under **Elasticsearch Clients** called `Java API`. It contains the `elasticsearch-java` and `elasticsearch` repositories as sources.

**DO NOT merge before https://github.com/elastic/docs/pull/2231**