### PR TITLE
Update branches for 2.13.0 release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,6 +78,7 @@ variables:
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-65: master
     ms-62: master
     ms-59: master
     ms-57: master
@@ -842,8 +843,8 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-62
-            branches:   [ {'ms-62': 2.12}, {'ms-59': 2.11}, {'ms-57': 2.10}, {'ms-53': 2.9}, {'ms-49': 2.8}, {'ms-47': 2.7}, {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
+            current:    ms-65
+            branches:   [ {'ms-65': 2.13}, {'ms-62': 2.12}, {'ms-59': 2.11}, {'ms-57': 2.10}, {'ms-53': 2.9}, {'ms-49': 2.8}, {'ms-47': 2.7}, {'release-ms-41': 2.6}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.1, 1.0 ]
             index:      docs/cloud-enterprise/index.asciidoc
             chunk:      2
             private:    1
@@ -859,6 +860,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-65: master
                   ms-62: master
                   ms-59: master
                   ms-57: master
@@ -932,8 +934,8 @@ contents:
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
-            current:    1.6
-            branches:   [ master, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            current:    1.7
+            branches:   [ master, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Related to https://github.com/elastic/dev/issues/1814

Updates the branches for: ECE, ecctl for the
upcoming ECE 2.13.0 release.