### PR TITLE
[DOCS] 7.16.1 version bump

### DIFF
--- a/shared/versions/stack/7.16.asciidoc
+++ b/shared/versions/stack/7.16.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.16.0
+:version:                7.16.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.16.0
-:logstash_version:       7.16.0
-:elasticsearch_version:  7.16.0
-:kibana_version:         7.16.0
-:apm_server_version:     7.16.0
+:bare_version:           7.16.1
+:logstash_version:       7.16.1
+:elasticsearch_version:  7.16.1
+:kibana_version:         7.16.1
+:apm_server_version:     7.16.1
 :branch:                 7.16
 :minor-version:          7.16
 :major-version:          7.x


### PR DESCRIPTION
Bumps version to `7.16.1`.

**DO NOT MERGE UNTIL RELEASE DAY.**