### PR TITLE
More apm aws dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1326,6 +1326,7 @@ contents:
                         path:   docs
                         exclude_branches:   [ 0.7, 0.6 ]
                         map_branches: 
+                          main: *stackcurrent
                           1.x: *stackcurrent
                   - title:      APM .NET Agent
                     prefix:     dotnet
@@ -1365,6 +1366,7 @@ contents:
                         path:   docs
                         exclude_branches:   [ 2.x, 1.x, 0.x ]
                         map_branches: 
+                          main: *stackcurrent
                           3.x: *stackcurrent
                   - title:      APM PHP Agent
                     prefix:     php
@@ -1404,6 +1406,7 @@ contents:
                         path:   docs
                         exclude_branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x ]
                         map_branches: 
+                          main: *stackcurrent
                           6.x: *stackcurrent
                   - title:      APM Ruby Agent
                     prefix:     ruby


### PR DESCRIPTION
Follow up to https://github.com/elastic/docs/pull/2404. `main` needs to temporarily map to current for ci to pass. This will be reverted in a future PR.

For https://github.com/elastic/apm-agent-java/pull/2556.