### PR TITLE
apm: Neutral naming for apm-agent-java

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1279,8 +1279,8 @@ contents:
                   - title:      APM Java Agent
                     prefix:     java
                     current:    1.x
-                    branches:   [ master, 1.x, 0.7, 0.6 ]
-                    live:       [ master, 1.x ]
+                    branches:   [ {main: master}, 1.x, 0.7, 0.6 ]
+                    live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Neutral naming for elastic/apm-agent-java

**Requires** https://github.com/elastic/apm-agent-java/pull/2401