### PR TITLE
Deprecates Java REST Client book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -601,7 +601,7 @@ contents:
                     path:   docs/ 
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
-                current:    *stackcurrent
+                current:   7.15
                 branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 live:       [ 7.15, 6.8 ]
                 index:      docs/java-rest/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -458,34 +458,6 @@ contents:
           - title:      Elasticsearch Clients
             base_dir:   en/elasticsearch/client
             sections:
-              - title:      Java REST Client
-                prefix:     java-rest
-                current:    *stackcurrent
-                branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                live:       [ 7.x, 7.15, 6.8 ]
-                index:      docs/java-rest/index.asciidoc
-                tags:       Clients/JavaREST
-                subject:    Clients
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-rest
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                  -
-                    repo:   elasticsearch
-                    path:   client
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               - title:      Java API
                 prefix:     java-api-client
                 current:    7.x
@@ -627,6 +599,34 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
+              - title:      Java REST Client (deprecated)
+                prefix:     java-rest
+                current:    *stackcurrent
+                branches:   [ 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                live:       [ 7.x, 7.15, 6.8 ]
+                index:      docs/java-rest/index.asciidoc
+                tags:       Clients/JavaREST
+                subject:    Clients
+                chunk:      1
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-rest
+                  -
+                    repo:   elasticsearch
+                    path:   docs/Versions.asciidoc
+                  -
+                    repo:   elasticsearch
+                    path:   client
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               - title:      Java Transport Client (deprecated)
                 prefix:     java-api
                 current:    *stackcurrent

--- a/conf.yaml
+++ b/conf.yaml
@@ -602,8 +602,8 @@ contents:
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
                 current:    *stackcurrent
-                branches:   [ 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                live:       [ 7.16, 7.15, 6.8 ]
+                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                live:       [ 7.15, 6.8 ]
                 index:      docs/java-rest/index.asciidoc
                 tags:       Clients/JavaREST
                 subject:    Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -598,7 +598,7 @@ contents:
                 sources:
                   -
                     repo:   elasticsearch-rs
-                    path:   docs 
+                    path:   docs/ 
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
                 current:    *stackcurrent


### PR DESCRIPTION
## Overview

This PR deprecates the Java REST Client book in favor of the Java API Client book. The PR appends the word `(deprecated)` to the book title and moves it down in the TOC of ES Client books.

**This PR needs to be merged after the 7.16 version release.**

Related PR: https://github.com/elastic/elasticsearch/pull/81513