### PR TITLE
Support canonical links for section chunks

### DIFF
--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -132,6 +132,7 @@ module Chunker
       attrs['subdoc'] = true # Mark the subdoc so we don't try and chunk it
       attrs['noheader'] = true
       attrs['title-separator'] = ''
+      attrs['canonical-url'] = section.attributes['canonical-url']
       attrs.merge! find_related(section)
       attrs
     end

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -24,7 +24,7 @@ module Chunker
         link_rel('up', attributes['up_section']),
         link_rel('prev', attributes['prev_section']),
         link_rel('next', attributes['next_section']),
-        link_rel('canonical', attributes['canonical-url'])
+        link_rel('canonical', attributes['canonical-url']),
       ].compact.join "\n"
     end
 

--- a/resources/asciidoctor/lib/chunker/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/chunker/extra_docinfo.rb
@@ -24,17 +24,22 @@ module Chunker
         link_rel('up', attributes['up_section']),
         link_rel('prev', attributes['prev_section']),
         link_rel('next', attributes['next_section']),
+        link_rel('canonical', attributes['canonical-url'])
       ].compact.join "\n"
     end
 
     def link_rel(rel, related)
       return unless related
 
-      extra = related.context == :document ? related.attr('title-extra') : ''
-      title = "#{strip_tags(link_text(related))}#{extra}"
-      # We're in an attribute so escape quotes too!
-      title = title.gsub '"', '&quot;'
-      %(<link rel="#{rel}" #{link_href related} title="#{title}"/>)
+      if related.is_a?(String)
+        %(<link rel="#{rel}" href="#{related}"/>)
+      else
+        extra = related.context == :document ? related.attr('title-extra') : ''
+        title = "#{strip_tags(link_text(related))}#{extra}"
+        # We're in an attribute so escape quotes too!
+        title = title.gsub '"', '&quot;'
+        %(<link rel="#{rel}" #{link_href related} title="#{title}"/>)
+      end
     end
   end
 end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -529,6 +529,38 @@ RSpec.describe Chunker do
           end
         end
       end
+      context 'the section has a canonical link' do
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            [id="otd",canonical-url="bazbar"]
+            == Outdated
+
+            [[current]]
+            == Current
+
+            Words.
+          ASCIIDOC
+        end
+        file_context 'first subpage', 'otd.html' do
+          let(:next_title) { "Current" }
+          include_examples 'standard page', 'index', 'current'
+          it 'contains a <link rel="canonical" ...> header tag' do
+            expect(contents).to include <<~HTML
+              <link rel="canonical" href="bazbar"/>
+            HTML
+          end
+        end
+        file_context 'second subpage', 'current.html' do
+          let(:prev_title) { "Outdated" }
+          include_examples 'standard page', 'otd', nil
+          it 'does not contains a canonical header tag' do
+            expect(contents).not_to include "canonical"
+            expect(contents).not_to include "bazbar"
+          end
+        end
+      end
     end
     context 'when chunk level is 2' do
       let(:convert_attributes) do

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -544,7 +544,7 @@ RSpec.describe Chunker do
           ASCIIDOC
         end
         file_context 'first subpage', 'otd.html' do
-          let(:next_title) { "Current" }
+          let(:next_title) { 'Current' }
           include_examples 'standard page', 'index', 'current'
           it 'contains a <link rel="canonical" ...> header tag' do
             expect(contents).to include <<~HTML
@@ -553,11 +553,11 @@ RSpec.describe Chunker do
           end
         end
         file_context 'second subpage', 'current.html' do
-          let(:prev_title) { "Outdated" }
+          let(:prev_title) { 'Outdated' }
           include_examples 'standard page', 'otd', nil
           it 'does not contains a canonical header tag' do
-            expect(contents).not_to include "canonical"
-            expect(contents).not_to include "bazbar"
+            expect(contents).not_to include 'canonical'
+            expect(contents).not_to include 'bazbar'
           end
         end
       end


### PR DESCRIPTION
By adding a `canonical-url` attribute to a section, the chunked HTML
page for that section will contain a `<link rel="canonical" ...>` tag in
the page header. This tag does not get included in later chunks of the
same input document.

Fixes #2357

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
