### PR TITLE
Bump current version to 7.17

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -653,9 +653,9 @@ contents:
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               - title:      Java Transport Client (deprecated)
                 prefix:     java-api
-                current:    *stackcurrent
+                current:    7.17
                 branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                live:       *stacklive
+                live:       [7.17, 6.8]
                 index:      docs/java-api/index.asciidoc
                 tags:       Clients/Java
                 subject:    Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -71,10 +71,10 @@ contents_title:     Elastic Stack and Product Documentation
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 7.16
-  stacklive: &stacklive [ master, 8.0, 7.17, 7.16, 6.8 ]
+  stackcurrent: &stackcurrent 7.17
+  stacklive: &stacklive [ master, 8.0, 7.17, 6.8 ]
 
-  stacklivemain: &stacklivemain [ main, 8.0, 7.17, 7.16, 6.8 ]
+  stacklivemain: &stacklivemain [ main, 8.0, 7.17, 6.8 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-68
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,7 +1,7 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-bare:             https://www.elastic.co/guide/en/elasticsearch/reference
 :ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
-:ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.16
+:ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.17
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0
 :ref-64:               https://www.elastic.co/guide/en/elasticsearch/reference/6.4
@@ -61,7 +61,7 @@ Elastic-level pages
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
-:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.16
+:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.17
 :plugins-6x:           https://www.elastic.co/guide/en/elasticsearch/plugins/6.8
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
@@ -430,7 +430,7 @@ Legacy definitions
 ///////
 Temporarily reroute APM Agent links to the new APM documentation book
 ///////
-ifeval::["{branch}"=="7.16"]
+ifeval::["{branch}"=="7.17"]
 :apm-server-ref:       {apm-guide-ref}
 :apm-server-ref-v:     {apm-guide-ref}
 :apm-overview-ref-v:   {apm-guide-ref}

--- a/shared/versions/stack/7.16.asciidoc
+++ b/shared/versions/stack/7.16.asciidoc
@@ -22,7 +22,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -17,12 +17,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::7.16.asciidoc[]
+include::7.17.asciidoc[]


### PR DESCRIPTION
Bumps the Elastic documentation to version 7.17.