### PR TITLE
Set 8.1 as the current ECS branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -263,9 +263,9 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.0
+            current:    8.1
             branches:   [  {main: master}, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.2, 8.1, 8.0, 1.12 ]
+            live:       [ main, 8.2, 8.1, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference


### PR DESCRIPTION
Will merge this change when ECS 8.1.0 is released.
