### PR TITLE
Update conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1387,7 +1387,7 @@ contents:
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
               - title:      Legacy APM (standalone)
                 sections:
-                  - title:      APM Overview
+                  - title:      Legacy APM Overview
                     prefix:     get-started
                     index:      docs/guide/index.asciidoc
                     current:    7.15
@@ -1403,7 +1403,7 @@ contents:
                       -
                         repo:   apm-server
                         path:   docs
-                  - title:      APM Server Reference
+                  - title:      Legacy APM Server Reference
                     prefix:     server
                     index:      docs/index.asciidoc
                     current:    7.15


### PR DESCRIPTION
A follow-up to https://github.com/elastic/docs/pull/2324 that adds `Legacy` titles to the old APM books.

Before:

<img width="765" alt="Screen Shot 2021-12-21 at 1 17 46 PM" src="https://user-images.githubusercontent.com/5618806/146998974-e0ec9519-512c-4d3c-b3bb-5133cf21b2fa.png">
 