### PR TITLE
Remove references to Kibana settings which were removed in 8.0

### DIFF
--- a/shared/settings.asciidoc
+++ b/shared/settings.asciidoc
@@ -8,11 +8,11 @@ settings dynamically with the
 |{xpack} Feature           |{es} Settings                         |{kib} Settings                                       |Logstash Settings
 |APM UI                    |No                                    |{kibana-ref}/apm-settings-kb.html[Yes]               |No
 |Cross cluster replication |{ref}/ccr-settings.html[Yes]          |No                                                   |No
-|Development Tools         |No                                    |{kibana-ref}/dev-settings-kb.html[Yes]               |No
-|Graph                     |No                                    |{kibana-ref}/graph-settings-kb.html[Yes]             |No
+|Development Tools         |No                                    |No                                                   |No
+|Graph                     |No                                    |No                                                   |No
 |Infrastructure UI         |No                                    |{kibana-ref}/infrastructure-ui-settings-kb.html[Yes] |No
 |Logs UI                   |No                                    |{kibana-ref}/logs-ui-settings-kb.html[Yes]           |No
-|Machine learning          |{ref}/ml-settings.html[Yes]           |{kibana-ref}/ml-settings-kb.html[Yes]                |No
+|Machine learning          |{ref}/ml-settings.html[Yes]           |No                                                   |No
 |Management                |No                                    |No                                                   |{logstash-ref}/configuring-centralized-pipelines.html#configuration-management-settings[Yes]
 |Monitoring                |{ref}/monitoring-settings.html[Yes]   |{kibana-ref}/monitoring-settings-kb.html[Yes]        |Yes
 |Reporting                 |No                                    |{kibana-ref}/reporting-settings-kb.html[Yes]         |No


### PR DESCRIPTION
In https://github.com/elastic/kibana/pull/113495, we removed settings for a few Kibana plugins which only had a single documented setting. As a result, the entire settings pages for this plugins were removed from the docs.

This resulted in broken links originating from `shared/settings.asciidoc`, which I am fixing here.