### PR TITLE
conf.yaml: add apm-agent-go 2.x branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1273,9 +1273,9 @@ contents:
                 sections:
                   - title:      APM Go Agent
                     prefix:     go
-                    current:    1.x
-                    branches:   [ {main: master}, 1.x, 0.5 ]
-                    live:       [ main, 1.x ]
+                    current:    2.x
+                    branches:   [ {main: master}, 2.x, 1.x, 0.5 ]
+                    live:       [ main, 2.x, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
                     subject:    APM

--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -32,7 +32,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-go-branch:         1.x
+:apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x

--- a/shared/versions/stack/8.0.asciidoc
+++ b/shared/versions/stack/8.0.asciidoc
@@ -33,7 +33,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-go-branch:         1.x
+:apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -33,7 +33,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-go-branch:         1.x
+:apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -33,7 +33,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-go-branch:         1.x
+:apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x


### PR DESCRIPTION
Add the apm-agent-go 2.x branch, and mark it as the current branch. v2.0.0 has just been released.