### PR TITLE
docs: add `apm-aws-lambda` as a dependency

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1321,6 +1321,11 @@ contents:
                         repo:   apm-agent-java
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 0.7, 0.6]
+                      -
+                        repo:   apm-aws-lambda
+                        path:   docs
+                        exclude_branches:   [ 0.7, 0.6 ]
+                        map_branches: *mapMasterToMain
                   - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.12
@@ -1354,6 +1359,11 @@ contents:
                         repo:   apm-agent-nodejs
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 1.x, 0.x ]
+                      -
+                        repo:   apm-aws-lambda
+                        path:   docs
+                        exclude_branches:   [ 2.x, 1.x, 0.x ]
+                        map_branches: *mapMasterToMain
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x
@@ -1387,6 +1397,11 @@ contents:
                         repo:   apm-agent-python
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 4.x, 3.x, 2.x, 1.x ]
+                      -
+                        repo:   apm-aws-lambda
+                        path:   docs
+                        exclude_branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x ]
+                        map_branches: *mapMasterToMain
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -160,13 +160,13 @@ alias docbldidg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/do
 alias docbldapm=' $GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/integrations-index.asciidoc --resource=$GIT_HOME/observability-docs/ --resource=$GIT_HOME/apm-aws-lambda --chunk 2 --open'
 
 # APM Agents
-alias docbldamn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1'
+alias docbldamn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1 --resource $GIT_HOME/apm-aws-lambda/docs'
 
-alias docbldamp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1'
+alias docbldamp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-python/docs/index.asciidoc --chunk 1 --resource $GIT_HOME/apm-aws-lambda/docs'
 
 alias docbldamry='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ruby/docs/index.asciidoc --chunk 1'
 
-alias docbldamj='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1'
+alias docbldamj='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-java/docs/index.asciidoc --chunk 1 --resource $GIT_HOME/apm-aws-lambda/docs'
 
 alias docbldamjs='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-rum-js/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
### Summary

Adds the docs directory in [`elastic/apm-aws-lambda`](https://github.com/elastic/apm-aws-lambda) as a dependency to the following repos:

* `elastic/apm-agent-java`
* `elastic/apm-agent-nodejs`
* `elastic/apm-agent-python`

For https://github.com/elastic/observability-docs/issues/1707.