### PR TITLE
Adds tech preview macro, updates experimental

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1629,17 +1629,30 @@ This param is in development and may change in the future.
 [[new-feature]]
 === New experimental feature
 
-experimental::[]
+Experimental language is deprecated.
 
-experimental::[https://github.com/elastic/docs/issues/505]
+We decided on the much less raw sounding "technical preview".
 
-experimental::[{issue}505]
+See below.
 
-experimental::["Custom text goes here."]
+=== Using the technical `preview` admonition
 
-experimental::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
+[source,asciidoc]
+----
+[[new-feature]]
+=== New feature in technical preview
 
-experimental::["Custom text goes here.",{issue}505]
+preview::[]
+
+preview::[https://github.com/elastic/docs/issues/505]
+
+preview::[{issue}505]
+
+preview::["Custom text goes here."]
+
+preview::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
+
+preview::["Custom text goes here.",{issue}505]
 
 Text about new feature...
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1534,9 +1534,9 @@ deprecated::[0.90.4,Replace by `foo.baz`. See <<new-section>>]
 Text about old functionality...
 
 [[experimental]]
-== Beta, Dev, and Experimental
+== Beta, Dev, and Preview (experimental)
 
-APIs or parameters that are in beta, in development, or experimental can be
+APIs or parameters that are in beta, in development, or in technical preview (formerly experimental) can be
 marked as such, using markup similar to that used in <<changes>>.
 
 In the block format, you have the option of adding a related GitHub issue link.
@@ -1624,11 +1624,6 @@ This param is in development and may change in the future.
 
 === Using the `experimental` admonition
 
-[source,asciidoc]
-----
-[[new-feature]]
-=== New experimental feature
-
 Experimental language is deprecated.
 
 We decided on the much less raw sounding "technical preview".
@@ -1660,18 +1655,18 @@ Text about new feature...
 === Established feature
 
 This feature has been around for a while, but we're adding
-a new experimental parameter:
+a new preview parameter:
 
 `established_param`::
 This param has been around for ages and won't change.
 
 `experimental_param`::
-experimental:[]
-This param is experimental and may change in the future.
+preview:[]
+This param is in technical preview and may change in the future.
 
 `experimental_param`::
-experimental:["Custom text goes here."]
-This param is experimental and may change in the future.
+preview:["Custom text goes here."]
+This param is in technical preview and may change in the future.
 ----
 
 [[images]]

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe 'building a single book' do
     page_context 'chapter.html' do
       it 'includes the experimental text' do
         expect(body).to include(
-          'This functionality is experimental and may be changed or removed'
+          'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.'
         )
       end
     end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -287,7 +287,10 @@ RSpec.describe 'building a single book' do
     page_context 'chapter.html' do
       it 'includes the experimental text' do
         expect(body).to include(
-          'This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.'
+          'This functionality is in technical preview and may be changed or '\
+          'removed in a future release. Elastic will apply best effort to fix '\
+          'any issues, but features in technical preview are not subject to '\
+          'the support SLA of official GA features.'
         )
       end
     end

--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -287,7 +287,7 @@ RSpec.describe 'building a single book' do
     page_context 'chapter.html' do
       it 'includes the experimental text' do
         expect(body).to include(
-          'This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.'
+          'This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.'
         )
       end
     end

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -3,7 +3,7 @@
 require 'asciidoctor/extensions'
 
 ##
-# Extensions for marking when something as `beta`, `dev`, or technical `preview`.
+# Extensions for marking something as `beta`, `dev`, or technical `preview`.
 #
 # Usage
 #
@@ -13,11 +13,10 @@ require 'asciidoctor/extensions'
 #   Foo beta:[]
 #   Foo dev:[]
 #   Foo preview:[]
-#   
+#
 # !! `experimental:[]` is supported as a deprecated alternative to `preview:[]`.
 # !! But please use `preview:[]` instead.
 #
-
 class CareAdmonition < Asciidoctor::Extensions::Group
   BETA_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -37,7 +37,6 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       [:dev, 'dev', DEV_DEFAULT_TEXT],
       [:experimental, 'experimental', EXPERIMENTAL_DEFAULT_TEXT],
       [:preview, 'experimental', PREVIEW_DEFAULT_TEXT],
-
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name
       registry.inline_macro ChangeAdmonitionInline.new(role, default_text), name

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -36,7 +36,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       [:beta, 'beta', BETA_DEFAULT_TEXT],
       [:dev, 'dev', DEV_DEFAULT_TEXT],
       [:experimental, 'experimental', EXPERIMENTAL_DEFAULT_TEXT],
-      [:preview, 'experimental', PREVIEW_DEFAULT_TEXT],
+      [:preview, 'preview', PREVIEW_DEFAULT_TEXT],
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name
       registry.inline_macro ChangeAdmonitionInline.new(role, default_text), name

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -35,7 +35,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     [
       [:beta, 'beta', BETA_DEFAULT_TEXT],
       [:dev, 'dev', DEV_DEFAULT_TEXT],
-      [:experimental, 'experimental', EXPERIMENTAL_DEFAULT_TEXT],
+      [:experimental, 'experimental', PREVIEW_DEFAULT_TEXT],
       [:preview, 'preview', PREVIEW_DEFAULT_TEXT],
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -12,8 +12,10 @@ require 'asciidoctor/extensions'
 #   preview::[]
 #   Foo beta:[]
 #   Foo dev:[]
+#   Foo preview:[]
 #   
-# !! `experimental:[]` is supported as deprecated alternative to `preview:[]`. But please use `preview:[]` instead.
+# !! `experimental:[]` is supported as deprecated alternative to `preview:[]`. 
+# !! But please use `preview:[]` instead.
 #
 
 
@@ -23,9 +25,6 @@ class CareAdmonition < Asciidoctor::Extensions::Group
   TEXT
   DEV_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
-  TEXT
-  EXPERIMENTAL_DEFAULT_TEXT = <<~TEXT.strip
-    This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
   PREVIEW_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-
 require 'asciidoctor/extensions'
 
 ##
@@ -17,7 +16,6 @@ require 'asciidoctor/extensions'
 # !! `experimental:[]` is supported as deprecated alternative to `preview:[]`. 
 # !! But please use `preview:[]` instead.
 #
-
 
 class CareAdmonition < Asciidoctor::Extensions::Group
   BETA_DEFAULT_TEXT = <<~TEXT.strip

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -3,17 +3,20 @@
 require 'asciidoctor/extensions'
 
 ##
-# Extensions for marking when something as `beta`, `dev`, or `experimental`.
+# Extensions for marking when something as `beta`, `dev`, or technical `preview`.
 #
 # Usage
 #
 #   beta::[]
 #   dev::[]
-#   experimental::[]
+#   preview::[]
 #   Foo beta:[]
 #   Foo dev:[]
-#   Foo experimental:[]
+#   
+# !! experimental is deprecated, use preview
 #
+
+
 class CareAdmonition < Asciidoctor::Extensions::Group
   BETA_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'asciidoctor/extensions'
 
 ##
@@ -25,7 +26,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   PREVIEW_DEFAULT_TEXT = <<~TEXT.strip
-    This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
 
   def activate(registry)

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -13,7 +13,7 @@ require 'asciidoctor/extensions'
 #   Foo beta:[]
 #   Foo dev:[]
 #   
-# !! experimental is deprecated, use preview
+# !! `experimental:[]` is supported as deprecated alternative to `preview:[]`. But please use `preview:[]` instead.
 #
 
 

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -22,7 +22,10 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   EXPERIMENTAL_DEFAULT_TEXT = <<~TEXT.strip
-    This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
+    This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  TEXT
+  PREVIEW_DEFAULT_TEXT = <<~TEXT.strip
+    This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
 
   def activate(registry)
@@ -30,6 +33,8 @@ class CareAdmonition < Asciidoctor::Extensions::Group
       [:beta, 'beta', BETA_DEFAULT_TEXT],
       [:dev, 'dev', DEV_DEFAULT_TEXT],
       [:experimental, 'experimental', EXPERIMENTAL_DEFAULT_TEXT],
+      [:preview, 'experimental', PREVIEW_DEFAULT_TEXT],
+
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name
       registry.inline_macro ChangeAdmonitionInline.new(role, default_text), name

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -14,7 +14,7 @@ require 'asciidoctor/extensions'
 #   Foo dev:[]
 #   Foo preview:[]
 #   
-# !! `experimental:[]` is supported as deprecated alternative to `preview:[]`. 
+# !! `experimental:[]` is supported as a deprecated alternative to `preview:[]`.
 # !! But please use `preview:[]` instead.
 #
 

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -247,7 +247,17 @@ RSpec.describe CareAdmonition do
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip
-        This functionality is experimental and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but experimental features are not subject to the support SLA of official GA features.
+        This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+      TEXT
+    end
+    include_examples 'care admonition'
+  end
+  context 'preview' do
+    let(:key) { 'preview' }
+    let(:admon_class) { 'warning' }
+    let(:default_text) do
+      <<~TEXT.strip
+        This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       TEXT
     end
     include_examples 'care admonition'

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe CareAdmonition do
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip
-        This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       TEXT
     end
     include_examples 'care admonition'
@@ -257,7 +257,7 @@ RSpec.describe CareAdmonition do
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip
-        This functionality is in technical preview and may be changed or removed completely in a future release. Elastic will take a best effort approach to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       TEXT
     end
     include_examples 'care admonition'


### PR DESCRIPTION
Adds a new macro for tech preview, updates old experimental macro to keep them both.

Closes https://github.com/elastic/docs/issues/2305.