### PR TITLE
APM: simulate bump to 7.16

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1156,7 +1156,7 @@ contents:
               - title:      APM Guide
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
-                current:    master
+                current:    7.16
                 branches:   [ master, 8.0, 7.16 ]
                 live:       [ master, 8.0, 7.16 ]
                 chunk:      2

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -39,7 +39,7 @@
 ///////
 Temporarily reroute APM Agent links to the new APM documentation book
 ///////
-ifeval::["{source_branch}"=="7.16"]
+ifeval::["{branch}"=="7.16"]
 :apm-server-ref:       {apm-guide-ref}
 :apm-server-ref-v:     {apm-guide-ref}
 :apm-overview-ref-v:   {apm-guide-ref}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -37,13 +37,13 @@
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 ///////
-APM does not build n.x documentation. Links from .x branches should point to master instead
+Temporarily reroute APM Agent links to the new APM documentation book
 ///////
-ifeval::["{source_branch}"=="7.x"]
-:apm-server-ref:       {apm-server-ref-m}
-:apm-server-ref-v:     {apm-server-ref-m}
-:apm-overview-ref-v:   {apm-overview-ref-m}
-:apm-get-started-ref:  {apm-overview-ref-m}
+ifeval::["{source_branch}"=="7.16"]
+:apm-server-ref:       {apm-guide-ref}
+:apm-server-ref-v:     {apm-guide-ref}
+:apm-overview-ref-v:   {apm-guide-ref}
+:apm-get-started-ref:  {apm-guide-ref}
 endif::[]
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current

--- a/shared/versions/stack/7.15.asciidoc
+++ b/shared/versions/stack/7.15.asciidoc
@@ -22,7 +22,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/7.16.asciidoc
+++ b/shared/versions/stack/7.16.asciidoc
@@ -17,12 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::7.15.asciidoc[]
+include::7.16.asciidoc[]


### PR DESCRIPTION
This PR bumps current from `7.15` to `7.16`. I fear this will lead to hundreds of broken APM agent links, so I'm trying to get ahead of them.