### PR TITLE
Rename Fleet User Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1621,8 +1621,8 @@ contents:
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
-            tags:       Fleet/Guide
-            subject:    Fleet
+            tags:       Fleet/Guide/Elastic Agent
+            subject:    Fleet and Elastic Agent
             sources:
               -
                 repo:   observability-docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1614,7 +1614,7 @@ contents:
 
     -   title:      "Fleet: Install and Manage Elastic Agents"
         sections:
-          - title:      Fleet User Guide
+          - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
             branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]


### PR DESCRIPTION
Changes the name of the Fleet User Guide as described in https://github.com/elastic/observability-docs/issues/1104.

@gtback I think we should change the following settings, too, but TBH, I don't remember how these settings are used, so I'm unsure what settings make sense.

````
tags:       Fleet/Guide
subject:    Fleet
````

Maybe this?

````
tags:       Fleet/Elastic Agent/Guide
subject:    Fleet and Elastic Agent
````
