### PR TITLE
Bump current version to 8.2

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -71,10 +71,10 @@ contents_title:     Elastic Stack and Product Documentation
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.1
-  stacklive: &stacklive [ master, 8.1, 7.17 ]
+  stackcurrent: &stackcurrent 8.2
+  stacklive: &stacklive [ master, 8.2, 7.17 ]
 
-  stacklivemain: &stacklivemain [ main, 8.1, 7.17 ]
+  stacklivemain: &stacklivemain [ main, 8.2, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-71
 
@@ -122,7 +122,7 @@ contents:
             prefix:     en/welcome-to-elastic
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
-            branches:   [ 8.1 ]
+            branches:   [ 8.2 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic/Welcome

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -23,7 +23,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.2.asciidoc
+++ b/shared/versions/stack/8.2.asciidoc
@@ -18,12 +18,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.1.asciidoc[]
+include::8.2.asciidoc[]


### PR DESCRIPTION
Chanes the "current" version of Elastic documentation to 8.2.