### PR TITLE
Adds search variables to Kibana link checker

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -361,11 +361,12 @@ sub check_kibana_links {
 # ${STACK_DOCS}upgrading-elastic-stack.html
 # ${SECURITY_SOLUTION_DOCS}sec-requirements.html
 # ${STACK_GETTING_STARTED}get-started-elastic-stack.html
+# ${APP_SEARCH_DOCS}authentication.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS|SECURITY_SOLUTION_DOCS|STACK_GETTING_STARTED)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS|SECURITY_SOLUTION_DOCS|STACK_GETTING_STARTED|APP_SEARCH_DOCS|ENTERPRISE_SEARCH_DOCS|WORKPLACE_SEARCH_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$version/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -380,6 +381,9 @@ sub check_kibana_links {
                 $path =~ s!\$\{STACK_DOCS\}!en/elastic-stack/$version/!;
                 $path =~ s!\$\{SECURITY_SOLUTION_DOCS\}!en/security/$version/!;
                 $path =~ s!\$\{STACK_GETTING_STARTED\}!en/elastic-stack-get-started/$version/!;
+                $path =~ s!\$\{APP_SEARCH_DOCS\}!en/app-search/$version/!;
+                $path =~ s!\$\{ENTERPRISE_SEARCH_DOCS\}!en/enterprise-search/$version/!;
+                $path =~ s!\$\{WORKPLACE_SEARCH_DOCS\}!en/workplace-search/$version/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -362,6 +362,8 @@ sub check_kibana_links {
 # ${SECURITY_SOLUTION_DOCS}sec-requirements.html
 # ${STACK_GETTING_STARTED}get-started-elastic-stack.html
 # ${APP_SEARCH_DOCS}authentication.html
+# ${ENTERPRISE_SEARCH_DOCS}authentication.html
+# ${WORKPLACE_SEARCH_DOCS}workplace-search-getting-started.html
 
     my $extractor = sub {
         my $contents = shift;

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -193,6 +193,7 @@ RSpec.describe 'building all books' do
                       '${STACK_GETTING_STARTED}not-a-page.html', true
       include_examples 'there are broken links in kibana',
                        'en/elastic-stack-get-started/master/not-a-page.html'
+    end
     describe 'when there is a broken App Search link' do
       include_context 'there is a kibana link', true,
                       '${APP_SEARCH_DOCS}not-a-search-page.html', true

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -193,6 +193,23 @@ RSpec.describe 'building all books' do
                       '${STACK_GETTING_STARTED}not-a-page.html', true
       include_examples 'there are broken links in kibana',
                        'en/elastic-stack-get-started/master/not-a-page.html'
+    describe 'when there is a broken App Search link' do
+      include_context 'there is a kibana link', true,
+                      '${APP_SEARCH_DOCS}not-a-search-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/app-search/master/not-a-search-page.html'
+    end
+    describe 'when there is a broken Enterprise Search link' do
+      include_context 'there is a kibana link', true,
+                      '${ENTERPRISE_SEARCH_DOCS}not-a-search-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/enterprise-search/master/not-a-search-page.html'
+    end
+    describe 'when there is a broken Workplace Search link' do
+      include_context 'there is a kibana link', true,
+                      '${WORKPLACE_SEARCH_DOCS}not-a-search-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/workplace-search/master/not-a-search-page.html'
     end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do


### PR DESCRIPTION
This PR adds APP_SEARCH_DOCS, ENTERPRISE_SEARCH_DOCS, and WORKPLACE_SEARCH_DOCS variables to align with the variables in the Kibana documentation link service

Related to https://github.com/elastic/kibana/pull/118814