### PR TITLE
ESS - Change current to ms-77

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -77,7 +77,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.3, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-75
+  cloudSaasCurrent: &cloudSaasCurrent ms-77
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-77 and should be merged on ms-77 release day.