### PR TITLE
ESS - Change current to ms-80

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,7 +78,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.4, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-78
+  cloudSaasCurrent: &cloudSaasCurrent ms-80
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-80 and should be merged on ms-80 release day.