### PR TITLE
Add alias for Integrations Developer Guide

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -140,11 +140,11 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
-# Fleet user guide
+# Fleet and Elastic Agent guide
 alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/apm-server/docs --chunk 2'
 
-# Fleet developer guide
-alias docbldfdg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/fleet-developer/index.asciidoc --chunk 2'
+# Integrations developer guide
+alias docbldidg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/integrations/index.asciidoc --resource=$GIT_HOME/package-spec/versions --chunk 2'
 
 # APM
 alias docbldapm='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/integrations-index.asciidoc --chunk 2'


### PR DESCRIPTION
Updates alias file by removing the Fleet Developer Guide, which no longer exists, and adding the Integrations Developer Guide.