### PR TITLE
Add shared attribute for actions and connectors

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -164,6 +164,7 @@ Kibana app and UI names
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
 :rules-ui:           Rules and Connectors
+:connectors-feature: Actions and Connectors
 :user-experience:    User Experience
 :ems:                Elastic Maps Service
 :ems-init:           EMS


### PR DESCRIPTION
When you grant privileges to a role in Kibana, it refers to an "Actions and Connectors" feature. It would be useful to have a shared attribute for this feature name.
