### PR TITLE
Update Enterprise Search getting started for 8.4

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -51,7 +51,7 @@
       <td style="width: 50%; padding-top: 0px !important;">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-appsearch.html">Build a custom search engine experience with Elastic Enterprise Search</a></li>
+            <li class="listitem"><a href="en/enterprise-search/current/start.html">Build a custom search engine experience with Elastic Enterprise Search</a></li>
             <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-general-purpose.html">Deploy your own platform to store, search, and visualize any data</a></li>
           </ul>
         </div>


### PR DESCRIPTION
The getting started doc for Enterprise Search now lives within the Enterprise Search docs. Update the link on the landing page.

https://github.com/elastic/enterprise-search-team/issues/2450