### PR TITLE
Add live branches for ECS docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -236,6 +236,7 @@ contents:
             prefix:     en/ecs
             current:    1.12
             branches:   [  {main: master}, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.0, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
Based on the suggestion shared [here](https://github.com/elastic/docs/pull/2260#pullrequestreview-789637003), adding a `live` branch list for the ECS documentation. 