### PR TITLE
Bump docs version to 8.4.2

### DIFF
--- a/shared/versions/stack/8.4.asciidoc
+++ b/shared/versions/stack/8.4.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.4.1
+:version:                8.4.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.4.1
-:logstash_version:       8.4.1
-:elasticsearch_version:  8.4.1
-:kibana_version:         8.4.1
-:apm_server_version:     8.4.1
+:bare_version:           8.4.2
+:logstash_version:       8.4.2
+:elasticsearch_version:  8.4.2
+:kibana_version:         8.4.2
+:apm_server_version:     8.4.2
 :branch:                 8.4
 :minor-version:          8.4
 :major-version:          8.x


### PR DESCRIPTION
**DO NOT MERGE UNTIL RELEASE DAY**

[Doc release issue](https://github.com/elastic/dev/issues/2120)