### PR TITLE
Make 2.1 current ECK branch.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -944,7 +944,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.0
+            current:    2.1
             branches:   [ {main: master}, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Make the 2.1 branch the current one. To be merged on release day.