### PR TITLE
Updates conf.yml for 7.16 for Js Client.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -507,9 +507,9 @@ contents:
                     path:   client
               - title:      JavaScript Client
                 prefix:     javascript-api
-                current:    7.x
-                branches:   [ {main: master}, 7.x, 6.x, 5.x, 16.x ]
-                live:       [ main, 7.x ]
+                current:    7.16
+                branches:   [ {main: master}, 7.16, 6.x, 5.x, 16.x ]
+                live:       [ main, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/JavaScript


### PR DESCRIPTION
## Overview

This PR updates the conf.yaml for the Js book to build from the 7.16 branch instead of the 7.x branch.
