### PR TITLE
obs11: first batch to use main branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1324,7 +1324,7 @@ contents:
               - title:      ECS Logging Overview
                 prefix:     overview
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1343,7 +1343,7 @@ contents:
               - title:      ECS Logging Go (Logrus) Reference
                 prefix:     go-logrus
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1365,7 +1365,7 @@ contents:
               - title:      ECS Logging Go (Zap) Reference
                 prefix:     go-zap
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1384,10 +1384,11 @@ contents:
                   -
                     repo:   ecs-logging
                     path:   docs
+
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x
-                branches:   [ main, 1.x, 0.x ]
+                branches:   [ {main: master}, 1.x, 0.x ]
                 live:       [ main, 1.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1412,7 +1413,7 @@ contents:
               - title:      ECS Logging .NET Reference
                 prefix:     dotnet
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1434,7 +1435,7 @@ contents:
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
                 current:    master
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1456,7 +1457,7 @@ contents:
               - title:      ECS Logging Ruby Reference
                 prefix:     ruby
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1478,7 +1479,7 @@ contents:
               - title:      ECS Logging PHP Reference
                 prefix:     php
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1500,7 +1501,7 @@ contents:
               - title:      ECS Logging Python Reference
                 prefix:     python
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -619,7 +619,7 @@ contents:
                 sources:
                   -
                     repo:   elasticsearch-rs
-                    path:   docs/ 
+                    path:   docs/
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
                 current:   7.15
@@ -1323,9 +1323,9 @@ contents:
             sections:
               - title:      ECS Logging Overview
                 prefix:     overview
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/Guide
@@ -1342,9 +1342,9 @@ contents:
                     path:   shared/attributes.asciidoc
               - title:      ECS Logging Go (Logrus) Reference
                 prefix:     go-logrus
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/go-logrus/Guide
@@ -1364,9 +1364,9 @@ contents:
                     path:   docs
               - title:      ECS Logging Go (Zap) Reference
                 prefix:     go-zap
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/go-zap/Guide
@@ -1387,8 +1387,8 @@ contents:
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x
-                branches:   [ master, 1.x, 0.x ]
-                live:       [ master, 1.x ]
+                branches:   [ main, 1.x, 0.x ]
+                live:       [ main, 1.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/java/Guide
@@ -1407,13 +1407,13 @@ contents:
                     repo:   ecs-logging
                     path:   docs
                     map_branches:
-                      1.x: master
-                      0.x: master
+                      1.x: main
+                      0.x: main
               - title:      ECS Logging .NET Reference
                 prefix:     dotnet
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/.NET/Guide
@@ -1434,8 +1434,8 @@ contents:
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
                 current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/nodejs/Guide
@@ -1455,9 +1455,9 @@ contents:
                     path:   docs
               - title:      ECS Logging Ruby Reference
                 prefix:     ruby
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/ruby/Guide
@@ -1477,9 +1477,9 @@ contents:
                     path:   docs
               - title:      ECS Logging PHP Reference
                 prefix:     php
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/php/Guide
@@ -1499,9 +1499,9 @@ contents:
                     path:   docs
               - title:      ECS Logging Python Reference
                 prefix:     python
-                current:    master
-                branches:   [ master ]
-                live:       [ master ]
+                current:    main
+                branches:   [ main ]
+                live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/python/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1434,7 +1434,7 @@ contents:
                     path:   docs
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
-                current:    master
+                current:    main
                 branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc


### PR DESCRIPTION
### What

Some repositories have been changed from default `master` branch to `main`.

### Issues

Relates:
- https://github.com/elastic/ecs-logging-ruby/pull/24
- https://github.com/elastic/ecs-logging-python/pull/75
- https://github.com/elastic/ecs-logging-php/pull/36
- https://github.com/elastic/ecs-logging-nodejs/pull/111
- https://github.com/elastic/ecs-logging-java/pull/160
- https://github.com/elastic/ecs-logging-go-zap/pull/41
- https://github.com/elastic/ecs-logging-go-logrus/pull/16
- https://github.com/elastic/ecs-logging/pull/65
- https://github.com/elastic/ecs-dotnet/pull/172