### PR TITLE
Publish additional branches of enterprise-search-php

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1138,9 +1138,9 @@ contents:
                     path:   shared/versions/stack/{version}.asciidoc
               - title:      Enterprise Search PHP client
                 prefix:     php
-                current:    7.16
-                branches:   [ 7.16 ]
-                live:       [ 7.16 ]
+                current:    *stackcurrent
+                branches:   [ master, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
                 subject:    Enterprise Search Clients


### PR DESCRIPTION
It seems versions after 7.16 never got added to the build.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
