### PR TITLE
Remove 16.x branch from ES JS client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -501,7 +501,7 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.16, 6.x, 5.x, 16.x ]
+                branches:   [ {main: master}, 8.0, 7.16, 6.x, 5.x ]
                 live:       [ main, 8.0, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1


### PR DESCRIPTION
Removes the 16.x branch from the Elasticsearch JavaScript client docs.

This docs are now published as the [legacy elasticsearch.js docs](https://www.elastic.co/guide/en/elasticsearch/client/elasticsearch-js/current/index.html).

Merging is blocked until we confirm redirects are in place.