### PR TITLE
Remove excess margin and padding on guide index

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -90,7 +90,7 @@
   </table>
 
   <h3 style="margin-top: 0px !important">Need help?</h3>
-  <table width="100%">
+  <table width="100%;margin-bottom: 5px !important;">
     <tr>
       <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -35,9 +35,9 @@
   <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
-  <table style="width: 100%">
+  <table style="width: 100%;margin-bottom: 5px !important;">
     <tr>
-      <td style="width: 50%">
+      <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
             <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-observability.html">Monitor applications and systems with Elastic Observability</a></li>
@@ -46,7 +46,7 @@
           </ul>
         </div>
       </td>
-      <td style="width: 50%">
+      <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
             <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-appsearch.html">Build a custom search engine experience with Elastic Enterprise Search</a></li>
@@ -57,10 +57,10 @@
     </tr>
   </table>
 
-  <table style="width: 100%">
+  <table style="width: 100%;margin-bottom: 5px !important;">
     <tr>
-      <th style="width: 50%"><h3>Featured topics</h3></th>
-      <th style="width: 50%"><h3>Subscribe</h3></th>
+      <th style="width: 50%; padding-top: 0px !important;"><h3 style="margin-top: 0px !important">Featured topics</h3></th>
+      <th style="width: 50%; padding-top: 0px !important;"><h3 style="margin-top: 0px !important">Subscribe</h3></th>
     </tr>
     <tr>
       <td style="width: 50%">
@@ -89,10 +89,10 @@
     </tr>
   </table>
 
-  <h3>Need help?</h3>
+  <h3 style="margin-top: 0px !important">Need help?</h3>
   <table width="100%">
     <tr>
-      <td style="width: 50%">
+      <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
             <li class="listitem"><a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a></li>
@@ -101,7 +101,7 @@
           </ul>
         </div>
       </td>
-      <td style="width: 50%">
+      <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
             <li class="listitem"><a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a></li>
@@ -114,4 +114,4 @@
   </table>
 </div>
 
-<hr id="viewall"/>
+<hr id="viewall" style="margin-top: 0px;margin-bottom: 0px !important;"/>


### PR DESCRIPTION
### Summary

I feel like there's a lot of empty space in the custom header on [elastic.co/guide](https://www.elastic.co/guide/index.html). This PR removes excess margin and padding to tighten things up a bit. I really wanted to figure out to get this to work for the rest of the elements on the page, but unfortunately, it appears that the doc build treats the TOC page the same as every other documentation page, so the only way I could specifically target the TOC H3s was by using jQuery.

Here's a screenshot of this change (or see the [preview](https://docs_2463.docs-preview.app.elstc.co/guide/index.html))

<img width="623" alt="Screen Shot 2022-06-23 at 2 54 41 PM" src="https://user-images.githubusercontent.com/5618806/175420783-7a438858-edd2-415d-a117-4bdd789a4a4a.png">

