### PR TITLE
Adds 8.0 branch for elasticsearch-perl docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -578,8 +578,8 @@ contents:
               - title:      Perl Client
                 prefix:     perl-api
                 current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                branches:   [ master, 8.0 ]
+                live:       [ master, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl


### PR DESCRIPTION
This PR adds the 8.0 branch for the [Elasticsearch Perl client docs](https://www.elastic.co/guide/en/elasticsearch/client/perl-api/current/index.html), now that the branch exists in https://github.com/elastic/elasticsearch-perl