### PR TITLE
Removes .NET 7.x from docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -567,7 +567,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ master, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ master, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -554,7 +554,7 @@ contents:
               - title:      .NET Clients
                 prefix:     net-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x ]
+                branches:   [ {main: master}, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
@@ -567,7 +567,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ master, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ master, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1


### PR DESCRIPTION
## Overview

This PR removes the `7.x` branch from the .NET docs as 7.x has been deleted in the .NET repo.