### PR TITLE
Move legacy APM books back to `/en/apm/*`

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2296,42 +2296,45 @@ contents:
 
     -   title:      Legacy Documentation
         sections:
-          - title:      APM Overview
-            prefix:     get-started
-            index:      docs/guide/index.asciidoc
-            current:    7.15
-            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       [ 7.15, 6.8 ]
-            chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
-            sources:
-              -
-                repo:   apm-server
-                path:   docs/guide
-              -
-                repo:   apm-server
-                path:   docs
-          - title:      APM Server Reference
-            prefix:     server
-            index:      docs/index.asciidoc
-            current:    7.15
-            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       [ 7.15, 6.8 ]
-            chunk:      1
-            tags:       APM Server/Reference
-            subject:    APM
-            sources:
-              -
-                repo:   apm-server
-                path:   changelogs
-                exclude_branches:   [ 6.0 ]
-              -
-                repo:   apm-server
-                path:   docs
-              -
-                repo:   apm-server
-                path:   CHANGELOG.asciidoc
+          - title:      Application Performance Monitoring (APM)
+            base_dir:   en/apm
+            sections:
+              - title:      APM Overview
+                prefix:     get-started
+                index:      docs/guide/index.asciidoc
+                current:    7.15
+                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                live:       [ 7.15, 6.8 ]
+                chunk:      1
+                tags:       APM Server/Reference
+                subject:    APM
+                sources:
+                  -
+                    repo:   apm-server
+                    path:   docs/guide
+                  -
+                    repo:   apm-server
+                    path:   docs
+              - title:      APM Server Reference
+                prefix:     server
+                index:      docs/index.asciidoc
+                current:    7.15
+                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                live:       [ 7.15, 6.8 ]
+                chunk:      1
+                tags:       APM Server/Reference
+                subject:    APM
+                sources:
+                  -
+                    repo:   apm-server
+                    path:   changelogs
+                    exclude_branches:   [ 6.0 ]
+                  -
+                    repo:   apm-server
+                    path:   docs
+                  -
+                    repo:   apm-server
+                    path:   CHANGELOG.asciidoc
           - title:      Elastic Stack and Google Cloud's Anthos
             prefix:     en/elastic-stack-gke
             current:    main

--- a/conf.yaml
+++ b/conf.yaml
@@ -1318,6 +1318,44 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
+              - title:      Legacy APM (standalone)
+                sections:
+                  - title:      APM Overview
+                    prefix:     get-started
+                    index:      docs/guide/index.asciidoc
+                    current:    7.15
+                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                    live:       [ 7.15, 6.8 ]
+                    chunk:      1
+                    tags:       APM Server/Reference
+                    subject:    APM
+                    sources:
+                      -
+                        repo:   apm-server
+                        path:   docs/guide
+                      -
+                        repo:   apm-server
+                        path:   docs
+                  - title:      APM Server Reference
+                    prefix:     server
+                    index:      docs/index.asciidoc
+                    current:    7.15
+                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                    live:       [ 7.15, 6.8 ]
+                    chunk:      1
+                    tags:       APM Server/Reference
+                    subject:    APM
+                    sources:
+                      -
+                        repo:   apm-server
+                        path:   changelogs
+                        exclude_branches:   [ 6.0 ]
+                      -
+                        repo:   apm-server
+                        path:   docs
+                      -
+                        repo:   apm-server
+                        path:   CHANGELOG.asciidoc
           - title:      ECS logging
             base_dir:   en/ecs-logging
             sections:
@@ -2296,45 +2334,6 @@ contents:
 
     -   title:      Legacy Documentation
         sections:
-          - title:      Application Performance Monitoring (APM)
-            base_dir:   en/apm
-            sections:
-              - title:      APM Overview
-                prefix:     get-started
-                index:      docs/guide/index.asciidoc
-                current:    7.15
-                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                live:       [ 7.15, 6.8 ]
-                chunk:      1
-                tags:       APM Server/Reference
-                subject:    APM
-                sources:
-                  -
-                    repo:   apm-server
-                    path:   docs/guide
-                  -
-                    repo:   apm-server
-                    path:   docs
-              - title:      APM Server Reference
-                prefix:     server
-                index:      docs/index.asciidoc
-                current:    7.15
-                branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                live:       [ 7.15, 6.8 ]
-                chunk:      1
-                tags:       APM Server/Reference
-                subject:    APM
-                sources:
-                  -
-                    repo:   apm-server
-                    path:   changelogs
-                    exclude_branches:   [ 6.0 ]
-                  -
-                    repo:   apm-server
-                    path:   docs
-                  -
-                    repo:   apm-server
-                    path:   CHANGELOG.asciidoc
           - title:      Elastic Stack and Google Cloud's Anthos
             prefix:     en/elastic-stack-gke
             current:    main


### PR DESCRIPTION
Amends https://github.com/elastic/docs/pull/2309 by moving legacy APM books back to `/en/apm/*`.