### PR TITLE
Fixes eland-docs attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -107,7 +107,7 @@ Elastic-level pages
 :ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
-:eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland-docs/{branch}
+:eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland/{branch}
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide
 :subscriptions:        https://www.elastic.co/subscriptions
 :extendtrial:          https://www.elastic.co/trialextension


### PR DESCRIPTION
The `eland-docs` attribute in https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc has an incorrect URL, which results in broken links. The correct URL should match https://www.elastic.co/guide/en/elasticsearch/client/eland/master/installation.html