### PR TITLE
apm: Neutral naming for apm-agent-nodejs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1312,8 +1312,8 @@ contents:
                   - title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    3.x
-                    branches:   [ master, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ master, 3.x ]
+                    branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ main, 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-nodejs

### Issues

**Requires** https://github.com/elastic/apm-agent-nodejs/pull/2535

