### PR TITLE
ESS - Change current to MS-68

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.0, 7.17, 7.16, 6.8 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-66
+  cloudSaasCurrent: &cloudSaasCurrent ms-68
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-68.