### PR TITLE
Add link on docs landing page for new troubleshooting and FAQs page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -100,6 +100,7 @@
             <li class="listitem"><a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a></li>
             <li class="listitem"><a href="https://discuss.elastic.co/">Forums</a></li>
             <li class="listitem"><a href="https://www.elastic.co/training/">Training</a></li>
+            <li class="listitem"><a href="en/welcome-to-elastic/current/faqs-and-troubleshooting.html">Troubleshooting and FAQs</a></li>
           </ul>
         </div>
       </td>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -100,7 +100,7 @@
             <li class="listitem"><a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a></li>
             <li class="listitem"><a href="https://discuss.elastic.co/">Forums</a></li>
             <li class="listitem"><a href="https://www.elastic.co/training/">Training</a></li>
-            <li class="listitem"><a href="en/welcome-to-elastic/current/faqs-and-troubleshooting.html">Troubleshooting and FAQs</a></li>
+            <li class="listitem"><a href="en/welcome-to-elastic/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a></li>
           </ul>
         </div>
       </td>


### PR DESCRIPTION
This adds a link on the docs landing page to our new [Troubleshooting and FAQs page](https://www.elastic.co/guide/en/welcome-to-elastic/current/troubleshooting-and-faqs.html).