### PR TITLE
Update docbldela alias

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -224,7 +224,7 @@ alias docbldecc='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/co
 
 alias docbldesh='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/index.adoc'
 
-alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-eland-docs/docs/en/index.asciidoc --chunk 1'
+alias docbldela='$GIT_HOME/docs/build_docs --doc $GIT_HOME/eland/docs/guide/index.asciidoc --chunk 1'
 
 alias docbldejsl='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch-js-legacy/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
This PR updates the doc_build_aliases.sh file to align with the documentation build information in https://github.com/elastic/docs/blob/b09ea3aea2fc8699e132124f51be2cd83340f804/conf.yaml#L609

