### PR TITLE
Promote ECK 2.2

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -948,7 +948,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.1
+            current:    2.2
             branches:   [ {main: master}, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -949,7 +949,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.1
-            branches:   [ {main: master}, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Based off of #2422. This promotes the ECK 2.2 release branch to current.

I am submitting this early to get approval. It should only be merged on Tuesday, April 26 after ECK 2.2 is released.