### PR TITLE
ESS - Change current to ms-72

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.1, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-71
+  cloudSaasCurrent: &cloudSaasCurrent ms-72
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-72 and should be merged on ms-72 release day.