### PR TITLE
Add ECS 8.1 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -253,7 +253,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    1.12
-            branches:   [  {main: master}, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [  {main: master}, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.0, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            master
+:ecs_version:            8.1
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
### Summary

Adds the `8.1` ECS branch and points the stack `master` to ECS 8.1.

### Additional context

I am sharing some background for why the stack `master` branch will no longer point to ECS `master` (`main`).

With upcoming ECS versions aligned with stack versioning, ECS is adopting a [new process](https://docs.google.com/document/d/1z8KXg8UdSpyE_0eUfXTqWa4QOac_0RHoIDA-xeBGfj4/edit#) to communicate better and align upcoming schema changes. ECS will enter a Soft Feature Freeze (SFF) one release in advance* of the stack. Some teams kick off their development cycles for a minor release as soon as the FF happens for the previous one, so this schedule would mean that the next version of ECS would be stable enough to start consuming in development.

With this change, the `main` ECS branch pointing ECS 8.2 and is ahead of the stack (which points to 8.1). The ECS team takes responsibility to keep `shared/versions/stack/master.asciidoc` pointed to the correct version of ECS after FF.

_*This process was a WIP at the 8.0 FF, so the timing is shortened for 8.1_ 
