### PR TITLE
docs: update versions/stack rum agent

### DIFF
--- a/shared/versions/stack/8.0.asciidoc
+++ b/shared/versions/stack/8.0.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        4.x
+:apm-rum-branch:        5.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        4.x
+:apm-rum-branch:        5.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x

--- a/shared/versions/stack/8.2.asciidoc
+++ b/shared/versions/stack/8.2.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        4.x
+:apm-rum-branch:        5.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x

--- a/shared/versions/stack/8.3.asciidoc
+++ b/shared/versions/stack/8.3.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        4.x
+:apm-rum-branch:        5.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-go-branch:         2.x
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
-:apm-rum-branch:        4.x
+:apm-rum-branch:        5.x
 :apm-node-branch:       3.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x


### PR DESCRIPTION
This makes stack links from master, and 8.x point to the 5.x RUM agent documentation. 

Thank you @yakhinvadim for bringing this to our notice!

Example of docs pointing to 4.x:  https://www.elastic.co/guide/en/apm/guide/current/apm-rum.html

**Question:** 

Does the current documentation will start pointing to the new link automatically once this is merged? Or do I need to do something else? Many thanks!!!

