### PR TITLE
[DOCS] Add docbook for legacy elasticsearch.js client

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -31,6 +31,7 @@ repos:
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
+    elasticsearch-js-legacy:  https://github.com/elastic/elasticsearch-js-legacy.git
     elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
     elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
     elasticsearch-php:    https://github.com/elastic/elasticsearch-php.git
@@ -2670,6 +2671,20 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+          - title:      Elasticsearch.js for 5.6-7.6
+            prefix:     en/elasticsearch/client/elasticsearch-js
+            current:    16.x
+            branches:   [ 16.x ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Clients/Elasticsearch-js
+            subject:    Clients
+            sources:
+              -
+                repo:   elasticsearch-js-legacy
+                path:   docs
 
 redirects:
     -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -211,6 +211,8 @@ alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/
 
 alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc --chunk 1'
 
+alias docbldejsl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js-legacy/docs/index.asciidoc --chunk 1'
+
 # X-Pack Reference 5.4 to 6.2
 
 alias docbldx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/x-pack/docs/en/index.asciidoc --resource=$GIT_HOME/kibana-extra/x-pack-kibana/docs --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs --chunk 1'


### PR DESCRIPTION
Adds a separate docbook for the legacy elasticsearch.js client docs.

We plan to remove similar docs from the current Elasticsearch JavaScript client docbook as part of https://github.com/elastic/docs/issues/2317.

### Preview
Legacy docs: https://docs_2318.docs-preview.app.elstc.co/guide/en/elasticsearch/client/elasticsearch-js/current/index.html

TOC: https://docs_2318.docs-preview.app.elstc.co/guide/index.html
<img width="642" alt="Screen Shot 2021-12-15 at 9 33 35 AM" src="https://user-images.githubusercontent.com/40268737/146205667-93ae32ed-5083-4c51-af0a-aedd180a92bd.PNG">

