### PR TITLE
ECE - change current to ECE 3.1.0

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -856,7 +856,7 @@ contents:
             subject:    ECE
             current:    ms-70
             branches:
-              - ms-70: 3.1.0
+              - ms-70: 3.1
               - ms-69: 3.0
               - ms-65: 2.13
               - ms-62: 2.12

--- a/conf.yaml
+++ b/conf.yaml
@@ -890,6 +890,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-70: master
                   ms-69: master
                   ms-65: master
                   ms-62: master

--- a/conf.yaml
+++ b/conf.yaml
@@ -81,6 +81,7 @@ variables:
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-70: master
     ms-69: master
     ms-65: master
     ms-62: master
@@ -853,8 +854,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-69
+            current:    ms-70
             branches:
+              - ms-70: 3.1.0
               - ms-69: 3.0
               - ms-65: 2.13
               - ms-62: 2.12


### PR DESCRIPTION
DO NOT MERGE BEFORE RELEASE DATE MARCH 8.

This PR changes `current` to 3.1.0.

Related to https://github.com/elastic/dev/issues/1929