### PR TITLE
Publish 8.1 branch of Welcome docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -120,9 +120,10 @@ contents:
         sections:
           - title:      "Welcome to Elastic"
             prefix:     en/welcome-to-elastic
-            current:    main
+            current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
-            branches:   [ {main: master} ]
+            branches:   [ 8.1 ]
+            live:       *stacklivemain
             chunk:      1
             tags:       Elastic/Welcome
             subject:    Welcome to Elastic


### PR DESCRIPTION
This has the side effect of removing the master version from the published docs, but we expect the impact to be minimal. They were more a side-effect of having a single version than intentional, and were not surfacing in Google searches.

Going forward, we'll publish in sync with the stack versioning.