### PR TITLE
Bump 6.8 to version 6.8.21

### DIFF
--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -1,12 +1,12 @@
-:version:                6.8.20
+:version:                6.8.21
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           6.8.20
-:logstash_version:       6.8.20
-:elasticsearch_version:  6.8.20
-:kibana_version:         6.8.20
-:apm_server_version:     6.8.20
+:bare_version:           6.8.21
+:logstash_version:       6.8.21
+:elasticsearch_version:  6.8.21
+:kibana_version:         6.8.21
+:apm_server_version:     6.8.21
 :branch:                 6.8
 :minor-version:          6.8
 :major-version:          6.x


### PR DESCRIPTION
Bumps the 6.8 docs to 6.8.21.