### PR TITLE
Add content to docs landing page

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -513,6 +513,7 @@ RSpec.describe 'building all books' do
     file_context 'the toc', 'raw/index.html' do
       it 'includes the extra html' do
         expect(contents).to include(<<~HTML)
+          <!--EXTRA-->
           <div id="extra">
           <p>extra html</p>
           </div>

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -250,7 +250,7 @@ sub build_single {
 
     if ( $extra ) {
         my $contents = $html_file->slurp( iomode => '<:encoding(UTF-8)' );
-        $contents =~ s{<div class="(article|book)"}{<div id="extra">\n$extra\n</div>\n<div class="$1"} or
+        $contents =~ s{<!--EXTRA-->}{<!--EXTRA-->\n<div id="extra">\n$extra\n</div>} or
             die "Couldn't add toc_extra to $contents";
         $html_file->spew( iomode => '>:utf8', $contents );
     }

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -82,6 +82,7 @@ module DocbookCompat
       result + <<~HTML.strip
         </div>
         <hr>
+        <!--EXTRA-->
       HTML
     end
 

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe DocbookCompat do
           <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
           </div>
           <hr>
+          <!--EXTRA-->
           </div>
         HTML
       end
@@ -117,6 +118,7 @@ RSpec.describe DocbookCompat do
             <div><h1 class="title"><a id="title-id"></a>Title</h1></div>
             </div>
             <hr>
+            <!--EXTRA-->
             </div>
           HTML
         end
@@ -152,6 +154,7 @@ RSpec.describe DocbookCompat do
             <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
             </div>
             <hr>
+            <!--EXTRA-->
           HTML
         end
       end
@@ -159,6 +162,7 @@ RSpec.describe DocbookCompat do
         it 'is outside the titlepage' do
           expect(converted).to include(<<~HTML)
             <hr>
+            <!--EXTRA-->
             </div>
             <div id="content">
             <!--START_TOC-->
@@ -355,6 +359,7 @@ RSpec.describe DocbookCompat do
             <div><h2 class="subtitle">Subtitle</h2></div>
             </div>
             <hr>
+            <!--EXTRA-->
             </div>
           HTML
         end
@@ -381,6 +386,7 @@ RSpec.describe DocbookCompat do
             <div><h1 class="title"><a id="id-1"></a><code class="literal">foo</code></h1></div>
             </div>
             <hr>
+            <!--EXTRA-->
             </div>
           HTML
         end


### PR DESCRIPTION
This builds on #1909 and #1434 to allow inserting extra content below the primary heading on Docs Landing pages (like https://www.elastic.co/guide/index.html).

To actually add content, change what's in `extra/docs_landing.html`