### PR TITLE
[DOCS] Use consistent ES client titles

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -486,7 +486,7 @@ contents:
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              - title:      Java API Client
+              - title:      Java Client
                 prefix:     java-api-client
                 current:    7.x
                 branches:   [ {main: master}, 7.x, ]
@@ -601,7 +601,7 @@ contents:
                   -
                     repo:   elasticsearch-py
                     path:   docs/guide/
-              - title:      Eland Python Client
+              - title:      eland
                 prefix:     eland
                 current:    main
                 branches:   [ {main: master} ]


### PR DESCRIPTION
Retitles our client doc books to consistently use `<LANG> Client`.