### PR TITLE
[DOCS] Fix release state for master branch

### DIFF
--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -17,7 +17,7 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          prerelease
+:release-state:          unreleased
 
 //////////
 is-current-version can be: true | false


### PR DESCRIPTION
As of writing, the `master` branch is a proxy for 8.1.0. 8.1.0 is unreleased, not in prerelease.