### PR TITLE
Update `{ref-7x}` to point to `7.16`

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,7 +1,7 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-bare:             https://www.elastic.co/guide/en/elasticsearch/reference
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
-:ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.x
+:ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.16
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4


### PR DESCRIPTION
7.x doesn't exist. Let's point to 7.16 instead!