### PR TITLE
Fix Kibana link checking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
+Metrics/AbcSize:
+  Max: 20
+
 # The blocks in context and describe can be pretty long and that is ok.
 Metrics/BlockLength:
   ExcludedMethods:
@@ -26,3 +29,9 @@ Metrics/BlockLength:
     - page_context
     - shared_context
     - shared_examples
+
+Metrics/ClassLength:
+  Max: 120
+
+Metrics/MethodLength:
+  Max: 20

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -363,7 +363,7 @@ sub check_kibana_links {
         return sub {
             # We want all links from the Kibana "main" branch to still go to "master" URLs
             # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-            $branch = "master" if $branch == "main";
+            $branch = "master" if $branch eq "main";
             while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
@@ -424,7 +424,7 @@ sub check_kibana_links {
             #
             # TODO: remove as part of
             # https://github.com/elastic/docs/issues/2264
-            $branch = "main" if $branch == "master";
+            $branch = "main" if $branch eq "master";
             $repo->show_file( $link_check_name, $branch, $links_file );
         };
         die "failed to find kibana links file;\n$@" unless $source;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -346,6 +346,7 @@ sub check_kibana_links {
     my $build_dir    = shift;
     my $link_checker = shift;
     my $branch;
+    my $version;
 
     say "Checking Kibana links";
 
@@ -361,20 +362,17 @@ sub check_kibana_links {
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            # We want all links from the Kibana "main" branch to still go to "master" URLs
-            # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-            $branch = "master" if $branch eq "main";
             while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
-                $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$branch/;
+                $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$version/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
                 # the Elasticsearch Guide. In newer branches, the
                 # variable is called `${ELASTICSEARCH_DOCS}`
-                $path =~ s!\$\{ELASTIC_DOCS\}!en/elasticsearch/reference/$branch/!;
-                $path =~ s!\$\{ELASTICSEARCH_DOCS\}!en/elasticsearch/reference/$branch/!;
-                $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$branch/!;
-                $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$branch/!;
-                $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$branch/!;
+                $path =~ s!\$\{ELASTIC_DOCS\}!en/elasticsearch/reference/$version/!;
+                $path =~ s!\$\{ELASTICSEARCH_DOCS\}!en/elasticsearch/reference/$version/!;
+                $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$version/!;
+                $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$version/!;
+                $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$version/!;
                 $path =~ s!\$\{APM_DOCS\}!en/apm/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
@@ -394,15 +392,22 @@ sub check_kibana_links {
     my $legacy_path = 'src/legacy/ui/public/documentation_links/documentation_links';
     my $repo     = ES::Repo->get_repo('kibana');
 
-    my @branches = sort map { $_->basename }
+    my @versions = sort map { $_->basename }
         grep { $_->is_dir } $build_dir->subdir('en/kibana')->children;
 
     my $link_check_name = 'link-check-kibana';
 
-    for (@branches) {
-        $branch = $_;
-        next if $branch eq 'current' || $branch =~ /^\d/ && $branch lt 5;
-        say "  Branch $branch";
+    for (@versions) {
+        $version = $_;
+        next if $version eq 'current' || $version =~ /^\d/ && $version lt 5;
+        # @versions is looping through the directories in the output (which
+        # still contains `master`), but we need to look in the `main` branch of
+        # the Kibana repo for this file.
+        #
+        # TODO: remove as part of
+        # https://github.com/elastic/docs/issues/2264
+        $branch = $version eq "master" ? "main" : $version;
+        say "  Branch: $branch, Version: $version";
         my $links_file;
         my $source = eval {
             $links_file = $src_path . ".js";
@@ -418,19 +423,12 @@ sub check_kibana_links {
             $repo->show_file( $link_check_name, $branch, $links_file );
         } || eval {
             $links_file = "src/core/public/doc_links/doc_links_service.ts";
-            # @branches is looping through the directories in the output (which
-            # is still `master`), but we need to look in the `main` branch of
-            # the Kibana repo for this file.
-            #
-            # TODO: remove as part of
-            # https://github.com/elastic/docs/issues/2264
-            $branch = "main" if $branch eq "master";
             $repo->show_file( $link_check_name, $branch, $links_file );
         };
         die "failed to find kibana links file;\n$@" unless $source;
 
         $link_checker->check_source( $source, $extractor,
-            "Kibana [$branch]: $links_file" );
+            "Kibana [$version]: $links_file" );
 
         # Mark the file that we need for the link check done so we can use
         # --keep_hash with it during some other build.

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -418,6 +418,13 @@ sub check_kibana_links {
             $repo->show_file( $link_check_name, $branch, $links_file );
         } || eval {
             $links_file = "src/core/public/doc_links/doc_links_service.ts";
+            # @branches is looping through the directories in the output (which
+            # is still `master`), but we need to look in the `main` branch of
+            # the Kibana repo for this file.
+            #
+            # TODO: remove as part of
+            # https://github.com/elastic/docs/issues/2264
+            $branch = "main" if $branch == "master";
             $repo->show_file( $link_check_name, $branch, $links_file );
         };
         die "failed to find kibana links file;\n$@" unless $source;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -330,7 +330,7 @@ sub check_links {
 
     $link_checker->check;
 
-    # check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
+    check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
     if ( $link_checker->has_bad ) {
         say $link_checker->report;
     }

--- a/integtest/Makefile
+++ b/integtest/Makefile
@@ -1,7 +1,7 @@
 include ../common.mk
 
 .PHONY: check
-check: rspec style
+check: style rspec
 
 .PHONY: style
 style: pycodestyle rubocop

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -93,16 +93,15 @@ RSpec.describe 'building all books' do
       end
     end
     shared_examples 'there are broken links in kibana' do |url|
-      # it 'logs there are bad cross document links' do
-      #   expect(outputs[-1]).to include('Bad cross-document links:')
-      # end
-      # it 'logs the bad link' do
-      #   expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
-      #     Kibana [master]: src/core/public/doc_links/doc_links_service.ts
-      #  contains broken links to:
-      #      - #{url}
-      #   LOG
-      # end
+      it 'logs there are bad cross document links' do
+        expect(outputs[-1]).to include('Bad cross-document links:')
+      end
+      it 'logs the bad link' do
+        expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
+          Kibana [master]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
+           - #{url}
+        LOG
+      end
     end
     describe 'when all of the links are intact' do
       convert_before do |src, dest|

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -36,12 +36,26 @@ RSpec.describe 'building all books' do
       JS
       kibana_repo.commit 'init'
 
+      # TODO: remove as part of https://github.com/elastic/docs/issues/2264,
+      # and make "main" the default branch for all repos.
+      kibana_repo.rename_branch 'main'
+
       # The preview of the book is important here because it is how we detect
       # the versions of kibana to check.
       # TODO: This is probably worth generalizing. Lots of repos reference docs.
       repo = src.repo_with_index 'repo', "Doesn't matter"
+
+      # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+      repo.rename_branch 'main'
+
       book = src.book 'Test', prefix: 'en/kibana'
       book.source repo, 'index.asciidoc'
+
+      # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+      book.branches = [{"main": "master"}]
+      book.live_branches = ["main"]
+      book.current_branch = "main"
+
       convert = dest.prepare_convert_all src.conf
       convert.skip_link_check unless check_links
       convert.convert(expect_failure: expect_failure)
@@ -222,13 +236,34 @@ RSpec.describe 'building all books' do
       describe 'when there is a broken link in kibana' do
         def self.setup(src, dest)
           kibana_repo = src.repo_with_index 'kibana', "Doesn't matter"
+
+          # TODO: remove as part of https://github.com/elastic/docs/issues/2264,
+          # and make "main" the default branch for all repos.
+          kibana_repo.rename_branch 'main'
+
           kibana_repo.write KIBANA_LINKS_FILE, 'no links here'
           kibana_repo.commit 'add empty links file'
           kibana_book = src.book 'Kibana', prefix: 'en/kibana'
           kibana_book.source kibana_repo, 'index.asciidoc'
+
+          # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+          kibana_book.branches = [{"main": "master"}]
+          kibana_book.live_branches = ["main"]
+          kibana_book.current_branch = "main"
+
           repo2 = src.repo_with_index 'repo2', "Also doesn't matter"
+
+          # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+          repo2.rename_branch 'main'
+
           book2 = src.book 'Test2'
           book2.source repo2, 'index.asciidoc'
+
+          # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+          book2.branches = [{"main": "master"}]
+          book2.live_branches = ["main"]
+          book2.current_branch = "main"
+
           dest.prepare_convert_all(src.conf).convert
 
           kibana_repo.write KIBANA_LINKS_FILE, <<~JS
@@ -266,7 +301,7 @@ RSpec.describe 'building all books' do
             setup src, dest
             dest.prepare_convert_all(src.conf)
                 .keep_hash
-                .sub_dir(src.repo('kibana'), 'master')
+                .sub_dir(src.repo('kibana'), 'main')
                 .convert(expect_failure: true)
           end
           include_examples 'there are broken links in kibana', 'bar'

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -52,9 +52,9 @@ RSpec.describe 'building all books' do
       book.source repo, 'index.asciidoc'
 
       # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-      book.branches = [{"main": "master"}]
-      book.live_branches = ["main"]
-      book.current_branch = "main"
+      book.branches = [{ "main": 'master' }]
+      book.live_branches = ['main']
+      book.current_branch = 'main'
 
       convert = dest.prepare_convert_all src.conf
       convert.skip_link_check unless check_links
@@ -247,9 +247,9 @@ RSpec.describe 'building all books' do
           kibana_book.source kibana_repo, 'index.asciidoc'
 
           # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-          kibana_book.branches = [{"main": "master"}]
-          kibana_book.live_branches = ["main"]
-          kibana_book.current_branch = "main"
+          kibana_book.branches = [{ "main": 'master' }]
+          kibana_book.live_branches = ['main']
+          kibana_book.current_branch = 'main'
 
           repo2 = src.repo_with_index 'repo2', "Also doesn't matter"
 
@@ -260,9 +260,9 @@ RSpec.describe 'building all books' do
           book2.source repo2, 'index.asciidoc'
 
           # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-          book2.branches = [{"main": "master"}]
-          book2.live_branches = ["main"]
-          book2.current_branch = "main"
+          book2.branches = [{ "main": 'master' }]
+          book2.live_branches = ['main']
+          book2.current_branch = 'main'
 
           dest.prepare_convert_all(src.conf).convert
 

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -320,6 +320,11 @@ RSpec.describe 'building all books' do
               # 2. A special links file in the repo
               # 3. A book at `en/kibana`
               kibana_repo = src.repo_with_index 'kibana', 'words'
+
+              # TODO: remove as part of https://github.com/elastic/docs/issues/2264,
+              # and make "main" the default branch for all repos.
+              kibana_repo.rename_branch 'main'
+
               kibana_repo.write(
                 'src/core/public/doc_links/doc_links_service.ts',
                 'text but no links actually'
@@ -327,6 +332,11 @@ RSpec.describe 'building all books' do
               kibana_repo.commit 'add links file'
               kibana_book = src.book 'Kibana', prefix: 'en/kibana'
               kibana_book.source kibana_repo, 'index.asciidoc'
+
+              # TODO: remove as part of https://github.com/elastic/docs/issues/2264
+              kibana_book.branches = [{"main": "master"}]
+              kibana_book.live_branches = ["main"]
+              kibana_book.current_branch = "main"
             end
           )
           include_examples 'second build is noop'

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -334,9 +334,9 @@ RSpec.describe 'building all books' do
               kibana_book.source kibana_repo, 'index.asciidoc'
 
               # TODO: remove as part of https://github.com/elastic/docs/issues/2264
-              kibana_book.branches = [{"main": "master"}]
-              kibana_book.live_branches = ["main"]
-              kibana_book.current_branch = "main"
+              kibana_book.branches = [{ "main": 'master' }]
+              kibana_book.live_branches = ['main']
+              kibana_book.current_branch = 'main'
             end
           )
           include_examples 'second build is noop'

--- a/integtest/spec/helper/repo.rb
+++ b/integtest/spec/helper/repo.rb
@@ -100,6 +100,14 @@ class Repo
   end
 
   ##
+  # Rename the current branch
+  def rename_branch(new_branch)
+    Dir.chdir @root do
+      sh "git branch -m #{new_branch}"
+    end
+  end
+
+  ##
   # The hash of the last commit.
   def short_hash
     Dir.chdir @root do


### PR DESCRIPTION
We need to look at the 'main' branch when checking links for 'master' in the output.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
