### PR TITLE
ESS - Change current to ms-74

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.2, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-72
+  cloudSaasCurrent: &cloudSaasCurrent ms-74
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
Combines and releases MS-73 and MS-74.

This changes "current" for the Cloud ESS docs to MS-74.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
