### PR TITLE
Change Installation and Upgrade Guide path to apm-server repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -126,7 +126,7 @@ contents:
                 path:   docs/en
               -
                 repo:   apm-server
-                path:   docs/guide
+                path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                 map_branches: *mapMainToMaster
               -


### PR DESCRIPTION
The APM breaking changes have moved from `docs/guide` to `docs/`.

I think this is why I keep seeing the following error in https://github.com/elastic/stack-docs/pull/1850

```
14:27:49 INFO:build_docs:ERROR building Installation and Upgrade Guide version master
14:27:49 INFO:build_docs:asciidoctor: ERROR: breaking.asciidoc: line 32: include file not found: /tmp/docsbuild/USkIJ27emi/apm-server/docs/apm-breaking.asciidoc
```