### PR TITLE
Update ES clients to use `stackcurrent` and `stacklivemain` variables

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -485,7 +485,7 @@ contents:
             sections:
               - title:      Java Client
                 prefix:     java-api-client
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
@@ -507,7 +507,7 @@ contents:
                     path:   client
               - title:      JavaScript Client
                 prefix:     javascript-api
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
@@ -520,7 +520,7 @@ contents:
                     path:   docs/
               - title:      Ruby Client
                 prefix:     ruby-api
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/index.asciidoc
@@ -533,7 +533,7 @@ contents:
                     path:   docs/
               - title:      Go Client
                 prefix:     go-api
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      .doc/index.asciidoc
@@ -548,7 +548,7 @@ contents:
                 prefix:     net-api
                 # The elasticsearch-net repo only keeps .x branches. Do not
                 # bump these with the rest of the stack.
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16, 7.x ]
                 index:      docs/index.asciidoc
@@ -561,7 +561,7 @@ contents:
                     path:   docs/
               - title:      PHP Client
                 prefix:     php-api
-                current:    7.16
+                current:    8.0
                 # need to keep 7.x until all tooling is switched over to 7.16
                 branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       [ master, 8.1, 8.0, 7.17, 7.16, 7.x ]
@@ -591,7 +591,7 @@ contents:
                     path:   docs/
               - title:      Python Client
                 prefix:     python-api
-                current:    7.16
+                current:    8.0
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
                 live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
                 index:      docs/guide/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -485,9 +485,9 @@ contents:
             sections:
               - title:      Java Client
                 prefix:     java-api-client
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Java
@@ -507,9 +507,9 @@ contents:
                     path:   client
               - title:      JavaScript Client
                 prefix:     javascript-api
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/JavaScript
@@ -520,9 +520,9 @@ contents:
                     path:   docs/
               - title:      Ruby Client
                 prefix:     ruby-api
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Ruby
@@ -533,9 +533,9 @@ contents:
                     path:   docs/
               - title:      Go Client
                 prefix:     go-api
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 index:      .doc/index.asciidoc
                 chunk:      1
                 tags:       Clients/Go
@@ -546,11 +546,9 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                # The elasticsearch-net repo only keeps .x branches. Do not
-                # bump these with the rest of the stack.
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16, 7.x ]
+                live:       *stacklivemain
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -561,10 +559,9 @@ contents:
                     path:   docs/
               - title:      PHP Client
                 prefix:     php-api
-                current:    8.0
-                # need to keep 7.x until all tooling is switched over to 7.16
+                current:    *stackcurrent
                 branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       [ master, 8.1, 8.0, 7.17, 7.16, 7.x ]
+                live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP
@@ -591,9 +588,9 @@ contents:
                     path:   docs/
               - title:      Python Client
                 prefix:     python-api
-                current:    8.0
+                current:    *stackcurrent
                 branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
                 index:      docs/guide/index.asciidoc
                 chunk:     1
                 tags:       Clients/Python


### PR DESCRIPTION
Updates the following ES clients docs to use the `stackcurrent` and `stacklivemain` variables:

- Java
- JavaScript
- Ruby
- Go
- .NET
- PHP
- Python

This will bump the `current` branch for these docs to 8.0. It'll also ensure the clients stay synced with stack releases in the future.

This **does not** update the current version for the Perl or Rust clients.