### PR TITLE
Update version in eland-docs attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -107,7 +107,7 @@ Elastic-level pages
 :ecs-logging-python-ref:  https://www.elastic.co/guide/en/ecs-logging/python/{ecs-logging-python}
 :ecs-logging-ruby-ref:    https://www.elastic.co/guide/en/ecs-logging/ruby/{ecs-logging-ruby}
 :ml-docs:              https://www.elastic.co/guide/en/machine-learning/{branch}
-:eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland/{branch}
+:eland-docs:           https://www.elastic.co/guide/en/elasticsearch/client/eland/current
 :eql-ref:              https://eql.readthedocs.io/en/latest/query-guide
 :subscriptions:        https://www.elastic.co/subscriptions
 :extendtrial:          https://www.elastic.co/trialextension


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2327

Since there is only a single version of the Eland client documentation at this time, the eland-docs attribute must use `current` as its version, otherwise links from branches other than master fail.

If more versions are added to this book in the future, we can handle it more like`ecs-logging-ref`, for example.