### PR TITLE
apm: Neutral naming for apm-agent-go

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1246,8 +1246,8 @@ contents:
                   - title:      APM Go Agent
                     prefix:     go
                     current:    1.x
-                    branches:   [ master, 1.x, 0.5 ]
-                    live:       [ master, 1.x ]
+                    branches:   [ {main: master}, 1.x, 0.5 ]
+                    live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Neutral naming for elastic/apm-agent-go

**Requires** https://github.com/elastic/apm-agent-go/pull/1197