### PR TITLE
[DOCS] Add attributes for ESS breaking changes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -143,6 +143,8 @@ Elastic Cloud
 :ess-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud.svg[link="{ess-trial}", title="Supported on {ess}"]
 :ece-icon: image:https://doc-icons.s3.us-east-2.amazonaws.com/logo_cloud_ece.svg[link="{ess-trial}", title="Supported on {ece}"]
 :cloud-only: This feature is designed for indirect use by {ess-trial}[{ess}], {ece-ref}[{ece}], and {eck-ref}[{eck}]. Direct use is not supported.
+:ess-setting-change: {ess-icon} indicates a change to a supported {cloud}/ec-add-user-settings.html[user setting] for {ess}.
+:ess-skip-section: If you use {ess}, skip this section. {ess} handles these changes for you.
 
 //////////
 Commonly referenced paths in commonly referenced repositories.


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/79162 reorganized the ES breaking changes. The PR added [attributes](https://github.com/jrodewig/elasticsearch/blame/101809cc6a10761f609832ba3708d4c5124ca02e/docs/reference/migration/index.asciidoc#L4-L5) to help Cloud users know which changes to skip or review.

This adds those attributes to the docs repo so they can be reused in the Installation and Upgrade Guide. The copy was already approved as part of https://github.com/elastic/elasticsearch/pull/79162.