### PR TITLE
add simple docker-compose.yml for simpler air-gapped docs starting

### DIFF
--- a/air_gapped/docker-compose.yml
+++ b/air_gapped/docker-compose.yml
@@ -1,0 +1,10 @@
+---
+version: "3.7"
+
+services:
+  # Run build.sh first to build latest image from source
+  elastic-docs:
+    container_name: elastic-docs
+    image: docker.elastic.co/docs-private/air_gapped:latest
+    ports:
+      - 8000:8000/tcp


### PR DESCRIPTION
Air-gapped docs are really useful, but it would be nicer to be able to run `docker-compose up -d` and `docker-compose down`.
