### PR TITLE
ESS - Change current to ms-71

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.1, 8.0, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-70
+  cloudSaasCurrent: &cloudSaasCurrent ms-71
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,82 +1,82 @@
 repos:
-  apm-aws-lambda: https://github.com/elastic/apm-aws-lambda.git
-  apm-server: https://github.com/elastic/apm-server.git
-  apm-agent-nodejs: https://github.com/elastic/apm-agent-nodejs.git
-  apm-agent-python: https://github.com/elastic/apm-agent-python.git
-  apm-agent-ruby: https://github.com/elastic/apm-agent-ruby.git
-  apm-agent-rum-js: https://github.com/elastic/apm-agent-rum-js.git
-  apm-agent-go: https://github.com/elastic/apm-agent-go.git
-  apm-agent-java: https://github.com/elastic/apm-agent-java.git
-  apm-agent-dotnet: https://github.com/elastic/apm-agent-dotnet.git
-  apm-agent-php: https://github.com/elastic/apm-agent-php.git
-  apm-agent-ios: https://github.com/elastic/apm-agent-ios.git
-  azure-marketplace: https://github.com/elastic/azure-marketplace.git
-  beats: https://github.com/elastic/beats.git
-  clients-team: https://github.com/elastic/clients-team.git
-  cloud: https://github.com/elastic/cloud.git
-  cloud-assets: https://github.com/elastic/cloud-assets.git
-  cloud-on-k8s: https://github.com/elastic/cloud-on-k8s.git
-  curator: https://github.com/elastic/curator.git
-  ecctl: https://github.com/elastic/ecctl.git
-  ecs: https://github.com/elastic/ecs.git
-  ecs-dotnet: https://github.com/elastic/ecs-dotnet.git
-  ecs-logging: https://github.com/elastic/ecs-logging.git
-  ecs-logging-go-logrus: https://github.com/elastic/ecs-logging-go-logrus.git
-  ecs-logging-go-zap: https://github.com/elastic/ecs-logging-go-zap.git
-  ecs-logging-java: https://github.com/elastic/ecs-logging-java.git
-  ecs-logging-nodejs: https://github.com/elastic/ecs-logging-nodejs.git
-  ecs-logging-php: https://github.com/elastic/ecs-logging-php.git
-  ecs-logging-python: https://github.com/elastic/ecs-logging-python.git
-  ecs-logging-ruby: https://github.com/elastic/ecs-logging-ruby.git
-  eland: https://github.com/elastic/eland.git
-  elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
-  elasticsearch-java: https://github.com/elastic/elasticsearch-java.git
-  elasticsearch-js: https://github.com/elastic/elasticsearch-js.git
-  elasticsearch-js-legacy: https://github.com/elastic/elasticsearch-js-legacy.git
-  elasticsearch-ruby: https://github.com/elastic/elasticsearch-ruby.git
-  elasticsearch-net: https://github.com/elastic/elasticsearch-net.git
-  elasticsearch-php: https://github.com/elastic/elasticsearch-php.git
-  elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
-  elasticsearch-py: https://github.com/elastic/elasticsearch-py.git
-  elasticsearch-perl: https://github.com/elastic/elasticsearch-perl.git
-  go-elasticsearch: https://github.com/elastic/go-elasticsearch.git
-  elasticsearch-rs: https://github.com/elastic/elasticsearch-rs.git
-  elasticsearch: https://github.com/elastic/elasticsearch.git
-  enterprise-search-pubs: https://github.com/elastic/enterprise-search-pubs.git
-  enterprise-search-php: https://github.com/elastic/enterprise-search-php.git
-  enterprise-search-python: https://github.com/elastic/enterprise-search-python.git
-  enterprise-search-ruby: https://github.com/elastic/enterprise-search-ruby.git
-  guide: https://github.com/elastic/elasticsearch-definitive-guide.git
-  guide-cn: https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
-  kibana: https://github.com/elastic/kibana.git
-  kibana-cn: https://github.com/elasticsearch-cn/kibana.git
-  logstash: https://github.com/elastic/logstash.git
-  logstash-docs: https://github.com/elastic/logstash-docs.git
-  observability-docs: https://github.com/elastic/observability-docs.git
-  package-spec: https://github.com/elastic/package-spec.git
-  security-docs: https://github.com/elastic/security-docs.git
-  sense: https://github.com/elastic/sense.git
-  stack-docs: https://github.com/elastic/stack-docs.git
-  swiftype: https://github.com/elastic/swiftype-doc-placeholder.git
-  tech-content: https://github.com/elastic/tech-content.git
-  terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
-  x-pack: https://github.com/elastic/x-pack.git
-  x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
-  x-pack-kibana: https://github.com/elastic/x-pack-kibana.git
-  x-pack-logstash: https://github.com/elastic/x-pack-logstash.git
+    apm-aws-lambda:       https://github.com/elastic/apm-aws-lambda.git
+    apm-server:           https://github.com/elastic/apm-server.git
+    apm-agent-nodejs:     https://github.com/elastic/apm-agent-nodejs.git
+    apm-agent-python:     https://github.com/elastic/apm-agent-python.git
+    apm-agent-ruby:       https://github.com/elastic/apm-agent-ruby.git
+    apm-agent-rum-js:     https://github.com/elastic/apm-agent-rum-js.git
+    apm-agent-go:         https://github.com/elastic/apm-agent-go.git
+    apm-agent-java:       https://github.com/elastic/apm-agent-java.git
+    apm-agent-dotnet:     https://github.com/elastic/apm-agent-dotnet.git
+    apm-agent-php:        https://github.com/elastic/apm-agent-php.git
+    apm-agent-ios:        https://github.com/elastic/apm-agent-ios.git
+    azure-marketplace:    https://github.com/elastic/azure-marketplace.git
+    beats:                https://github.com/elastic/beats.git
+    clients-team:         https://github.com/elastic/clients-team.git
+    cloud:                https://github.com/elastic/cloud.git
+    cloud-assets:         https://github.com/elastic/cloud-assets.git
+    cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
+    curator:              https://github.com/elastic/curator.git
+    ecctl:                https://github.com/elastic/ecctl.git
+    ecs:                  https://github.com/elastic/ecs.git
+    ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
+    ecs-logging:          https://github.com/elastic/ecs-logging.git
+    ecs-logging-go-logrus:  https://github.com/elastic/ecs-logging-go-logrus.git
+    ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
+    ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
+    ecs-logging-nodejs:   https://github.com/elastic/ecs-logging-nodejs.git
+    ecs-logging-php:      https://github.com/elastic/ecs-logging-php.git
+    ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
+    ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
+    eland:                https://github.com/elastic/eland.git
+    elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
+    elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
+    elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
+    elasticsearch-js-legacy:  https://github.com/elastic/elasticsearch-js-legacy.git
+    elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
+    elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
+    elasticsearch-php:    https://github.com/elastic/elasticsearch-php.git
+    elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
+    elasticsearch-py:     https://github.com/elastic/elasticsearch-py.git
+    elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl.git
+    go-elasticsearch:     https://github.com/elastic/go-elasticsearch.git
+    elasticsearch-rs:     https://github.com/elastic/elasticsearch-rs.git
+    elasticsearch:        https://github.com/elastic/elasticsearch.git
+    enterprise-search-pubs: https://github.com/elastic/enterprise-search-pubs.git
+    enterprise-search-php: https://github.com/elastic/enterprise-search-php.git
+    enterprise-search-python: https://github.com/elastic/enterprise-search-python.git
+    enterprise-search-ruby: https://github.com/elastic/enterprise-search-ruby.git
+    guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
+    guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
+    kibana:               https://github.com/elastic/kibana.git
+    kibana-cn:            https://github.com/elasticsearch-cn/kibana.git
+    logstash:             https://github.com/elastic/logstash.git
+    logstash-docs:        https://github.com/elastic/logstash-docs.git
+    observability-docs:   https://github.com/elastic/observability-docs.git
+    package-spec:         https://github.com/elastic/package-spec.git
+    security-docs:        https://github.com/elastic/security-docs.git
+    sense:                https://github.com/elastic/sense.git
+    stack-docs:           https://github.com/elastic/stack-docs.git
+    swiftype:             https://github.com/elastic/swiftype-doc-placeholder.git
+    tech-content:         https://github.com/elastic/tech-content.git
+    terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
+    x-pack:               https://github.com/elastic/x-pack.git
+    x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
+    x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
+    x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
 
-contents_title: Elastic Stack and Product Documentation
+contents_title:     Elastic Stack and Product Documentation
 
 # Each item should take the form:
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 8.0
-  stacklive: &stacklive [master, 8.1, 8.0, 7.17]
+  stacklive: &stacklive [ master, 8.1, 8.0, 7.17 ]
 
-  stacklivemain: &stacklivemain [main, 8.1, 8.0, 7.17]
+  stacklivemain: &stacklivemain [ main, 8.1, 8.0, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-71
+  cloudSaasCurrent: &cloudSaasCurrent ms-70
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
@@ -107,5667 +107,2692 @@ variables:
   mapMasterToMain: &mapMasterToMain
     master: main
 
-  beatsSharedExclude:
-    &beatsSharedExclude [
-      6.2,
-      6.1,
-      6.0,
-      5.6,
-      5.5,
-      5.4,
-      5.3,
-      5.2,
-      5.1,
-      5.0,
-      1.3,
-      1.2,
-      1.1,
-      1.0.1,
-    ]
-  beatsXpackLibbeatExclude:
-    &beatsXpackLibbeatExclude [
-      7.3,
-      7.2,
-      7.1,
-      7.0,
-      6.8,
-      6.7,
-      6.6,
-      6.5,
-      6.4,
-      6.3,
-      6.2,
-      6.1,
-      6.0,
-      5.6,
-      5.5,
-      5.4,
-      5.3,
-      5.2,
-      5.1,
-      5.0,
-      1.3,
-      1.2,
-      1.1,
-      1.0.1,
-    ]
-  beatsProcessorExclude:
-    &beatsProcessorExclude [
-      7.4,
-      7.3,
-      7.2,
-      7.1,
-      7.0,
-      6.8,
-      6.7,
-      6.6,
-      6.5,
-      6.4,
-      6.3,
-      6.2,
-      6.1,
-      6.0,
-      5.6,
-      5.5,
-      5.4,
-      5.3,
-      5.2,
-      5.1,
-      5.0,
-      1.3,
-      1.2,
-      1.1,
-      1.0.1,
-    ]
-  beatsOutputExclude:
-    &beatsOutputExclude [
-      7.4,
-      7.3,
-      7.2,
-      7.1,
-      7.0,
-      6.8,
-      6.7,
-      6.6,
-      6.5,
-      6.4,
-      6.3,
-      6.2,
-      6.1,
-      6.0,
-      5.6,
-      5.5,
-      5.4,
-      5.3,
-      5.2,
-      5.1,
-      5.0,
-      1.3,
-      1.2,
-      1.1,
-      1.0.1,
-    ]
+  beatsSharedExclude: &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsXpackLibbeatExclude: &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsProcessorExclude: &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+  beatsOutputExclude: &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+
 
 toc_extra: extra/docs_landing.html
 contents:
-  - title: Elastic Documentation
-    sections:
-      - title: "Welcome to Elastic"
-        prefix: en/welcome-to-elastic
-        current: main
-        index: welcome-to-elastic/index.asciidoc
-        branches: [{ main: master }]
-        chunk: 1
-        tags: Elastic/Welcome
-        subject: Welcome to Elastic
-        sources:
-          - repo: tech-content
-            path: welcome-to-elastic
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-
-  - title: Elastic Stack
-    sections:
-      - title: Installation and Upgrade Guide
-        prefix: en/elastic-stack
-        current: *stackcurrent
-        index: docs/en/install-upgrade/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Elastic Stack/Installation and Upgrade
-        subject: Elastic Stack
-        sources:
-          - repo: stack-docs
-            path: docs/en
-          - repo: apm-server
-            path: docs/
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: beats
-            path: libbeat/docs
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: elasticsearch
-            path: docs/
-            map_branches: *mapMainToMaster
-          - repo: elasticsearch-hadoop
-            path: docs/src/reference/asciidoc
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-            map_branches: *mapMainToMaster
-          - repo: security-docs
-            path: docs/
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: kibana
-            path: docs/
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: logstash
-            path: docs/
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: observability-docs
-            path: docs/en/observability
-            exclude_branches:
-              [
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
-            map_branches: *mapMainToMaster
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
-          - repo: docs
-            path: shared/attributes62.asciidoc
-            exclude_branches:
-              [
-                main,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-      - title: Getting Started
-        prefix: en/elastic-stack-get-started
-        current: *stackcurrent
-        index: docs/en/getting-started/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Elastic Stack/Getting started
-        subject: Elastic Stack
-        sources:
-          - repo: stack-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: elasticsearch
-            path: docs/
-            map_branches: *mapMainToMaster
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-              ]
-      - title: Glossary
-        prefix: en/elastic-stack-glossary
-        current: main
-        index: docs/en/glossary/index.asciidoc
-        branches: [{ main: master }]
-        tags: Elastic Stack/Glossary
-        subject: Elastic Stack
-        sources:
-          - repo: stack-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Machine Learning
-        prefix: en/machine-learning
-        current: *stackcurrent
-        index: docs/en/stack/ml/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Elastic Stack/Machine Learning
-        subject: Machine Learning
-        sources:
-          - repo: stack-docs
-            path: docs/en/stack
-          - repo: elasticsearch
-            path: docs
-            map_branches: *mapMainToMaster
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: docs
-            path: shared/settings.asciidoc
-      - title: Elastic Common Schema (ECS) Reference
-        prefix: en/ecs
-        current: 8.0
-        branches:
-          [
-            { main: master },
-            8.2,
-            8.1,
-            8.0,
-            1.12,
-            1.11,
-            1.10,
-            1.9,
-            1.8,
-            1.7,
-            1.6,
-            1.5,
-            1.4,
-            1.3,
-            1.2,
-            1.1,
-            1.0,
-          ]
-        live: [main, 8.2, 8.1, 8.0, 1.12]
-        index: docs/index.asciidoc
-        chunk: 2
-        tags: Elastic Common Schema (ECS)/Reference
-        subject: Elastic Common Schema (ECS)
-        sources:
-          - repo: ecs
-            path: docs/
-      - title: Azure Marketplace and Resource Manager (ARM) template
-        prefix: en/elastic-stack-deploy
-        current: 7.11
-        index: docs/index.asciidoc
-        branches:
-          [
-            master,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-          ]
-        chunk: 1
-        tags: Elastic Stack/Azure
-        subject: Azure Marketplace and Resource Manager (ARM) template
-        sources:
-          - repo: azure-marketplace
-            path: docs
-
-  - title: "Elasticsearch: Store, Search, and Analyze"
-    sections:
-      - title: Elasticsearch Guide
-        prefix: en/elasticsearch/reference
-        current: *stackcurrent
-        branches:
-          [
-            master,
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            2.4,
-            2.3,
-            2.2,
-            2.1,
-            2.0,
-            1.7,
-            1.6,
-            1.5,
-            1.4,
-            1.3,
-            0.90,
-          ]
-        live: *stacklive
-        index: docs/reference/index.x.asciidoc
-        chunk: 1
-        tags: Elasticsearch/Reference
-        subject: Elasticsearch
-        sources:
-          - repo: elasticsearch
-            path: docs/reference
-          - repo: x-pack-elasticsearch
-            prefix: elasticsearch-extra/x-pack-elasticsearch
-            path: docs/en
-            private: true
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: x-pack-elasticsearch
-            prefix: elasticsearch-extra/x-pack-elasticsearch
-            path: qa/sql
-            private: true
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: docs/Versions.asciidoc
-            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-          - repo: elasticsearch
-            path: docs/src/test/cluster/config
-            exclude_branches:
-              [5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-          - repo: elasticsearch
-            path: plugins/examples
-            exclude_branches:
-              [
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: buildSrc/
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: build-tools-internal/
-            exclude_branches:
-              [
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: docs/painless
-            exclude_branches:
-              [
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: x-pack/docs
-            private: true
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: x-pack/qa/sql
-            # only exists from 6.3 to 6.5
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: x-pack/plugin/sql/qa
-            exclude_branches:
-              [
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - alternatives: { source_lang: console, alternative_lang: php }
-            repo: elasticsearch-php
-            path: docs/examples
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - alternatives: { source_lang: console, alternative_lang: csharp }
-            repo: elasticsearch-net
-            path: examples
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            map_branches: *mapMasterToMain
-          - alternatives: { source_lang: console, alternative_lang: python }
-            repo: elasticsearch-py
-            path: docs/examples
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            map_branches: *mapMasterToMain
-          - alternatives: { source_lang: console, alternative_lang: ruby }
-            repo: elasticsearch-ruby
-            path: docs/examples/guide
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            map_branches: *mapMasterToMain
-          - alternatives: { source_lang: console, alternative_lang: go }
-            repo: go-elasticsearch
-            path: .doc/examples/doc/
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            map_branches: *mapMasterToMain
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/attributes62.asciidoc
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - alternatives: { source_lang: console, alternative_lang: js }
-            repo: elasticsearch-js
-            path: docs/doc_examples
-            exclude_branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            map_branches: *mapMasterToMain
-      - title: Elasticsearch Resiliency Status
-        prefix: en/elasticsearch/resiliency
-        toc: 1
-        branches: [master]
-        current: master
-        index: docs/resiliency/index.asciidoc
-        single: 1
-        tags: Elasticsearch/Resiliency Status
-        subject: Elasticsearch
-        sources:
-          - repo: elasticsearch
-            path: docs/resiliency
-          - repo: elasticsearch
-            path: docs/Versions.asciidoc
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-      - title: Painless Scripting Language
-        prefix: en/elasticsearch/painless
-        current: *stackcurrent
-        branches:
-          [
-            master,
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-          ]
-        live: *stacklive
-        index: docs/painless/index.asciidoc
-        chunk: 1
-        tags: Elasticsearch/Painless
-        subject: Elasticsearch
-        sources:
-          - repo: elasticsearch
-            path: docs/painless
-          - repo: elasticsearch
-            path: docs/Versions.asciidoc
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-      - title: Plugins and Integrations
-        prefix: en/elasticsearch/plugins
-        repo: elasticsearch
-        current: *stackcurrent
-        index: docs/plugins/index.asciidoc
-        branches:
-          [
-            master,
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            2.4,
-            2.3,
-            2.2,
-            2.1,
-            2.0,
-            1.7,
-          ]
-        live: *stacklive
-        chunk: 2
-        tags: Elasticsearch/Plugins
-        subject: Elasticsearch
-        sources:
-          - repo: elasticsearch
-            path: docs/plugins
-          - repo: elasticsearch
-            path: docs/Versions.asciidoc
-            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-          - repo: elasticsearch
-            path: buildSrc/src/main/resources/
-            exclude_branches:
-              [
-                master,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: build-tools-internal/src/main/resources/
-            exclude_branches:
-              [
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: elasticsearch
-            path: build-tools/src/main/resources/
-            exclude_branches:
-              [
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-      - title: Elasticsearch Clients
-        base_dir: en/elasticsearch/client
+    -   title: Elastic Documentation
         sections:
-          - title: Java Client
-            prefix: java-api-client
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklivemain
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/Java
-            subject: Clients
+          - title:      "Welcome to Elastic"
+            prefix:     en/welcome-to-elastic
+            current:    main
+            index:      welcome-to-elastic/index.asciidoc
+            branches:   [ {main: master} ]
+            chunk:      1
+            tags:       Elastic/Welcome
+            subject:    Welcome to Elastic
             sources:
-              - repo: elasticsearch-java
-                path: docs/
-              - repo: elasticsearch-java
-                path: java-client/src/test/java/co/elastic/clients/documentation
-              - repo: elasticsearch
-                path: docs/java-rest/
-              - repo: elasticsearch
-                path: client
-          - title: JavaScript Client
-            prefix: javascript-api
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x]
-            live: *stacklivemain
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/JavaScript
-            subject: Clients
-            sources:
-              - repo: elasticsearch-js
-                path: docs/
-          - title: Ruby Client
-            prefix: ruby-api
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklivemain
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/Ruby
-            subject: Clients
-            sources:
-              - repo: elasticsearch-ruby
-                path: docs/
-          - title: Go Client
-            prefix: go-api
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklivemain
-            index: .doc/index.asciidoc
-            chunk: 1
-            tags: Clients/Go
-            subject: Clients
-            sources:
-              - repo: go-elasticsearch
-                path: .doc/
-          - title: .NET Clients
-            prefix: net-api
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x]
-            live: *stacklivemain
-            index: docs/index.asciidoc
-            tags: Clients/.Net
-            subject: Clients
-            chunk: 1
-            sources:
-              - repo: elasticsearch-net
-                path: docs/
-          - title: PHP Client
-            prefix: php-api
-            current: *stackcurrent
-            branches: [master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4]
-            live: *stacklivemain
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/PHP
-            subject: Clients
-            sources:
-              - repo: elasticsearch-php
-                path: docs/
-              - repo: docs
-                path: shared/attributes.asciidoc
-          - title: Perl Client
-            prefix: perl-api
-            current: master
-            branches: [master, 8.1, 8.0]
-            live: [master, 8.1, 8.0]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/Perl
-            subject: Clients
-            sources:
-              - repo: elasticsearch-perl
-                path: docs/
-          - title: Python Client
-            prefix: python-api
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklivemain
-            index: docs/guide/index.asciidoc
-            chunk: 1
-            tags: Clients/Python
-            subject: Clients
-            sources:
-              - repo: elasticsearch-py
-                path: docs/guide/
-          - title: eland
-            prefix: eland
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/guide/index.asciidoc
-            chunk: 1
-            tags: Clients/eland
-            subject: Clients
-            sources:
-              - repo: eland
-                path: docs/guide
-          - title: Rust Client
-            prefix: rust-api
-            current: master
-            branches: [master, 8.1, 8.0]
-            live: [master, 8.1, 8.0]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: Clients/Rust
-            subject: Clients
-            sources:
-              - repo: elasticsearch-rs
-                path: docs/
-          - title: Java REST Client (deprecated)
-            prefix: java-rest
-            current: 7.17
-            branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-            live: [7.17, 6.8]
-            index: docs/java-rest/index.asciidoc
-            tags: Clients/JavaREST
-            subject: Clients
-            chunk: 1
-            sources:
-              - repo: elasticsearch
-                path: docs/java-rest
-              - repo: elasticsearch
-                path: docs/Versions.asciidoc
-              - repo: elasticsearch
-                path: client
-                exclude_branches: [5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-                exclude_branches:
-                  [
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: docs
-                path: shared/attributes.asciidoc
-                exclude_branches:
-                  [
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-          - title: Java Transport Client (deprecated)
-            prefix: java-api
-            current: 7.17
-            branches:
-              [
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.7,
-                1.6,
-                1.5,
-                1.4,
-                1.3,
-                0.90,
-              ]
-            live: [7.17, 6.8]
-            index: docs/java-api/index.asciidoc
-            tags: Clients/Java
-            subject: Clients
-            chunk: 1
-            sources:
-              - repo: elasticsearch
-                path: docs/java-api
-              - repo: elasticsearch
-                path: docs/Versions.asciidoc
-                exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-              - repo: elasticsearch
-                path: client/rest-high-level/src/test/java/org/elasticsearch/client
-                exclude_branches:
-                  [
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
+              -
+                repo:   tech-content
+                path:   welcome-to-elastic
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
 
-              - repo: elasticsearch
-                path: server/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                exclude_branches:
-                  [
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: elasticsearch
-                path: server/src/test/java/org/elasticsearch/client/documentation
-                exclude_branches:
-                  [
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: elasticsearch
-                path: modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                exclude_branches:
-                  [
-                    7.9,
-                    7.8,
-                    7.7,
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: elasticsearch
-                path: modules/reindex/src/test/java/org/elasticsearch/client/documentation
-                exclude_branches:
-                  [
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-                exclude_branches:
-                  [
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-              - repo: docs
-                path: shared/attributes.asciidoc
-                exclude_branches:
-                  [
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                    2.4,
-                    2.3,
-                    2.2,
-                    2.1,
-                    2.0,
-                    1.7,
-                    1.6,
-                    1.5,
-                    1.4,
-                    1.3,
-                    0.90,
-                  ]
-
-          - title: Community Contributed Clients
-            prefix: community
-            branches: [master]
-            current: master
-            index: docs/community-clients/index.asciidoc
-            single: 1
-            tags: Clients/Community
-            subject: Clients
-            sources:
-              - repo: elasticsearch
-                path: docs/community-clients
-      - title: Elasticsearch for Apache Hadoop and Spark
-        prefix: en/elasticsearch/hadoop
-        current: *stackcurrent
-        branches:
-          [
-            master,
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            2.4,
-            2.3,
-            2.2,
-            2.1,
-            2.0,
-          ]
-        live: *stacklive
-        index: docs/src/reference/asciidoc/index.adoc
-        tags: Elasticsearch/Apache Hadoop
-        subject: Elasticsearch
-        sources:
-          - repo: elasticsearch-hadoop
-            path: docs/src/reference/asciidoc
-      - title: Curator Index Management
-        prefix: en/elasticsearch/client/curator
-        current: 5.8
-        branches:
-          [
-            5.x,
-            5.8,
-            5.7,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            4.3,
-            4.2,
-            4.1,
-            4.0,
-            3.5,
-            3.4,
-            3.3,
-          ]
-        index: docs/asciidoc/index.asciidoc
-        tags: Clients/Curator
-        subject: Clients
-        sources:
-          - repo: curator
-            path: docs/asciidoc
-
-  - title: "Cloud: Provision, Manage and Monitor the Elastic Stack"
-    sections:
-      - title: Elasticsearch Service - Hosted Elastic Stack
-        prefix: en/cloud
-        tags: Cloud/Reference
-        subject: Elastic Cloud
-        current: *cloudSaasCurrent
-        branches: [{ *cloudSaasCurrent : latest }]
-        index: docs/saas/index.asciidoc
-        chunk: 1
-        private: 1
-        sources:
-          - repo: cloud
-            path: docs/saas
-          - repo: cloud
-            path: docs/shared
-          - alternatives: { source_lang: console, alternative_lang: php }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/php
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: go }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/go
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: ruby }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/ruby
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: java }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/java
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: javascript }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/javascript
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: python }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/python
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: csharp }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/csharp
-            map_branches: *mapCloudSaasToClientsTeam
-      - title:
-          Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku
-          Users
-        prefix: en/cloud-heroku
-        tags: Cloud-Heroku/Reference
-        subject: Elasticsearch Add-On for Heroku
-        current: *cloudSaasCurrent
-        branches: [{ *cloudSaasCurrent : latest }]
-        index: docs/heroku/index.asciidoc
-        chunk: 1
-        noindex: 1
-        private: 1
-        sources:
-          - repo: cloud
-            path: docs/saas
-          - repo: cloud
-            path: docs/shared
-          - repo: cloud
-            path: docs/heroku
-          - alternatives: { source_lang: console, alternative_lang: php }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/php
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: go }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/go
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: ruby }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/ruby
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: java }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/java
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: javascript }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/javascript
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: python }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/python
-            map_branches: *mapCloudSaasToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: csharp }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/csharp
-            map_branches: *mapCloudSaasToClientsTeam
-      - title: Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
-        prefix: en/cloud-enterprise
-        tags: CloudEnterprise/Reference
-        subject: ECE
-        current: ms-69
-        branches:
-          - ms-69: 3.0
-          - ms-65: 2.13
-          - ms-62: 2.12
-          - ms-59: 2.11
-          - ms-57: 2.10
-          - ms-53: 2.9
-          - ms-49: 2.8
-          - ms-47: 2.7
-          - release-ms-41: 2.6
-          - 2.5
-          - 2.4
-          - 2.3
-          - 2.2
-          - 2.1
-          - 2.0
-          - 1.1
-          - 1.0
-        index: docs/cloud-enterprise/index.asciidoc
-        chunk: 2
-        private: 1
-        sources:
-          - repo: cloud
-            # Grab the entire docs/ directory to get `ece-version.asciidoc`
-            path: docs
-          - repo: cloud
-            path: docs/shared
-            exclude_branches: [1.0]
-          - repo: cloud-assets
-            path: docs
-            map_branches:
-              ms-69: master
-              ms-65: master
-              ms-62: master
-              ms-59: master
-              ms-57: master
-              ms-53: master
-              ms-49: master
-              ms-47: master
-              release-ms-41: master
-              2.5: master
-              2.4: master
-              2.3: master
-              2.2: master
-              2.1: master
-              2.0: master
-              1.1: master
-              1.0: master
-          - alternatives: { source_lang: console, alternative_lang: php }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/php
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: go }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/go
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: ruby }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/ruby
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: java }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/java
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: javascript }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/javascript
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: python }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/python
-            map_branches: *mapCloudEceToClientsTeam
-          - alternatives: { source_lang: console, alternative_lang: csharp }
-            repo: clients-team
-            path: docs/examples/elastic-cloud/csharp
-            map_branches: *mapCloudEceToClientsTeam
-      - title: Elastic Cloud on Kubernetes
-        prefix: en/cloud-on-k8s
-        tags: Kubernetes/Reference
-        subject: ECK
-        current: 2.0
-        branches:
-          [
-            { main: master },
-            2.0,
-            1.9,
-            1.8,
-            1.7,
-            1.6,
-            1.5,
-            1.4,
-            1.3,
-            1.2,
-            1.1,
-            1.0,
-            1.0-beta,
-            0.9,
-            0.8,
-          ]
-        index: docs/index.asciidoc
-        chunk: 1
-        sources:
-          - repo: cloud-on-k8s
-            path: docs/
-          - repo: docs
-            path: shared/versions/stack/current.asciidoc
-            exclude_branches: [0.9, 0.8]
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title:
-          Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and
-          ECE
-        prefix: en/ecctl
-        tags: CloudControl/Reference
-        subject: ECCTL
-        current: 1.8
-        branches: [master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0]
-        index: docs/index.asciidoc
-        chunk: 1
-        sources:
-          - repo: ecctl
-            path: docs/
-      - title: Elastic Cloud Terraform Provider
-        prefix: en/tpec
-        tags: CloudTerraform/Reference
-        subject: TPEC
-        current: 0.2
-        branches: [master, 0.2, 0.1]
-        index: docs-elastic/index.asciidoc
-        single: 1
-        chunk: 1
-        sources:
-          - repo: terraform-provider-ec
-            path: docs-elastic/
-
-  - title: "Kibana: Explore, Visualize, and Share"
-    sections:
-      - title: Kibana Guide
-        prefix: en/kibana
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            4.6,
-            4.5,
-            4.4,
-            4.3,
-            4.2,
-            4.1,
-            4.0,
-            3.0,
-          ]
-        live: *stacklivemain
-        index: docs/index.x.asciidoc
-        chunk: 1
-        tags: Kibana/Reference
-        subject: Kibana
-        toc_extra: extra/kibana_landing.html
-        sources:
-          - repo: kibana
-            path: docs/
-          - repo: x-pack-kibana
-            prefix: kibana-extra/x-pack-kibana
-            path: docs/en
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-          - repo: docs
-            path: shared/attributes62.asciidoc
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                3.0,
-              ]
-          - repo: kibana
-            # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
-            path: ":(glob)examples/**/*.asciidoc"
-            exclude_branches:
-              [
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-          - repo: kibana
-            path: ":(glob)src/**/*.asciidoc"
-            exclude_branches:
-              [
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-          - repo: kibana
-            path: ":(glob)x-pack/**/*.asciidoc"
-            exclude_branches:
-              [
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                4.6,
-                4.5,
-                4.4,
-                4.3,
-                4.2,
-                4.1,
-                4.0,
-                3.0,
-              ]
-
-  - title: Enterprise Search
-    sections:
-      - title: Enterprise Search Guide
-        prefix: en/enterprise-search
-        index: enterprise-search-docs/index.asciidoc
-        private: 1
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-          ]
-        live: *stacklive
-        chunk: 1
-        tags: Enterprise Search/Guide
-        subject: Enterprise Search
-        sources:
-          - repo: enterprise-search-pubs
-            path: enterprise-search-docs
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-      - title: Workplace Search Guide
-        prefix: en/workplace-search
-        index: workplace-search-docs/index.asciidoc
-        private: 1
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-          ]
-        live: *stacklive
-        chunk: 1
-        tags: Workplace Search/Guide
-        subject: Workplace Search
-        sources:
-          - repo: enterprise-search-pubs
-            path: workplace-search-docs
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-      - title: App Search Guide
-        prefix: en/app-search
-        index: app-search-docs/index.asciidoc
-        private: 1
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-          ]
-        live: *stacklive
-        chunk: 1
-        tags: App Search/Guide
-        subject: App Search
-        sources:
-          - repo: enterprise-search-pubs
-            path: app-search-docs
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-      - title: Site Search Reference
-        prefix: en/swiftype/sitesearch
-        index: docs/sitesearch/index.asciidoc
-        private: 1
-        current: master
-        branches: [master]
-        single: 1
-        tags: Site Search/Reference
-        subject: Swiftype
-        sources:
-          - repo: swiftype
-            path: docs
-      - title: Enterprise Search Clients
-        base_dir: en/enterprise-search-clients
+    -   title:      Elastic Stack
         sections:
-          - title: App Search JavaScript client
-            prefix: app-search-javascript
-            private: 1
-            single: 1
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklive
-            index: client-docs/app-search-javascript/index.asciidoc
-            tags: App Search Clients/JavaScript
-            subject: App Search Clients
+          - title:      Installation and Upgrade Guide
+            prefix:     en/elastic-stack
+            current:    *stackcurrent
+            index:      docs/en/install-upgrade/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Elastic Stack/Installation and Upgrade
+            subject:    Elastic Stack
             sources:
-              - repo: enterprise-search-pubs
-                path: client-docs/app-search-javascript
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-          - title: App Search Node.js client
-            prefix: app-search-node
-            private: 1
-            single: 1
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklive
-            index: client-docs/app-search-node/index.asciidoc
-            tags: App Search Clients/Node.js
-            subject: App Search Clients
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   apm-server
+                path:   docs/
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   beats
+                path:   libbeat/docs
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   elasticsearch
+                path:   docs/
+                map_branches: *mapMainToMaster
+              -
+                repo:   elasticsearch-hadoop
+                path:   docs/src/reference/asciidoc
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
+              -
+                repo:   security-docs
+                path:   docs/
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   kibana
+                path:   docs/
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   logstash
+                path:   docs/
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   observability-docs
+                path:   docs/en/observability
+                exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMainToMaster
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ main, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+          - title:      Getting Started
+            prefix:     en/elastic-stack-get-started
+            current:    *stackcurrent
+            index:      docs/en/getting-started/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Elastic Stack/Getting started
+            subject:    Elastic Stack
             sources:
-              - repo: enterprise-search-pubs
-                path: client-docs/app-search-node
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-          - title: Enterprise Search PHP client
-            prefix: php
-            current: 7.16
-            branches: [7.16]
-            live: [7.16]
-            index: docs/guide/index.asciidoc
-            tags: Enterprise Search Clients/PHP
-            subject: Enterprise Search Clients
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   elasticsearch
+                path:   docs/
+                map_branches: *mapMainToMaster
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+          - title:      Glossary
+            prefix:     en/elastic-stack-glossary
+            current:    main
+            index:      docs/en/glossary/index.asciidoc
+            branches:   [ {main: master} ]
+            tags:       Elastic Stack/Glossary
+            subject:    Elastic Stack
             sources:
-              - repo: enterprise-search-php
-                path: docs/guide/
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-          - title: Enterprise Search Python client
-            prefix: python
-            current: *stackcurrent
-            branches:
-              [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11]
-            live: *stacklive
-            index: docs/guide/index.asciidoc
-            tags: Enterprise Search Clients/Python
-            subject: Enterprise Search Clients
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Machine Learning
+            prefix:     en/machine-learning
+            current:    *stackcurrent
+            index:      docs/en/stack/ml/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Elastic Stack/Machine Learning
+            subject:    Machine Learning
             sources:
-              - repo: enterprise-search-python
-                path: docs/guide/
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-          - title: Enterprise Search Ruby client
-            prefix: ruby
-            current: *stackcurrent
-            branches:
-              [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11]
-            live: *stacklive
-            index: docs/guide/index.asciidoc
-            tags: Enterprise Search Clients/Ruby
-            subject: Enterprise Search Clients
+              -
+                repo:   stack-docs
+                path:   docs/en/stack
+              -
+                repo:   elasticsearch
+                path:   docs
+                map_branches: *mapMainToMaster
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
+          - title:      Elastic Common Schema (ECS) Reference
+            prefix:     en/ecs
+            current:    8.0
+            branches:   [  {main: master}, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.2, 8.1, 8.0, 1.12 ]
+            index:      docs/index.asciidoc
+            chunk:      2
+            tags:       Elastic Common Schema (ECS)/Reference
+            subject:    Elastic Common Schema (ECS)
             sources:
-              - repo: enterprise-search-ruby
-                path: docs/guide/
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
+              -
+                repo:   ecs
+                path:   docs/
+          - title:      Azure Marketplace and Resource Manager (ARM) template
+            prefix:     en/elastic-stack-deploy
+            current:    7.11
+            index:      docs/index.asciidoc
+            branches:   [ master, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            chunk:      1
+            tags:       Elastic Stack/Azure
+            subject:    Azure Marketplace and Resource Manager (ARM) template
+            sources:
+              -
+                repo:   azure-marketplace
+                path:   docs
 
-          - title: Workplace Search Node.js client
-            prefix: workplace-search-node
-            private: 1
-            single: 1
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklive
-            index: client-docs/workplace-search-node/index.asciidoc
-            tags: Workplace Search Clients/Node.js
-            subject: Workplace Search Clients
-            sources:
-              - repo: enterprise-search-pubs
-                path: client-docs/workplace-search-node
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-  - title: "Observability: APM, Logs, Metrics, and Uptime"
-    sections:
-      - title: Observability
-        prefix: en/observability
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-          ]
-        live: *stacklivemain
-        index: docs/en/observability/index.asciidoc
-        chunk: 2
-        tags: Observability/Guide
-        subject: Observability
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: apm-server
-            path: docs
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: beats
-            path: libbeat/docs
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Application Performance Monitoring (APM)
-        base_dir: en/apm
+    -   title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
-          - title: APM Guide
-            prefix: guide
-            index: docs/integrations-index.asciidoc
-            current: *stackcurrent
-            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
-            live: *stacklivemain
-            chunk: 2
-            tags: APM Guide
-            subject: APM
+          - title:      Elasticsearch Guide
+            prefix:     en/elasticsearch/reference
+            current:    *stackcurrent
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            live:       *stacklive
+            index:      docs/reference/index.x.asciidoc
+            chunk:      1
+            tags:       Elasticsearch/Reference
+            subject:    Elasticsearch
             sources:
-              - repo: apm-server
-                path: changelogs
-                exclude_branches: [6.0]
-              - repo: apm-server
-                path: docs
-              - repo: apm-server
-                path: CHANGELOG.asciidoc
-              - repo: observability-docs
-                path: docs/en
-                exclude_branches:
-                  [
-                    7.15,
-                    7.14,
-                    7.13,
-                    7.12,
-                    7.11,
-                    7.10,
-                    7.9,
-                    7.8,
-                    7.7,
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                  ]
+              -
+                repo:   elasticsearch
+                path:   docs/reference
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   docs/en
+                private: true
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   qa/sql
+                private: true
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   docs/src/test/cluster/config
+                exclude_branches:   [ 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   plugins/examples
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   buildSrc/
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   build-tools-internal/
+                exclude_branches:   [7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   docs/painless
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   x-pack/docs
+                private: true
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   x-pack/qa/sql
+                # only exists from 6.3 to 6.5
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   x-pack/plugin/sql/qa
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: php }
+                repo:   elasticsearch-php
+                path:   docs/examples
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   elasticsearch-net
+                path:   examples
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 map_branches: *mapMasterToMain
-              - repo: apm-aws-lambda
-                path: docs
-                exclude_branches:
-                  [
-                    7.15,
-                    7.14,
-                    7.13,
-                    7.12,
-                    7.11,
-                    7.10,
-                    7.9,
-                    7.8,
-                    7.7,
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                    5.6,
-                    5.5,
-                    5.4,
-                    5.3,
-                    5.2,
-                    5.1,
-                    5.0,
-                  ]
+              -
+                alternatives: { source_lang: console, alternative_lang: python }
+                repo:   elasticsearch-py
+                path:   docs/examples
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
                 map_branches: *mapMasterToMain
-          - title: APM Agents
-            base_dir: agent
+              -
+                alternatives: { source_lang: console, alternative_lang: ruby }
+                repo:   elasticsearch-ruby
+                path:   docs/examples/guide
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
+              -
+                alternatives: { source_lang: console, alternative_lang: go }
+                repo:   go-elasticsearch
+                path:   .doc/examples/doc/
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                alternatives: { source_lang: console, alternative_lang: js }
+                repo:   elasticsearch-js
+                path:   docs/doc_examples
+                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
+          - title:      Elasticsearch Resiliency Status
+            prefix:     en/elasticsearch/resiliency
+            toc:        1
+            branches:   [master]
+            current:    master
+            index:      docs/resiliency/index.asciidoc
+            single:     1
+            tags:       Elasticsearch/Resiliency Status
+            subject:    Elasticsearch
+            sources:
+              -
+                repo:   elasticsearch
+                path:   docs/resiliency
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Painless Scripting Language
+            prefix:     en/elasticsearch/painless
+            current:    *stackcurrent
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            live:       *stacklive
+            index:      docs/painless/index.asciidoc
+            chunk:      1
+            tags:       Elasticsearch/Painless
+            subject:    Elasticsearch
+            sources:
+              -
+                repo:   elasticsearch
+                path:   docs/painless
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Plugins and Integrations
+            prefix:     en/elasticsearch/plugins
+            repo:       elasticsearch
+            current:    *stackcurrent
+            index:      docs/plugins/index.asciidoc
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            live:       *stacklive
+            chunk:      2
+            tags:       Elasticsearch/Plugins
+            subject:    Elasticsearch
+            sources:
+              -
+                repo:   elasticsearch
+                path:   docs/plugins
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   buildSrc/src/main/resources/
+                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   build-tools-internal/src/main/resources/
+                exclude_branches:   [7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   build-tools/src/main/resources/
+                exclude_branches:   [ 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Elasticsearch Clients
+            base_dir:   en/elasticsearch/client
             sections:
-              - title: APM Go Agent
-                prefix: go
-                current: 1.x
-                branches: [{ main: master }, 1.x, 0.5]
-                live: [main, 1.x]
-                index: docs/index.asciidoc
-                tags: APM Go Agent/Reference
-                subject: APM
-                chunk: 1
+              - title:      Java Client
+                prefix:     java-api-client
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/Java
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-go
-                    path: docs
-                  - repo: apm-agent-go
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [0.5]
-              - title: APM iOS Agent
-                prefix: swift
-                current: 0.x
-                branches: [main, 0.x]
-                live: [main, 0.x]
-                index: docs/index.asciidoc
-                tags: APM iOS Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-java
+                    path:   docs/
+                  -
+                    repo:   elasticsearch-java
+                    path:   java-client/src/test/java/co/elastic/clients/documentation
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-rest/
+                  -
+                    repo:   elasticsearch
+                    path:   client
+              - title:      JavaScript Client
+                prefix:     javascript-api
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                live:       *stacklivemain
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/JavaScript
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-ios
-                    path: docs
-                  - repo: apm-agent-ios
-                    path: CHANGELOG.asciidoc
-              - title: APM Java Agent
-                prefix: java
-                current: 1.x
-                branches: [{ main: master }, 1.x, 0.7, 0.6]
-                live: [main, 1.x]
-                index: docs/index.asciidoc
-                tags: APM Java Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-js
+                    path:   docs/
+              - title:      Ruby Client
+                prefix:     ruby-api
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/Ruby
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-java
-                    path: docs
-                  - repo: apm-agent-java
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [0.7, 0.6]
-              - title: APM .NET Agent
-                prefix: dotnet
-                current: 1.12
-                branches: [{ main: master }, 1.12, 1.11, 1.10, 1.9, 1.8]
-                live: [main, 1.12]
-                index: docs/index.asciidoc
-                tags: APM .NET Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-ruby
+                    path:   docs/
+              - title:      Go Client
+                prefix:     go-api
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      .doc/index.asciidoc
+                chunk:      1
+                tags:       Clients/Go
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-dotnet
-                    path: docs
-                  - repo: apm-agent-dotnet
-                    path: CHANGELOG.asciidoc
-              - title: APM Node.js Agent
-                prefix: nodejs
-                current: 3.x
-                branches: [{ main: master }, 3.x, 2.x, 1.x, 0.x]
-                live: [main, 3.x]
-                index: docs/index.asciidoc
-                tags: APM Node.js Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   go-elasticsearch
+                    path:   .doc/
+              - title:      .NET Clients
+                prefix:     net-api
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
+                live:       *stacklivemain
+                index:      docs/index.asciidoc
+                tags:       Clients/.Net
+                subject:    Clients
+                chunk:      1
                 sources:
-                  - repo: apm-agent-nodejs
-                    path: docs
-                  - repo: apm-agent-nodejs
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [1.x, 0.x]
-              - title: APM PHP Agent
-                prefix: php
-                current: 1.x
-                branches: [{ main: master }, 1.x]
-                live: [main, 1.x]
-                index: docs/index.asciidoc
-                tags: APM PHP Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-net
+                    path:   docs/
+              - title:      PHP Client
+                prefix:     php-api
+                current:    *stackcurrent
+                branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                live:       *stacklivemain
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/PHP
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-php
-                    path: docs
-                  - repo: apm-agent-php
-                    path: CHANGELOG.asciidoc
-              - title: APM Python Agent
-                prefix: python
-                current: 6.x
-                branches: [{ main: master }, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x]
-                live: [main, 6.x, 5.x]
-                index: docs/index.asciidoc
-                tags: APM Python Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-php
+                    path:   docs/
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+              - title:      Perl Client
+                prefix:     perl-api
+                current:    master
+                branches:   [ master, 8.1, 8.0 ]
+                live:       [ master, 8.1, 8.0 ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       Clients/Perl
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-python
-                    path: docs
-                  - repo: apm-agent-python
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [4.x, 3.x, 2.x, 1.x]
-              - title: APM Ruby Agent
-                prefix: ruby
-                current: 4.x
-                branches: [{ main: master }, 4.x, 3.x, 2.x, 1.x]
-                live: [main, 4.x]
-                index: docs/index.asciidoc
-                tags: APM Ruby Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-perl
+                    path:   docs/
+              - title:      Python Client
+                prefix:     python-api
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      docs/guide/index.asciidoc
+                chunk:     1
+                tags:       Clients/Python
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-ruby
-                    path: docs
-                  - repo: apm-agent-ruby
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [1.x, 0.x]
-              - title: APM Real User Monitoring JavaScript Agent
-                prefix: rum-js
-                current: 5.x
-                branches: [{ main: master }, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x]
-                live: [main, 5.x, 4.x]
-                index: docs/index.asciidoc
-                tags: APM Real User Monitoring JavaScript Agent/Reference
-                subject: APM
-                chunk: 1
+                  -
+                    repo:   elasticsearch-py
+                    path:   docs/guide/
+              - title:      eland
+                prefix:     eland
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/guide/index.asciidoc
+                chunk:     1
+                tags:       Clients/eland
+                subject:    Clients
                 sources:
-                  - repo: apm-agent-rum-js
-                    path: docs
-                  - repo: apm-agent-rum-js
-                    path: CHANGELOG.asciidoc
-                    exclude_branches: [3.x, 2.x, 1.x, 0.x]
-          - title: Legacy APM (standalone)
-            sections:
-              - title: Legacy APM Overview
-                prefix: get-started
-                index: docs/guide/index.asciidoc
-                current: 7.15
-                branches:
-                  [
-                    7.15,
-                    7.14,
-                    7.13,
-                    7.12,
-                    7.11,
-                    7.10,
-                    7.9,
-                    7.8,
-                    7.7,
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                  ]
-                live: [7.15, 6.8]
-                chunk: 1
-                tags: APM Server/Reference
-                subject: APM
+                  -
+                    repo:   eland
+                    path:   docs/guide
+              - title:      Rust Client
+                prefix:     rust-api
+                current:    master
+                branches:   [ master, 8.1, 8.0 ]
+                live:       [ master, 8.1, 8.0 ]
+                index:      docs/index.asciidoc
+                chunk:     1
+                tags:       Clients/Rust
+                subject:    Clients
                 sources:
-                  - repo: apm-server
-                    path: docs/guide
-                  - repo: apm-server
-                    path: docs
-              - title: Legacy APM Server Reference
-                prefix: server
-                index: docs/index.asciidoc
-                current: 7.15
-                branches:
-                  [
-                    7.15,
-                    7.14,
-                    7.13,
-                    7.12,
-                    7.11,
-                    7.10,
-                    7.9,
-                    7.8,
-                    7.7,
-                    7.6,
-                    7.5,
-                    7.4,
-                    7.3,
-                    7.2,
-                    7.1,
-                    7.0,
-                    6.8,
-                    6.7,
-                    6.6,
-                    6.5,
-                    6.4,
-                    6.3,
-                    6.2,
-                    6.1,
-                    6.0,
-                  ]
-                live: [7.15, 6.8]
-                chunk: 1
-                tags: APM Server/Reference
-                subject: APM
+                  -
+                    repo:   elasticsearch-rs
+                    path:   docs/
+              - title:      Java REST Client (deprecated)
+                prefix:     java-rest
+                current:   7.17
+                branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                live:       [ 7.17, 6.8 ]
+                index:      docs/java-rest/index.asciidoc
+                tags:       Clients/JavaREST
+                subject:    Clients
+                chunk:      1
                 sources:
-                  - repo: apm-server
-                    path: changelogs
-                    exclude_branches: [6.0]
-                  - repo: apm-server
-                    path: docs
-                  - repo: apm-server
-                    path: CHANGELOG.asciidoc
-      - title: ECS logging
-        base_dir: en/ecs-logging
-        sections:
-          - title: ECS Logging Overview
-            prefix: overview
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/Guide
-            subject: ECS Logging Overview
-            sources:
-              - repo: ecs-logging
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-          - title: ECS Logging Go (Logrus) Reference
-            prefix: go-logrus
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/go-logrus/Guide
-            subject: ECS Logging Go (Logrus) Reference
-            sources:
-              - repo: ecs-logging-go-logrus
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
-          - title: ECS Logging Go (Zap) Reference
-            prefix: go-zap
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/go-zap/Guide
-            subject: ECS Logging Go (Zap) Reference
-            sources:
-              - repo: ecs-logging-go-zap
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-rest
+                  -
+                    repo:   elasticsearch
+                    path:   docs/Versions.asciidoc
+                  -
+                    repo:   elasticsearch
+                    path:   client
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              - title:      Java Transport Client (deprecated)
+                prefix:     java-api
+                current:    7.17
+                branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                live:       [7.17, 6.8]
+                index:      docs/java-api/index.asciidoc
+                tags:       Clients/Java
+                subject:    Clients
+                chunk:      1
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/java-api
+                  -
+                    repo:   elasticsearch
+                    path:   docs/Versions.asciidoc
+                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   client/rest-high-level/src/test/java/org/elasticsearch/client
+                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
-          - title: ECS Logging Java Reference
-            prefix: java
-            current: 1.x
-            branches: [{ main: master }, 1.x, 0.x]
-            live: [main, 1.x]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/java/Guide
-            subject: ECS Logging Java Reference
+                  -
+                   repo:   elasticsearch
+                   path:   server/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                   exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   server/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   elasticsearch
+                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
+                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+
+              - title:      Community Contributed Clients
+                prefix:     community
+                branches:   [master]
+                current:    master
+                index:      docs/community-clients/index.asciidoc
+                single:     1
+                tags:       Clients/Community
+                subject:    Clients
+                sources:
+                  -
+                    repo:   elasticsearch
+                    path:   docs/community-clients
+          - title:      Elasticsearch for Apache Hadoop and Spark
+            prefix:     en/elasticsearch/hadoop
+            current:    *stackcurrent
+            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            live:       *stacklive
+            index:      docs/src/reference/asciidoc/index.adoc
+            tags:       Elasticsearch/Apache Hadoop
+            subject:    Elasticsearch
             sources:
-              - repo: ecs-logging-java
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
+              -
+                repo:   elasticsearch-hadoop
+                path:   docs/src/reference/asciidoc
+          - title:      Curator Index Management
+            prefix:     en/elasticsearch/client/curator
+            current:    5.8
+            branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
+            index:      docs/asciidoc/index.asciidoc
+            tags:       Clients/Curator
+            subject:    Clients
+            sources:
+              -
+                repo:   curator
+                path:   docs/asciidoc
+
+    -   title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
+        sections:
+          - title:      Elasticsearch Service - Hosted Elastic Stack
+            prefix:     en/cloud
+            tags:       Cloud/Reference
+            subject:    Elastic Cloud
+            current:    *cloudSaasCurrent
+            branches:   [ { *cloudSaasCurrent : latest} ]
+            index:      docs/saas/index.asciidoc
+            chunk:      1
+            private:    1
+            sources:
+              -
+                repo:   cloud
+                path:   docs/saas
+              -
+                repo:   cloud
+                path:   docs/shared
+              -
+                alternatives: { source_lang: console, alternative_lang: php }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/php
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: go }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/go
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: ruby }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/ruby
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: java }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/java
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: javascript }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/javascript
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: python }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/python
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/csharp
+                map_branches: *mapCloudSaasToClientsTeam
+          - title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
+            prefix:     en/cloud-heroku
+            tags:       Cloud-Heroku/Reference
+            subject:    Elasticsearch Add-On for Heroku
+            current:    *cloudSaasCurrent
+            branches:   [ { *cloudSaasCurrent : latest} ]
+            index:      docs/heroku/index.asciidoc
+            chunk:      1
+            noindex:    1
+            private:    1
+            sources:
+              -
+                repo:   cloud
+                path:   docs/saas
+              -
+                repo:   cloud
+                path:   docs/shared
+              -
+                repo:   cloud
+                path:   docs/heroku
+              -
+                alternatives: { source_lang: console, alternative_lang: php }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/php
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: go }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/go
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: ruby }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/ruby
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: java }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/java
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: javascript }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/javascript
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: python }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/python
+                map_branches: *mapCloudSaasToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/csharp
+                map_branches: *mapCloudSaasToClientsTeam
+          - title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
+            prefix:     en/cloud-enterprise
+            tags:       CloudEnterprise/Reference
+            subject:    ECE
+            current:    ms-69
+            branches:
+              - ms-69: 3.0
+              - ms-65: 2.13
+              - ms-62: 2.12
+              - ms-59: 2.11
+              - ms-57: 2.10
+              - ms-53: 2.9
+              - ms-49: 2.8
+              - ms-47: 2.7
+              - release-ms-41: 2.6
+              - 2.5
+              - 2.4
+              - 2.3
+              - 2.2
+              - 2.1
+              - 2.0
+              - 1.1
+              - 1.0
+            index:      docs/cloud-enterprise/index.asciidoc
+            chunk:      2
+            private:    1
+            sources:
+              -
+                repo:   cloud
+                # Grab the entire docs/ directory to get `ece-version.asciidoc`
+                path:   docs
+              -
+                repo:   cloud
+                path:   docs/shared
+                exclude_branches: [ 1.0 ]
+              -
+                repo:   cloud-assets
+                path:   docs
                 map_branches:
-                  1.x: main
-                  0.x: main
-          - title: ECS Logging .NET Reference
-            prefix: dotnet
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/.NET/Guide
-            subject: ECS Logging .NET Reference
+                  ms-69: master
+                  ms-65: master
+                  ms-62: master
+                  ms-59: master
+                  ms-57: master
+                  ms-53: master
+                  ms-49: master
+                  ms-47: master
+                  release-ms-41: master
+                  2.5: master
+                  2.4: master
+                  2.3: master
+                  2.2: master
+                  2.1: master
+                  2.0: master
+                  1.1: master
+                  1.0: master
+              -
+                alternatives: { source_lang: console, alternative_lang: php }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/php
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: go }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/go
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: ruby }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/ruby
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: java }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/java
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: javascript }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/javascript
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: python }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/python
+                map_branches: *mapCloudEceToClientsTeam
+              -
+                alternatives: { source_lang: console, alternative_lang: csharp }
+                repo:   clients-team
+                path:   docs/examples/elastic-cloud/csharp
+                map_branches: *mapCloudEceToClientsTeam
+          - title:      Elastic Cloud on Kubernetes
+            prefix:     en/cloud-on-k8s
+            tags:       Kubernetes/Reference
+            subject:    ECK
+            current:    2.0
+            branches:   [ {main: master}, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            index:      docs/index.asciidoc
+            chunk:      1
             sources:
-              - repo: ecs-dotnet
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
-          - title: ECS Logging Node.js Reference
-            prefix: nodejs
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/nodejs/Guide
-            subject: ECS Logging Node.js Reference
+              -
+                repo:   cloud-on-k8s
+                path:   docs/
+              -
+                repo:   docs
+                path:   shared/versions/stack/current.asciidoc
+                exclude_branches:   [ 0.9, 0.8 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and ECE
+            prefix:     en/ecctl
+            tags:       CloudControl/Reference
+            subject:    ECCTL
+            current:    1.8
+            branches:   [ master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            index:      docs/index.asciidoc
+            chunk:      1
             sources:
-              - repo: ecs-logging-nodejs
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
-          - title: ECS Logging Ruby Reference
-            prefix: ruby
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/ruby/Guide
-            subject: ECS Logging Ruby Reference
+              -
+                repo:   ecctl
+                path:   docs/
+          - title:      Elastic Cloud Terraform Provider
+            prefix:     en/tpec
+            tags:       CloudTerraform/Reference
+            subject:    TPEC
+            current:    0.2
+            branches:   [ master, 0.2, 0.1 ]
+            index:      docs-elastic/index.asciidoc
+            single:     1
+            chunk:      1
             sources:
-              - repo: ecs-logging-ruby
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
-          - title: ECS Logging PHP Reference
-            prefix: php
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/php/Guide
-            subject: ECS Logging PHP Reference
-            sources:
-              - repo: ecs-logging-php
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
-          - title: ECS Logging Python Reference
-            prefix: python
-            current: main
-            branches: [{ main: master }]
-            live: [main]
-            index: docs/index.asciidoc
-            chunk: 1
-            tags: ECS-logging/python/Guide
-            subject: ECS Logging Python Reference
-            sources:
-              - repo: ecs-logging-python
-                path: docs
-              - repo: docs
-                path: shared/versions/stack/{version}.asciidoc
-              - repo: docs
-                path: shared/attributes.asciidoc
-              - repo: ecs-logging
-                path: docs
+              -
+                repo:   terraform-provider-ec
+                path:   docs-elastic/
 
-  - title: Elastic Security
-    sections:
-      - title: Elastic Security
-        prefix: en/security
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-          ]
-        live: *stacklivemain
-        index: docs/index.asciidoc
-        chunk: 1
-        tags: Security/Guide
-        subject: Security
-        sources:
-          - repo: security-docs
-            path: docs
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: stack-docs
-            path: docs/en
-      - title: SIEM Guide
-        prefix: en/siem/guide
-        current: 7.8
-        branches: [7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2]
-        live: [7.8]
-        index: docs/en/siem/index.asciidoc
-        chunk: 1
-        tags: SIEM/Guide
-        subject: SIEM
-        sources:
-          - repo: stack-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-
-  - title: "Logstash: Collect, Enrich, and Transport"
-    sections:
-      - title: Logstash Reference
-        prefix: en/logstash
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            2.4,
-            2.3,
-            2.2,
-            2.1,
-            2.0,
-            1.5,
-          ]
-        live: *stacklivemain
-        index: docs/index.x.asciidoc
-        chunk: 1
-        tags: Logstash/Reference
-        subject: Logstash
-        respect_edit_url_overrides: true
-        sources:
-          - repo: logstash
-            path: docs/
-          - repo: x-pack-logstash
-            prefix: logstash-extra/x-pack-logstash
-            path: docs/en
-            private: true
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.5,
-              ]
-          - repo: logstash-docs
-            path: docs/
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches:
-              [
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.5,
-              ]
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches:
-              [
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.5,
-              ]
-          - repo: docs
-            path: shared/attributes62.asciidoc
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-                1.5,
-              ]
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-            exclude_branches:
-              [
-                main,
-                8.1,
-                8.0,
-                7.17,
-                7.16,
-                7.15,
-                7.14,
-                7.13,
-                7.12,
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                2.4,
-                2.3,
-                2.2,
-                2.1,
-                2.0,
-              ]
-      - title: Logstash Versioned Plugin Reference
-        prefix: en/logstash-versioned-plugins
-        current: versioned_plugin_docs
-        branches: [versioned_plugin_docs]
-        index: docs/versioned-plugins/index.asciidoc
-        private: 1
-        chunk: 1
-        noindex: 1
-        tags: Logstash/Plugin Reference
-        subject: Logstash
-        sources:
-          - repo: logstash-docs
-            path: docs/versioned-plugins
-          - repo: docs
-            path: shared/attributes.asciidoc
-
-  - title: "Fleet: Install and Manage Elastic Agents"
-    sections:
-      - title: Fleet and Elastic Agent Guide
-        prefix: en/fleet
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-          ]
-        live: *stacklivemain
-        index: docs/en/ingest-management/index.asciidoc
-        chunk: 2
-        tags: Fleet/Guide/Elastic Agent
-        subject: Fleet and Elastic Agent
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: apm-server
-            path: docs
-            exclude_branches:
-              [
-                7.11,
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-
-      - title: Integrations Developer Guide
-        prefix: en/integrations-developer
-        current: main
-        branches: [{ main: master }]
-        live: [main]
-        index: docs/en/integrations/index.asciidoc
-        chunk: 1
-        tags: Integrations/Developer
-        subject: Integrations
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: package-spec
-            path: versions
-
-  - title: "Beats: Collect, Parse, and Ship"
-    sections:
-      - title: Beats Platform Reference
-        prefix: en/beats/libbeat
-        index: libbeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            1.3,
-            1.2,
-            1.1,
-            1.0.1,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Libbeat/Reference
-        subject: libbeat
-        respect_edit_url_overrides: true
-        sources:
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Auditbeat Reference
-        prefix: en/beats/auditbeat
-        index: auditbeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Auditbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Auditbeat
-        sources:
-          - repo: beats
-            path: auditbeat
-          - repo: beats
-            path: auditbeat/docs
-          - repo: beats
-            path: x-pack/auditbeat
-            exclude_branches: [6.5, 6.4, 6.3, 6.2, 6.1, 6.0]
-          - repo: beats
-            path: auditbeat/module
-          - repo: beats
-            path: auditbeat/scripts
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Filebeat Reference
-        prefix: en/beats/filebeat
-        index: filebeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            1.3,
-            1.2,
-            1.1,
-            1.0.1,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Filebeat/Reference
-        respect_edit_url_overrides: true
-        subject: Filebeat
-        sources:
-          - repo: beats
-            path: filebeat
-          - repo: beats
-            path: filebeat/docs
-          - repo: beats
-            path: x-pack/filebeat/docs
-            exclude_branches:
-              [
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: x-pack/libbeat/docs
-            exclude_branches: *beatsXpackLibbeatExclude
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/filebeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Functionbeat Reference
-        prefix: en/beats/functionbeat
-        current: *stackcurrent
-        index: x-pack/functionbeat/docs/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Functionbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Functionbeat
-        sources:
-          - repo: beats
-            path: x-pack/functionbeat
-          - repo: beats
-            path: x-pack/functionbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: beats
-            path: x-pack/libbeat/docs
-            exclude_branches: *beatsXpackLibbeatExclude
-          - repo: beats
-            path: filebeat/docs
-            exclude_branches:
-              [
-                7.10,
-                7.9,
-                7.8,
-                7.7,
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-              ]
-      - title: Heartbeat Reference
-        prefix: en/beats/heartbeat
-        current: *stackcurrent
-        index: heartbeat/docs/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Heartbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Heartbeat
-        sources:
-          - repo: beats
-            path: heartbeat
-          - repo: beats
-            path: heartbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: x-pack/libbeat/docs
-            exclude_branches: *beatsXpackLibbeatExclude
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Metricbeat Reference
-        prefix: en/beats/metricbeat
-        index: metricbeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Metricbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Metricbeat
-        sources:
-          - repo: beats
-            path: metricbeat
-          - repo: beats
-            path: metricbeat/docs
-          - repo: beats
-            path: metricbeat/module
-          - repo: beats
-            path: x-pack/libbeat/docs
-            exclude_branches: *beatsXpackLibbeatExclude
-          - repo: beats
-            path: x-pack/metricbeat/module
-            exclude_branches:
-              [
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-              ]
-          - repo: beats
-            path: metricbeat/scripts
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Packetbeat Reference
-        prefix: en/beats/packetbeat
-        index: packetbeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            1.3,
-            1.2,
-            1.1,
-            1.0.1,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Packetbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Packetbeat
-        sources:
-          - repo: beats
-            path: packetbeat
-          - repo: beats
-            path: packetbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Winlogbeat Reference
-        prefix: en/beats/winlogbeat
-        index: winlogbeat/docs/index.asciidoc
-        current: *stackcurrent
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-            5.6,
-            5.5,
-            5.4,
-            5.3,
-            5.2,
-            5.1,
-            5.0,
-            1.3,
-            1.2,
-            1.1,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Winlogbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Winlogbeat
-        sources:
-          - repo: beats
-            path: winlogbeat
-          - repo: beats
-            path: winlogbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Beats Developer Guide
-        prefix: en/beats/devguide
-        index: docs/devguide/index.asciidoc
-        current: main
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-            6.4,
-            6.3,
-            6.2,
-            6.1,
-            6.0,
-          ]
-        live: *stacklivemain
-        chunk: 1
-        tags: Devguide/Reference
-        subject: Beats
-        respect_edit_url_overrides: true
-        sources:
-          - repo: beats
-            path: docs
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: metricbeat/module
-          - repo: beats
-            path: metricbeat/scripts
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-            exclude_branches: *beatsSharedExclude
-          - repo: docs
-            path: shared/attributes.asciidoc
-            exclude_branches: *beatsSharedExclude
-      - title: Elastic Logging Plugin for Docker
-        prefix: en/beats/loggingplugin
-        current: *stackcurrent
-        index: x-pack/dockerlogbeat/docs/index.asciidoc
-        branches:
-          [
-            { main: master },
-            8.1,
-            8.0,
-            7.17,
-            7.16,
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-          ]
-        chunk: 1
-        tags: Elastic Logging Plugin/Reference
-        respect_edit_url_overrides: true
-        subject: Elastic Logging Plugin
-        sources:
-          - repo: beats
-            path: x-pack/dockerlogbeat/docs
-          - repo: beats
-            path: libbeat/docs
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-
-  - title: Docs in Your Native Tongue
-    sections:
-      - title: 简体中文
-        base_dir: cn
-        lang: zh_cn
+    -   title:      "Kibana: Explore, Visualize, and Share"
         sections:
-          - title: 《Elasticsearch 权威指南》中文版
-            prefix: elasticsearch/guide
-            index: book.asciidoc
-            current: cn
-            branches: [{ cn: 2.x }]
-            chunk: 1
-            private: 1
-            lang: zh_cn
-            tags: Elasticsearch/Definitive Guide
-            subject: Elasticsearch
+          - title:      Kibana Guide
+            prefix:     en/kibana
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            live:       *stacklivemain
+            index:      docs/index.x.asciidoc
+            chunk:      1
+            tags:       Kibana/Reference
+            subject:    Kibana
+            toc_extra:  extra/kibana_landing.html
+            sources:
+              -
+                repo:   kibana
+                path:   docs/
+              -
+                repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
+                path:   docs/en
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches: [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
+              -
+                repo:   kibana
+                # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
+                path:   ":(glob)examples/**/*.asciidoc"
+                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   kibana
+                path:   ":(glob)src/**/*.asciidoc"
+                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+              -
+                repo:   kibana
+                path:   ":(glob)x-pack/**/*.asciidoc"
+                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+
+    -   title:      Enterprise Search
+        sections:
+          - title:      Enterprise Search Guide
+            prefix:     en/enterprise-search
+            index:      enterprise-search-docs/index.asciidoc
+            private:    1
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Enterprise Search/Guide
+            subject:    Enterprise Search
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   enterprise-search-docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+          - title:      Workplace Search Guide
+            prefix:     en/workplace-search
+            index:      workplace-search-docs/index.asciidoc
+            private:    1
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Workplace Search/Guide
+            subject:    Workplace Search
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   workplace-search-docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+          - title:      App Search Guide
+            prefix:     en/app-search
+            index:      app-search-docs/index.asciidoc
+            private:    1
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       App Search/Guide
+            subject:    App Search
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   app-search-docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+          - title:      Site Search Reference
+            prefix:     en/swiftype/sitesearch
+            index:      docs/sitesearch/index.asciidoc
+            private:    1
+            current:    master
+            branches:   [ master ]
+            single:     1
+            tags:       Site Search/Reference
+            subject:    Swiftype
+            sources:
+              -
+                repo:   swiftype
+                path:   docs
+          - title:      Enterprise Search Clients
+            base_dir:   en/enterprise-search-clients
+            sections:
+              - title:      App Search JavaScript client
+                prefix:     app-search-javascript
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/app-search-javascript/index.asciidoc
+                tags:       App Search Clients/JavaScript
+                subject:    App Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/app-search-javascript
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      App Search Node.js client
+                prefix:     app-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/app-search-node/index.asciidoc
+                tags:       App Search Clients/Node.js
+                subject:    App Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/app-search-node
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      Enterprise Search PHP client
+                prefix:     php
+                current:    7.16
+                branches:   [ 7.16 ]
+                live:       [ 7.16 ]
+                index:      docs/guide/index.asciidoc
+                tags:       Enterprise Search Clients/PHP
+                subject:    Enterprise Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-php
+                    path:   docs/guide/
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      Enterprise Search Python client
+                prefix:     python
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                live:       *stacklive
+                index:      docs/guide/index.asciidoc
+                tags:       Enterprise Search Clients/Python
+                subject:    Enterprise Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-python
+                    path:   docs/guide/
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      Enterprise Search Ruby client
+                prefix:     ruby
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                live:       *stacklive
+                index:      docs/guide/index.asciidoc
+                tags:       Enterprise Search Clients/Ruby
+                subject:    Enterprise Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-ruby
+                    path:   docs/guide/
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+
+              - title:      Workplace Search Node.js client
+                prefix:     workplace-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
+                index:      client-docs/workplace-search-node/index.asciidoc
+                tags:       Workplace Search Clients/Node.js
+                subject:    Workplace Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/workplace-search-node
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+    -   title:      "Observability: APM, Logs, Metrics, and Uptime"
+        sections:
+          - title:      Observability
+            prefix:     en/observability
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
+            live:       *stacklivemain
+            index:      docs/en/observability/index.asciidoc
+            chunk:      2
+            tags:       Observability/Guide
+            subject:    Observability
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   apm-server
+                path:   docs
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   beats
+                path:   libbeat/docs
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Application Performance Monitoring (APM)
+            base_dir:   en/apm
+            sections:
+              - title:      APM Guide
+                prefix:     guide
+                index:      docs/integrations-index.asciidoc
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                chunk:      2
+                tags:       APM Guide
+                subject:    APM
+                sources:
+                  -
+                    repo:   apm-server
+                    path:   changelogs
+                    exclude_branches:   [ 6.0 ]
+                  -
+                    repo:   apm-server
+                    path:   docs
+                  -
+                    repo:   apm-server
+                    path:   CHANGELOG.asciidoc
+                  -
+                    repo:   observability-docs
+                    path:   docs/en
+                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                    map_branches: *mapMasterToMain
+                  -
+                    repo:   apm-aws-lambda
+                    path:   docs
+                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                    map_branches: *mapMasterToMain
+              - title:      APM Agents
+                base_dir:   agent
+                sections:
+                  - title:      APM Go Agent
+                    prefix:     go
+                    current:    1.x
+                    branches:   [ {main: master}, 1.x, 0.5 ]
+                    live:       [ main, 1.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Go Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-go
+                        path:   docs
+                      -
+                        repo:   apm-agent-go
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 0.5 ]
+                  - title: APM iOS Agent
+                    prefix: swift
+                    current: 0.x
+                    branches: [ main, 0.x ]
+                    live: [ main, 0.x ]
+                    index: docs/index.asciidoc
+                    tags: APM iOS Agent/Reference
+                    subject: APM
+                    chunk: 1
+                    sources:
+                      -
+                        repo: apm-agent-ios
+                        path: docs
+                      -
+                        repo: apm-agent-ios
+                        path: CHANGELOG.asciidoc
+                  - title:      APM Java Agent
+                    prefix:     java
+                    current:    1.x
+                    branches:   [ {main: master}, 1.x, 0.7, 0.6 ]
+                    live:       [ main, 1.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Java Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-java
+                        path:   docs
+                      -
+                        repo:   apm-agent-java
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 0.7, 0.6]
+                  - title:      APM .NET Agent
+                    prefix:     dotnet
+                    current:    1.12
+                    branches:   [ {main: master}, 1.12, 1.11, 1.10, 1.9, 1.8 ]
+                    live:       [ main, 1.12 ]
+                    index:      docs/index.asciidoc
+                    tags:       APM .NET Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-dotnet
+                        path:   docs
+                      -
+                        repo:   apm-agent-dotnet
+                        path:   CHANGELOG.asciidoc
+                  - title:      APM Node.js Agent
+                    prefix:     nodejs
+                    current:    3.x
+                    branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ main, 3.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Node.js Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-nodejs
+                        path:   docs
+                      -
+                        repo:   apm-agent-nodejs
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 1.x, 0.x ]
+                  - title:      APM PHP Agent
+                    prefix:     php
+                    current:    1.x
+                    branches:   [ {main: master}, 1.x ]
+                    live:       [ main, 1.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM PHP Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-php
+                        path:   docs
+                      -
+                        repo:   apm-agent-php
+                        path:   CHANGELOG.asciidoc
+                  - title:      APM Python Agent
+                    prefix:     python
+                    current:    6.x
+                    branches:   [ {main: master}, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ main, 6.x, 5.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Python Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-python
+                        path:   docs
+                      -
+                        repo:   apm-agent-python
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 4.x, 3.x, 2.x, 1.x ]
+                  - title:      APM Ruby Agent
+                    prefix:     ruby
+                    current:    4.x
+                    branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ main, 4.x ]
+                    index:      docs/index.asciidoc
+                    tags:       APM Ruby Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-ruby
+                        path:   docs
+                      -
+                        repo:   apm-agent-ruby
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 1.x, 0.x ]
+                  - title:      APM Real User Monitoring JavaScript Agent
+                    prefix:     rum-js
+                    current:    5.x
+                    branches:   [ {main: master}, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ main, 5.x, 4.x]
+                    index:      docs/index.asciidoc
+                    tags:       APM Real User Monitoring JavaScript Agent/Reference
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   apm-agent-rum-js
+                        path:   docs
+                      -
+                        repo:   apm-agent-rum-js
+                        path:   CHANGELOG.asciidoc
+                        exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
+              - title:      Legacy APM (standalone)
+                sections:
+                  - title:      Legacy APM Overview
+                    prefix:     get-started
+                    index:      docs/guide/index.asciidoc
+                    current:    7.15
+                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                    live:       [ 7.15, 6.8 ]
+                    chunk:      1
+                    tags:       APM Server/Reference
+                    subject:    APM
+                    sources:
+                      -
+                        repo:   apm-server
+                        path:   docs/guide
+                      -
+                        repo:   apm-server
+                        path:   docs
+                  - title:      Legacy APM Server Reference
+                    prefix:     server
+                    index:      docs/index.asciidoc
+                    current:    7.15
+                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+                    live:       [ 7.15, 6.8 ]
+                    chunk:      1
+                    tags:       APM Server/Reference
+                    subject:    APM
+                    sources:
+                      -
+                        repo:   apm-server
+                        path:   changelogs
+                        exclude_branches:   [ 6.0 ]
+                      -
+                        repo:   apm-server
+                        path:   docs
+                      -
+                        repo:   apm-server
+                        path:   CHANGELOG.asciidoc
+          - title:      ECS logging
+            base_dir:   en/ecs-logging
+            sections:
+              - title:      ECS Logging Overview
+                prefix:     overview
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/Guide
+                subject:    ECS Logging Overview
+                sources:
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+              - title:      ECS Logging Go (Logrus) Reference
+                prefix:     go-logrus
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/go-logrus/Guide
+                subject:    ECS Logging Go (Logrus) Reference
+                sources:
+                  -
+                    repo:   ecs-logging-go-logrus
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Go (Zap) Reference
+                prefix:     go-zap
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/go-zap/Guide
+                subject:    ECS Logging Go (Zap) Reference
+                sources:
+                  -
+                    repo:   ecs-logging-go-zap
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+
+              - title:      ECS Logging Java Reference
+                prefix:     java
+                current:    1.x
+                branches:   [ {main: master}, 1.x, 0.x ]
+                live:       [ main, 1.x ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/java/Guide
+                subject:    ECS Logging Java Reference
+                sources:
+                  -
+                    repo:   ecs-logging-java
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+                    map_branches:
+                      1.x: main
+                      0.x: main
+              - title:      ECS Logging .NET Reference
+                prefix:     dotnet
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/.NET/Guide
+                subject:    ECS Logging .NET Reference
+                sources:
+                  -
+                    repo:   ecs-dotnet
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Node.js Reference
+                prefix:     nodejs
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/nodejs/Guide
+                subject:    ECS Logging Node.js Reference
+                sources:
+                  -
+                    repo:   ecs-logging-nodejs
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Ruby Reference
+                prefix:     ruby
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/ruby/Guide
+                subject:    ECS Logging Ruby Reference
+                sources:
+                  -
+                    repo:   ecs-logging-ruby
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging PHP Reference
+                prefix:     php
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/php/Guide
+                subject:    ECS Logging PHP Reference
+                sources:
+                  -
+                    repo:   ecs-logging-php
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+              - title:      ECS Logging Python Reference
+                prefix:     python
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                chunk:      1
+                tags:       ECS-logging/python/Guide
+                subject:    ECS Logging Python Reference
+                sources:
+                  -
+                    repo:   ecs-logging-python
+                    path:   docs
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+                  -
+                    repo:   docs
+                    path:   shared/attributes.asciidoc
+                  -
+                    repo:   ecs-logging
+                    path:   docs
+
+    -   title:      Elastic Security
+        sections:
+          - title:      Elastic Security
+            prefix:     en/security
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            live:       *stacklivemain
+            index:      docs/index.asciidoc
+            chunk:      1
+            tags:       Security/Guide
+            subject:    Security
+            sources:
+              -
+                repo:   security-docs
+                path:   docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   stack-docs
+                path:   docs/en
+          - title:      SIEM Guide
+            prefix:     en/siem/guide
+            current:    7.8
+            branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            live:       [ 7.8 ]
+            index:      docs/en/siem/index.asciidoc
+            chunk:      1
+            tags:       SIEM/Guide
+            subject:    SIEM
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
+
+    -   title:      "Logstash: Collect, Enrich, and Transport"
+        sections:
+          - title:      Logstash Reference
+            prefix:     en/logstash
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            live:       *stacklivemain
+            index:      docs/index.x.asciidoc
+            chunk:      1
+            tags:       Logstash/Reference
+            subject:    Logstash
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   logstash
+                path:   docs/
+              -
+                repo:   x-pack-logstash
+                prefix: logstash-extra/x-pack-logstash
+                path:   docs/en
+                private: true
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   logstash-docs
+                path:   docs/
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+          - title:      Logstash Versioned Plugin Reference
+            prefix:     en/logstash-versioned-plugins
+            current:    versioned_plugin_docs
+            branches:   [ versioned_plugin_docs ]
+            index:      docs/versioned-plugins/index.asciidoc
+            private:    1
+            chunk:      1
+            noindex:    1
+            tags:       Logstash/Plugin Reference
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash-docs
+                path:   docs/versioned-plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
+    -   title:      "Fleet: Install and Manage Elastic Agents"
+        sections:
+          - title:      Fleet and Elastic Agent Guide
+            prefix:     en/fleet
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            live:       *stacklivemain
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      2
+            tags:       Fleet/Guide/Elastic Agent
+            subject:    Fleet and Elastic Agent
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   apm-server
+                path:   docs
+                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+
+          - title:      Integrations Developer Guide
+            prefix:     en/integrations-developer
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            index:      docs/en/integrations/index.asciidoc
+            chunk:      1
+            tags:       Integrations/Developer
+            subject:    Integrations
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   package-spec
+                path:   versions
+
+    -   title:      "Beats: Collect, Parse, and Ship"
+        sections:
+          - title:      Beats Platform Reference
+            prefix:     en/beats/libbeat
+            index:      libbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Libbeat/Reference
+            subject:    libbeat
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Auditbeat Reference
+            prefix:     en/beats/auditbeat
+            index:      auditbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Auditbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Auditbeat
+            sources:
+              -
+                repo:   beats
+                path:   auditbeat
+              -
+                repo:   beats
+                path:   auditbeat/docs
+              -
+                repo:   beats
+                path:   x-pack/auditbeat
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+              -
+                repo:   beats
+                path:   auditbeat/module
+              -
+                repo:   beats
+                path:   auditbeat/scripts
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Filebeat Reference
+            prefix:     en/beats/filebeat
+            index:      filebeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Filebeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Filebeat
+            sources:
+              -
+                repo:   beats
+                path:   filebeat
+              -
+                repo:   beats
+                path:   filebeat/docs
+              -
+                repo:   beats
+                path:   x-pack/filebeat/docs
+                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/filebeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Functionbeat Reference
+            prefix:     en/beats/functionbeat
+            current:    *stackcurrent
+            index:      x-pack/functionbeat/docs/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Functionbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Functionbeat
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/functionbeat
+              -
+                repo:   beats
+                path:   x-pack/functionbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   filebeat/docs
+                exclude_branches: [ 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+          - title:      Heartbeat Reference
+            prefix:     en/beats/heartbeat
+            current:    *stackcurrent
+            index:      heartbeat/docs/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Heartbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Heartbeat
+            sources:
+              -
+                repo:   beats
+                path:   heartbeat
+              -
+                repo:   beats
+                path:   heartbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Metricbeat Reference
+            prefix:     en/beats/metricbeat
+            index:      metricbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Metricbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Metricbeat
+            sources:
+              -
+                repo:   beats
+                path:   metricbeat
+              -
+                repo:   beats
+                path:   metricbeat/docs
+              -
+                repo:   beats
+                path:   metricbeat/module
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   x-pack/metricbeat/module
+                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+              -
+                repo:   beats
+                path:   metricbeat/scripts
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Packetbeat Reference
+            prefix:     en/beats/packetbeat
+            index:      packetbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Packetbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Packetbeat
+            sources:
+              -
+                repo:   beats
+                path:   packetbeat
+              -
+                repo:   beats
+                path:   packetbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Winlogbeat Reference
+            prefix:     en/beats/winlogbeat
+            index:      winlogbeat/docs/index.asciidoc
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Winlogbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Winlogbeat
+            sources:
+              -
+                repo:   beats
+                path:   winlogbeat
+              -
+                repo:   beats
+                path:   winlogbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Beats Developer Guide
+            prefix:     en/beats/devguide
+            index:      docs/devguide/index.asciidoc
+            current:    main
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            live:       *stacklivemain
+            chunk:      1
+            tags:       Devguide/Reference
+            subject:    Beats
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   beats
+                path:   docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   metricbeat/module
+              -
+                repo:   beats
+                path:   metricbeat/scripts
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   *beatsSharedExclude
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   *beatsSharedExclude
+          - title:      Elastic Logging Plugin for Docker
+            prefix:     en/beats/loggingplugin
+            current:    *stackcurrent
+            index:      x-pack/dockerlogbeat/docs/index.asciidoc
+            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            chunk:      1
+            tags:       Elastic Logging Plugin/Reference
+            respect_edit_url_overrides: true
+            subject:    Elastic Logging Plugin
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/dockerlogbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
+    - title:     Docs in Your Native Tongue
+      sections:
+        - title:      简体中文
+          base_dir:   cn
+          lang:       zh_cn
+          sections:
+            - title:      《Elasticsearch 权威指南》中文版
+              prefix:     elasticsearch/guide
+              index:      book.asciidoc
+              current:    cn
+              branches:   [ {cn: 2.x} ]
+              chunk:      1
+              private:    1
+              lang:       zh_cn
+              tags:       Elasticsearch/Definitive Guide
+              subject:    Elasticsearch
+              suppress_migration_warnings: true
+              sources:
+                -
+                  repo: guide-cn
+                  path: /
+            - title:      PHP API
+              prefix:     elasticsearch/php
+              index:      index.asciidoc
+              current:    cn
+              branches:   [ {cn: 6.0} ]
+              lang:       zh_cn
+              tags:       Elasticsearch/PHP
+              subject:    Elasticsearch
+              sources:
+                -
+                  repo: elasticsearch-php-cn
+                  path: /
+            - title:      Kibana 用户手册
+              prefix:     kibana
+              index:      docs/index.asciidoc
+              current:    cn
+              branches:   [ {cn: 6.0} ]
+              lang:       zh_cn
+              chunk:      1
+              private:    1
+              tags:       Kibana/Reference
+              subject:    Kibana
+              sources:
+                -
+                  repo: kibana-cn
+                  path: /docs
+        - title:      日本語
+          base_dir:   jp
+          lang:       ja
+          sections:
+            - title:      Elasticsearchリファレンス
+              prefix:     elasticsearch/reference
+              index:      docs/jp/reference/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ja
+              tags:       Elasticsearch/Reference
+              subject:    Elasticsearch
+              sources:
+                -
+                  repo: elasticsearch
+                  path: /docs/jp/reference
+                -
+                  repo: elasticsearch
+                  path: /docs
+            - title:      Logstashリファレンス
+              prefix:     logstash
+              index:      docs/jp/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ja
+              tags:       Logstash/Reference
+              subject:    Logstash
+              sources:
+                -
+                  repo: logstash
+                  path: /docs/jp
+            - title:      Kibanaユーザーガイド
+              prefix:     kibana
+              index:      docs/jp/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ja
+              tags:       Kibana/Reference
+              subject:    Kibana
+              sources:
+                -
+                  repo: kibana
+                  path: /docs/jp
+            - title:      X-Packリファレンス
+              prefix:     x-pack
+              index:      docs/jp/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4 ]
+              chunk:      1
+              private:    1
+              lang:       ja
+              tags:       X-Pack/Reference
+              subject:    X-Pack
+              sources:
+                -
+                  repo: x-pack
+                  path: /docs/jp
+                -
+                  repo:   x-pack-kibana
+                  path:   docs/jp
+                  prefix: kibana-extra/x-pack-kibana
+                -
+                  repo: x-pack-elasticsearch
+                  path: /docs/jp
+                  prefix: elasticsearch-extra/x-pack-elasticsearch
+        - title:      한국어
+          base_dir:   kr
+          lang:       ko
+          sections:
+            - title:      Elasticsearch 참조
+              prefix:     elasticsearch/reference
+              index:      docs/kr/reference/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ko
+              tags:       Elasticsearch/Reference
+              subject:    Elasticsearch
+              sources:
+                -
+                  repo: elasticsearch
+                  path: /docs/kr/reference
+                -
+                  repo: elasticsearch
+                  path: /docs
+            - title:      Logstash 참조
+              prefix:     logstash
+              index:      docs/kr/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ko
+              tags:       Logstash/Reference
+              subject:    Logstash
+              sources:
+                -
+                  repo: logstash
+                  path: /docs/kr
+            - title:      Kibana 사용자 가이드
+              prefix:     kibana
+              index:      docs/kr/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4, 5.3 ]
+              chunk:      1
+              private:    1
+              lang:       ko
+              tags:       Kibana/Reference
+              subject:    Kibana
+              sources:
+                -
+                  repo: kibana
+                  path: /docs/kr
+            - title:      X-Pack 참조
+              prefix:     x-pack
+              index:      docs/kr/gs-index.asciidoc
+              current:    5.4
+              branches:   [ 5.4 ]
+              chunk:      1
+              private:    1
+              lang:       ko
+              tags:       X-Pack/Reference
+              subject:    X-Pack
+              sources:
+                -
+                  repo: x-pack
+                  path: /docs/kr
+                -
+                  repo: x-pack-kibana
+                  path: /docs/kr
+                  prefix: kibana-extra/x-pack-kibana
+                -
+                  repo: x-pack-elasticsearch
+                  path: /docs/kr
+                  prefix: elasticsearch-extra/x-pack-elasticsearch
+
+    -   title:      Legacy Documentation
+        sections:
+          - title:      Elastic Stack and Google Cloud's Anthos
+            prefix:     en/elastic-stack-gke
+            current:    main
+            index:      docs/en/gke-on-prem/index.asciidoc
+            branches:   [ {main: master} ]
+            private:    1
+            noindex:    1
+            chunk:      1
+            tags:       Elastic Stack/Google
+            subject:    Elastic Stack
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/gke-on-prem
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Journalbeat Reference for 6.5-7.15
+            prefix:     en/beats/journalbeat
+            current:    7.15
+            index:      journalbeat/docs/index.asciidoc
+            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            chunk:      1
+            tags:       Journalbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Journalbeat
+            sources:
+              -
+                repo:   beats
+                path:   journalbeat
+              -
+                repo:   beats
+                path:   journalbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Logs Monitoring Guide for 7.5-7.9
+            prefix:     en/logs/guide
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
+            index:      docs/en/logs/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Logs/Guide
+            subject:    Logs
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Metrics Monitoring Guide for 7.5-7.9
+            prefix:     en/metrics/guide
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
+            index:      docs/en/metrics/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Metrics/Guide
+            subject:    Metrics
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Uptime Monitoring Guide for 7.2-7.9
+            prefix:     en/uptime
+            current:    7.9
+            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
+            index:      docs/en/uptime/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Uptime/Guide
+            subject:    Uptime
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Infrastructure Monitoring Guide for 6.5-7.4
+            prefix:     en/infrastructure/guide
+            current:    7.4
+            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            index:      docs/en/infraops/index.asciidoc
+            chunk:      1
+            private:    1
+            tags:       Infrastructure/Guide
+            subject:    Infrastructure
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Stack Overview
+            prefix:     en/elastic-stack-overview
+            current:    7.4
+            index:      docs/en/stack/index.asciidoc
+            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            chunk:      1
+            noindex:    1
+            tags:       Legacy/Elastic Stack/Overview
+            subject:    Elastic Stack
+            sources:
+              -
+                repo:   stack-docs
+                path:   docs/en/stack
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   docs
+                path:   shared/settings.asciidoc
+          - title:      X-Pack Reference for 6.0-6.2 and 5.x
+            prefix:     en/x-pack
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/XPack/Reference
+            current:    6.2
+            subject:    X-Pack
+            index:      docs/en/index.asciidoc
+            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            sources:
+              -
+                repo:   x-pack
+                path:   docs/en
+              -
+                repo:   x-pack-kibana
+                prefix: kibana-extra/x-pack-kibana
+                path:   docs/en
+                exclude_branches:   [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   x-pack-elasticsearch
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+                path:   docs/en
+                exclude_branches: [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
+          - title:      Elasticsearch - The Definitive Guide
+            prefix:     en/elasticsearch/guide
+            current:    2.x
+            branches:   [ master, 2.x, 1.x ]
+            index:      book.asciidoc
+            chunk:      1
+            noindex:    1
+            private:    1
+            tags:       Legacy/Elasticsearch/Definitive Guide
+            subject:    Elasticsearch
             suppress_migration_warnings: true
             sources:
-              - repo: guide-cn
-                path: /
-          - title: PHP API
-            prefix: elasticsearch/php
-            index: index.asciidoc
-            current: cn
-            branches: [{ cn: 6.0 }]
-            lang: zh_cn
-            tags: Elasticsearch/PHP
-            subject: Elasticsearch
+              -
+                repo:   guide
+                path:   /
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches:   [ master, 2.x]
+          - title:      Sense Editor for 4.x
+            prefix:     en/sense
+            current:    master
+            branches:   [ master ]
+            index:      docs/index.asciidoc
+            noindex:    1
+            private:    1
+            tags:       Legacy/Elasticsearch/Sense-Editor
+            subject:    Sense
             sources:
-              - repo: elasticsearch-php-cn
-                path: /
-          - title: Kibana 用户手册
-            prefix: kibana
-            index: docs/index.asciidoc
-            current: cn
-            branches: [{ cn: 6.0 }]
-            lang: zh_cn
-            chunk: 1
-            private: 1
-            tags: Kibana/Reference
-            subject: Kibana
+              -
+                repo:   sense
+                path:   docs
+          - title:      Marvel Reference for 2.x and 1.x
+            prefix:     en/marvel
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Marvel/Reference
+            subject:    Marvel
+            current:    2.4
+            index:      docs/public/marvel/index.asciidoc
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
             sources:
-              - repo: kibana-cn
-                path: /docs
-      - title: 日本語
-        base_dir: jp
-        lang: ja
-        sections:
-          - title: Elasticsearchリファレンス
-            prefix: elasticsearch/reference
-            index: docs/jp/reference/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ja
-            tags: Elasticsearch/Reference
-            subject: Elasticsearch
+              -
+                repo:   x-pack
+                path:   docs/public/marvel
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches: [marvel-1.3]
+          - title:      Shield Reference for 2.x and 1.x
+            prefix:     en/shield
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Shield/Reference
+            subject:    Shield
+            current:    2.4
+            index:      docs/public/shield/index.asciidoc
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
             sources:
-              - repo: elasticsearch
-                path: /docs/jp/reference
-              - repo: elasticsearch
-                path: /docs
-          - title: Logstashリファレンス
-            prefix: logstash
-            index: docs/jp/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ja
-            tags: Logstash/Reference
-            subject: Logstash
+              -
+                repo:   x-pack
+                path:   docs/public/shield
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches: [shield-1.2, shield-1.1 , shield-1.0]
+          - title:      Watcher Reference for 2.x and 1.x
+            prefix:     en/watcher
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Watcher/Reference
+            subject:    Watcher
+            current:    2.4
+            index:      docs/public/watcher/index.asciidoc
+            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
             sources:
-              - repo: logstash
-                path: /docs/jp
-          - title: Kibanaユーザーガイド
-            prefix: kibana
-            index: docs/jp/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ja
-            tags: Kibana/Reference
-            subject: Kibana
+              -
+                repo:   x-pack
+                path:   docs/public/watcher
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+          - title:      Reporting Reference for 2.x
+            prefix:     en/reporting
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Reporting/Reference
+            subject:    Reporting
+            current:    2.4
+            index:      docs/public/reporting/index.asciidoc
+            branches:   [ 2.4 ]
             sources:
-              - repo: kibana
-                path: /docs/jp
-          - title: X-Packリファレンス
-            prefix: x-pack
-            index: docs/jp/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4]
-            chunk: 1
-            private: 1
-            lang: ja
-            tags: X-Pack/Reference
-            subject: X-Pack
+              -
+                repo:   x-pack
+                path:   docs/public/reporting
+          - title:      Graph Reference for 2.x
+            prefix:     en/graph
+            repo:       x-pack
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Graph/Reference
+            subject:    Graph
+            current:    2.4
+            index:      docs/public/graph/index.asciidoc
+            branches:   [ 2.4, 2.3 ]
             sources:
-              - repo: x-pack
-                path: /docs/jp
-              - repo: x-pack-kibana
-                path: docs/jp
-                prefix: kibana-extra/x-pack-kibana
-              - repo: x-pack-elasticsearch
-                path: /docs/jp
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-      - title: 한국어
-        base_dir: kr
-        lang: ko
-        sections:
-          - title: Elasticsearch 참조
-            prefix: elasticsearch/reference
-            index: docs/kr/reference/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ko
-            tags: Elasticsearch/Reference
-            subject: Elasticsearch
+              -
+                repo:   x-pack
+                path:   docs/public/graph
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+          - title:      Groovy API
+            prefix:     en/elasticsearch/client/groovy-api
+            current:    2.4
+            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            index:      docs/groovy-api/index.asciidoc
+            private:    1
+            noindex:    1
+            tags:       Legacy/Clients/Groovy
+            subject:    Clients
             sources:
-              - repo: elasticsearch
-                path: /docs/kr/reference
-              - repo: elasticsearch
-                path: /docs
-          - title: Logstash 참조
-            prefix: logstash
-            index: docs/kr/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ko
-            tags: Logstash/Reference
-            subject: Logstash
+              -
+                repo:   elasticsearch
+                path:   docs/groovy-api
+              -
+                repo:   elasticsearch
+                path:   docs/Versions.asciidoc
+                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+          - title:      Topbeat Reference
+            prefix:     en/beats/topbeat
+            index:      topbeat/docs/index.asciidoc
+            current:    1.3
+            branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
+            chunk:      1
+            noindex:    1
+            tags:       Legacy/Topbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Topbeat
             sources:
-              - repo: logstash
-                path: /docs/kr
-          - title: Kibana 사용자 가이드
-            prefix: kibana
-            index: docs/kr/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4, 5.3]
-            chunk: 1
-            private: 1
-            lang: ko
-            tags: Kibana/Reference
-            subject: Kibana
+              -
+                repo:   beats
+                path:   topbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+          - title:      Elasticsearch.js for 5.6-7.6
+            prefix:     en/elasticsearch/client/elasticsearch-js
+            current:    16.x
+            branches:   [ 16.x ]
+            index:      docs/index.asciidoc
+            chunk:      1
+            private:    1
+            noindex:    1
+            tags:       Legacy/Clients/Elasticsearch-js
+            subject:    Clients
             sources:
-              - repo: kibana
-                path: /docs/kr
-          - title: X-Pack 참조
-            prefix: x-pack
-            index: docs/kr/gs-index.asciidoc
-            current: 5.4
-            branches: [5.4]
-            chunk: 1
-            private: 1
-            lang: ko
-            tags: X-Pack/Reference
-            subject: X-Pack
-            sources:
-              - repo: x-pack
-                path: /docs/kr
-              - repo: x-pack-kibana
-                path: /docs/kr
-                prefix: kibana-extra/x-pack-kibana
-              - repo: x-pack-elasticsearch
-                path: /docs/kr
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-
-  - title: Legacy Documentation
-    sections:
-      - title: Elastic Stack and Google Cloud's Anthos
-        prefix: en/elastic-stack-gke
-        current: main
-        index: docs/en/gke-on-prem/index.asciidoc
-        branches: [{ main: master }]
-        private: 1
-        noindex: 1
-        chunk: 1
-        tags: Elastic Stack/Google
-        subject: Elastic Stack
-        sources:
-          - repo: stack-docs
-            path: docs/en/gke-on-prem
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Journalbeat Reference for 6.5-7.15
-        prefix: en/beats/journalbeat
-        current: 7.15
-        index: journalbeat/docs/index.asciidoc
-        branches:
-          [
-            7.15,
-            7.14,
-            7.13,
-            7.12,
-            7.11,
-            7.10,
-            7.9,
-            7.8,
-            7.7,
-            7.6,
-            7.5,
-            7.4,
-            7.3,
-            7.2,
-            7.1,
-            7.0,
-            6.8,
-            6.7,
-            6.6,
-            6.5,
-          ]
-        chunk: 1
-        tags: Journalbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Journalbeat
-        sources:
-          - repo: beats
-            path: journalbeat
-          - repo: beats
-            path: journalbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-          - repo: beats
-            path: libbeat/processors/*/docs/*
-            exclude_branches: *beatsProcessorExclude
-          - repo: beats
-            path: x-pack/libbeat/processors/*/docs/*
-            exclude_branches:
-              [
-                7.6,
-                7.5,
-                7.4,
-                7.3,
-                7.2,
-                7.1,
-                7.0,
-                6.8,
-                6.7,
-                6.6,
-                6.5,
-                6.4,
-                6.3,
-                6.2,
-                6.1,
-                6.0,
-                5.6,
-                5.5,
-                5.4,
-                5.3,
-                5.2,
-                5.1,
-                5.0,
-                1.3,
-                1.2,
-                1.1,
-                1.0.1,
-              ]
-          - repo: beats
-            path: libbeat/outputs/*/docs/*
-            exclude_branches: *beatsOutputExclude
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Logs Monitoring Guide for 7.5-7.9
-        prefix: en/logs/guide
-        current: 7.9
-        branches: [7.9, 7.8, 7.7, 7.6, 7.5]
-        index: docs/en/logs/index.asciidoc
-        chunk: 1
-        private: 1
-        tags: Logs/Guide
-        subject: Logs
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Metrics Monitoring Guide for 7.5-7.9
-        prefix: en/metrics/guide
-        current: 7.9
-        branches: [7.9, 7.8, 7.7, 7.6, 7.5]
-        index: docs/en/metrics/index.asciidoc
-        chunk: 1
-        private: 1
-        tags: Metrics/Guide
-        subject: Metrics
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Uptime Monitoring Guide for 7.2-7.9
-        prefix: en/uptime
-        current: 7.9
-        branches: [7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2]
-        index: docs/en/uptime/index.asciidoc
-        chunk: 1
-        private: 1
-        tags: Uptime/Guide
-        subject: Uptime
-        sources:
-          - repo: observability-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Infrastructure Monitoring Guide for 6.5-7.4
-        prefix: en/infrastructure/guide
-        current: 7.4
-        branches: [7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5]
-        index: docs/en/infraops/index.asciidoc
-        chunk: 1
-        private: 1
-        tags: Infrastructure/Guide
-        subject: Infrastructure
-        sources:
-          - repo: stack-docs
-            path: docs/en
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-      - title: Stack Overview
-        prefix: en/elastic-stack-overview
-        current: 7.4
-        index: docs/en/stack/index.asciidoc
-        branches: [7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3]
-        chunk: 1
-        noindex: 1
-        tags: Legacy/Elastic Stack/Overview
-        subject: Elastic Stack
-        sources:
-          - repo: stack-docs
-            path: docs/en/stack
-          - repo: docs
-            path: shared/versions/stack/{version}.asciidoc
-          - repo: docs
-            path: shared/attributes.asciidoc
-          - repo: docs
-            path: shared/settings.asciidoc
-      - title: X-Pack Reference for 6.0-6.2 and 5.x
-        prefix: en/x-pack
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/XPack/Reference
-        current: 6.2
-        subject: X-Pack
-        index: docs/en/index.asciidoc
-        branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
-        sources:
-          - repo: x-pack
-            path: docs/en
-          - repo: x-pack-kibana
-            prefix: kibana-extra/x-pack-kibana
-            path: docs/en
-            exclude_branches: [master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
-          - repo: x-pack-elasticsearch
-            prefix: elasticsearch-extra/x-pack-elasticsearch
-            path: docs/en
-            exclude_branches: [master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
-          - repo: docs
-            path: shared/attributes62.asciidoc
-            exclude_branches: [5.4, 5.3, 5.2, 5.1, 5.0]
-      - title: Elasticsearch - The Definitive Guide
-        prefix: en/elasticsearch/guide
-        current: 2.x
-        branches: [master, 2.x, 1.x]
-        index: book.asciidoc
-        chunk: 1
-        noindex: 1
-        private: 1
-        tags: Legacy/Elasticsearch/Definitive Guide
-        subject: Elasticsearch
-        suppress_migration_warnings: true
-        sources:
-          - repo: guide
-            path: /
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-            exclude_branches: [master, 2.x]
-      - title: Sense Editor for 4.x
-        prefix: en/sense
-        current: master
-        branches: [master]
-        index: docs/index.asciidoc
-        noindex: 1
-        private: 1
-        tags: Legacy/Elasticsearch/Sense-Editor
-        subject: Sense
-        sources:
-          - repo: sense
-            path: docs
-      - title: Marvel Reference for 2.x and 1.x
-        prefix: en/marvel
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Marvel/Reference
-        subject: Marvel
-        current: 2.4
-        index: docs/public/marvel/index.asciidoc
-        branches: [2.4, 2.3, 2.2, 2.1, 2.0, { marvel-1.3: 1.3 }]
-        sources:
-          - repo: x-pack
-            path: docs/public/marvel
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-            exclude_branches: [marvel-1.3]
-      - title: Shield Reference for 2.x and 1.x
-        prefix: en/shield
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Shield/Reference
-        subject: Shield
-        current: 2.4
-        index: docs/public/shield/index.asciidoc
-        branches:
-          [
-            2.4,
-            2.3,
-            2.2,
-            2.1,
-            2.0,
-            { shield-1.3: 1.3 },
-            { shield-1.2: 1.2 },
-            { shield-1.1: 1.1 },
-            { shield-1.0: 1.0 },
-          ]
-        sources:
-          - repo: x-pack
-            path: docs/public/shield
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-            exclude_branches: [shield-1.2, shield-1.1, shield-1.0]
-      - title: Watcher Reference for 2.x and 1.x
-        prefix: en/watcher
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Watcher/Reference
-        subject: Watcher
-        current: 2.4
-        index: docs/public/watcher/index.asciidoc
-        branches: [2.4, 2.3, 2.2, 2.1, 2.0, { watcher-1.0: 1.0 }]
-        sources:
-          - repo: x-pack
-            path: docs/public/watcher
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-      - title: Reporting Reference for 2.x
-        prefix: en/reporting
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Reporting/Reference
-        subject: Reporting
-        current: 2.4
-        index: docs/public/reporting/index.asciidoc
-        branches: [2.4]
-        sources:
-          - repo: x-pack
-            path: docs/public/reporting
-      - title: Graph Reference for 2.x
-        prefix: en/graph
-        repo: x-pack
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Graph/Reference
-        subject: Graph
-        current: 2.4
-        index: docs/public/graph/index.asciidoc
-        branches: [2.4, 2.3]
-        sources:
-          - repo: x-pack
-            path: docs/public/graph
-          - repo: docs
-            path: shared/legacy-attrs.asciidoc
-      - title: Groovy API
-        prefix: en/elasticsearch/client/groovy-api
-        current: 2.4
-        branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-        index: docs/groovy-api/index.asciidoc
-        private: 1
-        noindex: 1
-        tags: Legacy/Clients/Groovy
-        subject: Clients
-        sources:
-          - repo: elasticsearch
-            path: docs/groovy-api
-          - repo: elasticsearch
-            path: docs/Versions.asciidoc
-            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
-      - title: Topbeat Reference
-        prefix: en/beats/topbeat
-        index: topbeat/docs/index.asciidoc
-        current: 1.3
-        branches: [1.3, 1.2, 1.1, 1.0.1]
-        chunk: 1
-        noindex: 1
-        tags: Legacy/Topbeat/Reference
-        respect_edit_url_overrides: true
-        subject: Topbeat
-        sources:
-          - repo: beats
-            path: topbeat/docs
-          - repo: beats
-            path: CHANGELOG.asciidoc
-          - repo: beats
-            path: libbeat/docs
-      - title: Elasticsearch.js for 5.6-7.6
-        prefix: en/elasticsearch/client/elasticsearch-js
-        current: 16.x
-        branches: [16.x]
-        index: docs/index.asciidoc
-        chunk: 1
-        private: 1
-        noindex: 1
-        tags: Legacy/Clients/Elasticsearch-js
-        subject: Clients
-        sources:
-          - repo: elasticsearch-js-legacy
-            path: docs
+              -
+                repo:   elasticsearch-js-legacy
+                path:   docs
 
 redirects:
-  - prefix: en/
-    redirect: /guide
-  - prefix: en/elasticsearch
-    redirect: /guide
-  - prefix: cn/elasticsearch
-    redirect: /cn
+    -
+        prefix:         en/
+        redirect:       /guide
+    -
+        prefix:         en/elasticsearch
+        redirect:       /guide
+    -
+        prefix:         cn/elasticsearch
+        redirect:       /cn

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,82 +1,82 @@
 repos:
-    apm-aws-lambda:       https://github.com/elastic/apm-aws-lambda.git
-    apm-server:           https://github.com/elastic/apm-server.git
-    apm-agent-nodejs:     https://github.com/elastic/apm-agent-nodejs.git
-    apm-agent-python:     https://github.com/elastic/apm-agent-python.git
-    apm-agent-ruby:       https://github.com/elastic/apm-agent-ruby.git
-    apm-agent-rum-js:     https://github.com/elastic/apm-agent-rum-js.git
-    apm-agent-go:         https://github.com/elastic/apm-agent-go.git
-    apm-agent-java:       https://github.com/elastic/apm-agent-java.git
-    apm-agent-dotnet:     https://github.com/elastic/apm-agent-dotnet.git
-    apm-agent-php:        https://github.com/elastic/apm-agent-php.git
-    apm-agent-ios:        https://github.com/elastic/apm-agent-ios.git
-    azure-marketplace:    https://github.com/elastic/azure-marketplace.git
-    beats:                https://github.com/elastic/beats.git
-    clients-team:         https://github.com/elastic/clients-team.git
-    cloud:                https://github.com/elastic/cloud.git
-    cloud-assets:         https://github.com/elastic/cloud-assets.git
-    cloud-on-k8s:         https://github.com/elastic/cloud-on-k8s.git
-    curator:              https://github.com/elastic/curator.git
-    ecctl:                https://github.com/elastic/ecctl.git
-    ecs:                  https://github.com/elastic/ecs.git
-    ecs-dotnet:           https://github.com/elastic/ecs-dotnet.git
-    ecs-logging:          https://github.com/elastic/ecs-logging.git
-    ecs-logging-go-logrus:  https://github.com/elastic/ecs-logging-go-logrus.git
-    ecs-logging-go-zap:   https://github.com/elastic/ecs-logging-go-zap.git
-    ecs-logging-java:     https://github.com/elastic/ecs-logging-java.git
-    ecs-logging-nodejs:   https://github.com/elastic/ecs-logging-nodejs.git
-    ecs-logging-php:      https://github.com/elastic/ecs-logging-php.git
-    ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
-    ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
-    eland:                https://github.com/elastic/eland.git
-    elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
-    elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
-    elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
-    elasticsearch-js-legacy:  https://github.com/elastic/elasticsearch-js-legacy.git
-    elasticsearch-ruby:   https://github.com/elastic/elasticsearch-ruby.git
-    elasticsearch-net:    https://github.com/elastic/elasticsearch-net.git
-    elasticsearch-php:    https://github.com/elastic/elasticsearch-php.git
-    elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
-    elasticsearch-py:     https://github.com/elastic/elasticsearch-py.git
-    elasticsearch-perl:   https://github.com/elastic/elasticsearch-perl.git
-    go-elasticsearch:     https://github.com/elastic/go-elasticsearch.git
-    elasticsearch-rs:     https://github.com/elastic/elasticsearch-rs.git
-    elasticsearch:        https://github.com/elastic/elasticsearch.git
-    enterprise-search-pubs: https://github.com/elastic/enterprise-search-pubs.git
-    enterprise-search-php: https://github.com/elastic/enterprise-search-php.git
-    enterprise-search-python: https://github.com/elastic/enterprise-search-python.git
-    enterprise-search-ruby: https://github.com/elastic/enterprise-search-ruby.git
-    guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
-    guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
-    kibana:               https://github.com/elastic/kibana.git
-    kibana-cn:            https://github.com/elasticsearch-cn/kibana.git
-    logstash:             https://github.com/elastic/logstash.git
-    logstash-docs:        https://github.com/elastic/logstash-docs.git
-    observability-docs:   https://github.com/elastic/observability-docs.git
-    package-spec:         https://github.com/elastic/package-spec.git
-    security-docs:        https://github.com/elastic/security-docs.git
-    sense:                https://github.com/elastic/sense.git
-    stack-docs:           https://github.com/elastic/stack-docs.git
-    swiftype:             https://github.com/elastic/swiftype-doc-placeholder.git
-    tech-content:         https://github.com/elastic/tech-content.git
-    terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
-    x-pack:               https://github.com/elastic/x-pack.git
-    x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
-    x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
-    x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
+  apm-aws-lambda: https://github.com/elastic/apm-aws-lambda.git
+  apm-server: https://github.com/elastic/apm-server.git
+  apm-agent-nodejs: https://github.com/elastic/apm-agent-nodejs.git
+  apm-agent-python: https://github.com/elastic/apm-agent-python.git
+  apm-agent-ruby: https://github.com/elastic/apm-agent-ruby.git
+  apm-agent-rum-js: https://github.com/elastic/apm-agent-rum-js.git
+  apm-agent-go: https://github.com/elastic/apm-agent-go.git
+  apm-agent-java: https://github.com/elastic/apm-agent-java.git
+  apm-agent-dotnet: https://github.com/elastic/apm-agent-dotnet.git
+  apm-agent-php: https://github.com/elastic/apm-agent-php.git
+  apm-agent-ios: https://github.com/elastic/apm-agent-ios.git
+  azure-marketplace: https://github.com/elastic/azure-marketplace.git
+  beats: https://github.com/elastic/beats.git
+  clients-team: https://github.com/elastic/clients-team.git
+  cloud: https://github.com/elastic/cloud.git
+  cloud-assets: https://github.com/elastic/cloud-assets.git
+  cloud-on-k8s: https://github.com/elastic/cloud-on-k8s.git
+  curator: https://github.com/elastic/curator.git
+  ecctl: https://github.com/elastic/ecctl.git
+  ecs: https://github.com/elastic/ecs.git
+  ecs-dotnet: https://github.com/elastic/ecs-dotnet.git
+  ecs-logging: https://github.com/elastic/ecs-logging.git
+  ecs-logging-go-logrus: https://github.com/elastic/ecs-logging-go-logrus.git
+  ecs-logging-go-zap: https://github.com/elastic/ecs-logging-go-zap.git
+  ecs-logging-java: https://github.com/elastic/ecs-logging-java.git
+  ecs-logging-nodejs: https://github.com/elastic/ecs-logging-nodejs.git
+  ecs-logging-php: https://github.com/elastic/ecs-logging-php.git
+  ecs-logging-python: https://github.com/elastic/ecs-logging-python.git
+  ecs-logging-ruby: https://github.com/elastic/ecs-logging-ruby.git
+  eland: https://github.com/elastic/eland.git
+  elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
+  elasticsearch-java: https://github.com/elastic/elasticsearch-java.git
+  elasticsearch-js: https://github.com/elastic/elasticsearch-js.git
+  elasticsearch-js-legacy: https://github.com/elastic/elasticsearch-js-legacy.git
+  elasticsearch-ruby: https://github.com/elastic/elasticsearch-ruby.git
+  elasticsearch-net: https://github.com/elastic/elasticsearch-net.git
+  elasticsearch-php: https://github.com/elastic/elasticsearch-php.git
+  elasticsearch-php-cn: https://github.com/elasticsearch-cn/elasticsearch-php.git
+  elasticsearch-py: https://github.com/elastic/elasticsearch-py.git
+  elasticsearch-perl: https://github.com/elastic/elasticsearch-perl.git
+  go-elasticsearch: https://github.com/elastic/go-elasticsearch.git
+  elasticsearch-rs: https://github.com/elastic/elasticsearch-rs.git
+  elasticsearch: https://github.com/elastic/elasticsearch.git
+  enterprise-search-pubs: https://github.com/elastic/enterprise-search-pubs.git
+  enterprise-search-php: https://github.com/elastic/enterprise-search-php.git
+  enterprise-search-python: https://github.com/elastic/enterprise-search-python.git
+  enterprise-search-ruby: https://github.com/elastic/enterprise-search-ruby.git
+  guide: https://github.com/elastic/elasticsearch-definitive-guide.git
+  guide-cn: https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
+  kibana: https://github.com/elastic/kibana.git
+  kibana-cn: https://github.com/elasticsearch-cn/kibana.git
+  logstash: https://github.com/elastic/logstash.git
+  logstash-docs: https://github.com/elastic/logstash-docs.git
+  observability-docs: https://github.com/elastic/observability-docs.git
+  package-spec: https://github.com/elastic/package-spec.git
+  security-docs: https://github.com/elastic/security-docs.git
+  sense: https://github.com/elastic/sense.git
+  stack-docs: https://github.com/elastic/stack-docs.git
+  swiftype: https://github.com/elastic/swiftype-doc-placeholder.git
+  tech-content: https://github.com/elastic/tech-content.git
+  terraform-provider-ec: https://github.com/elastic/terraform-provider-ec.git
+  x-pack: https://github.com/elastic/x-pack.git
+  x-pack-elasticsearch: https://github.com/elastic/x-pack-elasticsearch.git
+  x-pack-kibana: https://github.com/elastic/x-pack-kibana.git
+  x-pack-logstash: https://github.com/elastic/x-pack-logstash.git
 
-contents_title:     Elastic Stack and Product Documentation
+contents_title: Elastic Stack and Product Documentation
 
 # Each item should take the form:
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 8.0
-  stacklive: &stacklive [ master, 8.1, 8.0, 7.17 ]
+  stacklive: &stacklive [master, 8.1, 8.0, 7.17]
 
-  stacklivemain: &stacklivemain [ main, 8.1, 8.0, 7.17 ]
+  stacklivemain: &stacklivemain [main, 8.1, 8.0, 7.17]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-70
+  cloudSaasCurrent: &cloudSaasCurrent ms-71
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
@@ -107,2692 +107,5667 @@ variables:
   mapMasterToMain: &mapMasterToMain
     master: main
 
-  beatsSharedExclude: &beatsSharedExclude [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-  beatsXpackLibbeatExclude: &beatsXpackLibbeatExclude [ 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-  beatsProcessorExclude: &beatsProcessorExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-  beatsOutputExclude: &beatsOutputExclude [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-
+  beatsSharedExclude:
+    &beatsSharedExclude [
+      6.2,
+      6.1,
+      6.0,
+      5.6,
+      5.5,
+      5.4,
+      5.3,
+      5.2,
+      5.1,
+      5.0,
+      1.3,
+      1.2,
+      1.1,
+      1.0.1,
+    ]
+  beatsXpackLibbeatExclude:
+    &beatsXpackLibbeatExclude [
+      7.3,
+      7.2,
+      7.1,
+      7.0,
+      6.8,
+      6.7,
+      6.6,
+      6.5,
+      6.4,
+      6.3,
+      6.2,
+      6.1,
+      6.0,
+      5.6,
+      5.5,
+      5.4,
+      5.3,
+      5.2,
+      5.1,
+      5.0,
+      1.3,
+      1.2,
+      1.1,
+      1.0.1,
+    ]
+  beatsProcessorExclude:
+    &beatsProcessorExclude [
+      7.4,
+      7.3,
+      7.2,
+      7.1,
+      7.0,
+      6.8,
+      6.7,
+      6.6,
+      6.5,
+      6.4,
+      6.3,
+      6.2,
+      6.1,
+      6.0,
+      5.6,
+      5.5,
+      5.4,
+      5.3,
+      5.2,
+      5.1,
+      5.0,
+      1.3,
+      1.2,
+      1.1,
+      1.0.1,
+    ]
+  beatsOutputExclude:
+    &beatsOutputExclude [
+      7.4,
+      7.3,
+      7.2,
+      7.1,
+      7.0,
+      6.8,
+      6.7,
+      6.6,
+      6.5,
+      6.4,
+      6.3,
+      6.2,
+      6.1,
+      6.0,
+      5.6,
+      5.5,
+      5.4,
+      5.3,
+      5.2,
+      5.1,
+      5.0,
+      1.3,
+      1.2,
+      1.1,
+      1.0.1,
+    ]
 
 toc_extra: extra/docs_landing.html
 contents:
-    -   title: Elastic Documentation
+  - title: Elastic Documentation
+    sections:
+      - title: "Welcome to Elastic"
+        prefix: en/welcome-to-elastic
+        current: main
+        index: welcome-to-elastic/index.asciidoc
+        branches: [{ main: master }]
+        chunk: 1
+        tags: Elastic/Welcome
+        subject: Welcome to Elastic
+        sources:
+          - repo: tech-content
+            path: welcome-to-elastic
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+
+  - title: Elastic Stack
+    sections:
+      - title: Installation and Upgrade Guide
+        prefix: en/elastic-stack
+        current: *stackcurrent
+        index: docs/en/install-upgrade/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Elastic Stack/Installation and Upgrade
+        subject: Elastic Stack
+        sources:
+          - repo: stack-docs
+            path: docs/en
+          - repo: apm-server
+            path: docs/
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: beats
+            path: libbeat/docs
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: elasticsearch
+            path: docs/
+            map_branches: *mapMainToMaster
+          - repo: elasticsearch-hadoop
+            path: docs/src/reference/asciidoc
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+            map_branches: *mapMainToMaster
+          - repo: security-docs
+            path: docs/
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: kibana
+            path: docs/
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: logstash
+            path: docs/
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: observability-docs
+            path: docs/en/observability
+            exclude_branches:
+              [
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
+            map_branches: *mapMainToMaster
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
+          - repo: docs
+            path: shared/attributes62.asciidoc
+            exclude_branches:
+              [
+                main,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+      - title: Getting Started
+        prefix: en/elastic-stack-get-started
+        current: *stackcurrent
+        index: docs/en/getting-started/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Elastic Stack/Getting started
+        subject: Elastic Stack
+        sources:
+          - repo: stack-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: elasticsearch
+            path: docs/
+            map_branches: *mapMainToMaster
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+              ]
+      - title: Glossary
+        prefix: en/elastic-stack-glossary
+        current: main
+        index: docs/en/glossary/index.asciidoc
+        branches: [{ main: master }]
+        tags: Elastic Stack/Glossary
+        subject: Elastic Stack
+        sources:
+          - repo: stack-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Machine Learning
+        prefix: en/machine-learning
+        current: *stackcurrent
+        index: docs/en/stack/ml/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Elastic Stack/Machine Learning
+        subject: Machine Learning
+        sources:
+          - repo: stack-docs
+            path: docs/en/stack
+          - repo: elasticsearch
+            path: docs
+            map_branches: *mapMainToMaster
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: docs
+            path: shared/settings.asciidoc
+      - title: Elastic Common Schema (ECS) Reference
+        prefix: en/ecs
+        current: 8.0
+        branches:
+          [
+            { main: master },
+            8.2,
+            8.1,
+            8.0,
+            1.12,
+            1.11,
+            1.10,
+            1.9,
+            1.8,
+            1.7,
+            1.6,
+            1.5,
+            1.4,
+            1.3,
+            1.2,
+            1.1,
+            1.0,
+          ]
+        live: [main, 8.2, 8.1, 8.0, 1.12]
+        index: docs/index.asciidoc
+        chunk: 2
+        tags: Elastic Common Schema (ECS)/Reference
+        subject: Elastic Common Schema (ECS)
+        sources:
+          - repo: ecs
+            path: docs/
+      - title: Azure Marketplace and Resource Manager (ARM) template
+        prefix: en/elastic-stack-deploy
+        current: 7.11
+        index: docs/index.asciidoc
+        branches:
+          [
+            master,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+          ]
+        chunk: 1
+        tags: Elastic Stack/Azure
+        subject: Azure Marketplace and Resource Manager (ARM) template
+        sources:
+          - repo: azure-marketplace
+            path: docs
+
+  - title: "Elasticsearch: Store, Search, and Analyze"
+    sections:
+      - title: Elasticsearch Guide
+        prefix: en/elasticsearch/reference
+        current: *stackcurrent
+        branches:
+          [
+            master,
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            2.4,
+            2.3,
+            2.2,
+            2.1,
+            2.0,
+            1.7,
+            1.6,
+            1.5,
+            1.4,
+            1.3,
+            0.90,
+          ]
+        live: *stacklive
+        index: docs/reference/index.x.asciidoc
+        chunk: 1
+        tags: Elasticsearch/Reference
+        subject: Elasticsearch
+        sources:
+          - repo: elasticsearch
+            path: docs/reference
+          - repo: x-pack-elasticsearch
+            prefix: elasticsearch-extra/x-pack-elasticsearch
+            path: docs/en
+            private: true
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: x-pack-elasticsearch
+            prefix: elasticsearch-extra/x-pack-elasticsearch
+            path: qa/sql
+            private: true
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: docs/Versions.asciidoc
+            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+          - repo: elasticsearch
+            path: docs/src/test/cluster/config
+            exclude_branches:
+              [5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+          - repo: elasticsearch
+            path: plugins/examples
+            exclude_branches:
+              [
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: buildSrc/
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: build-tools-internal/
+            exclude_branches:
+              [
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: docs/painless
+            exclude_branches:
+              [
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: x-pack/docs
+            private: true
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: x-pack/qa/sql
+            # only exists from 6.3 to 6.5
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: x-pack/plugin/sql/qa
+            exclude_branches:
+              [
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - alternatives: { source_lang: console, alternative_lang: php }
+            repo: elasticsearch-php
+            path: docs/examples
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - alternatives: { source_lang: console, alternative_lang: csharp }
+            repo: elasticsearch-net
+            path: examples
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            map_branches: *mapMasterToMain
+          - alternatives: { source_lang: console, alternative_lang: python }
+            repo: elasticsearch-py
+            path: docs/examples
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            map_branches: *mapMasterToMain
+          - alternatives: { source_lang: console, alternative_lang: ruby }
+            repo: elasticsearch-ruby
+            path: docs/examples/guide
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            map_branches: *mapMasterToMain
+          - alternatives: { source_lang: console, alternative_lang: go }
+            repo: go-elasticsearch
+            path: .doc/examples/doc/
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            map_branches: *mapMasterToMain
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/attributes62.asciidoc
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - alternatives: { source_lang: console, alternative_lang: js }
+            repo: elasticsearch-js
+            path: docs/doc_examples
+            exclude_branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            map_branches: *mapMasterToMain
+      - title: Elasticsearch Resiliency Status
+        prefix: en/elasticsearch/resiliency
+        toc: 1
+        branches: [master]
+        current: master
+        index: docs/resiliency/index.asciidoc
+        single: 1
+        tags: Elasticsearch/Resiliency Status
+        subject: Elasticsearch
+        sources:
+          - repo: elasticsearch
+            path: docs/resiliency
+          - repo: elasticsearch
+            path: docs/Versions.asciidoc
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+      - title: Painless Scripting Language
+        prefix: en/elasticsearch/painless
+        current: *stackcurrent
+        branches:
+          [
+            master,
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+          ]
+        live: *stacklive
+        index: docs/painless/index.asciidoc
+        chunk: 1
+        tags: Elasticsearch/Painless
+        subject: Elasticsearch
+        sources:
+          - repo: elasticsearch
+            path: docs/painless
+          - repo: elasticsearch
+            path: docs/Versions.asciidoc
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+      - title: Plugins and Integrations
+        prefix: en/elasticsearch/plugins
+        repo: elasticsearch
+        current: *stackcurrent
+        index: docs/plugins/index.asciidoc
+        branches:
+          [
+            master,
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            2.4,
+            2.3,
+            2.2,
+            2.1,
+            2.0,
+            1.7,
+          ]
+        live: *stacklive
+        chunk: 2
+        tags: Elasticsearch/Plugins
+        subject: Elasticsearch
+        sources:
+          - repo: elasticsearch
+            path: docs/plugins
+          - repo: elasticsearch
+            path: docs/Versions.asciidoc
+            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+          - repo: elasticsearch
+            path: buildSrc/src/main/resources/
+            exclude_branches:
+              [
+                master,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: build-tools-internal/src/main/resources/
+            exclude_branches:
+              [
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: elasticsearch
+            path: build-tools/src/main/resources/
+            exclude_branches:
+              [
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+      - title: Elasticsearch Clients
+        base_dir: en/elasticsearch/client
         sections:
-          - title:      "Welcome to Elastic"
-            prefix:     en/welcome-to-elastic
-            current:    main
-            index:      welcome-to-elastic/index.asciidoc
-            branches:   [ {main: master} ]
-            chunk:      1
-            tags:       Elastic/Welcome
-            subject:    Welcome to Elastic
+          - title: Java Client
+            prefix: java-api-client
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklivemain
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/Java
+            subject: Clients
             sources:
-              -
-                repo:   tech-content
-                path:   welcome-to-elastic
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-
-    -   title:      Elastic Stack
-        sections:
-          - title:      Installation and Upgrade Guide
-            prefix:     en/elastic-stack
-            current:    *stackcurrent
-            index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Elastic Stack/Installation and Upgrade
-            subject:    Elastic Stack
+              - repo: elasticsearch-java
+                path: docs/
+              - repo: elasticsearch-java
+                path: java-client/src/test/java/co/elastic/clients/documentation
+              - repo: elasticsearch
+                path: docs/java-rest/
+              - repo: elasticsearch
+                path: client
+          - title: JavaScript Client
+            prefix: javascript-api
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x]
+            live: *stacklivemain
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/JavaScript
+            subject: Clients
             sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   apm-server
-                path:   docs/
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   beats
-                path:   libbeat/docs
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   elasticsearch
-                path:   docs/
-                map_branches: *mapMainToMaster
-              -
-                repo:   elasticsearch-hadoop
-                path:   docs/src/reference/asciidoc
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
-              -
-                repo:   security-docs
-                path:   docs/
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   kibana
-                path:   docs/
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   logstash
-                path:   docs/
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   observability-docs
-                path:   docs/en/observability
-                exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-          - title:      Getting Started
-            prefix:     en/elastic-stack-get-started
-            current:    *stackcurrent
-            index:      docs/en/getting-started/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Elastic Stack/Getting started
-            subject:    Elastic Stack
+              - repo: elasticsearch-js
+                path: docs/
+          - title: Ruby Client
+            prefix: ruby-api
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklivemain
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/Ruby
+            subject: Clients
             sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   elasticsearch
-                path:   docs/
-                map_branches: *mapMainToMaster
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-          - title:      Glossary
-            prefix:     en/elastic-stack-glossary
-            current:    main
-            index:      docs/en/glossary/index.asciidoc
-            branches:   [ {main: master} ]
-            tags:       Elastic Stack/Glossary
-            subject:    Elastic Stack
+              - repo: elasticsearch-ruby
+                path: docs/
+          - title: Go Client
+            prefix: go-api
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklivemain
+            index: .doc/index.asciidoc
+            chunk: 1
+            tags: Clients/Go
+            subject: Clients
             sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Machine Learning
-            prefix:     en/machine-learning
-            current:    *stackcurrent
-            index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Elastic Stack/Machine Learning
-            subject:    Machine Learning
+              - repo: go-elasticsearch
+                path: .doc/
+          - title: .NET Clients
+            prefix: net-api
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x]
+            live: *stacklivemain
+            index: docs/index.asciidoc
+            tags: Clients/.Net
+            subject: Clients
+            chunk: 1
             sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/stack
-              -
-                repo:   elasticsearch
-                path:   docs
-                map_branches: *mapMainToMaster
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   docs
-                path:   shared/settings.asciidoc
-          - title:      Elastic Common Schema (ECS) Reference
-            prefix:     en/ecs
-            current:    8.0
-            branches:   [  {main: master}, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.2, 8.1, 8.0, 1.12 ]
-            index:      docs/index.asciidoc
-            chunk:      2
-            tags:       Elastic Common Schema (ECS)/Reference
-            subject:    Elastic Common Schema (ECS)
+              - repo: elasticsearch-net
+                path: docs/
+          - title: PHP Client
+            prefix: php-api
+            current: *stackcurrent
+            branches: [master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4]
+            live: *stacklivemain
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/PHP
+            subject: Clients
             sources:
-              -
-                repo:   ecs
-                path:   docs/
-          - title:      Azure Marketplace and Resource Manager (ARM) template
-            prefix:     en/elastic-stack-deploy
-            current:    7.11
-            index:      docs/index.asciidoc
-            branches:   [ master, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            chunk:      1
-            tags:       Elastic Stack/Azure
-            subject:    Azure Marketplace and Resource Manager (ARM) template
+              - repo: elasticsearch-php
+                path: docs/
+              - repo: docs
+                path: shared/attributes.asciidoc
+          - title: Perl Client
+            prefix: perl-api
+            current: master
+            branches: [master, 8.1, 8.0]
+            live: [master, 8.1, 8.0]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/Perl
+            subject: Clients
             sources:
-              -
-                repo:   azure-marketplace
-                path:   docs
-
-    -   title:      "Elasticsearch: Store, Search, and Analyze"
-        sections:
-          - title:      Elasticsearch Guide
-            prefix:     en/elasticsearch/reference
-            current:    *stackcurrent
-            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            live:       *stacklive
-            index:      docs/reference/index.x.asciidoc
-            chunk:      1
-            tags:       Elasticsearch/Reference
-            subject:    Elasticsearch
+              - repo: elasticsearch-perl
+                path: docs/
+          - title: Python Client
+            prefix: python-api
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklivemain
+            index: docs/guide/index.asciidoc
+            chunk: 1
+            tags: Clients/Python
+            subject: Clients
             sources:
-              -
-                repo:   elasticsearch
-                path:   docs/reference
-              -
-                repo:   x-pack-elasticsearch
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-                path:   docs/en
-                private: true
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   x-pack-elasticsearch
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-                path:   qa/sql
-                private: true
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   docs/Versions.asciidoc
-                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   docs/src/test/cluster/config
-                exclude_branches:   [ 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   plugins/examples
-                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   buildSrc/
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   build-tools-internal/
-                exclude_branches:   [7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   docs/painless
-                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   x-pack/docs
-                private: true
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   x-pack/qa/sql
-                # only exists from 6.3 to 6.5
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   x-pack/plugin/sql/qa
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   elasticsearch-php
-                path:   docs/examples
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   elasticsearch-net
-                path:   examples
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   elasticsearch-py
-                path:   docs/examples
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   elasticsearch-ruby
-                path:   docs/examples/guide
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   go-elasticsearch
-                path:   .doc/examples/doc/
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                alternatives: { source_lang: console, alternative_lang: js }
-                repo:   elasticsearch-js
-                path:   docs/doc_examples
-                exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
-          - title:      Elasticsearch Resiliency Status
-            prefix:     en/elasticsearch/resiliency
-            toc:        1
-            branches:   [master]
-            current:    master
-            index:      docs/resiliency/index.asciidoc
-            single:     1
-            tags:       Elasticsearch/Resiliency Status
-            subject:    Elasticsearch
+              - repo: elasticsearch-py
+                path: docs/guide/
+          - title: eland
+            prefix: eland
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/guide/index.asciidoc
+            chunk: 1
+            tags: Clients/eland
+            subject: Clients
             sources:
-              -
-                repo:   elasticsearch
-                path:   docs/resiliency
-              -
-                repo:   elasticsearch
-                path:   docs/Versions.asciidoc
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      Painless Scripting Language
-            prefix:     en/elasticsearch/painless
-            current:    *stackcurrent
-            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
-            live:       *stacklive
-            index:      docs/painless/index.asciidoc
-            chunk:      1
-            tags:       Elasticsearch/Painless
-            subject:    Elasticsearch
+              - repo: eland
+                path: docs/guide
+          - title: Rust Client
+            prefix: rust-api
+            current: master
+            branches: [master, 8.1, 8.0]
+            live: [master, 8.1, 8.0]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: Clients/Rust
+            subject: Clients
             sources:
-              -
-                repo:   elasticsearch
-                path:   docs/painless
-              -
-                repo:   elasticsearch
-                path:   docs/Versions.asciidoc
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      Plugins and Integrations
-            prefix:     en/elasticsearch/plugins
-            repo:       elasticsearch
-            current:    *stackcurrent
-            index:      docs/plugins/index.asciidoc
-            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
-            live:       *stacklive
-            chunk:      2
-            tags:       Elasticsearch/Plugins
-            subject:    Elasticsearch
-            sources:
-              -
-                repo:   elasticsearch
-                path:   docs/plugins
-              -
-                repo:   elasticsearch
-                path:   docs/Versions.asciidoc
-                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   buildSrc/src/main/resources/
-                exclude_branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   build-tools-internal/src/main/resources/
-                exclude_branches:   [7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   elasticsearch
-                path:   build-tools/src/main/resources/
-                exclude_branches:   [ 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      Elasticsearch Clients
-            base_dir:   en/elasticsearch/client
-            sections:
-              - title:      Java Client
-                prefix:     java-api-client
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       Clients/Java
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-java
-                    path:   docs/
-                  -
-                    repo:   elasticsearch-java
-                    path:   java-client/src/test/java/co/elastic/clients/documentation
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-rest/
-                  -
-                    repo:   elasticsearch
-                    path:   client
-              - title:      JavaScript Client
-                prefix:     javascript-api
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
-                live:       *stacklivemain
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       Clients/JavaScript
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-js
-                    path:   docs/
-              - title:      Ruby Client
-                prefix:     ruby-api
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       Clients/Ruby
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-ruby
-                    path:   docs/
-              - title:      Go Client
-                prefix:     go-api
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      .doc/index.asciidoc
-                chunk:      1
-                tags:       Clients/Go
-                subject:    Clients
-                sources:
-                  -
-                    repo:   go-elasticsearch
-                    path:   .doc/
-              - title:      .NET Clients
-                prefix:     net-api
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
-                live:       *stacklivemain
-                index:      docs/index.asciidoc
-                tags:       Clients/.Net
-                subject:    Clients
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch-net
-                    path:   docs/
-              - title:      PHP Client
-                prefix:     php-api
-                current:    *stackcurrent
-                branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       *stacklivemain
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       Clients/PHP
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-php
-                    path:   docs/
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-              - title:      Perl Client
-                prefix:     perl-api
-                current:    master
-                branches:   [ master, 8.1, 8.0 ]
-                live:       [ master, 8.1, 8.0 ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       Clients/Perl
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-perl
-                    path:   docs/
-              - title:      Python Client
-                prefix:     python-api
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      docs/guide/index.asciidoc
-                chunk:     1
-                tags:       Clients/Python
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-py
-                    path:   docs/guide/
-              - title:      eland
-                prefix:     eland
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/guide/index.asciidoc
-                chunk:     1
-                tags:       Clients/eland
-                subject:    Clients
-                sources:
-                  -
-                    repo:   eland
-                    path:   docs/guide
-              - title:      Rust Client
-                prefix:     rust-api
-                current:    master
-                branches:   [ master, 8.1, 8.0 ]
-                live:       [ master, 8.1, 8.0 ]
-                index:      docs/index.asciidoc
-                chunk:     1
-                tags:       Clients/Rust
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch-rs
-                    path:   docs/
-              - title:      Java REST Client (deprecated)
-                prefix:     java-rest
-                current:   7.17
-                branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                live:       [ 7.17, 6.8 ]
-                index:      docs/java-rest/index.asciidoc
-                tags:       Clients/JavaREST
-                subject:    Clients
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-rest
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                  -
-                    repo:   elasticsearch
-                    path:   client
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-              - title:      Java Transport Client (deprecated)
-                prefix:     java-api
-                current:    7.17
-                branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                live:       [7.17, 6.8]
-                index:      docs/java-api/index.asciidoc
-                tags:       Clients/Java
-                subject:    Clients
-                chunk:      1
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/java-api
-                  -
-                    repo:   elasticsearch
-                    path:   docs/Versions.asciidoc
-                    exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   client/rest-high-level/src/test/java/org/elasticsearch/client
-                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
-                  -
-                   repo:   elasticsearch
-                   path:   server/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                   exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   server/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   elasticsearch
-                    path:   modules/reindex/src/test/java/org/elasticsearch/client/documentation
-                    exclude_branches:   [ 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                    exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-
-              - title:      Community Contributed Clients
-                prefix:     community
-                branches:   [master]
-                current:    master
-                index:      docs/community-clients/index.asciidoc
-                single:     1
-                tags:       Clients/Community
-                subject:    Clients
-                sources:
-                  -
-                    repo:   elasticsearch
-                    path:   docs/community-clients
-          - title:      Elasticsearch for Apache Hadoop and Spark
-            prefix:     en/elasticsearch/hadoop
-            current:    *stackcurrent
-            branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
-            live:       *stacklive
-            index:      docs/src/reference/asciidoc/index.adoc
-            tags:       Elasticsearch/Apache Hadoop
-            subject:    Elasticsearch
-            sources:
-              -
-                repo:   elasticsearch-hadoop
-                path:   docs/src/reference/asciidoc
-          - title:      Curator Index Management
-            prefix:     en/elasticsearch/client/curator
-            current:    5.8
-            branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
-            index:      docs/asciidoc/index.asciidoc
-            tags:       Clients/Curator
-            subject:    Clients
-            sources:
-              -
-                repo:   curator
-                path:   docs/asciidoc
-
-    -   title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
-        sections:
-          - title:      Elasticsearch Service - Hosted Elastic Stack
-            prefix:     en/cloud
-            tags:       Cloud/Reference
-            subject:    Elastic Cloud
-            current:    *cloudSaasCurrent
-            branches:   [ { *cloudSaasCurrent : latest} ]
-            index:      docs/saas/index.asciidoc
-            chunk:      1
-            private:    1
-            sources:
-              -
-                repo:   cloud
-                path:   docs/saas
-              -
-                repo:   cloud
-                path:   docs/shared
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/go
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/ruby
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/java
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/javascript
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/python
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
-          - title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
-            prefix:     en/cloud-heroku
-            tags:       Cloud-Heroku/Reference
-            subject:    Elasticsearch Add-On for Heroku
-            current:    *cloudSaasCurrent
-            branches:   [ { *cloudSaasCurrent : latest} ]
-            index:      docs/heroku/index.asciidoc
-            chunk:      1
-            noindex:    1
-            private:    1
-            sources:
-              -
-                repo:   cloud
-                path:   docs/saas
-              -
-                repo:   cloud
-                path:   docs/shared
-              -
-                repo:   cloud
-                path:   docs/heroku
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/go
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/ruby
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/java
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/javascript
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/python
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
-          - title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
-            prefix:     en/cloud-enterprise
-            tags:       CloudEnterprise/Reference
-            subject:    ECE
-            current:    ms-69
+              - repo: elasticsearch-rs
+                path: docs/
+          - title: Java REST Client (deprecated)
+            prefix: java-rest
+            current: 7.17
             branches:
-              - ms-69: 3.0
-              - ms-65: 2.13
-              - ms-62: 2.12
-              - ms-59: 2.11
-              - ms-57: 2.10
-              - ms-53: 2.9
-              - ms-49: 2.8
-              - ms-47: 2.7
-              - release-ms-41: 2.6
-              - 2.5
-              - 2.4
-              - 2.3
-              - 2.2
-              - 2.1
-              - 2.0
-              - 1.1
-              - 1.0
-            index:      docs/cloud-enterprise/index.asciidoc
-            chunk:      2
-            private:    1
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+            live: [7.17, 6.8]
+            index: docs/java-rest/index.asciidoc
+            tags: Clients/JavaREST
+            subject: Clients
+            chunk: 1
             sources:
-              -
-                repo:   cloud
-                # Grab the entire docs/ directory to get `ece-version.asciidoc`
-                path:   docs
-              -
-                repo:   cloud
-                path:   docs/shared
-                exclude_branches: [ 1.0 ]
-              -
-                repo:   cloud-assets
-                path:   docs
+              - repo: elasticsearch
+                path: docs/java-rest
+              - repo: elasticsearch
+                path: docs/Versions.asciidoc
+              - repo: elasticsearch
+                path: client
+                exclude_branches: [5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+                exclude_branches:
+                  [
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: docs
+                path: shared/attributes.asciidoc
+                exclude_branches:
+                  [
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+          - title: Java Transport Client (deprecated)
+            prefix: java-api
+            current: 7.17
+            branches:
+              [
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.7,
+                1.6,
+                1.5,
+                1.4,
+                1.3,
+                0.90,
+              ]
+            live: [7.17, 6.8]
+            index: docs/java-api/index.asciidoc
+            tags: Clients/Java
+            subject: Clients
+            chunk: 1
+            sources:
+              - repo: elasticsearch
+                path: docs/java-api
+              - repo: elasticsearch
+                path: docs/Versions.asciidoc
+                exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+              - repo: elasticsearch
+                path: client/rest-high-level/src/test/java/org/elasticsearch/client
+                exclude_branches:
+                  [
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+
+              - repo: elasticsearch
+                path: server/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                exclude_branches:
+                  [
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: elasticsearch
+                path: server/src/test/java/org/elasticsearch/client/documentation
+                exclude_branches:
+                  [
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: elasticsearch
+                path: modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation
+                exclude_branches:
+                  [
+                    7.9,
+                    7.8,
+                    7.7,
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: elasticsearch
+                path: modules/reindex/src/test/java/org/elasticsearch/client/documentation
+                exclude_branches:
+                  [
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+                exclude_branches:
+                  [
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+              - repo: docs
+                path: shared/attributes.asciidoc
+                exclude_branches:
+                  [
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                    2.4,
+                    2.3,
+                    2.2,
+                    2.1,
+                    2.0,
+                    1.7,
+                    1.6,
+                    1.5,
+                    1.4,
+                    1.3,
+                    0.90,
+                  ]
+
+          - title: Community Contributed Clients
+            prefix: community
+            branches: [master]
+            current: master
+            index: docs/community-clients/index.asciidoc
+            single: 1
+            tags: Clients/Community
+            subject: Clients
+            sources:
+              - repo: elasticsearch
+                path: docs/community-clients
+      - title: Elasticsearch for Apache Hadoop and Spark
+        prefix: en/elasticsearch/hadoop
+        current: *stackcurrent
+        branches:
+          [
+            master,
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            2.4,
+            2.3,
+            2.2,
+            2.1,
+            2.0,
+          ]
+        live: *stacklive
+        index: docs/src/reference/asciidoc/index.adoc
+        tags: Elasticsearch/Apache Hadoop
+        subject: Elasticsearch
+        sources:
+          - repo: elasticsearch-hadoop
+            path: docs/src/reference/asciidoc
+      - title: Curator Index Management
+        prefix: en/elasticsearch/client/curator
+        current: 5.8
+        branches:
+          [
+            5.x,
+            5.8,
+            5.7,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            4.3,
+            4.2,
+            4.1,
+            4.0,
+            3.5,
+            3.4,
+            3.3,
+          ]
+        index: docs/asciidoc/index.asciidoc
+        tags: Clients/Curator
+        subject: Clients
+        sources:
+          - repo: curator
+            path: docs/asciidoc
+
+  - title: "Cloud: Provision, Manage and Monitor the Elastic Stack"
+    sections:
+      - title: Elasticsearch Service - Hosted Elastic Stack
+        prefix: en/cloud
+        tags: Cloud/Reference
+        subject: Elastic Cloud
+        current: *cloudSaasCurrent
+        branches: [{ *cloudSaasCurrent : latest }]
+        index: docs/saas/index.asciidoc
+        chunk: 1
+        private: 1
+        sources:
+          - repo: cloud
+            path: docs/saas
+          - repo: cloud
+            path: docs/shared
+          - alternatives: { source_lang: console, alternative_lang: php }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/php
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: go }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/go
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: ruby }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/ruby
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: java }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/java
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: javascript }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/javascript
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: python }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/python
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: csharp }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/csharp
+            map_branches: *mapCloudSaasToClientsTeam
+      - title:
+          Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku
+          Users
+        prefix: en/cloud-heroku
+        tags: Cloud-Heroku/Reference
+        subject: Elasticsearch Add-On for Heroku
+        current: *cloudSaasCurrent
+        branches: [{ *cloudSaasCurrent : latest }]
+        index: docs/heroku/index.asciidoc
+        chunk: 1
+        noindex: 1
+        private: 1
+        sources:
+          - repo: cloud
+            path: docs/saas
+          - repo: cloud
+            path: docs/shared
+          - repo: cloud
+            path: docs/heroku
+          - alternatives: { source_lang: console, alternative_lang: php }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/php
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: go }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/go
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: ruby }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/ruby
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: java }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/java
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: javascript }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/javascript
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: python }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/python
+            map_branches: *mapCloudSaasToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: csharp }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/csharp
+            map_branches: *mapCloudSaasToClientsTeam
+      - title: Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
+        prefix: en/cloud-enterprise
+        tags: CloudEnterprise/Reference
+        subject: ECE
+        current: ms-69
+        branches:
+          - ms-69: 3.0
+          - ms-65: 2.13
+          - ms-62: 2.12
+          - ms-59: 2.11
+          - ms-57: 2.10
+          - ms-53: 2.9
+          - ms-49: 2.8
+          - ms-47: 2.7
+          - release-ms-41: 2.6
+          - 2.5
+          - 2.4
+          - 2.3
+          - 2.2
+          - 2.1
+          - 2.0
+          - 1.1
+          - 1.0
+        index: docs/cloud-enterprise/index.asciidoc
+        chunk: 2
+        private: 1
+        sources:
+          - repo: cloud
+            # Grab the entire docs/ directory to get `ece-version.asciidoc`
+            path: docs
+          - repo: cloud
+            path: docs/shared
+            exclude_branches: [1.0]
+          - repo: cloud-assets
+            path: docs
+            map_branches:
+              ms-69: master
+              ms-65: master
+              ms-62: master
+              ms-59: master
+              ms-57: master
+              ms-53: master
+              ms-49: master
+              ms-47: master
+              release-ms-41: master
+              2.5: master
+              2.4: master
+              2.3: master
+              2.2: master
+              2.1: master
+              2.0: master
+              1.1: master
+              1.0: master
+          - alternatives: { source_lang: console, alternative_lang: php }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/php
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: go }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/go
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: ruby }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/ruby
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: java }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/java
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: javascript }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/javascript
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: python }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/python
+            map_branches: *mapCloudEceToClientsTeam
+          - alternatives: { source_lang: console, alternative_lang: csharp }
+            repo: clients-team
+            path: docs/examples/elastic-cloud/csharp
+            map_branches: *mapCloudEceToClientsTeam
+      - title: Elastic Cloud on Kubernetes
+        prefix: en/cloud-on-k8s
+        tags: Kubernetes/Reference
+        subject: ECK
+        current: 2.0
+        branches:
+          [
+            { main: master },
+            2.0,
+            1.9,
+            1.8,
+            1.7,
+            1.6,
+            1.5,
+            1.4,
+            1.3,
+            1.2,
+            1.1,
+            1.0,
+            1.0-beta,
+            0.9,
+            0.8,
+          ]
+        index: docs/index.asciidoc
+        chunk: 1
+        sources:
+          - repo: cloud-on-k8s
+            path: docs/
+          - repo: docs
+            path: shared/versions/stack/current.asciidoc
+            exclude_branches: [0.9, 0.8]
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title:
+          Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and
+          ECE
+        prefix: en/ecctl
+        tags: CloudControl/Reference
+        subject: ECCTL
+        current: 1.8
+        branches: [master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0]
+        index: docs/index.asciidoc
+        chunk: 1
+        sources:
+          - repo: ecctl
+            path: docs/
+      - title: Elastic Cloud Terraform Provider
+        prefix: en/tpec
+        tags: CloudTerraform/Reference
+        subject: TPEC
+        current: 0.2
+        branches: [master, 0.2, 0.1]
+        index: docs-elastic/index.asciidoc
+        single: 1
+        chunk: 1
+        sources:
+          - repo: terraform-provider-ec
+            path: docs-elastic/
+
+  - title: "Kibana: Explore, Visualize, and Share"
+    sections:
+      - title: Kibana Guide
+        prefix: en/kibana
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            4.6,
+            4.5,
+            4.4,
+            4.3,
+            4.2,
+            4.1,
+            4.0,
+            3.0,
+          ]
+        live: *stacklivemain
+        index: docs/index.x.asciidoc
+        chunk: 1
+        tags: Kibana/Reference
+        subject: Kibana
+        toc_extra: extra/kibana_landing.html
+        sources:
+          - repo: kibana
+            path: docs/
+          - repo: x-pack-kibana
+            prefix: kibana-extra/x-pack-kibana
+            path: docs/en
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+          - repo: docs
+            path: shared/attributes62.asciidoc
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                3.0,
+              ]
+          - repo: kibana
+            # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
+            path: ":(glob)examples/**/*.asciidoc"
+            exclude_branches:
+              [
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+          - repo: kibana
+            path: ":(glob)src/**/*.asciidoc"
+            exclude_branches:
+              [
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+          - repo: kibana
+            path: ":(glob)x-pack/**/*.asciidoc"
+            exclude_branches:
+              [
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                4.6,
+                4.5,
+                4.4,
+                4.3,
+                4.2,
+                4.1,
+                4.0,
+                3.0,
+              ]
+
+  - title: Enterprise Search
+    sections:
+      - title: Enterprise Search Guide
+        prefix: en/enterprise-search
+        index: enterprise-search-docs/index.asciidoc
+        private: 1
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+          ]
+        live: *stacklive
+        chunk: 1
+        tags: Enterprise Search/Guide
+        subject: Enterprise Search
+        sources:
+          - repo: enterprise-search-pubs
+            path: enterprise-search-docs
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+      - title: Workplace Search Guide
+        prefix: en/workplace-search
+        index: workplace-search-docs/index.asciidoc
+        private: 1
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+          ]
+        live: *stacklive
+        chunk: 1
+        tags: Workplace Search/Guide
+        subject: Workplace Search
+        sources:
+          - repo: enterprise-search-pubs
+            path: workplace-search-docs
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+      - title: App Search Guide
+        prefix: en/app-search
+        index: app-search-docs/index.asciidoc
+        private: 1
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+          ]
+        live: *stacklive
+        chunk: 1
+        tags: App Search/Guide
+        subject: App Search
+        sources:
+          - repo: enterprise-search-pubs
+            path: app-search-docs
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+      - title: Site Search Reference
+        prefix: en/swiftype/sitesearch
+        index: docs/sitesearch/index.asciidoc
+        private: 1
+        current: master
+        branches: [master]
+        single: 1
+        tags: Site Search/Reference
+        subject: Swiftype
+        sources:
+          - repo: swiftype
+            path: docs
+      - title: Enterprise Search Clients
+        base_dir: en/enterprise-search-clients
+        sections:
+          - title: App Search JavaScript client
+            prefix: app-search-javascript
+            private: 1
+            single: 1
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklive
+            index: client-docs/app-search-javascript/index.asciidoc
+            tags: App Search Clients/JavaScript
+            subject: App Search Clients
+            sources:
+              - repo: enterprise-search-pubs
+                path: client-docs/app-search-javascript
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+          - title: App Search Node.js client
+            prefix: app-search-node
+            private: 1
+            single: 1
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklive
+            index: client-docs/app-search-node/index.asciidoc
+            tags: App Search Clients/Node.js
+            subject: App Search Clients
+            sources:
+              - repo: enterprise-search-pubs
+                path: client-docs/app-search-node
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+          - title: Enterprise Search PHP client
+            prefix: php
+            current: 7.16
+            branches: [7.16]
+            live: [7.16]
+            index: docs/guide/index.asciidoc
+            tags: Enterprise Search Clients/PHP
+            subject: Enterprise Search Clients
+            sources:
+              - repo: enterprise-search-php
+                path: docs/guide/
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+          - title: Enterprise Search Python client
+            prefix: python
+            current: *stackcurrent
+            branches:
+              [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11]
+            live: *stacklive
+            index: docs/guide/index.asciidoc
+            tags: Enterprise Search Clients/Python
+            subject: Enterprise Search Clients
+            sources:
+              - repo: enterprise-search-python
+                path: docs/guide/
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+          - title: Enterprise Search Ruby client
+            prefix: ruby
+            current: *stackcurrent
+            branches:
+              [{ main: master }, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11]
+            live: *stacklive
+            index: docs/guide/index.asciidoc
+            tags: Enterprise Search Clients/Ruby
+            subject: Enterprise Search Clients
+            sources:
+              - repo: enterprise-search-ruby
+                path: docs/guide/
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+
+          - title: Workplace Search Node.js client
+            prefix: workplace-search-node
+            private: 1
+            single: 1
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklive
+            index: client-docs/workplace-search-node/index.asciidoc
+            tags: Workplace Search Clients/Node.js
+            subject: Workplace Search Clients
+            sources:
+              - repo: enterprise-search-pubs
+                path: client-docs/workplace-search-node
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+  - title: "Observability: APM, Logs, Metrics, and Uptime"
+    sections:
+      - title: Observability
+        prefix: en/observability
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+          ]
+        live: *stacklivemain
+        index: docs/en/observability/index.asciidoc
+        chunk: 2
+        tags: Observability/Guide
+        subject: Observability
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: apm-server
+            path: docs
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: beats
+            path: libbeat/docs
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Application Performance Monitoring (APM)
+        base_dir: en/apm
+        sections:
+          - title: APM Guide
+            prefix: guide
+            index: docs/integrations-index.asciidoc
+            current: *stackcurrent
+            branches: [{ main: master }, 8.1, 8.0, 7.17, 7.16]
+            live: *stacklivemain
+            chunk: 2
+            tags: APM Guide
+            subject: APM
+            sources:
+              - repo: apm-server
+                path: changelogs
+                exclude_branches: [6.0]
+              - repo: apm-server
+                path: docs
+              - repo: apm-server
+                path: CHANGELOG.asciidoc
+              - repo: observability-docs
+                path: docs/en
+                exclude_branches:
+                  [
+                    7.15,
+                    7.14,
+                    7.13,
+                    7.12,
+                    7.11,
+                    7.10,
+                    7.9,
+                    7.8,
+                    7.7,
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                  ]
+                map_branches: *mapMasterToMain
+              - repo: apm-aws-lambda
+                path: docs
+                exclude_branches:
+                  [
+                    7.15,
+                    7.14,
+                    7.13,
+                    7.12,
+                    7.11,
+                    7.10,
+                    7.9,
+                    7.8,
+                    7.7,
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                    5.6,
+                    5.5,
+                    5.4,
+                    5.3,
+                    5.2,
+                    5.1,
+                    5.0,
+                  ]
+                map_branches: *mapMasterToMain
+          - title: APM Agents
+            base_dir: agent
+            sections:
+              - title: APM Go Agent
+                prefix: go
+                current: 1.x
+                branches: [{ main: master }, 1.x, 0.5]
+                live: [main, 1.x]
+                index: docs/index.asciidoc
+                tags: APM Go Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-go
+                    path: docs
+                  - repo: apm-agent-go
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [0.5]
+              - title: APM iOS Agent
+                prefix: swift
+                current: 0.x
+                branches: [main, 0.x]
+                live: [main, 0.x]
+                index: docs/index.asciidoc
+                tags: APM iOS Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-ios
+                    path: docs
+                  - repo: apm-agent-ios
+                    path: CHANGELOG.asciidoc
+              - title: APM Java Agent
+                prefix: java
+                current: 1.x
+                branches: [{ main: master }, 1.x, 0.7, 0.6]
+                live: [main, 1.x]
+                index: docs/index.asciidoc
+                tags: APM Java Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-java
+                    path: docs
+                  - repo: apm-agent-java
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [0.7, 0.6]
+              - title: APM .NET Agent
+                prefix: dotnet
+                current: 1.12
+                branches: [{ main: master }, 1.12, 1.11, 1.10, 1.9, 1.8]
+                live: [main, 1.12]
+                index: docs/index.asciidoc
+                tags: APM .NET Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-dotnet
+                    path: docs
+                  - repo: apm-agent-dotnet
+                    path: CHANGELOG.asciidoc
+              - title: APM Node.js Agent
+                prefix: nodejs
+                current: 3.x
+                branches: [{ main: master }, 3.x, 2.x, 1.x, 0.x]
+                live: [main, 3.x]
+                index: docs/index.asciidoc
+                tags: APM Node.js Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-nodejs
+                    path: docs
+                  - repo: apm-agent-nodejs
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [1.x, 0.x]
+              - title: APM PHP Agent
+                prefix: php
+                current: 1.x
+                branches: [{ main: master }, 1.x]
+                live: [main, 1.x]
+                index: docs/index.asciidoc
+                tags: APM PHP Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-php
+                    path: docs
+                  - repo: apm-agent-php
+                    path: CHANGELOG.asciidoc
+              - title: APM Python Agent
+                prefix: python
+                current: 6.x
+                branches: [{ main: master }, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x]
+                live: [main, 6.x, 5.x]
+                index: docs/index.asciidoc
+                tags: APM Python Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-python
+                    path: docs
+                  - repo: apm-agent-python
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [4.x, 3.x, 2.x, 1.x]
+              - title: APM Ruby Agent
+                prefix: ruby
+                current: 4.x
+                branches: [{ main: master }, 4.x, 3.x, 2.x, 1.x]
+                live: [main, 4.x]
+                index: docs/index.asciidoc
+                tags: APM Ruby Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-ruby
+                    path: docs
+                  - repo: apm-agent-ruby
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [1.x, 0.x]
+              - title: APM Real User Monitoring JavaScript Agent
+                prefix: rum-js
+                current: 5.x
+                branches: [{ main: master }, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x]
+                live: [main, 5.x, 4.x]
+                index: docs/index.asciidoc
+                tags: APM Real User Monitoring JavaScript Agent/Reference
+                subject: APM
+                chunk: 1
+                sources:
+                  - repo: apm-agent-rum-js
+                    path: docs
+                  - repo: apm-agent-rum-js
+                    path: CHANGELOG.asciidoc
+                    exclude_branches: [3.x, 2.x, 1.x, 0.x]
+          - title: Legacy APM (standalone)
+            sections:
+              - title: Legacy APM Overview
+                prefix: get-started
+                index: docs/guide/index.asciidoc
+                current: 7.15
+                branches:
+                  [
+                    7.15,
+                    7.14,
+                    7.13,
+                    7.12,
+                    7.11,
+                    7.10,
+                    7.9,
+                    7.8,
+                    7.7,
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                  ]
+                live: [7.15, 6.8]
+                chunk: 1
+                tags: APM Server/Reference
+                subject: APM
+                sources:
+                  - repo: apm-server
+                    path: docs/guide
+                  - repo: apm-server
+                    path: docs
+              - title: Legacy APM Server Reference
+                prefix: server
+                index: docs/index.asciidoc
+                current: 7.15
+                branches:
+                  [
+                    7.15,
+                    7.14,
+                    7.13,
+                    7.12,
+                    7.11,
+                    7.10,
+                    7.9,
+                    7.8,
+                    7.7,
+                    7.6,
+                    7.5,
+                    7.4,
+                    7.3,
+                    7.2,
+                    7.1,
+                    7.0,
+                    6.8,
+                    6.7,
+                    6.6,
+                    6.5,
+                    6.4,
+                    6.3,
+                    6.2,
+                    6.1,
+                    6.0,
+                  ]
+                live: [7.15, 6.8]
+                chunk: 1
+                tags: APM Server/Reference
+                subject: APM
+                sources:
+                  - repo: apm-server
+                    path: changelogs
+                    exclude_branches: [6.0]
+                  - repo: apm-server
+                    path: docs
+                  - repo: apm-server
+                    path: CHANGELOG.asciidoc
+      - title: ECS logging
+        base_dir: en/ecs-logging
+        sections:
+          - title: ECS Logging Overview
+            prefix: overview
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/Guide
+            subject: ECS Logging Overview
+            sources:
+              - repo: ecs-logging
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+          - title: ECS Logging Go (Logrus) Reference
+            prefix: go-logrus
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/go-logrus/Guide
+            subject: ECS Logging Go (Logrus) Reference
+            sources:
+              - repo: ecs-logging-go-logrus
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+          - title: ECS Logging Go (Zap) Reference
+            prefix: go-zap
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/go-zap/Guide
+            subject: ECS Logging Go (Zap) Reference
+            sources:
+              - repo: ecs-logging-go-zap
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+
+          - title: ECS Logging Java Reference
+            prefix: java
+            current: 1.x
+            branches: [{ main: master }, 1.x, 0.x]
+            live: [main, 1.x]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/java/Guide
+            subject: ECS Logging Java Reference
+            sources:
+              - repo: ecs-logging-java
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
                 map_branches:
-                  ms-69: master
-                  ms-65: master
-                  ms-62: master
-                  ms-59: master
-                  ms-57: master
-                  ms-53: master
-                  ms-49: master
-                  ms-47: master
-                  release-ms-41: master
-                  2.5: master
-                  2.4: master
-                  2.3: master
-                  2.2: master
-                  2.1: master
-                  2.0: master
-                  1.1: master
-                  1.0: master
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/go
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/ruby
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/java
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/javascript
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/python
-                map_branches: *mapCloudEceToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/csharp
-                map_branches: *mapCloudEceToClientsTeam
-          - title:      Elastic Cloud on Kubernetes
-            prefix:     en/cloud-on-k8s
-            tags:       Kubernetes/Reference
-            subject:    ECK
-            current:    2.0
-            branches:   [ {main: master}, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
-            index:      docs/index.asciidoc
-            chunk:      1
+                  1.x: main
+                  0.x: main
+          - title: ECS Logging .NET Reference
+            prefix: dotnet
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/.NET/Guide
+            subject: ECS Logging .NET Reference
             sources:
-              -
-                repo:   cloud-on-k8s
-                path:   docs/
-              -
-                repo:   docs
-                path:   shared/versions/stack/current.asciidoc
-                exclude_branches:   [ 0.9, 0.8 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and ECE
-            prefix:     en/ecctl
-            tags:       CloudControl/Reference
-            subject:    ECCTL
-            current:    1.8
-            branches:   [ master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            index:      docs/index.asciidoc
-            chunk:      1
+              - repo: ecs-dotnet
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+          - title: ECS Logging Node.js Reference
+            prefix: nodejs
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/nodejs/Guide
+            subject: ECS Logging Node.js Reference
             sources:
-              -
-                repo:   ecctl
-                path:   docs/
-          - title:      Elastic Cloud Terraform Provider
-            prefix:     en/tpec
-            tags:       CloudTerraform/Reference
-            subject:    TPEC
-            current:    0.2
-            branches:   [ master, 0.2, 0.1 ]
-            index:      docs-elastic/index.asciidoc
-            single:     1
-            chunk:      1
+              - repo: ecs-logging-nodejs
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+          - title: ECS Logging Ruby Reference
+            prefix: ruby
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/ruby/Guide
+            subject: ECS Logging Ruby Reference
             sources:
-              -
-                repo:   terraform-provider-ec
-                path:   docs-elastic/
+              - repo: ecs-logging-ruby
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+          - title: ECS Logging PHP Reference
+            prefix: php
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/php/Guide
+            subject: ECS Logging PHP Reference
+            sources:
+              - repo: ecs-logging-php
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
+          - title: ECS Logging Python Reference
+            prefix: python
+            current: main
+            branches: [{ main: master }]
+            live: [main]
+            index: docs/index.asciidoc
+            chunk: 1
+            tags: ECS-logging/python/Guide
+            subject: ECS Logging Python Reference
+            sources:
+              - repo: ecs-logging-python
+                path: docs
+              - repo: docs
+                path: shared/versions/stack/{version}.asciidoc
+              - repo: docs
+                path: shared/attributes.asciidoc
+              - repo: ecs-logging
+                path: docs
 
-    -   title:      "Kibana: Explore, Visualize, and Share"
+  - title: Elastic Security
+    sections:
+      - title: Elastic Security
+        prefix: en/security
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+          ]
+        live: *stacklivemain
+        index: docs/index.asciidoc
+        chunk: 1
+        tags: Security/Guide
+        subject: Security
+        sources:
+          - repo: security-docs
+            path: docs
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: stack-docs
+            path: docs/en
+      - title: SIEM Guide
+        prefix: en/siem/guide
+        current: 7.8
+        branches: [7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2]
+        live: [7.8]
+        index: docs/en/siem/index.asciidoc
+        chunk: 1
+        tags: SIEM/Guide
+        subject: SIEM
+        sources:
+          - repo: stack-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+
+  - title: "Logstash: Collect, Enrich, and Transport"
+    sections:
+      - title: Logstash Reference
+        prefix: en/logstash
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            2.4,
+            2.3,
+            2.2,
+            2.1,
+            2.0,
+            1.5,
+          ]
+        live: *stacklivemain
+        index: docs/index.x.asciidoc
+        chunk: 1
+        tags: Logstash/Reference
+        subject: Logstash
+        respect_edit_url_overrides: true
+        sources:
+          - repo: logstash
+            path: docs/
+          - repo: x-pack-logstash
+            prefix: logstash-extra/x-pack-logstash
+            path: docs/en
+            private: true
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.5,
+              ]
+          - repo: logstash-docs
+            path: docs/
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches:
+              [
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.5,
+              ]
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches:
+              [
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.5,
+              ]
+          - repo: docs
+            path: shared/attributes62.asciidoc
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+                1.5,
+              ]
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+            exclude_branches:
+              [
+                main,
+                8.1,
+                8.0,
+                7.17,
+                7.16,
+                7.15,
+                7.14,
+                7.13,
+                7.12,
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                2.4,
+                2.3,
+                2.2,
+                2.1,
+                2.0,
+              ]
+      - title: Logstash Versioned Plugin Reference
+        prefix: en/logstash-versioned-plugins
+        current: versioned_plugin_docs
+        branches: [versioned_plugin_docs]
+        index: docs/versioned-plugins/index.asciidoc
+        private: 1
+        chunk: 1
+        noindex: 1
+        tags: Logstash/Plugin Reference
+        subject: Logstash
+        sources:
+          - repo: logstash-docs
+            path: docs/versioned-plugins
+          - repo: docs
+            path: shared/attributes.asciidoc
+
+  - title: "Fleet: Install and Manage Elastic Agents"
+    sections:
+      - title: Fleet and Elastic Agent Guide
+        prefix: en/fleet
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+          ]
+        live: *stacklivemain
+        index: docs/en/ingest-management/index.asciidoc
+        chunk: 2
+        tags: Fleet/Guide/Elastic Agent
+        subject: Fleet and Elastic Agent
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: apm-server
+            path: docs
+            exclude_branches:
+              [
+                7.11,
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+
+      - title: Integrations Developer Guide
+        prefix: en/integrations-developer
+        current: main
+        branches: [{ main: master }]
+        live: [main]
+        index: docs/en/integrations/index.asciidoc
+        chunk: 1
+        tags: Integrations/Developer
+        subject: Integrations
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: package-spec
+            path: versions
+
+  - title: "Beats: Collect, Parse, and Ship"
+    sections:
+      - title: Beats Platform Reference
+        prefix: en/beats/libbeat
+        index: libbeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            1.3,
+            1.2,
+            1.1,
+            1.0.1,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Libbeat/Reference
+        subject: libbeat
+        respect_edit_url_overrides: true
+        sources:
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Auditbeat Reference
+        prefix: en/beats/auditbeat
+        index: auditbeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Auditbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Auditbeat
+        sources:
+          - repo: beats
+            path: auditbeat
+          - repo: beats
+            path: auditbeat/docs
+          - repo: beats
+            path: x-pack/auditbeat
+            exclude_branches: [6.5, 6.4, 6.3, 6.2, 6.1, 6.0]
+          - repo: beats
+            path: auditbeat/module
+          - repo: beats
+            path: auditbeat/scripts
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Filebeat Reference
+        prefix: en/beats/filebeat
+        index: filebeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            1.3,
+            1.2,
+            1.1,
+            1.0.1,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Filebeat/Reference
+        respect_edit_url_overrides: true
+        subject: Filebeat
+        sources:
+          - repo: beats
+            path: filebeat
+          - repo: beats
+            path: filebeat/docs
+          - repo: beats
+            path: x-pack/filebeat/docs
+            exclude_branches:
+              [
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: x-pack/libbeat/docs
+            exclude_branches: *beatsXpackLibbeatExclude
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/filebeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Functionbeat Reference
+        prefix: en/beats/functionbeat
+        current: *stackcurrent
+        index: x-pack/functionbeat/docs/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Functionbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Functionbeat
+        sources:
+          - repo: beats
+            path: x-pack/functionbeat
+          - repo: beats
+            path: x-pack/functionbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: beats
+            path: x-pack/libbeat/docs
+            exclude_branches: *beatsXpackLibbeatExclude
+          - repo: beats
+            path: filebeat/docs
+            exclude_branches:
+              [
+                7.10,
+                7.9,
+                7.8,
+                7.7,
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+              ]
+      - title: Heartbeat Reference
+        prefix: en/beats/heartbeat
+        current: *stackcurrent
+        index: heartbeat/docs/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Heartbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Heartbeat
+        sources:
+          - repo: beats
+            path: heartbeat
+          - repo: beats
+            path: heartbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: x-pack/libbeat/docs
+            exclude_branches: *beatsXpackLibbeatExclude
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Metricbeat Reference
+        prefix: en/beats/metricbeat
+        index: metricbeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Metricbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Metricbeat
+        sources:
+          - repo: beats
+            path: metricbeat
+          - repo: beats
+            path: metricbeat/docs
+          - repo: beats
+            path: metricbeat/module
+          - repo: beats
+            path: x-pack/libbeat/docs
+            exclude_branches: *beatsXpackLibbeatExclude
+          - repo: beats
+            path: x-pack/metricbeat/module
+            exclude_branches:
+              [
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+              ]
+          - repo: beats
+            path: metricbeat/scripts
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Packetbeat Reference
+        prefix: en/beats/packetbeat
+        index: packetbeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            1.3,
+            1.2,
+            1.1,
+            1.0.1,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Packetbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Packetbeat
+        sources:
+          - repo: beats
+            path: packetbeat
+          - repo: beats
+            path: packetbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Winlogbeat Reference
+        prefix: en/beats/winlogbeat
+        index: winlogbeat/docs/index.asciidoc
+        current: *stackcurrent
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+            5.6,
+            5.5,
+            5.4,
+            5.3,
+            5.2,
+            5.1,
+            5.0,
+            1.3,
+            1.2,
+            1.1,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Winlogbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Winlogbeat
+        sources:
+          - repo: beats
+            path: winlogbeat
+          - repo: beats
+            path: winlogbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Beats Developer Guide
+        prefix: en/beats/devguide
+        index: docs/devguide/index.asciidoc
+        current: main
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+            6.4,
+            6.3,
+            6.2,
+            6.1,
+            6.0,
+          ]
+        live: *stacklivemain
+        chunk: 1
+        tags: Devguide/Reference
+        subject: Beats
+        respect_edit_url_overrides: true
+        sources:
+          - repo: beats
+            path: docs
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: metricbeat/module
+          - repo: beats
+            path: metricbeat/scripts
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+            exclude_branches: *beatsSharedExclude
+          - repo: docs
+            path: shared/attributes.asciidoc
+            exclude_branches: *beatsSharedExclude
+      - title: Elastic Logging Plugin for Docker
+        prefix: en/beats/loggingplugin
+        current: *stackcurrent
+        index: x-pack/dockerlogbeat/docs/index.asciidoc
+        branches:
+          [
+            { main: master },
+            8.1,
+            8.0,
+            7.17,
+            7.16,
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+          ]
+        chunk: 1
+        tags: Elastic Logging Plugin/Reference
+        respect_edit_url_overrides: true
+        subject: Elastic Logging Plugin
+        sources:
+          - repo: beats
+            path: x-pack/dockerlogbeat/docs
+          - repo: beats
+            path: libbeat/docs
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+
+  - title: Docs in Your Native Tongue
+    sections:
+      - title: 简体中文
+        base_dir: cn
+        lang: zh_cn
         sections:
-          - title:      Kibana Guide
-            prefix:     en/kibana
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-            live:       *stacklivemain
-            index:      docs/index.x.asciidoc
-            chunk:      1
-            tags:       Kibana/Reference
-            subject:    Kibana
-            toc_extra:  extra/kibana_landing.html
-            sources:
-              -
-                repo:   kibana
-                path:   docs/
-              -
-                repo:   x-pack-kibana
-                prefix: kibana-extra/x-pack-kibana
-                path:   docs/en
-                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches: [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
-              -
-                repo:   kibana
-                # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
-                path:   ":(glob)examples/**/*.asciidoc"
-                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   kibana
-                path:   ":(glob)src/**/*.asciidoc"
-                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-              -
-                repo:   kibana
-                path:   ":(glob)x-pack/**/*.asciidoc"
-                exclude_branches: [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-
-    -   title:      Enterprise Search
-        sections:
-          - title:      Enterprise Search Guide
-            prefix:     en/enterprise-search
-            index:      enterprise-search-docs/index.asciidoc
-            private:    1
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Enterprise Search/Guide
-            subject:    Enterprise Search
-            sources:
-              -
-                repo:   enterprise-search-pubs
-                path:   enterprise-search-docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-          - title:      Workplace Search Guide
-            prefix:     en/workplace-search
-            index:      workplace-search-docs/index.asciidoc
-            private:    1
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       Workplace Search/Guide
-            subject:    Workplace Search
-            sources:
-              -
-                repo:   enterprise-search-pubs
-                path:   workplace-search-docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-          - title:      App Search Guide
-            prefix:     en/app-search
-            index:      app-search-docs/index.asciidoc
-            private:    1
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
-            live:       *stacklive
-            chunk:      1
-            tags:       App Search/Guide
-            subject:    App Search
-            sources:
-              -
-                repo:   enterprise-search-pubs
-                path:   app-search-docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-          - title:      Site Search Reference
-            prefix:     en/swiftype/sitesearch
-            index:      docs/sitesearch/index.asciidoc
-            private:    1
-            current:    master
-            branches:   [ master ]
-            single:     1
-            tags:       Site Search/Reference
-            subject:    Swiftype
-            sources:
-              -
-                repo:   swiftype
-                path:   docs
-          - title:      Enterprise Search Clients
-            base_dir:   en/enterprise-search-clients
-            sections:
-              - title:      App Search JavaScript client
-                prefix:     app-search-javascript
-                private:    1
-                single:     1
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklive
-                index:      client-docs/app-search-javascript/index.asciidoc
-                tags:       App Search Clients/JavaScript
-                subject:    App Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/app-search-javascript
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-              - title:      App Search Node.js client
-                prefix:     app-search-node
-                private:    1
-                single:     1
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklive
-                index:      client-docs/app-search-node/index.asciidoc
-                tags:       App Search Clients/Node.js
-                subject:    App Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/app-search-node
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-              - title:      Enterprise Search PHP client
-                prefix:     php
-                current:    7.16
-                branches:   [ 7.16 ]
-                live:       [ 7.16 ]
-                index:      docs/guide/index.asciidoc
-                tags:       Enterprise Search Clients/PHP
-                subject:    Enterprise Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-php
-                    path:   docs/guide/
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-              - title:      Enterprise Search Python client
-                prefix:     python
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
-                live:       *stacklive
-                index:      docs/guide/index.asciidoc
-                tags:       Enterprise Search Clients/Python
-                subject:    Enterprise Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-python
-                    path:   docs/guide/
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-              - title:      Enterprise Search Ruby client
-                prefix:     ruby
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
-                live:       *stacklive
-                index:      docs/guide/index.asciidoc
-                tags:       Enterprise Search Clients/Ruby
-                subject:    Enterprise Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-ruby
-                    path:   docs/guide/
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-
-              - title:      Workplace Search Node.js client
-                prefix:     workplace-search-node
-                private:    1
-                single:     1
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklive
-                index:      client-docs/workplace-search-node/index.asciidoc
-                tags:       Workplace Search Clients/Node.js
-                subject:    Workplace Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/workplace-search-node
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-    -   title:      "Observability: APM, Logs, Metrics, and Uptime"
-        sections:
-          - title:      Observability
-            prefix:     en/observability
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
-            live:       *stacklivemain
-            index:      docs/en/observability/index.asciidoc
-            chunk:      2
-            tags:       Observability/Guide
-            subject:    Observability
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   apm-server
-                path:   docs
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   beats
-                path:   libbeat/docs
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Application Performance Monitoring (APM)
-            base_dir:   en/apm
-            sections:
-              - title:      APM Guide
-                prefix:     guide
-                index:      docs/integrations-index.asciidoc
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                chunk:      2
-                tags:       APM Guide
-                subject:    APM
-                sources:
-                  -
-                    repo:   apm-server
-                    path:   changelogs
-                    exclude_branches:   [ 6.0 ]
-                  -
-                    repo:   apm-server
-                    path:   docs
-                  -
-                    repo:   apm-server
-                    path:   CHANGELOG.asciidoc
-                  -
-                    repo:   observability-docs
-                    path:   docs/en
-                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMasterToMain
-                  -
-                    repo:   apm-aws-lambda
-                    path:   docs
-                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMasterToMain
-              - title:      APM Agents
-                base_dir:   agent
-                sections:
-                  - title:      APM Go Agent
-                    prefix:     go
-                    current:    1.x
-                    branches:   [ {main: master}, 1.x, 0.5 ]
-                    live:       [ main, 1.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Go Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-go
-                        path:   docs
-                      -
-                        repo:   apm-agent-go
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 0.5 ]
-                  - title: APM iOS Agent
-                    prefix: swift
-                    current: 0.x
-                    branches: [ main, 0.x ]
-                    live: [ main, 0.x ]
-                    index: docs/index.asciidoc
-                    tags: APM iOS Agent/Reference
-                    subject: APM
-                    chunk: 1
-                    sources:
-                      -
-                        repo: apm-agent-ios
-                        path: docs
-                      -
-                        repo: apm-agent-ios
-                        path: CHANGELOG.asciidoc
-                  - title:      APM Java Agent
-                    prefix:     java
-                    current:    1.x
-                    branches:   [ {main: master}, 1.x, 0.7, 0.6 ]
-                    live:       [ main, 1.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Java Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-java
-                        path:   docs
-                      -
-                        repo:   apm-agent-java
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 0.7, 0.6]
-                  - title:      APM .NET Agent
-                    prefix:     dotnet
-                    current:    1.12
-                    branches:   [ {main: master}, 1.12, 1.11, 1.10, 1.9, 1.8 ]
-                    live:       [ main, 1.12 ]
-                    index:      docs/index.asciidoc
-                    tags:       APM .NET Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-dotnet
-                        path:   docs
-                      -
-                        repo:   apm-agent-dotnet
-                        path:   CHANGELOG.asciidoc
-                  - title:      APM Node.js Agent
-                    prefix:     nodejs
-                    current:    3.x
-                    branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ main, 3.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Node.js Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-nodejs
-                        path:   docs
-                      -
-                        repo:   apm-agent-nodejs
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 1.x, 0.x ]
-                  - title:      APM PHP Agent
-                    prefix:     php
-                    current:    1.x
-                    branches:   [ {main: master}, 1.x ]
-                    live:       [ main, 1.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM PHP Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-php
-                        path:   docs
-                      -
-                        repo:   apm-agent-php
-                        path:   CHANGELOG.asciidoc
-                  - title:      APM Python Agent
-                    prefix:     python
-                    current:    6.x
-                    branches:   [ {main: master}, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ main, 6.x, 5.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Python Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-python
-                        path:   docs
-                      -
-                        repo:   apm-agent-python
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 4.x, 3.x, 2.x, 1.x ]
-                  - title:      APM Ruby Agent
-                    prefix:     ruby
-                    current:    4.x
-                    branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ main, 4.x ]
-                    index:      docs/index.asciidoc
-                    tags:       APM Ruby Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-ruby
-                        path:   docs
-                      -
-                        repo:   apm-agent-ruby
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 1.x, 0.x ]
-                  - title:      APM Real User Monitoring JavaScript Agent
-                    prefix:     rum-js
-                    current:    5.x
-                    branches:   [ {main: master}, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ main, 5.x, 4.x]
-                    index:      docs/index.asciidoc
-                    tags:       APM Real User Monitoring JavaScript Agent/Reference
-                    subject:    APM
-                    chunk:      1
-                    sources:
-                      -
-                        repo:   apm-agent-rum-js
-                        path:   docs
-                      -
-                        repo:   apm-agent-rum-js
-                        path:   CHANGELOG.asciidoc
-                        exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-              - title:      Legacy APM (standalone)
-                sections:
-                  - title:      Legacy APM Overview
-                    prefix:     get-started
-                    index:      docs/guide/index.asciidoc
-                    current:    7.15
-                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                    live:       [ 7.15, 6.8 ]
-                    chunk:      1
-                    tags:       APM Server/Reference
-                    subject:    APM
-                    sources:
-                      -
-                        repo:   apm-server
-                        path:   docs/guide
-                      -
-                        repo:   apm-server
-                        path:   docs
-                  - title:      Legacy APM Server Reference
-                    prefix:     server
-                    index:      docs/index.asciidoc
-                    current:    7.15
-                    branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                    live:       [ 7.15, 6.8 ]
-                    chunk:      1
-                    tags:       APM Server/Reference
-                    subject:    APM
-                    sources:
-                      -
-                        repo:   apm-server
-                        path:   changelogs
-                        exclude_branches:   [ 6.0 ]
-                      -
-                        repo:   apm-server
-                        path:   docs
-                      -
-                        repo:   apm-server
-                        path:   CHANGELOG.asciidoc
-          - title:      ECS logging
-            base_dir:   en/ecs-logging
-            sections:
-              - title:      ECS Logging Overview
-                prefix:     overview
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/Guide
-                subject:    ECS Logging Overview
-                sources:
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-              - title:      ECS Logging Go (Logrus) Reference
-                prefix:     go-logrus
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/go-logrus/Guide
-                subject:    ECS Logging Go (Logrus) Reference
-                sources:
-                  -
-                    repo:   ecs-logging-go-logrus
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-              - title:      ECS Logging Go (Zap) Reference
-                prefix:     go-zap
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/go-zap/Guide
-                subject:    ECS Logging Go (Zap) Reference
-                sources:
-                  -
-                    repo:   ecs-logging-go-zap
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-
-              - title:      ECS Logging Java Reference
-                prefix:     java
-                current:    1.x
-                branches:   [ {main: master}, 1.x, 0.x ]
-                live:       [ main, 1.x ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/java/Guide
-                subject:    ECS Logging Java Reference
-                sources:
-                  -
-                    repo:   ecs-logging-java
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-                    map_branches:
-                      1.x: main
-                      0.x: main
-              - title:      ECS Logging .NET Reference
-                prefix:     dotnet
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/.NET/Guide
-                subject:    ECS Logging .NET Reference
-                sources:
-                  -
-                    repo:   ecs-dotnet
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-              - title:      ECS Logging Node.js Reference
-                prefix:     nodejs
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/nodejs/Guide
-                subject:    ECS Logging Node.js Reference
-                sources:
-                  -
-                    repo:   ecs-logging-nodejs
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-              - title:      ECS Logging Ruby Reference
-                prefix:     ruby
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/ruby/Guide
-                subject:    ECS Logging Ruby Reference
-                sources:
-                  -
-                    repo:   ecs-logging-ruby
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-              - title:      ECS Logging PHP Reference
-                prefix:     php
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/php/Guide
-                subject:    ECS Logging PHP Reference
-                sources:
-                  -
-                    repo:   ecs-logging-php
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-              - title:      ECS Logging Python Reference
-                prefix:     python
-                current:    main
-                branches:   [ {main: master} ]
-                live:       [ main ]
-                index:      docs/index.asciidoc
-                chunk:      1
-                tags:       ECS-logging/python/Guide
-                subject:    ECS Logging Python Reference
-                sources:
-                  -
-                    repo:   ecs-logging-python
-                    path:   docs
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-                  -
-                    repo:   docs
-                    path:   shared/attributes.asciidoc
-                  -
-                    repo:   ecs-logging
-                    path:   docs
-
-    -   title:      Elastic Security
-        sections:
-          - title:      Elastic Security
-            prefix:     en/security
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklivemain
-            index:      docs/index.asciidoc
-            chunk:      1
-            tags:       Security/Guide
-            subject:    Security
-            sources:
-              -
-                repo:   security-docs
-                path:   docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   stack-docs
-                path:   docs/en
-          - title:      SIEM Guide
-            prefix:     en/siem/guide
-            current:    7.8
-            branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            live:       [ 7.8 ]
-            index:      docs/en/siem/index.asciidoc
-            chunk:      1
-            tags:       SIEM/Guide
-            subject:    SIEM
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
-
-    -   title:      "Logstash: Collect, Enrich, and Transport"
-        sections:
-          - title:      Logstash Reference
-            prefix:     en/logstash
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            live:       *stacklivemain
-            index:      docs/index.x.asciidoc
-            chunk:      1
-            tags:       Logstash/Reference
-            subject:    Logstash
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   logstash
-                path:   docs/
-              -
-                repo:   x-pack-logstash
-                prefix: logstash-extra/x-pack-logstash
-                path:   docs/en
-                private: true
-                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   logstash-docs
-                path:   docs/
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ main, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
-          - title:      Logstash Versioned Plugin Reference
-            prefix:     en/logstash-versioned-plugins
-            current:    versioned_plugin_docs
-            branches:   [ versioned_plugin_docs ]
-            index:      docs/versioned-plugins/index.asciidoc
-            private:    1
-            chunk:      1
-            noindex:    1
-            tags:       Logstash/Plugin Reference
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash-docs
-                path:   docs/versioned-plugins
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
-    -   title:      "Fleet: Install and Manage Elastic Agents"
-        sections:
-          - title:      Fleet and Elastic Agent Guide
-            prefix:     en/fleet
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklivemain
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      2
-            tags:       Fleet/Guide/Elastic Agent
-            subject:    Fleet and Elastic Agent
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   apm-server
-                path:   docs
-                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-
-          - title:      Integrations Developer Guide
-            prefix:     en/integrations-developer
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            index:      docs/en/integrations/index.asciidoc
-            chunk:      1
-            tags:       Integrations/Developer
-            subject:    Integrations
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   package-spec
-                path:   versions
-
-    -   title:      "Beats: Collect, Parse, and Ship"
-        sections:
-          - title:      Beats Platform Reference
-            prefix:     en/beats/libbeat
-            index:      libbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Libbeat/Reference
-            subject:    libbeat
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Auditbeat Reference
-            prefix:     en/beats/auditbeat
-            index:      auditbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Auditbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Auditbeat
-            sources:
-              -
-                repo:   beats
-                path:   auditbeat
-              -
-                repo:   beats
-                path:   auditbeat/docs
-              -
-                repo:   beats
-                path:   x-pack/auditbeat
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-              -
-                repo:   beats
-                path:   auditbeat/module
-              -
-                repo:   beats
-                path:   auditbeat/scripts
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Filebeat Reference
-            prefix:     en/beats/filebeat
-            index:      filebeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Filebeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Filebeat
-            sources:
-              -
-                repo:   beats
-                path:   filebeat
-              -
-                repo:   beats
-                path:   filebeat/docs
-              -
-                repo:   beats
-                path:   x-pack/filebeat/docs
-                exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/filebeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Functionbeat Reference
-            prefix:     en/beats/functionbeat
-            current:    *stackcurrent
-            index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Functionbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Functionbeat
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/functionbeat
-              -
-                repo:   beats
-                path:   x-pack/functionbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   filebeat/docs
-                exclude_branches: [ 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
-          - title:      Heartbeat Reference
-            prefix:     en/beats/heartbeat
-            current:    *stackcurrent
-            index:      heartbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Heartbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Heartbeat
-            sources:
-              -
-                repo:   beats
-                path:   heartbeat
-              -
-                repo:   beats
-                path:   heartbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Metricbeat Reference
-            prefix:     en/beats/metricbeat
-            index:      metricbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Metricbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Metricbeat
-            sources:
-              -
-                repo:   beats
-                path:   metricbeat
-              -
-                repo:   beats
-                path:   metricbeat/docs
-              -
-                repo:   beats
-                path:   metricbeat/module
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   x-pack/metricbeat/module
-                exclude_branches:   [ 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-              -
-                repo:   beats
-                path:   metricbeat/scripts
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Packetbeat Reference
-            prefix:     en/beats/packetbeat
-            index:      packetbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Packetbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Packetbeat
-            sources:
-              -
-                repo:   beats
-                path:   packetbeat
-              -
-                repo:   beats
-                path:   packetbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Winlogbeat Reference
-            prefix:     en/beats/winlogbeat
-            index:      winlogbeat/docs/index.asciidoc
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Winlogbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Winlogbeat
-            sources:
-              -
-                repo:   beats
-                path:   winlogbeat
-              -
-                repo:   beats
-                path:   winlogbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Beats Developer Guide
-            prefix:     en/beats/devguide
-            index:      docs/devguide/index.asciidoc
-            current:    main
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklivemain
-            chunk:      1
-            tags:       Devguide/Reference
-            subject:    Beats
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   beats
-                path:   docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   metricbeat/module
-              -
-                repo:   beats
-                path:   metricbeat/scripts
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   *beatsSharedExclude
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   *beatsSharedExclude
-          - title:      Elastic Logging Plugin for Docker
-            prefix:     en/beats/loggingplugin
-            current:    *stackcurrent
-            index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            chunk:      1
-            tags:       Elastic Logging Plugin/Reference
-            respect_edit_url_overrides: true
-            subject:    Elastic Logging Plugin
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/dockerlogbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-
-    - title:     Docs in Your Native Tongue
-      sections:
-        - title:      简体中文
-          base_dir:   cn
-          lang:       zh_cn
-          sections:
-            - title:      《Elasticsearch 权威指南》中文版
-              prefix:     elasticsearch/guide
-              index:      book.asciidoc
-              current:    cn
-              branches:   [ {cn: 2.x} ]
-              chunk:      1
-              private:    1
-              lang:       zh_cn
-              tags:       Elasticsearch/Definitive Guide
-              subject:    Elasticsearch
-              suppress_migration_warnings: true
-              sources:
-                -
-                  repo: guide-cn
-                  path: /
-            - title:      PHP API
-              prefix:     elasticsearch/php
-              index:      index.asciidoc
-              current:    cn
-              branches:   [ {cn: 6.0} ]
-              lang:       zh_cn
-              tags:       Elasticsearch/PHP
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch-php-cn
-                  path: /
-            - title:      Kibana 用户手册
-              prefix:     kibana
-              index:      docs/index.asciidoc
-              current:    cn
-              branches:   [ {cn: 6.0} ]
-              lang:       zh_cn
-              chunk:      1
-              private:    1
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana-cn
-                  path: /docs
-        - title:      日本語
-          base_dir:   jp
-          lang:       ja
-          sections:
-            - title:      Elasticsearchリファレンス
-              prefix:     elasticsearch/reference
-              index:      docs/jp/reference/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Elasticsearch/Reference
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch
-                  path: /docs/jp/reference
-                -
-                  repo: elasticsearch
-                  path: /docs
-            - title:      Logstashリファレンス
-              prefix:     logstash
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Logstash/Reference
-              subject:    Logstash
-              sources:
-                -
-                  repo: logstash
-                  path: /docs/jp
-            - title:      Kibanaユーザーガイド
-              prefix:     kibana
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana
-                  path: /docs/jp
-            - title:      X-Packリファレンス
-              prefix:     x-pack
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       X-Pack/Reference
-              subject:    X-Pack
-              sources:
-                -
-                  repo: x-pack
-                  path: /docs/jp
-                -
-                  repo:   x-pack-kibana
-                  path:   docs/jp
-                  prefix: kibana-extra/x-pack-kibana
-                -
-                  repo: x-pack-elasticsearch
-                  path: /docs/jp
-                  prefix: elasticsearch-extra/x-pack-elasticsearch
-        - title:      한국어
-          base_dir:   kr
-          lang:       ko
-          sections:
-            - title:      Elasticsearch 참조
-              prefix:     elasticsearch/reference
-              index:      docs/kr/reference/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Elasticsearch/Reference
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch
-                  path: /docs/kr/reference
-                -
-                  repo: elasticsearch
-                  path: /docs
-            - title:      Logstash 참조
-              prefix:     logstash
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Logstash/Reference
-              subject:    Logstash
-              sources:
-                -
-                  repo: logstash
-                  path: /docs/kr
-            - title:      Kibana 사용자 가이드
-              prefix:     kibana
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana
-                  path: /docs/kr
-            - title:      X-Pack 참조
-              prefix:     x-pack
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       X-Pack/Reference
-              subject:    X-Pack
-              sources:
-                -
-                  repo: x-pack
-                  path: /docs/kr
-                -
-                  repo: x-pack-kibana
-                  path: /docs/kr
-                  prefix: kibana-extra/x-pack-kibana
-                -
-                  repo: x-pack-elasticsearch
-                  path: /docs/kr
-                  prefix: elasticsearch-extra/x-pack-elasticsearch
-
-    -   title:      Legacy Documentation
-        sections:
-          - title:      Elastic Stack and Google Cloud's Anthos
-            prefix:     en/elastic-stack-gke
-            current:    main
-            index:      docs/en/gke-on-prem/index.asciidoc
-            branches:   [ {main: master} ]
-            private:    1
-            noindex:    1
-            chunk:      1
-            tags:       Elastic Stack/Google
-            subject:    Elastic Stack
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/gke-on-prem
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Journalbeat Reference for 6.5-7.15
-            prefix:     en/beats/journalbeat
-            current:    7.15
-            index:      journalbeat/docs/index.asciidoc
-            branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            chunk:      1
-            tags:       Journalbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Journalbeat
-            sources:
-              -
-                repo:   beats
-                path:   journalbeat
-              -
-                repo:   beats
-                path:   journalbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Logs Monitoring Guide for 7.5-7.9
-            prefix:     en/logs/guide
-            current:    7.9
-            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            index:      docs/en/logs/index.asciidoc
-            chunk:      1
-            private:    1
-            tags:       Logs/Guide
-            subject:    Logs
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Metrics Monitoring Guide for 7.5-7.9
-            prefix:     en/metrics/guide
-            current:    7.9
-            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
-            index:      docs/en/metrics/index.asciidoc
-            chunk:      1
-            private:    1
-            tags:       Metrics/Guide
-            subject:    Metrics
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Uptime Monitoring Guide for 7.2-7.9
-            prefix:     en/uptime
-            current:    7.9
-            branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
-            index:      docs/en/uptime/index.asciidoc
-            chunk:      1
-            private:    1
-            tags:       Uptime/Guide
-            subject:    Uptime
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Infrastructure Monitoring Guide for 6.5-7.4
-            prefix:     en/infrastructure/guide
-            current:    7.4
-            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            index:      docs/en/infraops/index.asciidoc
-            chunk:      1
-            private:    1
-            tags:       Infrastructure/Guide
-            subject:    Infrastructure
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Stack Overview
-            prefix:     en/elastic-stack-overview
-            current:    7.4
-            index:      docs/en/stack/index.asciidoc
-            branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            chunk:      1
-            noindex:    1
-            tags:       Legacy/Elastic Stack/Overview
-            subject:    Elastic Stack
-            sources:
-              -
-                repo:   stack-docs
-                path:   docs/en/stack
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   docs
-                path:   shared/settings.asciidoc
-          - title:      X-Pack Reference for 6.0-6.2 and 5.x
-            prefix:     en/x-pack
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/XPack/Reference
-            current:    6.2
-            subject:    X-Pack
-            index:      docs/en/index.asciidoc
-            branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            sources:
-              -
-                repo:   x-pack
-                path:   docs/en
-              -
-                repo:   x-pack-kibana
-                prefix: kibana-extra/x-pack-kibana
-                path:   docs/en
-                exclude_branches:   [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
-              -
-                repo:   x-pack-elasticsearch
-                prefix: elasticsearch-extra/x-pack-elasticsearch
-                path:   docs/en
-                exclude_branches: [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0 ]
-          - title:      Elasticsearch - The Definitive Guide
-            prefix:     en/elasticsearch/guide
-            current:    2.x
-            branches:   [ master, 2.x, 1.x ]
-            index:      book.asciidoc
-            chunk:      1
-            noindex:    1
-            private:    1
-            tags:       Legacy/Elasticsearch/Definitive Guide
-            subject:    Elasticsearch
+          - title: 《Elasticsearch 权威指南》中文版
+            prefix: elasticsearch/guide
+            index: book.asciidoc
+            current: cn
+            branches: [{ cn: 2.x }]
+            chunk: 1
+            private: 1
+            lang: zh_cn
+            tags: Elasticsearch/Definitive Guide
+            subject: Elasticsearch
             suppress_migration_warnings: true
             sources:
-              -
-                repo:   guide
-                path:   /
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ master, 2.x]
-          - title:      Sense Editor for 4.x
-            prefix:     en/sense
-            current:    master
-            branches:   [ master ]
-            index:      docs/index.asciidoc
-            noindex:    1
-            private:    1
-            tags:       Legacy/Elasticsearch/Sense-Editor
-            subject:    Sense
+              - repo: guide-cn
+                path: /
+          - title: PHP API
+            prefix: elasticsearch/php
+            index: index.asciidoc
+            current: cn
+            branches: [{ cn: 6.0 }]
+            lang: zh_cn
+            tags: Elasticsearch/PHP
+            subject: Elasticsearch
             sources:
-              -
-                repo:   sense
-                path:   docs
-          - title:      Marvel Reference for 2.x and 1.x
-            prefix:     en/marvel
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Marvel/Reference
-            subject:    Marvel
-            current:    2.4
-            index:      docs/public/marvel/index.asciidoc
-            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, {marvel-1.3: 1.3}]
+              - repo: elasticsearch-php-cn
+                path: /
+          - title: Kibana 用户手册
+            prefix: kibana
+            index: docs/index.asciidoc
+            current: cn
+            branches: [{ cn: 6.0 }]
+            lang: zh_cn
+            chunk: 1
+            private: 1
+            tags: Kibana/Reference
+            subject: Kibana
             sources:
-              -
-                repo:   x-pack
-                path:   docs/public/marvel
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches: [marvel-1.3]
-          - title:      Shield Reference for 2.x and 1.x
-            prefix:     en/shield
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Shield/Reference
-            subject:    Shield
-            current:    2.4
-            index:      docs/public/shield/index.asciidoc
-            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {shield-1.3: 1.3}, {shield-1.2: 1.2}, {shield-1.1: 1.1}, {shield-1.0: 1.0}]
+              - repo: kibana-cn
+                path: /docs
+      - title: 日本語
+        base_dir: jp
+        lang: ja
+        sections:
+          - title: Elasticsearchリファレンス
+            prefix: elasticsearch/reference
+            index: docs/jp/reference/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ja
+            tags: Elasticsearch/Reference
+            subject: Elasticsearch
             sources:
-              -
-                repo:   x-pack
-                path:   docs/public/shield
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches: [shield-1.2, shield-1.1 , shield-1.0]
-          - title:      Watcher Reference for 2.x and 1.x
-            prefix:     en/watcher
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Watcher/Reference
-            subject:    Watcher
-            current:    2.4
-            index:      docs/public/watcher/index.asciidoc
-            branches:   [2.4, 2.3, 2.2, 2.1, 2.0, {watcher-1.0: 1.0}]
+              - repo: elasticsearch
+                path: /docs/jp/reference
+              - repo: elasticsearch
+                path: /docs
+          - title: Logstashリファレンス
+            prefix: logstash
+            index: docs/jp/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ja
+            tags: Logstash/Reference
+            subject: Logstash
             sources:
-              -
-                repo:   x-pack
-                path:   docs/public/watcher
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-          - title:      Reporting Reference for 2.x
-            prefix:     en/reporting
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Reporting/Reference
-            subject:    Reporting
-            current:    2.4
-            index:      docs/public/reporting/index.asciidoc
-            branches:   [ 2.4 ]
+              - repo: logstash
+                path: /docs/jp
+          - title: Kibanaユーザーガイド
+            prefix: kibana
+            index: docs/jp/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ja
+            tags: Kibana/Reference
+            subject: Kibana
             sources:
-              -
-                repo:   x-pack
-                path:   docs/public/reporting
-          - title:      Graph Reference for 2.x
-            prefix:     en/graph
-            repo:       x-pack
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Graph/Reference
-            subject:    Graph
-            current:    2.4
-            index:      docs/public/graph/index.asciidoc
-            branches:   [ 2.4, 2.3 ]
+              - repo: kibana
+                path: /docs/jp
+          - title: X-Packリファレンス
+            prefix: x-pack
+            index: docs/jp/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4]
+            chunk: 1
+            private: 1
+            lang: ja
+            tags: X-Pack/Reference
+            subject: X-Pack
             sources:
-              -
-                repo:   x-pack
-                path:   docs/public/graph
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-          - title:      Groovy API
-            prefix:     en/elasticsearch/client/groovy-api
-            current:    2.4
-            branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            index:      docs/groovy-api/index.asciidoc
-            private:    1
-            noindex:    1
-            tags:       Legacy/Clients/Groovy
-            subject:    Clients
+              - repo: x-pack
+                path: /docs/jp
+              - repo: x-pack-kibana
+                path: docs/jp
+                prefix: kibana-extra/x-pack-kibana
+              - repo: x-pack-elasticsearch
+                path: /docs/jp
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+      - title: 한국어
+        base_dir: kr
+        lang: ko
+        sections:
+          - title: Elasticsearch 참조
+            prefix: elasticsearch/reference
+            index: docs/kr/reference/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ko
+            tags: Elasticsearch/Reference
+            subject: Elasticsearch
             sources:
-              -
-                repo:   elasticsearch
-                path:   docs/groovy-api
-              -
-                repo:   elasticsearch
-                path:   docs/Versions.asciidoc
-                exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      Topbeat Reference
-            prefix:     en/beats/topbeat
-            index:      topbeat/docs/index.asciidoc
-            current:    1.3
-            branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
-            chunk:      1
-            noindex:    1
-            tags:       Legacy/Topbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Topbeat
+              - repo: elasticsearch
+                path: /docs/kr/reference
+              - repo: elasticsearch
+                path: /docs
+          - title: Logstash 참조
+            prefix: logstash
+            index: docs/kr/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ko
+            tags: Logstash/Reference
+            subject: Logstash
             sources:
-              -
-                repo:   beats
-                path:   topbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-          - title:      Elasticsearch.js for 5.6-7.6
-            prefix:     en/elasticsearch/client/elasticsearch-js
-            current:    16.x
-            branches:   [ 16.x ]
-            index:      docs/index.asciidoc
-            chunk:      1
-            private:    1
-            noindex:    1
-            tags:       Legacy/Clients/Elasticsearch-js
-            subject:    Clients
+              - repo: logstash
+                path: /docs/kr
+          - title: Kibana 사용자 가이드
+            prefix: kibana
+            index: docs/kr/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4, 5.3]
+            chunk: 1
+            private: 1
+            lang: ko
+            tags: Kibana/Reference
+            subject: Kibana
             sources:
-              -
-                repo:   elasticsearch-js-legacy
-                path:   docs
+              - repo: kibana
+                path: /docs/kr
+          - title: X-Pack 참조
+            prefix: x-pack
+            index: docs/kr/gs-index.asciidoc
+            current: 5.4
+            branches: [5.4]
+            chunk: 1
+            private: 1
+            lang: ko
+            tags: X-Pack/Reference
+            subject: X-Pack
+            sources:
+              - repo: x-pack
+                path: /docs/kr
+              - repo: x-pack-kibana
+                path: /docs/kr
+                prefix: kibana-extra/x-pack-kibana
+              - repo: x-pack-elasticsearch
+                path: /docs/kr
+                prefix: elasticsearch-extra/x-pack-elasticsearch
+
+  - title: Legacy Documentation
+    sections:
+      - title: Elastic Stack and Google Cloud's Anthos
+        prefix: en/elastic-stack-gke
+        current: main
+        index: docs/en/gke-on-prem/index.asciidoc
+        branches: [{ main: master }]
+        private: 1
+        noindex: 1
+        chunk: 1
+        tags: Elastic Stack/Google
+        subject: Elastic Stack
+        sources:
+          - repo: stack-docs
+            path: docs/en/gke-on-prem
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Journalbeat Reference for 6.5-7.15
+        prefix: en/beats/journalbeat
+        current: 7.15
+        index: journalbeat/docs/index.asciidoc
+        branches:
+          [
+            7.15,
+            7.14,
+            7.13,
+            7.12,
+            7.11,
+            7.10,
+            7.9,
+            7.8,
+            7.7,
+            7.6,
+            7.5,
+            7.4,
+            7.3,
+            7.2,
+            7.1,
+            7.0,
+            6.8,
+            6.7,
+            6.6,
+            6.5,
+          ]
+        chunk: 1
+        tags: Journalbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Journalbeat
+        sources:
+          - repo: beats
+            path: journalbeat
+          - repo: beats
+            path: journalbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+          - repo: beats
+            path: libbeat/processors/*/docs/*
+            exclude_branches: *beatsProcessorExclude
+          - repo: beats
+            path: x-pack/libbeat/processors/*/docs/*
+            exclude_branches:
+              [
+                7.6,
+                7.5,
+                7.4,
+                7.3,
+                7.2,
+                7.1,
+                7.0,
+                6.8,
+                6.7,
+                6.6,
+                6.5,
+                6.4,
+                6.3,
+                6.2,
+                6.1,
+                6.0,
+                5.6,
+                5.5,
+                5.4,
+                5.3,
+                5.2,
+                5.1,
+                5.0,
+                1.3,
+                1.2,
+                1.1,
+                1.0.1,
+              ]
+          - repo: beats
+            path: libbeat/outputs/*/docs/*
+            exclude_branches: *beatsOutputExclude
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Logs Monitoring Guide for 7.5-7.9
+        prefix: en/logs/guide
+        current: 7.9
+        branches: [7.9, 7.8, 7.7, 7.6, 7.5]
+        index: docs/en/logs/index.asciidoc
+        chunk: 1
+        private: 1
+        tags: Logs/Guide
+        subject: Logs
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Metrics Monitoring Guide for 7.5-7.9
+        prefix: en/metrics/guide
+        current: 7.9
+        branches: [7.9, 7.8, 7.7, 7.6, 7.5]
+        index: docs/en/metrics/index.asciidoc
+        chunk: 1
+        private: 1
+        tags: Metrics/Guide
+        subject: Metrics
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Uptime Monitoring Guide for 7.2-7.9
+        prefix: en/uptime
+        current: 7.9
+        branches: [7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2]
+        index: docs/en/uptime/index.asciidoc
+        chunk: 1
+        private: 1
+        tags: Uptime/Guide
+        subject: Uptime
+        sources:
+          - repo: observability-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Infrastructure Monitoring Guide for 6.5-7.4
+        prefix: en/infrastructure/guide
+        current: 7.4
+        branches: [7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5]
+        index: docs/en/infraops/index.asciidoc
+        chunk: 1
+        private: 1
+        tags: Infrastructure/Guide
+        subject: Infrastructure
+        sources:
+          - repo: stack-docs
+            path: docs/en
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+      - title: Stack Overview
+        prefix: en/elastic-stack-overview
+        current: 7.4
+        index: docs/en/stack/index.asciidoc
+        branches: [7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3]
+        chunk: 1
+        noindex: 1
+        tags: Legacy/Elastic Stack/Overview
+        subject: Elastic Stack
+        sources:
+          - repo: stack-docs
+            path: docs/en/stack
+          - repo: docs
+            path: shared/versions/stack/{version}.asciidoc
+          - repo: docs
+            path: shared/attributes.asciidoc
+          - repo: docs
+            path: shared/settings.asciidoc
+      - title: X-Pack Reference for 6.0-6.2 and 5.x
+        prefix: en/x-pack
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/XPack/Reference
+        current: 6.2
+        subject: X-Pack
+        index: docs/en/index.asciidoc
+        branches: [6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0]
+        sources:
+          - repo: x-pack
+            path: docs/en
+          - repo: x-pack-kibana
+            prefix: kibana-extra/x-pack-kibana
+            path: docs/en
+            exclude_branches: [master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+          - repo: x-pack-elasticsearch
+            prefix: elasticsearch-extra/x-pack-elasticsearch
+            path: docs/en
+            exclude_branches: [master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+          - repo: docs
+            path: shared/attributes62.asciidoc
+            exclude_branches: [5.4, 5.3, 5.2, 5.1, 5.0]
+      - title: Elasticsearch - The Definitive Guide
+        prefix: en/elasticsearch/guide
+        current: 2.x
+        branches: [master, 2.x, 1.x]
+        index: book.asciidoc
+        chunk: 1
+        noindex: 1
+        private: 1
+        tags: Legacy/Elasticsearch/Definitive Guide
+        subject: Elasticsearch
+        suppress_migration_warnings: true
+        sources:
+          - repo: guide
+            path: /
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+            exclude_branches: [master, 2.x]
+      - title: Sense Editor for 4.x
+        prefix: en/sense
+        current: master
+        branches: [master]
+        index: docs/index.asciidoc
+        noindex: 1
+        private: 1
+        tags: Legacy/Elasticsearch/Sense-Editor
+        subject: Sense
+        sources:
+          - repo: sense
+            path: docs
+      - title: Marvel Reference for 2.x and 1.x
+        prefix: en/marvel
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Marvel/Reference
+        subject: Marvel
+        current: 2.4
+        index: docs/public/marvel/index.asciidoc
+        branches: [2.4, 2.3, 2.2, 2.1, 2.0, { marvel-1.3: 1.3 }]
+        sources:
+          - repo: x-pack
+            path: docs/public/marvel
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+            exclude_branches: [marvel-1.3]
+      - title: Shield Reference for 2.x and 1.x
+        prefix: en/shield
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Shield/Reference
+        subject: Shield
+        current: 2.4
+        index: docs/public/shield/index.asciidoc
+        branches:
+          [
+            2.4,
+            2.3,
+            2.2,
+            2.1,
+            2.0,
+            { shield-1.3: 1.3 },
+            { shield-1.2: 1.2 },
+            { shield-1.1: 1.1 },
+            { shield-1.0: 1.0 },
+          ]
+        sources:
+          - repo: x-pack
+            path: docs/public/shield
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+            exclude_branches: [shield-1.2, shield-1.1, shield-1.0]
+      - title: Watcher Reference for 2.x and 1.x
+        prefix: en/watcher
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Watcher/Reference
+        subject: Watcher
+        current: 2.4
+        index: docs/public/watcher/index.asciidoc
+        branches: [2.4, 2.3, 2.2, 2.1, 2.0, { watcher-1.0: 1.0 }]
+        sources:
+          - repo: x-pack
+            path: docs/public/watcher
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+      - title: Reporting Reference for 2.x
+        prefix: en/reporting
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Reporting/Reference
+        subject: Reporting
+        current: 2.4
+        index: docs/public/reporting/index.asciidoc
+        branches: [2.4]
+        sources:
+          - repo: x-pack
+            path: docs/public/reporting
+      - title: Graph Reference for 2.x
+        prefix: en/graph
+        repo: x-pack
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Graph/Reference
+        subject: Graph
+        current: 2.4
+        index: docs/public/graph/index.asciidoc
+        branches: [2.4, 2.3]
+        sources:
+          - repo: x-pack
+            path: docs/public/graph
+          - repo: docs
+            path: shared/legacy-attrs.asciidoc
+      - title: Groovy API
+        prefix: en/elasticsearch/client/groovy-api
+        current: 2.4
+        branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+        index: docs/groovy-api/index.asciidoc
+        private: 1
+        noindex: 1
+        tags: Legacy/Clients/Groovy
+        subject: Clients
+        sources:
+          - repo: elasticsearch
+            path: docs/groovy-api
+          - repo: elasticsearch
+            path: docs/Versions.asciidoc
+            exclude_branches: [2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90]
+      - title: Topbeat Reference
+        prefix: en/beats/topbeat
+        index: topbeat/docs/index.asciidoc
+        current: 1.3
+        branches: [1.3, 1.2, 1.1, 1.0.1]
+        chunk: 1
+        noindex: 1
+        tags: Legacy/Topbeat/Reference
+        respect_edit_url_overrides: true
+        subject: Topbeat
+        sources:
+          - repo: beats
+            path: topbeat/docs
+          - repo: beats
+            path: CHANGELOG.asciidoc
+          - repo: beats
+            path: libbeat/docs
+      - title: Elasticsearch.js for 5.6-7.6
+        prefix: en/elasticsearch/client/elasticsearch-js
+        current: 16.x
+        branches: [16.x]
+        index: docs/index.asciidoc
+        chunk: 1
+        private: 1
+        noindex: 1
+        tags: Legacy/Clients/Elasticsearch-js
+        subject: Clients
+        sources:
+          - repo: elasticsearch-js-legacy
+            path: docs
 
 redirects:
-    -
-        prefix:         en/
-        redirect:       /guide
-    -
-        prefix:         en/elasticsearch
-        redirect:       /guide
-    -
-        prefix:         cn/elasticsearch
-        redirect:       /cn
+  - prefix: en/
+    redirect: /guide
+  - prefix: en/elasticsearch
+    redirect: /guide
+  - prefix: cn/elasticsearch
+    redirect: /cn


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-71 and should be merged on ms-71 release day.