### PR TITLE
Add docs for Enterprise Search JavaScript clients

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1076,6 +1076,40 @@ contents:
           - title:      Enterprise Search Clients
             base_dir:   en/enterprise-search-clients
             sections:
+              - title:      App Search JavaScript client
+                prefix:     app-search-javascript
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/app-search-javascript/index.asciidoc
+                tags:       App Search Clients/JavaScript
+                subject:    App Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/app-search-javascript
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      App Search Node.js client
+                prefix:     app-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/app-search-node/index.asciidoc
+                tags:       App Search Clients/Node.js
+                subject:    App Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/app-search-node
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    7.16
@@ -1122,6 +1156,23 @@ contents:
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
 
+              - title:      Workplace Search Node.js client
+                prefix:     workplace-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/workplace-search-node/index.asciidoc
+                tags:       Workplace Search Clients/Node.js
+                subject:    Workplace Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/workplace-search-node
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
           - title:      Observability

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -92,11 +92,17 @@ alias docbldeas='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pub
 
 alias docbldews='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/workplace-search-docs/index.asciidoc --chunk=1'
 
-alias docbldeesp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-php/docs/guide/index.asciidoc'
+alias docbldeasj='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/client-docs/app-search-javascript/index.asciidoc --single'
+
+alias docbldeasn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/client-docs/app-search-node/index.asciidoc --single'
+
+alias docbldeesphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-php/docs/guide/index.asciidoc'
 
 alias docbldeesp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-python/docs/guide/index.asciidoc'
 
 alias docbldeesr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-ruby/docs/guide/index.asciidoc'
+
+alias docbldewsn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/client-docs/workplace-search-node/index.asciidoc --single'
 
 # Curator
 alias docbldcr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/curator/docs/asciidoc/index.asciidoc'


### PR DESCRIPTION
Preview: https://docs_2326.docs-preview.app.elstc.co/guide/en/enterprise-search-clients/index.html

Closes: https://github.com/elastic/enterprise-search-team/issues/888