### PR TITLE
Adds 8.0 branches to conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -617,8 +617,8 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                branches:   [ master, 8.0 ]
+                live:       [ master, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust


### PR DESCRIPTION
This PR adds the 8.0 branches to the conf.yaml.

It should be merged at the same time as https://github.com/elastic/docs/pull/2259.