### PR TITLE
Make ECS 8.0 the current release

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -253,7 +253,7 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    1.12
+            current:    8.0
             branches:   [  {main: master}, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.2, 8.1, 8.0, 1.12 ]
             index:      docs/index.asciidoc

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.2
+:ecs_version:            8.1
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
Do not merge. Please let the ECS team merge at release time.

Also correcting 8.1 platform docs to point to ECS 8.1.