### PR TITLE
docs: bump apm-py back to 6.x

### DIFF
--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -39,7 +39,7 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
-:apm-py-branch:         5.x
+:apm-py-branch:         6.x
 :apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.12
 

--- a/shared/versions/stack/8.2.asciidoc
+++ b/shared/versions/stack/8.2.asciidoc
@@ -39,7 +39,7 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
-:apm-py-branch:         5.x
+:apm-py-branch:         6.x
 :apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.12
 

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -39,7 +39,7 @@ APM Agent versions
 :apm-rum-branch:        4.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
-:apm-py-branch:         5.x
+:apm-py-branch:         6.x
 :apm-ruby-branch:       4.x
 :apm-dotnet-branch:     1.12
 


### PR DESCRIPTION
There will be broken links... seeing what they are