### PR TITLE
Add 7.last attribute for APM Guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -27,15 +27,6 @@
 :apm-guide-ref:        https://www.elastic.co/guide/en/apm/guide/{branch}
 :apm-guide-7x:         https://www.elastic.co/guide/en/apm/guide/7.17
 :apm-app-ref:          https://www.elastic.co/guide/en/kibana/{branch}
-///////
-Temporarily reroute APM Agent links to the new APM documentation book
-///////
-ifeval::["{branch}"=="7.16"]
-:apm-server-ref:       {apm-guide-ref}
-:apm-server-ref-v:     {apm-guide-ref}
-:apm-overview-ref-v:   {apm-guide-ref}
-:apm-get-started-ref:  {apm-guide-ref}
-endif::[]
 :apm-agents-ref:       https://www.elastic.co/guide/en/apm/agent
 :apm-py-ref:           https://www.elastic.co/guide/en/apm/agent/python/current
 :apm-py-ref-3x:        https://www.elastic.co/guide/en/apm/agent/python/3.x
@@ -434,3 +425,12 @@ Legacy definitions
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
+///////
+Temporarily reroute APM Agent links to the new APM documentation book
+///////
+ifeval::["{branch}"=="7.16"]
+:apm-server-ref:       {apm-guide-ref}
+:apm-server-ref-v:     {apm-guide-ref}
+:apm-overview-ref-v:   {apm-guide-ref}
+:apm-get-started-ref:  {apm-guide-ref}
+endif::[]

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -25,17 +25,8 @@
 :ingest-guide:         https://www.elastic.co/guide/en/fleet/{branch}
 :fleet-guide:          https://www.elastic.co/guide/en/fleet/{branch}
 :apm-guide-ref:        https://www.elastic.co/guide/en/apm/guide/{branch}
-:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
-:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
+:apm-guide-7x:         https://www.elastic.co/guide/en/apm/guide/7.17
 :apm-app-ref:          https://www.elastic.co/guide/en/kibana/{branch}
-:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-m:     https://www.elastic.co/guide/en/apm/server/master
-:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
-:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
-:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 ///////
 Temporarily reroute APM Agent links to the new APM documentation book
 ///////
@@ -432,4 +423,14 @@ Issue and pull request URLs
 //////////
 Legacy definitions
 //////////
+:apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
+:apm-server-ref-m:     https://www.elastic.co/guide/en/apm/server/master
+:apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
+:apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
+:apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
+:apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
+:apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
+:apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}


### PR DESCRIPTION
- [x] Adds 7.last attribute for APM Guide: `{apm-guide-7x}`
- [x] Moves all APM legacy, never to be used again, attrs to the bottom of the page