### PR TITLE
Update Kibana link checking for `main` branch.

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -361,6 +361,9 @@ sub check_kibana_links {
     my $extractor = sub {
         my $contents = shift;
         return sub {
+            # We want all links from the Kibana "main" branch to still go to "master" URLs
+            # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+            $branch = "master" if $branch == "main";
             while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;


### PR DESCRIPTION
When checking Kibana links in the `main` branch, expect URLs to still
include `master`.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
