### PR TITLE
Set the noindex flag on the Stack Getting Started

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -203,6 +203,7 @@ contents:
             branches:   [ {main: master}, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklivemain
             chunk:      1
+            noindex:    1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
             sources:


### PR DESCRIPTION
We want to steer people toward the new onboarding content instead of to the old Stack Getting Started tutorial. The Docker information that's contained in this guide is largely replicated in the Elasticsearch guide and the ES pages appear at the top of the search results. The Kubernetes information is essentially a placeholder so we had something showing up in search results for ES + Kubernetes. Similar to Docker, the ECK docs appear at the top of the search results and are a better destination for people interested in deploying on Kubernetes. 

When this book is removed, we will set up the following redirects:

https://www.elastic.co/guide/en/elastic-stack-get-started/current/index.html
https://www.elastic.co/guide/index.html

https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-elastic-stack.html
https://www.elastic.co/guide/index.html

https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-docker.html
https://www.elastic.co/guide/en/elasticsearch/reference/8.2/docker.html

https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-kubernetes.html
https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-overview.html

