### PR TITLE
Add "Elastic" level

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -113,7 +113,7 @@ contents:
     -   title:      "Welcome to Elastic"
         prefix:     en/welcome-to-elastic
         current:    main
-        index:      welcome-to-elastic/index.asciidoc
+        index:      welcome-to-elastic/welcome-to-elastic.asciidoc
         branches:   [ {main: master} ]
         chunk:      1
         tags:       Elastic/Welcome

--- a/conf.yaml
+++ b/conf.yaml
@@ -113,7 +113,7 @@ contents:
     -   title:      "Welcome to Elastic"
         prefix:     en/welcome-to-elastic
         current:    main
-        index:      welcome-to-elastic/welcome-to-elastic.asciidoc
+        index:      index.asciidoc
         branches:   [ {main: master} ]
         chunk:      1
         tags:       Elastic/Welcome

--- a/conf.yaml
+++ b/conf.yaml
@@ -110,21 +110,23 @@ variables:
 
 toc_extra: extra/docs_landing.html
 contents:
-    -   title:      "Welcome to Elastic"
-        prefix:     en/welcome-to-elastic
-        current:    main
-        index:      welcome-to-elastic/index.asciidoc
-        branches:   [ {main: master} ]
-        chunk:      1
-        tags:       Elastic/Welcome
-        subject:    Welcome to Elastic
-        sources: 
-          -
-            repo:   tech-content
-            path:   welcome-to-elastic     
-          -
-            repo:   docs
-            path:   shared/versions/stack/{version}.asciidoc
+    -   title: Elastic Documentation
+        sections:
+          - title:      "Welcome to Elastic"
+            prefix:     en/welcome-to-elastic
+            current:    main
+            index:      welcome-to-elastic/index.asciidoc
+            branches:   [ {main: master} ]
+            chunk:      1
+            tags:       Elastic/Welcome
+            subject:    Welcome to Elastic
+            sources:
+              -
+                repo:   tech-content
+                path:   welcome-to-elastic
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
 
     -   title:      Elastic Stack
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -122,6 +122,9 @@ contents:
           -
             repo:   tech-content
             path:   welcome-to-elastic     
+          -
+            repo:   docs
+            path:   shared/versions/stack/{version}.asciidoc
 
     -   title:      Elastic Stack
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -109,6 +109,19 @@ variables:
 
 toc_extra: extra/docs_landing.html
 contents:
+    -   title:      "Welcome to Elastic"
+        prefix:     en/welcome-to-elastic
+        current:    main
+        index:      welcome-to-elastic/index.asciidoc
+        branches:   [ {main: master} ]
+        chunk:      1
+        tags:       Elastic/Welcome
+        subject:    Welcome to Elastic
+        sources: 
+          -
+            repo:   tech-content
+            path:   welcome-to-elastic     
+
     -   title:      Elastic Stack
         sections:
           - title:      Installation and Upgrade Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -113,7 +113,7 @@ contents:
     -   title:      "Welcome to Elastic"
         prefix:     en/welcome-to-elastic
         current:    main
-        index:      index.asciidoc
+        index:      welcome-to-elastic/index.asciidoc
         branches:   [ {main: master} ]
         chunk:      1
         tags:       Elastic/Welcome

--- a/conf.yaml
+++ b/conf.yaml
@@ -55,6 +55,7 @@ repos:
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
     swiftype:             https://github.com/elastic/swiftype-doc-placeholder.git
+    tech-content:         https://github.com/elastic/tech-content.git
     terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
     x-pack:               https://github.com/elastic/x-pack.git
     x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -55,6 +55,8 @@ alias docbldstkold2='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/e
 # Installation and Upgrade Guide 6.7 and earlier
 alias docbldstkold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --chunk 1'
 
+# Elastic general
+alias docbldestc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/tech-content/welcome-to-elastic/index.asciidoc --chunk 1'
 
 # Glossary
 alias docbldgls='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/glossary/index.asciidoc'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -37,6 +37,12 @@
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 ///////
+Elastic-level pages
+///////
+
+:estc-welcome: https://www.elastic.co/guide/en/welcome-to-elastic/{branch}
+
+///////
 APM does not build n.x documentation. Links from .x branches should point to master instead
 ///////
 ifeval::["{source_branch}"=="7.x"]

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -39,9 +39,7 @@
 ///////
 Elastic-level pages
 ///////
-
 :estc-welcome: https://www.elastic.co/guide/en/welcome-to-elastic/{branch}
-
 ///////
 APM does not build n.x documentation. Links from .x branches should point to master instead
 ///////


### PR DESCRIPTION
Relates to: https://github.com/elastic/docs.elastic.co/issues/1
Foundation for: https://github.com/elastic/elastic-docs-next/issues/335

---

Adds an "Elastic level" to the docs.

This is for:
 
1. @debadair's upgrade guide consolidation for 8.0
2. @goodroot's unified integration changes for 7.16

Content is located in a separate content repository: https://github.com/elastic/tech-content

DRAFT mode until more of the pieces land.