### PR TITLE
docs: add obs-docs dep to apm-server

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1172,6 +1172,11 @@ contents:
                   -
                     repo:   apm-server
                     path:   CHANGELOG.asciidoc
+                  -
+                    repo:   observability-docs
+                    path:   docs/en
+                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                    map_branches: *mapMainToMaster
               - title:      APM Agents
                 base_dir:   agent
                 sections:


### PR DESCRIPTION
Add `elastic/observability-docs` as a dependency to the APM Guide.

Required so that the Traces quick start guide can live in both the Observability guide and the APM guide. See https://github.com/elastic/observability-docs/issues/1231.