### PR TITLE
Update text for inline experimental admon

### DIFF
--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -32,7 +32,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     [
       [:beta, 'beta', BETA_DEFAULT_TEXT],
       [:dev, 'dev', DEV_DEFAULT_TEXT],
-      [:experimental, 'experimental', PREVIEW_DEFAULT_TEXT],
+      [:experimental, 'preview', PREVIEW_DEFAULT_TEXT],
       [:preview, 'preview', PREVIEW_DEFAULT_TEXT],
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -243,7 +243,7 @@ RSpec.describe CareAdmonition do
     include_examples 'care admonition'
   end
   context 'experimental' do
-    let(:key) { 'experimental' }
+    let(:key) { 'preview' }
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe ElasticCompatPreprocessor do
     context 'for experimental' do
       include_context 'care admonition'
       let(:name) { 'experimental' }
-      let(:inline_admon_class) { 'experimental' }
+      let(:inline_admon_class) { 'preview' }
     end
   end
 


### PR DESCRIPTION
Updates the old `experimental` admonition to use `preview` text when displayed inline.

Relates to https://github.com/elastic/docs/pull/2340

**Before**
<img width="330" alt="Screen Shot 2022-02-03 at 4 10 27 PM" src="https://user-images.githubusercontent.com/40268737/152429575-6f588d7d-3021-4b46-a9d3-eaf33370a94c.PNG">


**After**
<img width="347" alt="Screen Shot 2022-02-03 at 4 06 18 PM" src="https://user-images.githubusercontent.com/40268737/152429588-025de2f9-c6dd-4aa7-a3b4-3d10c43ac481.PNG">