### PR TITLE
[DOCS] Updated Welcome to Elastic attribute to use current

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -45,7 +45,7 @@
 ///////
 Elastic-level pages
 ///////
-:estc-welcome:         https://www.elastic.co/guide/en/welcome-to-elastic/{branch}
+:estc-welcome:         https://www.elastic.co/guide/en/welcome-to-elastic/current
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         https://www.elastic.co/guide/en/elastic-stack/6.7


### PR DESCRIPTION
We only publish one version of the Welcome guide & the attribute was set up using {branch}. 