### PR TITLE
Use `*stackcurrent` for APM Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1123,9 +1123,9 @@ contents:
               - title:      APM Guide
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
-                current:    master
+                current:    *stackcurrent
                 branches:   [ master, 8.0, 7.16 ]
-                live:       [ master, 8.0, 7.16 ]
+                live:       *stacklive
                 chunk:      2
                 tags:       APM Guide
                 subject:    APM


### PR DESCRIPTION
Not sure how I missed this. Updating for 7.16 docs.