### PR TITLE
ESS - Change current to MS-66

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -72,7 +72,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.0, 7.16, 7.15, 6.8 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-65
+  cloudSaasCurrent: &cloudSaasCurrent ms-66
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-66.
Do not merge until release day.