### PR TITLE
apm: Neutral naming for apm-agent-rum-js

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1379,8 +1379,8 @@ contents:
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
-                    branches:   [ master, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ master, 5.x, 4.x]
+                    branches:   [ {main: master}, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ main, 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
                     subject:    APM


### PR DESCRIPTION
### What

Neutral naming of git branches for the elastic/apm-agent-rum-js

### Issues

**Requires** https://github.com/elastic/apm-agent-rum-js/pull/1141

