### PR TITLE
Rename master to main for APM Server project

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1195,7 +1195,6 @@ contents:
                 repo:   apm-server
                 path:   docs
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
               -
                 repo:   beats
                 path:   libbeat/docs
@@ -1762,7 +1761,6 @@ contents:
                 repo:   apm-server
                 path:   docs
                 exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
 
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer

--- a/conf.yaml
+++ b/conf.yaml
@@ -151,7 +151,6 @@ contents:
                 repo:   apm-server
                 path:   docs/
                 exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
               -
                 repo:   beats
                 path:   libbeat/docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1214,8 +1214,8 @@ contents:
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 8.0, 7.17, 7.16 ]
-                live:       *stacklive
+                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 chunk:      2
                 tags:       APM Guide
                 subject:    APM


### PR DESCRIPTION
I'll transition to ready and poke you around when we can move forward

### What

Neutral name branch for elastic/apm-server

### Issues

Requires https://github.com/elastic/apm-server/pull/7098
