### PR TITLE
Add 8.4 branch to conf.yaml for Enterprise Search PHP client

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1139,7 +1139,7 @@ contents:
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    *stackcurrent
-                branches:   [ master, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ master, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP


### PR DESCRIPTION
Adds an 8.4 branch to conf.yaml specifically for the Enterprise Search PHP Client docs.

Rel: https://github.com/elastic/docs/pull/2483

Prep work for 8.4 release.