### PR TITLE
Add attribute for the integrations developer guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -122,6 +122,7 @@ endif::[]
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}
 :elastic-maps-service: https://maps.elastic.co
 :integrations-docs:    https://docs.elastic.co/en/integrations
+:integrations-devguide: https://www.elastic.co/guide/en/integrations-developer/current
 :time-units:           {ref}/api-conventions.html#time-units
 :byte-units:           {ref}/api-conventions.html#byte-units
 


### PR DESCRIPTION
Adds attribute to resolve path to the integrations developer guide.

@bmorelli25 Should we set this to `current` since we are not building in multiple branches?