### PR TITLE
[apm] main branch for apm-agent-ruby

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1362,8 +1362,8 @@ contents:
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x
-                    branches:   [ master, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ master, 4.x ]
+                    branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ main, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
                     subject:    APM


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-ruby

### Issues

**Requires** elastic/apm-agent-ruby#1219

Similar to https://github.com/elastic/docs/pull/2323