### PR TITLE
apm: Neutral naming for apm-agent-php

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1329,8 +1329,8 @@ contents:
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x
-                    branches:   [ master, 1.x ]
-                    live:       [ master, 1.x ]
+                    branches:   [ {main: master}, 1.x ]
+                    live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Neutral naming for elastic/apm-agent-php

**Requires** https://github.com/elastic/apm-agent-php/pull/606