### PR TITLE
Remove Fleet Developer Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1658,26 +1658,6 @@ contents:
                 path:   docs
                 exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
 
-          - title:      Fleet Developer Guide
-            prefix:     en/fleet-developer
-            current:    master
-            branches:   [ master ]
-            live:       [ master ]
-            index:      docs/en/fleet-developer/index.asciidoc
-            chunk:      2
-            tags:       Fleet/Developer
-            subject:    Fleet
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    master


### PR DESCRIPTION
The Fleet Developer Guide has very little content and there are currently no plans to add more. Therefore, we are removing it from the doc build. 

The content that's relevant to Fleet users has been added to the Fleet and Elastic Agent Guide in https://github.com/elastic/observability-docs/pull/1183