### PR TITLE
Add main branch to the ecs repo docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -236,7 +236,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.12
-            branches:   [ master, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [  {main: master}, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
A `main` branch exists in the ECS repo and is being automatically synced to `master` until the default branch is renamed: https://github.com/elastic/ecs/tree/main

Modeled this conf change after what I've seen from other projects, but feel free to make suggestions if there's a better/different approach.