### PR TITLE
Move Journalbeat to legacy section and turn off 7.16+ builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1919,47 +1919,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          - title:      Journalbeat Reference
-            prefix:     en/beats/journalbeat
-            current:    *stackcurrent
-            index:      journalbeat/docs/index.asciidoc
-            branches:   [ master, 8.0, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Journalbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Journalbeat
-            sources:
-              -
-                repo:   beats
-                path:   journalbeat
-              -
-                repo:   beats
-                path:   journalbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
@@ -2363,6 +2322,47 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en/gke-on-prem
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Journalbeat Reference
+            prefix:     en/beats/journalbeat
+            current:    *stackcurrent
+            index:      journalbeat/docs/index.asciidoc
+            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Journalbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Journalbeat
+            sources:
+              -
+                repo:   beats
+                path:   journalbeat
+              -
+                repo:   beats
+                path:   journalbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -2328,7 +2328,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Journalbeat Reference
+          - title:      Journalbeat Reference for 6.5-7.15
             prefix:     en/beats/journalbeat
             current:    7.15
             index:      journalbeat/docs/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -2330,10 +2330,9 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Journalbeat Reference
             prefix:     en/beats/journalbeat
-            current:    *stackcurrent
+            current:    7.15
             index:      journalbeat/docs/index.asciidoc
             branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
             chunk:      1
             tags:       Journalbeat/Reference
             respect_edit_url_overrides: true


### PR DESCRIPTION
Moves Journalbeat docs to the legacy section and stops building them in master, 8.0, and 7.16 branches.

![image](https://user-images.githubusercontent.com/14206422/143323792-9ed3db1a-4d82-45bb-b8d7-8e0488dd4f31.png)

Related docs PRs:
* https://github.com/elastic/beats/pull/29134
* https://github.com/elastic/beats/pull/29135
* https://github.com/elastic/beats/pull/29136
* https://github.com/elastic/stack-docs/pull/1893
* https://github.com/elastic/stack-docs/pull/1894
* https://github.com/elastic/stack-docs/pull/1895
* https://github.com/elastic/beats/pull/29137

Dev PR: https://github.com/elastic/beats/pull/29131
