### PR TITLE
Add ecs-version attribute to 6.8 versioning file

### DIFF
--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -11,6 +11,7 @@ bare_version never includes -alpha or -beta
 :minor-version:          6.8
 :major-version:          6.x
 :prev-major-version:     5.x
+:ecs_version:            1.0
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
We recently updated some Logstash plugins and made them available for 6.8 as part of our log4j response.  So this means that the ECS support in plugins is now available in Logstash 6.8. The Logstash plugin lockfile was updated to allow these docs changes to get picked up.  Before now, we haven't needed to resolve the `{ecs_version}` attribute for the 6.8 branch, but now we do.  (See broken links in https://github.com/elastic/logstash-docs/pull/1244.) 

I can think of several ways to approach this fix, but I believe that adding the attribute to the 6.8 shared version file is the best approach.  

@lcawl @ebeahan @yaauie: What do you think about this approach?  Here are my thoughts: 

- If no other doc set is calling the {ecs-version} attribute for 6.8, I don't think we'll break anything. Can you think of any risks that I'm not thinking of? 
- Is 1.0 the right setting? (Logstash plugins will likely support the current version. Would it be confusing to have 6.8 linked to a later version and then 7.0 mapped to ECS 1.0?)
- What other factors do I need to consider that I haven't thought of yet?  :-) 

IMPORTANT: I know that many people are out for the holidays, so I'm not expecting immediate feedback or resolution.  ☃️ 