### PR TITLE
Update landing page with Add data link and cloud context

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -19,6 +19,8 @@
       <p>Together, they form the <strong>Elastic Stack</strong> and provide
         powerful search, analysis, and monitoring capabilities for all types of data.</p>
 
+      <p>The Elastic Stack can be deployed on cloud, with marketplace support for Amazon Web Services, Google Cloud, and Microsoft Azure, or you can take the on-premises option and manage everything yourself.</p>
+
       <p>You can use the stack to:</p>
 
       <ul>
@@ -66,8 +68,8 @@
       <td style="width: 50%">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/cloud/current/ec-migrating-data.html">Migrate to Elastic Cloud</a></li>
-            <li class="listitem"><a href="en/kibana/current/connect-to-elasticsearch.html">Add data to the Elastic Stack</a></li>
+            <li class="listitem"><a href="en/cloud/current/ec-cloud-ingest-data.html">Add your data</a></li>
+            <li class="listitem"><a href="en/cloud/current/ec-migrating-data.html">Migrate to Elastic Cloud</a></li>            
             <li class="listitem"><a href="en/cloud/current/ec-planning.html">Plan for production</a></li>
             <li class="listitem"><a href="en/cloud/current/ec-monitoring.html">Keep your deployment healthy</a></li>
             <li class="listitem"><a href="en/elasticsearch/reference/current/example-using-index-lifecycle-policy.html">Manage data retention</a></li>


### PR DESCRIPTION
This PR changes the Add data link in Featured Topics from the Kibana page to the Cloud page, as discussed in https://github.com/elastic/observability-docs/issues/1759

Also contains additional sentence on Cloud context for Elastic Stack.