### PR TITLE
Set 8.2 as the current ECS branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -265,7 +265,7 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.1
+            current:    8.2
             branches:   [  {main: master}, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.3, 8.2, 8.1, 1.12 ]
             index:      docs/index.asciidoc


### PR DESCRIPTION
Will merge this change when ECS 8.2.0 is released.