### PR TITLE
Add 8.1 branch to docs build

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1212,7 +1212,7 @@ contents:
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 chunk:      2
                 tags:       APM Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -1212,7 +1212,7 @@ contents:
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 chunk:      2
                 tags:       APM Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -72,9 +72,9 @@ contents_title:     Elastic Stack and Product Documentation
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 7.17
-  stacklive: &stacklive [ master, 8.0, 7.17, 6.8 ]
+  stacklive: &stacklive [ master, 8.1, 8.0, 7.17, 6.8 ]
 
-  stacklivemain: &stacklivemain [ main, 8.0, 7.17, 6.8 ]
+  stacklivemain: &stacklivemain [ main, 8.1, 8.0, 7.17, 6.8 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-68
 
@@ -138,7 +138,7 @@ contents:
             prefix:     en/elastic-stack
             current:    *stackcurrent
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
@@ -194,7 +194,7 @@ contents:
             prefix:     en/elastic-stack-get-started
             current:    *stackcurrent
             index:      docs/en/getting-started/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Getting started
@@ -230,7 +230,7 @@ contents:
             prefix:     en/machine-learning
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Machine Learning
@@ -283,7 +283,7 @@ contents:
           - title:      Elasticsearch Guide
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
-            branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -298,13 +298,13 @@ contents:
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
                 private: true
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   qa/sql
                 private: true
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   docs/Versions.asciidoc
@@ -320,7 +320,7 @@ contents:
               -
                 repo:   elasticsearch
                 path:   buildSrc/
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   build-tools-internal/
@@ -338,7 +338,7 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/qa/sql
                 # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/plugin/sql/qa
@@ -383,7 +383,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
@@ -417,7 +417,7 @@ contents:
           - title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    *stackcurrent
-            branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklive
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -443,7 +443,7 @@ contents:
             repo:       elasticsearch
             current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
-            branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklive
             chunk:      2
             tags:       Elasticsearch/Plugins
@@ -459,7 +459,7 @@ contents:
               -
                 repo:   elasticsearch
                 path:   buildSrc/src/main/resources/
-                exclude_branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   build-tools-internal/src/main/resources/
@@ -482,8 +482,8 @@ contents:
               - title:      Java Client
                 prefix:     java-api-client
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Java
@@ -504,8 +504,8 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16, 6.x, 5.x ]
-                live:       [ main, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/JavaScript
@@ -517,8 +517,8 @@ contents:
               - title:      Ruby Client
                 prefix:     ruby-api
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Ruby
@@ -530,8 +530,8 @@ contents:
               - title:      Go Client
                 prefix:     go-api
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      .doc/index.asciidoc
                 chunk:      1
                 tags:       Clients/Go
@@ -545,8 +545,8 @@ contents:
                 # The elasticsearch-net repo only keeps .x branches. Do not
                 # bump these with the rest of the stack.
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ main, 8.0, 7.17, 7.16, 7.x ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -559,8 +559,8 @@ contents:
                 prefix:     php-api
                 current:    7.16
                 # need to keep 7.x until all tooling is switched over to 7.16
-                branches:   [ master, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 8.0, 7.17, 7.16, 7.x ]
+                branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       [ master, 8.1, 8.0, 7.17, 7.16, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP
@@ -575,8 +575,8 @@ contents:
               - title:      Perl Client
                 prefix:     perl-api
                 current:    master
-                branches:   [ master, 8.0 ]
-                live:       [ master, 8.0 ]
+                branches:   [ master, 8.1, 8.0 ]
+                live:       [ master, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl
@@ -588,8 +588,8 @@ contents:
               - title:      Python Client
                 prefix:     python-api
                 current:    7.16
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/guide/index.asciidoc
                 chunk:     1
                 tags:       Clients/Python
@@ -614,8 +614,8 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    master
-                branches:   [ master, 8.0 ]
-                live:       [ master, 8.0 ]
+                branches:   [ master, 8.1, 8.0 ]
+                live:       [ master, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust
@@ -714,7 +714,7 @@ contents:
           - title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
-            branches:   [ master, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -965,7 +965,7 @@ contents:
           - title:      Kibana Guide
             prefix:     en/kibana
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklivemain
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -980,7 +980,7 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -992,11 +992,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches: [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
+                exclude_branches: [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
               -
                 repo:   kibana
                 # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
@@ -1018,7 +1018,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -1035,7 +1035,7 @@ contents:
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
@@ -1052,7 +1052,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklive
             chunk:      1
             tags:       App Search/Guide
@@ -1085,7 +1085,7 @@ contents:
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      client-docs/app-search-javascript/index.asciidoc
                 tags:       App Search Clients/JavaScript
@@ -1102,7 +1102,7 @@ contents:
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      client-docs/app-search-node/index.asciidoc
                 tags:       App Search Clients/Node.js
@@ -1132,7 +1132,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -1147,7 +1147,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1165,7 +1165,7 @@ contents:
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      client-docs/workplace-search-node/index.asciidoc
                 tags:       Workplace Search Clients/Node.js
@@ -1182,7 +1182,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklivemain
             index:      docs/en/observability/index.asciidoc
             chunk:      2
@@ -1214,7 +1214,7 @@ contents:
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ master, 8.0, 7.17, 7.16 ]
+                branches:   [ master, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 chunk:      2
                 tags:       APM Guide
@@ -1639,7 +1639,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklivemain
             index:      docs/index.asciidoc
             chunk:      1
@@ -1684,7 +1684,7 @@ contents:
           - title:      Logstash Reference
             prefix:     en/logstash
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklivemain
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -1700,7 +1700,7 @@ contents:
                 prefix: logstash-extra/x-pack-logstash
                 path:   docs/en
                 private: true
-                exclude_branches:   [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   logstash-docs
                 path:   docs/
@@ -1715,11 +1715,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ main, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
@@ -1743,7 +1743,7 @@ contents:
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklivemain
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
@@ -1794,7 +1794,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Libbeat/Reference
@@ -1819,7 +1819,7 @@ contents:
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Auditbeat/Reference
@@ -1872,7 +1872,7 @@ contents:
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Filebeat/Reference
@@ -1927,7 +1927,7 @@ contents:
             prefix:     en/beats/functionbeat
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Functionbeat/Reference
@@ -1976,7 +1976,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Heartbeat/Reference
@@ -2023,7 +2023,7 @@ contents:
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Metricbeat/Reference
@@ -2080,7 +2080,7 @@ contents:
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Packetbeat/Reference
@@ -2123,7 +2123,7 @@ contents:
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -2166,7 +2166,7 @@ contents:
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    main
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Devguide/Reference
@@ -2197,7 +2197,7 @@ contents:
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true

--- a/conf.yaml
+++ b/conf.yaml
@@ -613,8 +613,8 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    master
-                branches:   [ master, 8.1, 8.0 ]
-                live:       [ master, 8.1, 8.0 ]
+                branches:   [ master, 8.0 ]
+                live:       [ master, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust

--- a/conf.yaml
+++ b/conf.yaml
@@ -1131,7 +1131,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python

--- a/conf.yaml
+++ b/conf.yaml
@@ -1131,7 +1131,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python

--- a/conf.yaml
+++ b/conf.yaml
@@ -613,8 +613,8 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    master
-                branches:   [ master, 8.0 ]
-                live:       [ master, 8.0 ]
+                branches:   [ master, 8.1, 8.0 ]
+                live:       [ master, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -7,7 +7,7 @@ bare_version never includes -alpha or -beta
 :elasticsearch_version:  8.1.0
 :kibana_version:         8.1.0
 :apm_server_version:     8.1.0
-:branch:                 master
+:branch:                 8.1
 :minor-version:          8.1
 :major-version:          8.x
 :prev-major-version:     7.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.1.0
+:version:                8.2.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.1.0
-:logstash_version:       8.1.0
-:elasticsearch_version:  8.1.0
-:kibana_version:         8.1.0
-:apm_server_version:     8.1.0
+:bare_version:           8.2.0
+:logstash_version:       8.2.0
+:elasticsearch_version:  8.2.0
+:kibana_version:         8.2.0
+:apm_server_version:     8.2.0
 :branch:                 master
-:minor-version:          8.1
+:minor-version:          8.2
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17


### PR DESCRIPTION
* Creates a new `/stack/versions/8.1.asciidoc` file copied from `master.asciidoc`
* Updates `conf.yaml` to include the 8.1 branch