### PR TITLE
Update lists that follow paragraphs

### DIFF
--- a/resources/web/style/list.pcss
+++ b/resources/web/style/list.pcss
@@ -38,14 +38,4 @@
       }
     }
   }
-  /* Moves lists that directly follow paragraphs inside of dd and li close under
-   * the paragraph so they look more "togeter". */
-  dd, li {
-    & > p + div {
-      &.orderedlist,
-      &.itemizedlist {
-        margin-top: 1em;
-      }
-    }
-  }
 }

--- a/resources/web/style/list.pcss
+++ b/resources/web/style/list.pcss
@@ -44,7 +44,7 @@
     & > p + div {
       &.orderedlist,
       &.itemizedlist {
-        margin-top: -0.9em;
+        margin-top: 1em;
       }
     }
   }


### PR DESCRIPTION
Currently, lists that follow paragraphs get mushed together in tabbed widgets. This change aims to fix that smushing.

![image](https://user-images.githubusercontent.com/25848033/141845792-da5ef2c9-e904-4a03-a481-6c71e3c5eb5a.png)
