### PR TITLE
Update ref-80 attribute value

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -1,6 +1,6 @@
 :ref:                  https://www.elastic.co/guide/en/elasticsearch/reference/{branch}
 :ref-bare:             https://www.elastic.co/guide/en/elasticsearch/reference
-:ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref-80:               https://www.elastic.co/guide/en/elasticsearch/reference/8.0
 :ref-7x:               https://www.elastic.co/guide/en/elasticsearch/reference/7.17
 :ref-70:               https://www.elastic.co/guide/en/elasticsearch/reference/7.0
 :ref-60:               https://www.elastic.co/guide/en/elasticsearch/reference/6.0


### PR DESCRIPTION
The ref-80 attribute value resolves to the "master" branch, whereas the name implies that it should resolve to the "8.0" branch

