### PR TITLE
Note that the full path is required for local doc build

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -70,7 +70,7 @@ generate the HTML version of the docs:
 [source,bash]
 ----------------------------
 cd path/to/your/repo
-~/path/to/docs/repo/build_docs --doc path/to/index.asciidoc
+~/path/to/docs/repo/build_docs --doc /full/path/to/index.asciidoc
 ----------------------------
 
 Each Elastic project may need its own documentation book build command.


### PR DESCRIPTION
When trying to confirm the issues on https://github.com/elastic/beats/pull/30014 I found this readme, but it wasn't clear that I needed a full path until I started reading through https://github.com/elastic/docs/blob/master/doc_build_aliases.sh

Seemed like we should probably clarify that a full path is expected. 