### PR TITLE
Include the whole cloud/docs directory for ECE

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -854,7 +854,8 @@ contents:
             sources:
               -
                 repo:   cloud
-                path:   docs/cloud-enterprise
+                # Grab the entire docs/ directory to get `ece-version.asciidoc`
+                path:   docs
               -
                 repo:   cloud
                 path:   docs/shared
@@ -2770,4 +2771,3 @@ redirects:
     -
         prefix:         cn/elasticsearch
         redirect:       /cn
-


### PR DESCRIPTION
We need this in order to grab the ece-version.asciidoc file that's
included in that directory.
