### PR TITLE
Add shared third-party connectors

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -235,7 +235,11 @@ Common words and phrases
 :elastic-sec:             Elastic Security
 :elastic-endpoint:        Elastic Endpoint
 :swimlane:                Swimlane
-:sn:                     ServiceNow
+:sn:                      ServiceNow
+:sn-itsm:                 ServiceNow ITSM
+:sn-sir:                  ServiceNow SecOps
+:jira:                    Jira
+:ibm-r:                   IBM Resilient
 :monitoring:              X-Pack monitoring
 :monitor-features:        monitoring features
 :stack-monitor-features:  {stack} {monitor-features}


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/126956

The [case APIs](https://www.elastic.co/guide/en/security/master/cases-api-overview.html) currently use shared attributes for some of the third-party incident management systems. Some of those attributes are defined only in  https://github.com/elastic/security-docs/blob/8.1/docs/index.asciidoc

Since cases are available across multiple solutions, those attributes also need to be shared.