### PR TITLE
Add attribute for App Search web crawler

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -200,6 +200,7 @@ Enterprise Search
 
 :crawler: Enterprise Search web crawler
 :ents: Enterprise Search
+:app-search-crawler: App Search web crawler
 
 //////////
 Ingest terms


### PR DESCRIPTION
Adding this attribute to distinguish the App Search web crawler from the new top level Elastic web crawler.