### PR TITLE
apm: Neutral naming for apm-agent-dotnet

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1296,8 +1296,8 @@ contents:
                   - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.12
-                    branches:   [ master, 1.12, 1.11, 1.10, 1.9, 1.8 ]
-                    live:       [ master, 1.12 ]
+                    branches:   [ {main: master}, 1.12, 1.11, 1.10, 1.9, 1.8 ]
+                    live:       [ main, 1.12 ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-dotnet

### Issues

**Requires** https://github.com/elastic/apm-agent-dotnet/pull/1606