### PR TITLE
[DOCS] Add `plugins-7x` and `plugins-6x` attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -61,6 +61,7 @@ Elastic-level pages
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
+:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.17
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 :blog-ref:             https://www.elastic.co/blog/

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -62,7 +62,7 @@ Elastic-level pages
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.16
-:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/6.8
+:plugins-6x:           https://www.elastic.co/guide/en/elasticsearch/plugins/6.8
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 :blog-ref:             https://www.elastic.co/blog/

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -61,7 +61,7 @@ Elastic-level pages
 :defguide:             https://www.elastic.co/guide/en/elasticsearch/guide/2.x
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
-:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.17
+:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.16
 :plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/6.8
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -62,6 +62,7 @@ Elastic-level pages
 :painless:             https://www.elastic.co/guide/en/elasticsearch/painless/{branch}
 :plugins:              https://www.elastic.co/guide/en/elasticsearch/plugins/{branch}
 :plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/7.17
+:plugins-7x:           https://www.elastic.co/guide/en/elasticsearch/plugins/6.8
 :glossary:             https://www.elastic.co/guide/en/elastic-stack-glossary/current
 :upgrade_guide:        https://www.elastic.co/products/upgrade_guide
 :blog-ref:             https://www.elastic.co/blog/


### PR DESCRIPTION
With https://github.com/elastic/elasticsearch/pull/81870, we migrated docs for the Azure, GCS, and S3 snapshot repositories to the ES guide from the ES plugin docs. However, this change only applies to Elastic 8.0+.

These attributes let the Cloud docs link to the "plugin" version of the docs when referencing 7.x and 6.x Elastic deployments without breaking links.

Relates to https://github.com/elastic/cloud/pull/95621 and https://github.com/elastic/docs/pull/2312