### PR TITLE
apm: Neutral naming for apm-agent-python

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1345,8 +1345,8 @@ contents:
                   - title:      APM Python Agent
                     prefix:     python
                     current:    6.x
-                    branches:   [ master, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ master, 6.x, 5.x ]
+                    branches:   [ {main: master}, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ main, 6.x, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Neutral naming for elastic/apm-agent-python

Requires https://github.com/elastic/apm-agent-python/pull/1447