### PR TITLE
Add stack and security variables to Kibana link check

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -358,11 +358,12 @@ sub check_kibana_links {
 # ${PLUGIN_DOCS}repository-s3.html
 # ${FLEET_DOCS}fleet-overview.html
 # ${APM_DOCS}overview.html
+# ${STACK_DOCS}upgrading-elastic-stack.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$version/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -374,6 +375,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$version/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$version/!;
                 $path =~ s!\$\{APM_DOCS\}!en/apm/!;
+                $path =~ s!\$\{STACK_DOCS\}!en/elastic-stack/$version/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -359,11 +359,13 @@ sub check_kibana_links {
 # ${FLEET_DOCS}fleet-overview.html
 # ${APM_DOCS}overview.html
 # ${STACK_DOCS}upgrading-elastic-stack.html
+# ${SECURITY_SOLUTION_DOCS}sec-requirements.html
+# ${STACK_GETTING_STARTED}get-started-elastic-stack.html
 
     my $extractor = sub {
         my $contents = shift;
         return sub {
-            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS)\}[^`]+)`!g ) {
+            while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS|SECURITY_SOLUTION_DOCS|STACK_GETTING_STARTED)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$version/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
@@ -376,6 +378,8 @@ sub check_kibana_links {
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$version/!;
                 $path =~ s!\$\{APM_DOCS\}!en/apm/!;
                 $path =~ s!\$\{STACK_DOCS\}!en/elastic-stack/$version/!;
+                $path =~ s!\$\{SECURITY_SOLUTION_DOCS\}!en/security/$version/!;
+                $path =~ s!\$\{STACK_GETTING_STARTED\}!en/elastic-stack-get-started/$version/!;
                 # Replace the "https://www.elastic.co/guide/" URL prefix so that
                 # it becomes a file path in the built docs.
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -160,9 +160,9 @@ RSpec.describe 'building all books' do
     end
     describe 'when there is a broken ES Plugin link' do
       include_context 'there is a kibana link', true,
-                      '${PLUGIN_DOCS}not-a-valid-plugin.html', true
+                      '${PLUGIN_DOCS}not-valid-plugin.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elasticsearch/plugins/master/not-a-valid-plugin.html'
+                       'en/elasticsearch/plugins/master/not-valid-plugin.html'
     end
     describe 'when there is a broken Fleet link' do
       include_context 'there is a kibana link', true,
@@ -190,9 +190,9 @@ RSpec.describe 'building all books' do
     end
     describe 'when there is a broken Stack Getting Started link' do
       include_context 'there is a kibana link', true,
-                      '${STACK_GETTING_STARTED}not-a-stack-page.html', true
+                      '${STACK_GETTING_STARTED}not-a-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elastic-stack-get-started/master/not-a-stack-page.html'
+                       'en/elastic-stack-get-started/master/not-a-page.html'
     end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -182,6 +182,18 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links in kibana',
                        'en/elastic-stack/master/not-a-stack-page.html'
     end
+    describe 'when there is a broken Security link' do
+      include_context 'there is a kibana link', true,
+                      '${SECURITY_SOLUTION_DOCS}not-a-security-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/security/master/not-a-security-page.html'
+    end
+    describe 'when there is a broken Stack Getting Started link' do
+      include_context 'there is a kibana link', true,
+                      '${STACK_GETTING_STARTED}not-a-stack-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/elastic-stack-get-started/master/not-a-stack-page.html'
+    end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do
         convert_before do |src, dest|

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -176,6 +176,12 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links in kibana',
                        'en/apm/not-an-apm-page.html'
     end
+    describe 'when there is a broken Stack link' do
+      include_context 'there is a kibana link', true,
+                      '${STACK_DOCS}not-a-stack-page.html', true
+      include_examples 'there are broken links in kibana',
+                       'en/elastic-stack/master/not-a-stack-page.html'
+    end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do
         convert_before do |src, dest|


### PR DESCRIPTION
This PR adds STACK_GETTING_STARTED, STACK_DOCS, and SECURITY_SOLUTION_DOCS variables to align with the variables in the Kibana documentation link service
