### PR TITLE
Add 7.16 version attributes

### DIFF
--- a/shared/versions/stack/7.16.asciidoc
+++ b/shared/versions/stack/7.16.asciidoc
@@ -1,0 +1,56 @@
+:version:                7.16.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           7.16.0
+:logstash_version:       7.16.0
+:elasticsearch_version:  7.16.0
+:kibana_version:         7.16.0
+:apm_server_version:     7.16.0
+:branch:                 7.16
+:minor-version:          7.16
+:major-version:          7.x
+:prev-major-version:     6.x
+:major-version-only:     7
+:ecs_version:            1.12
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
+
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
+////
+APM Agent versions
+////
+:apm-go-branch:         1.x
+:apm-ios-branch:        0.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        5.x
+:apm-node-branch:       3.x
+:apm-php-branch:        1.x
+:apm-py-branch:         5.x
+:apm-ruby-branch:       4.x
+:apm-dotnet-branch:     1.11
+
+////
+ECS Logging
+////
+:ecs-logging:           master
+:ecs-logging-go-logrus: master
+:ecs-logging-go-zap:    master
+:ecs-logging-java:      1.x
+:ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
+:ecs-logging-php:       master
+:ecs-logging-python:    master
+:ecs-logging-ruby:      master


### PR DESCRIPTION
This PR adds a shared attribute file for when 7.16 branches are forked. It's identical to the 7.x file, with the exception of the "branch" attribute.