### PR TITLE
Adds shared attribute for the new Java API Client

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -67,6 +67,7 @@ endif::[]
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :stack-gs-current:     https://www.elastic.co/guide/en/elastic-stack-get-started/current
 :javaclient:           https://www.elastic.co/guide/en/elasticsearch/client/java-api/{branch}
+:java-api-client:      https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/{branch}
 :java-rest:            https://www.elastic.co/guide/en/elasticsearch/client/java-rest/{branch}
 :jsclient:             https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/{branch}
 :jsclient-current:     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current


### PR DESCRIPTION
## Overview

This PR adds a new attribute to the `shared/attributes.asciidoc` file that substitutes the URL of the Java API Client guide.