### PR TITLE
Add ECK 2.3 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -951,7 +951,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.2
-            branches:   [ {main: master}, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Adds the `2.3` release branch for the upcoming ECK release.