### PR TITLE
Move APM Reference and Overview to Legacy section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1117,42 +1117,6 @@ contents:
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
-              - title:      APM Overview
-                prefix:     get-started
-                index:      docs/guide/index.asciidoc
-                current:    7.15
-                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                live:       [ 7.15, 6.8 ]
-                chunk:      1
-                tags:       APM Server/Reference
-                subject:    APM
-                sources:
-                  -
-                    repo:   apm-server
-                    path:   docs/guide
-                  -
-                    repo:   apm-server
-                    path:   docs
-              - title:      APM Server Reference
-                prefix:     server
-                index:      docs/index.asciidoc
-                current:    7.15
-                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                live:       [ 7.15, 6.8 ]
-                chunk:      1
-                tags:       APM Server/Reference
-                subject:    APM
-                sources:
-                  -
-                    repo:   apm-server
-                    path:   changelogs
-                    exclude_branches:   [ 6.0 ]
-                  -
-                    repo:   apm-server
-                    path:   docs
-                  -
-                    repo:   apm-server
-                    path:   CHANGELOG.asciidoc
               - title:      APM Guide
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
@@ -2308,6 +2272,42 @@ contents:
 
     -   title:      Legacy Documentation
         sections:
+          - title:      APM Overview
+            prefix:     get-started
+            index:      docs/guide/index.asciidoc
+            current:    7.15
+            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       [ 7.15, 6.8 ]
+            chunk:      1
+            tags:       APM Server/Reference
+            subject:    APM
+            sources:
+              -
+                repo:   apm-server
+                path:   docs/guide
+              -
+                repo:   apm-server
+                path:   docs
+          - title:      APM Server Reference
+            prefix:     server
+            index:      docs/index.asciidoc
+            current:    7.15
+            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       [ 7.15, 6.8 ]
+            chunk:      1
+            tags:       APM Server/Reference
+            subject:    APM
+            sources:
+              -
+                repo:   apm-server
+                path:   changelogs
+                exclude_branches:   [ 6.0 ]
+              -
+                repo:   apm-server
+                path:   docs
+              -
+                repo:   apm-server
+                path:   CHANGELOG.asciidoc
           - title:      Elastic Stack and Google Cloud's Anthos
             prefix:     en/elastic-stack-gke
             current:    main


### PR DESCRIPTION
Moves the APM Server Reference and APM Overview to the Legacy docs section of elastic.co/guide.

Merge after https://github.com/elastic/docs/pull/2299.