### PR TITLE
Adds ES java-rest folder to Java API book sources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -501,7 +501,7 @@ contents:
                     path:   docs/
                   - 
                     repo:   elasticsearch
-                    path:   docs/java-rest/low-level
+                    path:   docs/java-rest/
                   -
                     repo:   elasticsearch
                     path:   client


### PR DESCRIPTION
## Overview

This PR adds the whole `java-rest` folder to the source of the Java API book instead of `java-rest/low-level` as `java-rest` contains a license file that needs to be included.

Related to: https://github.com/elastic/elasticsearch-java/pull/21

It fixes the following build error:

```
INFO:build_docs:asciidoctor: ERROR: ../../elasticsearch/docs/java-rest/low-level/index.asciidoc: line 34: include file not found: /tmp/docsbuild/766KTRSny9/elasticsearch/docs/java-rest/license.asciidoc
```