### PR TITLE
Build `7.x` branch of APM Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1156,9 +1156,9 @@ contents:
               - title:      APM Guide
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    7.x
+                branches:   [ master, 7.x ]
+                live:       [ master, 7.x ]
                 chunk:      2
                 tags:       APM Guide
                 subject:    APM


### PR DESCRIPTION
Adds the 7.x branch of the APM Guide to the build. For https://github.com/elastic/observability-docs/issues/1073.