### PR TITLE
Add `infrastructure-app` shared attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -166,6 +166,7 @@ Kibana app and UI names
 :uptime-app:         Uptime app
 :logs-app:           Logs app
 :metrics-app:        Metrics app
+:infrastructure-app: Infrastructure app
 :siem-app:           SIEM app
 :security-app:       Elastic Security app
 :ml-app:             Machine Learning


### PR DESCRIPTION
Ref https://github.com/elastic/observability-docs/issues/2097, https://github.com/elastic/observability-docs/pull/2102

In 8.4 the high-level "Metrics" section of the Observability app will be changed to "Infrastructure". This PR adds an `infrastructure-app` shared attribute. I don't _think_ we want to replace the value of the `metrics-app` attribute since it will continue to be needed in pre-8.4 content, but going forward we should use `infrastructure-app` when referring to this section.