### PR TITLE
Removes es-java from Java REST Client book sources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -479,11 +479,6 @@ contents:
                     path:   client
                     exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                   -
-                    repo:   elasticsearch-java
-                    path:   docs/
-                    exclude_branches:   [ 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMasterToMain
-                  -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]


### PR DESCRIPTION
## Overview

This PR removes the `elasticsearc-java` repo from the sources of the Java REST Client book.

**DO NOT merge before https://github.com/elastic/elasticsearch/pull/78368** ✅ 