### PR TITLE
Removes es-java repo resource from Java REST Client doc build alias

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -179,7 +179,7 @@ alias docbldpls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/pa
 
 alias docbldepi='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/plugins/index.asciidoc --chunk 2'
 
-alias docbldjvr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-rest/index.asciidoc --resource $GIT_HOME/elasticsearch-java/docs --chunk 1'
+alias docbldjvr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-rest/index.asciidoc --chunk 1'
 
 alias docbldejv='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/java-api/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
## Overview

As https://github.com/elastic/docs/pull/2231 removed the `elasticsearch-java` content from the Java REST Client book, it's no longer needed to have the repo as a resource in the doc build alias of the book. This PR removes the resource from the alias.