### PR TITLE
Use main branch in ecs-logging repo

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1323,9 +1323,9 @@ contents:
             sections:
               - title:      ECS Logging Overview
                 prefix:     overview
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ {main: master} ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/Guide
@@ -1384,6 +1384,8 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
+
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x
@@ -1407,8 +1409,9 @@ contents:
                     repo:   ecs-logging
                     path:   docs
                     map_branches:
-                      1.x: master
-                      0.x: master
+                      1.x: main
+                      0.x: main
+                      master: main
               - title:      ECS Logging .NET Reference
                 prefix:     dotnet
                 current:    master
@@ -1431,6 +1434,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
                 current:    master
@@ -1453,6 +1457,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
               - title:      ECS Logging Ruby Reference
                 prefix:     ruby
                 current:    master
@@ -1475,6 +1480,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
               - title:      ECS Logging PHP Reference
                 prefix:     php
                 current:    master
@@ -1497,6 +1503,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
               - title:      ECS Logging Python Reference
                 prefix:     python
                 current:    master
@@ -1519,6 +1526,7 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+                    map_branches: *mapMasterToMain
 
     -   title:      Elastic Security
         sections:


### PR DESCRIPTION
This PR addresses the following build error:

> 09:38:55 INFO:build_docs:Error executing: git rev-parse master in GIT_DIR /docs_build/.repos/ecs-logging.git
09:38:55 INFO:build_docs:---out---
09:38:55 INFO:build_docs:master
09:38:55 INFO:build_docs:
09:38:55 INFO:build_docs:---err---
09:38:55 INFO:build_docs:fatal: ambiguous argument 'master': unknown revision or path not in the working tree.
