### PR TITLE
Add elasticsearch-java doc code snippets directory

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -498,6 +498,9 @@ contents:
                     repo:   elasticsearch-java
                     path:   docs/
                   -
+                    repo:   elasticsearch-java
+                    path:   java-client/src/test/java/co/elastic/clients/documentation
+                  -
                     repo:   elasticsearch
                     path:   docs/java-rest/
                   -


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-java/pull/52 pulls code snippets in the document from test source code, which is not checked out by the docs build process.

This PR adds the path to that test source code in the `elasticsearch-java` (`java-api-client`) configuration.