### PR TITLE
ESS - Change current to ms-79

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,7 +78,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.4, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-77
+  cloudSaasCurrent: &cloudSaasCurrent ms-79
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-79 and should be merged on ms-79 release day.