### PR TITLE
Add alias for Logstash K8s book

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -32,6 +32,8 @@ alias docbldlsx='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 
 alias docbldls=docbldlsx
 
+alias docbldlsk8s='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/k8sdocs/index.asciidoc --chunk 1'
+
 # Logstash 6.2 and earlier
 
 alias docbldlsold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/logstash/docs/index.x.asciidoc --resource=$GIT_HOME/logstash-docs/docs/ --resource=$GIT_HOME/logstash-extra/x-pack-logstash/docs/ --chunk 1'


### PR DESCRIPTION
This adds an alias so that we can build the proposed / test Logstash and Kubernetes book using `docbldlsk8s`.