### PR TITLE
Add shared attribute for Elasticsearch Service Console

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -127,6 +127,7 @@ Elastic Cloud
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
 :ess-console: https://cloud.elastic.co?baymax=docs-body&elektra=docs
+:ess-console-name: {ess} Console
 :ess-deployments: https://cloud.elastic.co/deployments?baymax=docs-body&elektra=docs
 :ess-baymax:  ?baymax=docs-body&elektra=docs
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current


### PR DESCRIPTION
This attribute is defined in index.asciidoc files in the cloud repo, but those are not available to other content. Therefore, this PR adds it to the list of shared attributes.

It can then be used in PRs like https://github.com/elastic/kibana/pull/134552