### PR TITLE
Removes branches to generate for PHP Client

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -567,7 +567,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ master, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1


### PR DESCRIPTION
## Overview

This PR removes 5.x, 2.x, 1.x, 0.4 from the docs branches generated for the PHP Client book from the conf.yml file. These branches no longer needed to be in the docs.