### PR TITLE
Update conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -723,7 +723,7 @@ contents:
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
             branches:   [ {main: master}, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
-            live:       *stacklive
+            live:       *stacklivemain
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch


### PR DESCRIPTION
Follow up to https://github.com/elastic/docs/pull/2434. Uses `main` instead of `master` for `elasticsearch-hadoop`.