### PR TITLE
Increase chunk level for Observability docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1093,7 +1093,7 @@ contents:
             branches:   [ master, 7.x, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
-            chunk:      1
+            chunk:      2
             tags:       Observability/Guide
             subject:    Observability
             sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -72,7 +72,7 @@ alias docbldsoold=docbldso
 alias docbldaz='$GIT_HOME/docs/build_docs --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 1 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide'
+alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide'
 
 alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/metrics/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
### Summary

This PR increases the chunk level for the Observability docs to `2`.

### Related PR

https://github.com/elastic/observability-docs/pull/1134