### PR TITLE
Add main branch to the cloud-on-k8s repo docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -917,7 +917,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    1.9
-            branches:   [ master, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Relates to https://github.com/elastic/cloud-on-k8s/issues/5017.

NOTE: I will take care of the merge once the renaming of the branch is effective.