### PR TITLE
[Docs release] Bump current version to 8.4

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -72,10 +72,10 @@ contents_title:     Welcome to Elastic Docs
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.3
-  stacklive: &stacklive [ master, 8.3, 7.17 ]
+  stackcurrent: &stackcurrent 8.4
+  stacklive: &stacklive [ master, 8.4, 7.17 ]
 
-  stacklivemain: &stacklivemain [ main, 8.3, 7.17 ]
+  stacklivemain: &stacklivemain [ main, 8.4, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-77
 
@@ -125,7 +125,7 @@ contents:
             prefix:     en/welcome-to-elastic
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
-            branches:   [ 8.3 ]
+            branches:   [ 8.4 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic/Welcome

--- a/shared/versions/stack/8.4.asciidoc
+++ b/shared/versions/stack/8.4.asciidoc
@@ -18,12 +18,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.3.asciidoc[]
+include::8.4.asciidoc[]


### PR DESCRIPTION
Changes the "current" version of Elastic documentation to 8.3.