### PR TITLE
Adds ES client folder to Java API book sources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -502,6 +502,9 @@ contents:
                   - 
                     repo:   elasticsearch
                     path:   docs/java-rest/low-level
+                  -
+                    repo:   elasticsearch
+                    path:   client
               - title:      JavaScript API
                 prefix:     javascript-api
                 current:    7.x


### PR DESCRIPTION
## Overview

This PR adds the `client` folder of the elasticsearch repo to the source of the Java API book.
Related to: https://github.com/elastic/elasticsearch-java/pull/21