### PR TITLE
Add 7.16 version of PHP & .NET client books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -545,6 +545,7 @@ contents:
               - title:      .NET Clients
                 prefix:     net-api
                 current:    7.16
+                # need to keep 7.x until all tooling is switched over to 7.16
                 branches:   [ master, 8.0, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
                 live:       [ master, 8.0, 7.16, 7.x ]
                 index:      docs/index.asciidoc
@@ -558,8 +559,9 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    7.16
+                # need to keep 7.x until all tooling is switched over to 7.16
                 branches:   [ master, 8.0, 7.16, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 8.0, 7.16 ]
+                live:       [ master, 8.0, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP

--- a/conf.yaml
+++ b/conf.yaml
@@ -544,11 +544,9 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                # The elasticsearch-net repo only keeps .x branches. Do not
-                # bump these with the rest of the stack.
-                current:    7.x
-                branches:   [ master, 8.0, 7.x, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ master, 8.0, 7.x ]
+                current:    7.16
+                branches:   [ master, 8.0, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ master, 8.0, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -559,9 +557,9 @@ contents:
                     path:   docs/
               - title:      PHP Client
                 prefix:     php-api
-                current:    7.x
-                branches:   [ master, 8.0, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 8.0, 7.x ]
+                current:    7.16
+                branches:   [ master, 8.0, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       [ master, 8.0, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP

--- a/conf.yaml
+++ b/conf.yaml
@@ -560,7 +560,7 @@ contents:
                 prefix:     php-api
                 current:    7.16
                 # need to keep 7.x until all tooling is switched over to 7.16
-                branches:   [ master, 8.0, 7.16, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ master, 8.0, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       [ master, 8.0, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -558,8 +558,8 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    7.16
-                branches:   [ master, 8.0, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 8.0, 7.16, 7.x ]
+                branches:   [ master, 8.0, 7.16, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       [ master, 8.0, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP


### PR DESCRIPTION
required versioned book references as it was blocking for https://github.com/elastic/kibana/issues/118591