### PR TITLE
Promote ECK 2.0 to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -919,7 +919,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    1.9
+            current:    2.0
             branches:   [ {main: master}, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Make the 2.0 branch the current one. To be merged on release day.