### PR TITLE
Remove unnecessary branch mapping for package-spec

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1787,7 +1787,6 @@ contents:
               -
                 repo:   package-spec
                 path:   versions
-                map_branches: *mapMainToMaster
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:


### PR DESCRIPTION
The https://github.com/elastic/package-spec repo's master branch has been renamed, therefore the conf.yaml needs to be updated. Otherwise, it's causing the following failures:

> 08:08:33 INFO:build_docs: -                      Elasticsearch Guide: Finished 7.16
08:08:46 INFO:build_docs:Error executing: git rev-parse master in GIT_DIR /docs_build/.repos/package-spec.git
08:08:46 INFO:build_docs:---out---
08:08:46 INFO:build_docs:master
08:08:46 INFO:build_docs:
08:08:46 INFO:build_docs:---err---
08:08:46 INFO:build_docs:fatal: ambiguous argument 'master': unknown revision or path not in the working tree.