### PR TITLE
ESS - Change current to MS-64

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -72,7 +72,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 7.x, 7.15, 6.8 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-63
+  cloudSaasCurrent: &cloudSaasCurrent ms-64
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-64.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
