### PR TITLE
Update conf.yml for 7.16 for Go

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -533,9 +533,9 @@ contents:
                     path:   docs/
               - title:      Go Client
                 prefix:     go-api
-                current:    7.x
-                branches:   [ {main: master}, 7.x ]
-                live:       [ main, 7.x ]
+                current:    7.16
+                branches:   [ {main: master}, 7.16 ]
+                live:       [ main, 7.16 ]
                 index:      .doc/index.asciidoc
                 chunk:      1
                 tags:       Clients/Go


### PR DESCRIPTION
## Overview

This PR updates the conf.yaml for the Go book to build from the 7.16 branch instead of the 7.x branch.
