### PR TITLE
Updates shared attributes to remove old path to fleet docs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -22,7 +22,7 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
-:ingest-guide:         https://www.elastic.co/guide/en/ingest-management/{branch}
+:ingest-guide:         https://www.elastic.co/guide/en/fleet/{branch}
 :fleet-guide:          https://www.elastic.co/guide/en/fleet/{branch}
 :apm-guide-ref:        https://www.elastic.co/guide/en/apm/guide/{branch}
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}


### PR DESCRIPTION
Fixes attribute that uses old path for Fleet docs. I should have changed this when we changed the path to all versions of the book.

After this PR is merged, we should be able to remove all the old files under https://github.com/elastic/built-docs/tree/master/html/en/ingest-management
