### PR TITLE
ESS - Change current to ms-76

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.2, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-75
+  cloudSaasCurrent: &cloudSaasCurrent ms-76
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-76 and should be merged on ms-76 release day.

