### PR TITLE
docs: add main branch to obs-docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1108,6 +1108,7 @@ contents:
                 repo:   beats
                 path:   libbeat/docs
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1089,7 +1089,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    *stackcurrent
-            branches:   [ master, 8.0, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
+            branches:   [ {main: master}, 8.0, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      2
@@ -1641,7 +1641,7 @@ contents:
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ master, 8.0, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, 8.0, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
@@ -1665,8 +1665,8 @@ contents:
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    master
-            branches:   [ master ]
-            live:       [ master ]
+            branches:   [ {main: master} ]
+            live:       [ {main: master} ]
             index:      docs/en/integrations/index.asciidoc
             chunk:      1
             tags:       Integrations/Developer

--- a/conf.yaml
+++ b/conf.yaml
@@ -1103,6 +1103,7 @@ contents:
                 repo:   apm-server
                 path:   docs
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
               -
                 repo:   beats
                 path:   libbeat/docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1685,6 +1685,7 @@ contents:
               -
                 repo:   package-spec
                 path:   versions
+                map_branches: *mapMainToMaster
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1177,7 +1177,7 @@ contents:
                     repo:   observability-docs
                     path:   docs/en
                     exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMainToMaster
+                    map_branches: *mapMasterToMain
               - title:      APM Agents
                 base_dir:   agent
                 sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1662,6 +1662,7 @@ contents:
                 repo:   apm-server
                 path:   docs
                 exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
 
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer


### PR DESCRIPTION
Change `master` --> `main` in obs-docs. This will fail for now.

Closes https://github.com/elastic/observability-docs/issues/991.