### PR TITLE
Promote ECK to 2.4

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -923,7 +923,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.3
+            current:    2.4
             branches:   [ {main: master}, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
Promotes ECK to `2.4`. Has to be merged _after_ https://github.com/elastic/docs/pull/2493.