### PR TITLE
bring widgets up to date with Cloud UI

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -141,6 +141,7 @@ Elastic Cloud
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
 :ess-console: https://cloud.elastic.co?baymax=docs-body&elektra=docs
+:ess-deployments: https://cloud.elastic.co/deployments?baymax=docs-body&elektra=docs
 :ess-baymax:  ?baymax=docs-body&elektra=docs
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current
 :eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current

--- a/shared/cloud/ess-getting-started-obs.asciidoc
+++ b/shared/cloud/ess-getting-started-obs.asciidoc
@@ -9,10 +9,10 @@
 
 . Give your deployment a name.
 
-. Click *Create deployment*
+. Click *Create deployment*.
 
-. Save your deployment credentials
+. Save your deployment credentials.
 
-You can find your Cloud ID and your APM endpoint in your deployments
-list at {ess-deployments}[cloud.elastic.co], and reset the provided
-password on the *Security* page for your deployment.
+You can find your Cloud ID and APM endpoint in your deployments
+list at {ess-deployments}[cloud.elastic.co]. To reset the provided
+password, go to the *Security* page for your deployment.

--- a/shared/cloud/ess-getting-started-obs.asciidoc
+++ b/shared/cloud/ess-getting-started-obs.asciidoc
@@ -1,23 +1,18 @@
 // Include this file in your docs:
 // include::{docs-root}/shared/cloud/ess-getting-started-obs.asciidoc[]
 
-// To include APM Server instructions, add this attribute:
-// :include-apm-instructions:
-
 . {ess-trial}[Get a free trial].
 
 . Log into {ess-console}[{ecloud}].
 
 . Click *Create deployment*.
 
-. Select *Elastic Observability* and give your deployment a name.
+. Give your deployment a name.
 
-ifdef::include-apm-instructions[]
-. Click *Create deployment* and copy the password for the `elastic` user.
+. Click *Create deployment*
 
-. Select *APM* from the menu on the left and make note of the APM endpoint and APM Server secret token.
-endif::include-apm-instructions[]
+. Save your deployment credentials
 
-ifndef::include-apm-instructions[]
-. Click *Create deployment* and copy the password for the `elastic` user and Cloud ID information.
-endif::include-apm-instructions[]
+You can find your Cloud ID and your APM endpoint in your deployments
+list at {ess-deployments}[cloud.elastic.co], and reset the provided
+password on the *Security* page for your deployment.

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -19,4 +19,4 @@ There's no faster way to get started than with our hosted {ess} on Elastic Cloud
 // end::generic[]
 
 That’s it! Now that you are up and running, it’s time to get some data into
-{kib}. You will automatically be launched into {kib}.
+{kib}. {kib} will open as soon as your deployment is ready.

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -13,9 +13,10 @@ There's no faster way to get started than with our hosted {ess} on Elastic Cloud
 
 . Click *Create deployment*.
 
-. Select a solution and give your deployment a name.
+. Give your deployment a name.
 
 . Click *Create deployment* and download the password for the `elastic` user.
 // end::generic[]
 
-That’s it! Now that you are up and running, it’s time to get some data into {kib}. Click *Launch Kibana*.
+That’s it! Now that you are up and running, it’s time to get some data into
+{kib}. You will automatically be launched into {kib}.


### PR DESCRIPTION
Closes https://github.com/elastic/docs/issues/2343

The widgets are used in the Kibana Quick Start, the Elasticsearch Quick Start, and the Observability docs (the Spin up the cluster page, which gets called from all over).  As far as I can tell, these are the only docs that use the widgets, but I did not search through every repo.  Here are before and after screenshots:

# Observability:

## Before:

<img width="809" alt="image" src="https://user-images.githubusercontent.com/25182304/148997054-11ecf22a-3e8f-4423-809e-6a2bad622d81.png">

## After:

<img width="966" alt="image" src="https://user-images.githubusercontent.com/25182304/148997154-7d2c9928-e182-4417-bfaf-f7871c57ccc2.png">

# Kibana Quick Start

## Before

<img width="816" alt="image" src="https://user-images.githubusercontent.com/25182304/148997344-1baefabb-101c-4714-86fd-400c058052db.png">

## After

<img width="883" alt="image" src="https://user-images.githubusercontent.com/25182304/148997391-172b084e-6c1c-49f2-947c-7c3839ef14f6.png">

# Elasticsearch Quick Start

## Before

<img width="837" alt="image" src="https://user-images.githubusercontent.com/25182304/148997478-36140321-c67a-4953-8a6f-f27cf66aeca4.png">

## After

<img width="810" alt="image" src="https://user-images.githubusercontent.com/25182304/148997538-a9a6fde4-5c58-4387-be21-ae6230f063b9.png">

Note 1:
I don't think that the tag used to differentiate between Observability without APM and Observability with APM use cases is needed any longer.  APM is always deployed.  I removed the ifndef logic and added a note that the Cloud ID and APM endpoint are available from the deployment page.

Note 2:
I added an attribute for the Cloud Deployments page and included the tags used by Marketing to track the referrals we send from the docs to the Cloud UI.  I think that the tags should stay the same, but if anyone knows exactly how these tags are used by Marketing let me know and I will check into it further.