### PR TITLE
Promote ECK 1.9 branch to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -894,7 +894,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.8
+            current:    1.9
             branches:   [ master, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR sets the ECK 1.9 branch as the current version.
I am submitting this early to get approval. It should only be merged after #2301 is merged and ECK 1.9 is released.