### PR TITLE
Update `master` attributes for the 8.4 release

### DIFF
--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.4.0
+:version:                8.5.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.4.0
-:logstash_version:       8.4.0
-:elasticsearch_version:  8.4.0
-:kibana_version:         8.4.0
-:apm_server_version:     8.4.0
+:bare_version:           8.5.0
+:logstash_version:       8.5.0
+:elasticsearch_version:  8.5.0
+:kibana_version:         8.5.0
+:apm_server_version:     8.5.0
 :branch:                 master
-:minor-version:          8.4
+:minor-version:          8.5
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17


### PR DESCRIPTION
Related: https://github.com/elastic/docs/pull/2484

Updates attributes in the `shared/versions/stack/master.asciidoc` file. 