### PR TITLE
Add main branch to output

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -546,7 +546,7 @@ contents:
                 prefix:     net-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                 live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -75,8 +75,6 @@ contents_title:     Welcome to Elastic Docs
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 8.5
-  stacklive: &stacklive [ master, 8.5, 7.17 ]
-
   stacklivemain: &stacklivemain [ main, 8.5, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-82
@@ -129,7 +127,7 @@ contents:
             prefix:     en/welcome-to-elastic
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 7.17 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 7.17 ]
             live:       [ 8.5 ]
             chunk:      1
             tags:       Elastic/Welcome
@@ -141,14 +139,13 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-
     -   title:      Elastic Stack
         sections:
           - title:      Installation and Upgrade Guide
             prefix:     en/elastic-stack
             current:    *stackcurrent
             index:      docs/en/install-upgrade/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ {main: master}, main, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
@@ -192,20 +189,22 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                map_branches: *mapMainToMaster
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ main, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                map_branches: *mapMasterToMain
           - title:      Glossary
             prefix:     en/elastic-stack-glossary
             current:    main
             index:      docs/en/glossary/index.asciidoc
-            branches:   [ {main: master} ]
+            branches:   [ main ]
             tags:       Elastic Stack/Glossary
             subject:    Elastic Stack
             sources:
@@ -215,14 +214,16 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Machine Learning
             prefix:     en/machine-learning
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {main: master}, main, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Elastic Stack/Machine Learning
@@ -237,16 +238,19 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/settings.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.5
-            branches:   [  {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            current:    8.4
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.6, 8.5, 8.4, 8.3, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
@@ -260,7 +264,7 @@ contents:
             prefix:     en/elastic-stack-deploy
             current:    7.11
             index:      docs/index.asciidoc
-            branches:   [ master, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ {master: main}, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template
@@ -268,13 +272,14 @@ contents:
               -
                 repo:   azure-marketplace
                 path:   docs
+                map_branches: *mapMasterToMain
 
     -   title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
           - title:      Elasticsearch Guide
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             live:       *stacklivemain
             index:      docs/reference/index.x.asciidoc
             chunk:      1
@@ -339,6 +344,7 @@ contents:
                 repo:   elasticsearch-php
                 path:   docs/examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   elasticsearch-net
@@ -363,14 +369,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 alternatives: { source_lang: console, alternative_lang: js }
                 repo:   elasticsearch-js
@@ -379,7 +388,7 @@ contents:
           - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1
-            branches:   [{main: master}]
+            branches:   [ main ]
             current:    main
             index:      docs/resiliency/index.asciidoc
             single:     1
@@ -396,14 +405,16 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
           - title:      Painless Scripting Language
             prefix:     en/elasticsearch/painless
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
             live:       *stacklivemain
             index:      docs/painless/index.asciidoc
             chunk:      1
@@ -420,16 +431,18 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
           - title:      Plugins and Integrations
             prefix:     en/elasticsearch/plugins
             repo:       elasticsearch
             current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
+            branches:   [ {main: master}, main, 8.6, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
             live:       *stacklivemain
             chunk:      2
             tags:       Elasticsearch/Plugins
@@ -458,17 +471,19 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                map_branches: *mapMasterToMain
           - title:      Elasticsearch Clients
             base_dir:   en/elasticsearch/client
             sections:
               - title:      Java Client
                 prefix:     java-api-client
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -490,7 +505,7 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -503,7 +518,7 @@ contents:
               - title:      Ruby Client
                 prefix:     ruby-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -516,7 +531,7 @@ contents:
               - title:      Go Client
                 prefix:     go-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      .doc/index.asciidoc
                 chunk:      1
@@ -528,9 +543,9 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                current:    8.0
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                current:    *stackcurrent
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                 live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients
@@ -542,7 +557,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -552,14 +567,16 @@ contents:
                   -
                     repo:   elasticsearch-php
                     path:   docs/
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Perl Client
                 prefix:     perl-api
-                current:    master
-                branches:   [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                current:    main
+                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                live:       [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl
@@ -568,10 +585,11 @@ contents:
                   -
                     repo:   elasticsearch-perl
                     path:   docs/
+                    map_branches: *mapMasterToMain
               - title:      Python Client
                 prefix:     python-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      docs/guide/index.asciidoc
                 chunk:     1
@@ -584,7 +602,7 @@ contents:
               - title:      eland
                 prefix:     eland
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/guide/index.asciidoc
                 chunk:     1
@@ -596,9 +614,9 @@ contents:
                     path:   docs/guide
               - title:      Rust Client
                 prefix:     rust-api
-                current:    master
-                branches:   [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                current:    main
+                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                live:       [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust
@@ -607,6 +625,7 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
+                    map_branches: *mapMasterToMain
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
                 current:   7.17
@@ -631,10 +650,12 @@ contents:
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    map_branches: *mapMasterToMain
               - title:      Java Transport Client (deprecated)
                 prefix:     java-api
                 current:    7.17
@@ -677,14 +698,16 @@ contents:
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                    map_branches: *mapMasterToMain
 
               - title:      Community Contributed Clients
                 prefix:     community
-                branches:   [{main: master}]
+                branches:   [ main ]
                 current:    main
                 index:      docs/community-clients/index.asciidoc
                 single:     1
@@ -697,7 +720,7 @@ contents:
           - title:      Elasticsearch for Apache Hadoop and Spark
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
             live:       *stacklivemain
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
@@ -932,7 +955,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.5
-            branches:   [ {main: master}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, main, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
@@ -943,27 +966,30 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/current.asciidoc
                 exclude_branches:   [ 0.9, 0.8 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Elastic Cloud Control - The Command-Line Interface for Elasticsearch Service and ECE
             prefix:     en/ecctl
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    1.8
-            branches:   [ master, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ {master: main}, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
               -
                 repo:   ecctl
                 path:   docs/
+                map_branches: *mapMasterToMain
           - title:      Elastic Cloud Terraform Provider
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
             subject:    TPEC
             current:    0.2
-            branches:   [ master, 0.2, 0.1 ]
+            branches:   [ {master: main}, 0.2, 0.1 ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1
@@ -971,13 +997,14 @@ contents:
               -
                 repo:   terraform-provider-ec
                 path:   docs-elastic/
+                map_branches: *mapMasterToMain
 
     -   title:      "Kibana: Explore, Visualize, and Share"
         sections:
           - title:      Kibana Guide
             prefix:     en/kibana
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
             live:       *stacklivemain
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -997,18 +1024,22 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches: [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 3.0 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   kibana
                 # git-archive requires `:(glob)` for ** to match no directory (in order to include `examples/README.asciidoc`)
@@ -1042,12 +1073,13 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Workplace Search Guide
             prefix:     en/workplace-search
             index:      workplace-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Workplace Search/Guide
@@ -1059,6 +1091,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
           - title:      App Search Guide
             prefix:     en/app-search
             index:      app-search-docs/index.asciidoc
@@ -1076,12 +1109,13 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Site Search Reference
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1
-            current:    master
-            branches:   [ master ]
+            current:    main
+            branches:   [ {main: master} ]
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
@@ -1089,6 +1123,7 @@ contents:
               -
                 repo:   swiftype
                 path:   docs
+                map_branches: *mapMasterToMain
           - title:      Enterprise Search Clients
             base_dir:   en/enterprise-search-clients
             sections:
@@ -1097,7 +1132,7 @@ contents:
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      client-docs/app-search-javascript/index.asciidoc
                 tags:       App Search Clients/JavaScript
@@ -1109,12 +1144,13 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      App Search Node.js client
                 prefix:     app-search-node
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      client-docs/app-search-node/index.asciidoc
                 tags:       App Search Clients/Node.js
@@ -1126,12 +1162,13 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1 ]
                 live:       [ main, 8.5 ]
                 index:      client-docs/enterprise-search-node/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
@@ -1143,10 +1180,11 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
@@ -1155,13 +1193,15 @@ contents:
                   -
                     repo:   enterprise-search-php
                     path:   docs/guide/
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklivemain
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -1173,10 +1213,11 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklivemain
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1188,12 +1229,13 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      Workplace Search Node.js client
                 prefix:     workplace-search-node
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 index:      client-docs/workplace-search-node/index.asciidoc
                 tags:       Workplace Search Clients/Node.js
@@ -1205,12 +1247,13 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
     -   title:      "Observability: APM, Logs, Metrics, and Uptime"
         sections:
           - title:      Observability
             prefix:     en/observability
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklivemain
             index:      docs/en/observability/index.asciidoc
             chunk:      2
@@ -1231,9 +1274,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
@@ -1241,7 +1286,7 @@ contents:
                 prefix:     guide
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklivemain
                 chunk:      2
                 tags:       APM Guide
@@ -1284,7 +1329,7 @@ contents:
                   - title:      APM Go Agent
                     prefix:     go
                     current:    2.x
-                    branches:   [ {main: master}, 2.x, 1.x, 0.5 ]
+                    branches:   [ main, 2.x, 1.x, 0.5 ]
                     live:       [ main, 2.x, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
@@ -1317,7 +1362,7 @@ contents:
                   - title:      APM Java Agent
                     prefix:     java
                     current:    1.x
-                    branches:   [ {main: master}, 1.x, 0.7, 0.6 ]
+                    branches:   [ main, 1.x, 0.7, 0.6 ]
                     live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
@@ -1340,7 +1385,7 @@ contents:
                   - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.x
-                    branches:   [ {main: master}, 1.x, 1.8 ]
+                    branches:   [ {main: master}, main, 1.x, 1.8 ]
                     live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
@@ -1356,7 +1401,7 @@ contents:
                   - title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    3.x
-                    branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
+                    branches:   [ main, 3.x, 2.x, 1.x, 0.x ]
                     live:       [ main, 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
@@ -1379,7 +1424,7 @@ contents:
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x
-                    branches:   [ {main: master}, 1.x ]
+                    branches:   [ main, 1.x ]
                     live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
@@ -1395,7 +1440,7 @@ contents:
                   - title:      APM Python Agent
                     prefix:     python
                     current:    6.x
-                    branches:   [ {main: master}, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    branches:   [ main, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
                     live:       [ main, 6.x, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
@@ -1418,7 +1463,7 @@ contents:
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x
-                    branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
+                    branches:   [ main, 4.x, 3.x, 2.x, 1.x ]
                     live:       [ main, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
@@ -1435,7 +1480,7 @@ contents:
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
-                    branches:   [ {main: master}, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    branches:   [ main, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
                     live:       [ main, 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
@@ -1522,7 +1567,7 @@ contents:
               - title:      ECS Logging Overview
                 prefix:     overview
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1535,13 +1580,15 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
               - title:      ECS Logging Go (Logrus) Reference
                 prefix:     go-logrus
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1554,16 +1601,18 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
               - title:      ECS Logging Go (Zap) Reference
                 prefix:     go-zap
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1576,9 +1625,11 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
@@ -1586,7 +1637,7 @@ contents:
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x
-                branches:   [ {main: master}, 1.x, 0.x ]
+                branches:   [ main, 1.x, 0.x ]
                 live:       [ main, 1.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1599,9 +1650,11 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
@@ -1611,7 +1664,7 @@ contents:
               - title:      ECS Logging .NET Reference
                 prefix:     dotnet
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1624,16 +1677,18 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1646,16 +1701,18 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
               - title:      ECS Logging Ruby Reference
                 prefix:     ruby
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1668,16 +1725,18 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
               - title:      ECS Logging PHP Reference
                 prefix:     php
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1690,16 +1749,18 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
               - title:      ECS Logging Python Reference
                 prefix:     python
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1712,9 +1773,11 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
+                    map_branches: *mapMasterToMain
                   -
                     repo:   ecs-logging
                     path:   docs
@@ -1724,7 +1787,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklivemain
             index:      docs/index.asciidoc
             chunk:      1
@@ -1737,9 +1800,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   stack-docs
                 path:   docs/en
@@ -1759,9 +1824,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
 
 
     -   title:      "Logstash: Collect, Enrich, and Transport"
@@ -1769,7 +1836,7 @@ contents:
           - title:      Logstash Reference
             prefix:     en/logstash
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
             live:       *stacklivemain
             index:      docs/index.x.asciidoc
             chunk:      1
@@ -1793,18 +1860,22 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
                 exclude_branches:   [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches:   [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+                map_branches: *mapMasterToMain
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
@@ -1822,13 +1893,14 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
 
     -   title:      "Fleet: Install and Manage Elastic Agents"
         sections:
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklivemain
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
@@ -1841,9 +1913,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   apm-server
                 path:   docs
@@ -1852,7 +1926,7 @@ contents:
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    main
-            branches:   [ {main: master} ]
+            branches:   [ main ]
             live:       [ main ]
             index:      docs/en/integrations/index.asciidoc
             chunk:      1
@@ -1865,9 +1939,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   package-spec
                 path:   versions
@@ -1881,7 +1957,7 @@ contents:
             prefix:     en/beats/libbeat
             index:      libbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Libbeat/Reference
@@ -1898,15 +1974,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Auditbeat/Reference
@@ -1951,15 +2029,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Filebeat/Reference
@@ -2006,15 +2086,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Functionbeat/Reference
@@ -2048,9 +2130,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   beats
                 path:   x-pack/libbeat/docs
@@ -2063,7 +2147,7 @@ contents:
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Heartbeat/Reference
@@ -2102,15 +2186,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Metricbeat/Reference
@@ -2159,15 +2245,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Packetbeat Reference
             prefix:     en/beats/packetbeat
             index:      packetbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
             live:       *stacklivemain
             chunk:      1
             tags:       Packetbeat/Reference
@@ -2202,15 +2290,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Winlogbeat Reference
             prefix:     en/beats/winlogbeat
             index:      winlogbeat/docs/index.asciidoc
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Winlogbeat/Reference
@@ -2245,15 +2335,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Beats Developer Guide
             prefix:     en/beats/devguide
             index:      docs/devguide/index.asciidoc
             current:    main
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Devguide/Reference
@@ -2276,15 +2368,17 @@ contents:
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
+                map_branches: *mapMasterToMain
           - title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent
             index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
             chunk:      1
             tags:       Elastic Logging Plugin/Reference
             respect_edit_url_overrides: true
@@ -2299,9 +2393,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
 
     - title:     Docs in Your Native Tongue
       sections:
@@ -2511,14 +2607,16 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Logstash and Kubernetes
             prefix:     en/logstash-kubernetes
             current:    main
             index:      docsk8s/index.asciidoc
-            branches:   [ {main: master} ]
+            branches:   [ {main: master}, main ]
             noindex:    1
             chunk:      1
             tags:       Logstash/Kubernetes
@@ -2530,7 +2628,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-
+                map_branches: *mapMasterToMain
     -   title:      Legacy Documentation
         sections:
           - title:      Getting Started
@@ -2553,6 +2651,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+
               -
                 repo:   elasticsearch
                 path:   docs/
@@ -2562,7 +2661,7 @@ contents:
             prefix:     en/elastic-stack-gke
             current:    main
             index:      docs/en/gke-on-prem/index.asciidoc
-            branches:   [ {main: master} ]
+            branches:   [ main ]
             private:    1
             noindex:    1
             chunk:      1
@@ -2575,9 +2674,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+                map_branches: *mapMasterToMain
           - title:      Journalbeat Reference for 6.5-7.15
             prefix:     en/beats/journalbeat
             current:    7.15
@@ -2734,12 +2835,12 @@ contents:
                 repo:   x-pack-kibana
                 prefix: kibana-extra/x-pack-kibana
                 path:   docs/en
-                exclude_branches:   [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches:   [ 5.3, 5.2, 5.1, 5.0]
               -
                 repo:   x-pack-elasticsearch
                 prefix: elasticsearch-extra/x-pack-elasticsearch
                 path:   docs/en
-                exclude_branches: [ master, 6.7, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0]
+                exclude_branches: [ 5.3, 5.2, 5.1, 5.0]
               -
                 repo:   docs
                 path:   shared/attributes62.asciidoc
@@ -2747,7 +2848,7 @@ contents:
           - title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide
             current:    2.x
-            branches:   [ master, 2.x, 1.x ]
+            branches:   [ {master: main}, 2.x, 1.x ]
             index:      book.asciidoc
             chunk:      1
             noindex:    1
@@ -2759,14 +2860,16 @@ contents:
               -
                 repo:   guide
                 path:   /
+                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ master, 2.x]
+                exclude_branches:   [ main, 2.x]
+                map_branches: *mapMasterToMain
           - title:      Sense Editor for 4.x
             prefix:     en/sense
-            current:    master
-            branches:   [ master ]
+            current:    main
+            branches:   [ {master: main} ]
             index:      docs/index.asciidoc
             noindex:    1
             private:    1
@@ -2776,6 +2879,7 @@ contents:
               -
                 repo:   sense
                 path:   docs
+                map_branches: *mapMasterToMain
           - title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -203,7 +203,7 @@ contents:
                 map_branches: *mapMasterToMain
           - title:      Glossary
             prefix:     en/elastic-stack-glossary
-            current:    master
+            current:    main
             index:      docs/en/glossary/index.asciidoc
             branches:   [ {main: master}, main ]
             tags:       Elastic Stack/Glossary

--- a/conf.yaml
+++ b/conf.yaml
@@ -203,7 +203,7 @@ contents:
                 map_branches: *mapMasterToMain
           - title:      Glossary
             prefix:     en/elastic-stack-glossary
-            current:    main
+            current:    master
             index:      docs/en/glossary/index.asciidoc
             branches:   [ {main: master}, main ]
             tags:       Elastic Stack/Glossary
@@ -265,7 +265,7 @@ contents:
             prefix:     en/elastic-stack-deploy
             current:    7.11
             index:      docs/index.asciidoc
-            branches:   [ {master: main}, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
+            branches:   [ master, {master: main}, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template
@@ -558,7 +558,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklivemain
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -575,9 +575,9 @@ contents:
                     map_branches: *mapMainToMaster
               - title:      Perl Client
                 prefix:     perl-api
-                current:    main
-                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                current:    master
+                branches:   [ master, {master: main}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                live:       [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl
@@ -615,9 +615,9 @@ contents:
                     path:   docs/guide
               - title:      Rust Client
                 prefix:     rust-api
-                current:    main
-                branches:   [ {master: main}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                current:    master
+                branches:   [ master, {master: main}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                live:       [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust
@@ -972,7 +972,7 @@ contents:
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    1.8
-            branches:   [ {master: main}, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ master, {master: main}, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
@@ -985,7 +985,7 @@ contents:
             tags:       CloudTerraform/Reference
             subject:    TPEC
             current:    0.2
-            branches:   [ {master: main}, 0.2, 0.1 ]
+            branches:   [ master, {master: main}, 0.2, 0.1 ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1
@@ -1110,8 +1110,8 @@ contents:
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1
-            current:    main
-            branches:   [ {main: master}, main ]
+            current:    master
+            branches:   [ master, {master: main} ]
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
@@ -1119,7 +1119,6 @@ contents:
               -
                 repo:   swiftype
                 path:   docs
-                map_branches: *mapMasterToMain
           - title:      Enterprise Search Clients
             base_dir:   en/enterprise-search-clients
             sections:
@@ -1189,7 +1188,6 @@ contents:
                   -
                     repo:   enterprise-search-php
                     path:   docs/guide/
-                    map_branches: *mapMainToMaster
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
@@ -1325,7 +1323,7 @@ contents:
                   - title:      APM Go Agent
                     prefix:     go
                     current:    2.x
-                    branches:   [ main, 2.x, 1.x, 0.5 ]
+                    branches:   [ {main: master}, main, 2.x, 1.x, 0.5 ]
                     live:       [ main, 2.x, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
@@ -1358,7 +1356,7 @@ contents:
                   - title:      APM Java Agent
                     prefix:     java
                     current:    1.x
-                    branches:   [ main, 1.x, 0.7, 0.6 ]
+                    branches:   [ {main: master}, main, 1.x, 0.7, 0.6 ]
                     live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
@@ -1397,7 +1395,7 @@ contents:
                   - title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    3.x
-                    branches:   [ main, 3.x, 2.x, 1.x, 0.x ]
+                    branches:   [ {main: master}, main, 3.x, 2.x, 1.x, 0.x ]
                     live:       [ main, 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
@@ -1420,7 +1418,7 @@ contents:
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x
-                    branches:   [ main, 1.x ]
+                    branches:   [ {main: master}, main, 1.x ]
                     live:       [ main, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
@@ -1436,7 +1434,7 @@ contents:
                   - title:      APM Python Agent
                     prefix:     python
                     current:    6.x
-                    branches:   [ main, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    branches:   [ {main: master}, main, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
                     live:       [ main, 6.x, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
@@ -1459,7 +1457,7 @@ contents:
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x
-                    branches:   [ main, 4.x, 3.x, 2.x, 1.x ]
+                    branches:   [ {main: master}, main, 4.x, 3.x, 2.x, 1.x ]
                     live:       [ main, 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
@@ -1476,7 +1474,7 @@ contents:
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
                     current:    5.x
-                    branches:   [ main, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    branches:   [ {main: master}, main, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
                     live:       [ main, 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
@@ -2840,7 +2838,7 @@ contents:
           - title:      Elasticsearch - The Definitive Guide
             prefix:     en/elasticsearch/guide
             current:    2.x
-            branches:   [ {master: main}, 2.x, 1.x ]
+            branches:   [ master, {master: main}, 2.x, 1.x ]
             index:      book.asciidoc
             chunk:      1
             noindex:    1
@@ -2856,12 +2854,12 @@ contents:
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ main, 2.x]
+                exclude_branches:   [ master, main, 2.x]
                 map_branches: *mapMainToMaster
           - title:      Sense Editor for 4.x
             prefix:     en/sense
             current:    master
-            branches:   [ {master: main} ]
+            branches:   [ master, {master: main} ]
             index:      docs/index.asciidoc
             noindex:    1
             private:    1

--- a/conf.yaml
+++ b/conf.yaml
@@ -105,11 +105,11 @@ variables:
     1.1: master
     1.0: master
 
-  # Use this when you're building a book that uses a "main" branch, but it has a dependency on a repo with a "master" branch
+  # Use this when you're building a book that uses a "master" branch, but it has a dependency on a repo with a "main" branch
   mapMainToMaster: &mapMainToMaster
     main: master
 
-  # Use this when you're building a book that uses a "master" branch, but it has a dependency on a repo with a "main" branch
+  # Use this when you're building a book that uses a "main" branch, but it has a dependency on a repo with a "master" branch
   mapMasterToMain: &mapMasterToMain
     master: main
 
@@ -139,6 +139,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
+                map_branches: *mapMasterToMain
     -   title:      Elastic Stack
         sections:
           - title:      Installation and Upgrade Guide
@@ -204,7 +205,7 @@ contents:
             prefix:     en/elastic-stack-glossary
             current:    main
             index:      docs/en/glossary/index.asciidoc
-            branches:   [ main ]
+            branches:   [ {main: master}, main ]
             tags:       Elastic Stack/Glossary
             subject:    Elastic Stack
             sources:
@@ -272,7 +273,7 @@ contents:
               -
                 repo:   azure-marketplace
                 path:   docs
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
 
     -   title:      "Elasticsearch: Store, Search, and Analyze"
         sections:
@@ -344,7 +345,7 @@ contents:
                 repo:   elasticsearch-php
                 path:   docs/examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
               -
                 alternatives: { source_lang: console, alternative_lang: csharp }
                 repo:   elasticsearch-net
@@ -388,7 +389,7 @@ contents:
           - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1
-            branches:   [ main ]
+            branches:   [ {main: master}, main ]
             current:    main
             index:      docs/resiliency/index.asciidoc
             single:     1
@@ -567,11 +568,11 @@ contents:
                   -
                     repo:   elasticsearch-php
                     path:   docs/
-                    map_branches: *mapMasterToMain
+                    map_branches: *mapMainToMaster
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
-                    map_branches: *mapMasterToMain
+                    map_branches: *mapMainToMaster
               - title:      Perl Client
                 prefix:     perl-api
                 current:    main
@@ -585,7 +586,7 @@ contents:
                   -
                     repo:   elasticsearch-perl
                     path:   docs/
-                    map_branches: *mapMasterToMain
+                    map_branches: *mapMainToMaster
               - title:      Python Client
                 prefix:     python-api
                 current:    *stackcurrent
@@ -602,7 +603,7 @@ contents:
               - title:      eland
                 prefix:     eland
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/guide/index.asciidoc
                 chunk:     1
@@ -625,7 +626,7 @@ contents:
                   -
                     repo:   elasticsearch-rs
                     path:   docs/
-                    map_branches: *mapMasterToMain
+                    map_branches: *mapMainToMaster
               - title:      Java REST Client (deprecated)
                 prefix:     java-rest
                 current:   7.17
@@ -650,12 +651,10 @@ contents:
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                    map_branches: *mapMasterToMain
               - title:      Java Transport Client (deprecated)
                 prefix:     java-api
                 current:    7.17
@@ -698,16 +697,13 @@ contents:
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                    map_branches: *mapMasterToMain
                   -
                     repo:   docs
                     path:   shared/attributes.asciidoc
                     exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                    map_branches: *mapMasterToMain
-
               - title:      Community Contributed Clients
                 prefix:     community
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 current:    main
                 index:      docs/community-clients/index.asciidoc
                 single:     1
@@ -983,7 +979,7 @@ contents:
               -
                 repo:   ecctl
                 path:   docs/
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
           - title:      Elastic Cloud Terraform Provider
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
@@ -997,7 +993,7 @@ contents:
               -
                 repo:   terraform-provider-ec
                 path:   docs-elastic/
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
 
     -   title:      "Kibana: Explore, Visualize, and Share"
         sections:
@@ -1061,7 +1057,7 @@ contents:
             index:      enterprise-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklivemain
             chunk:      1
             tags:       Enterprise Search/Guide
@@ -1097,7 +1093,7 @@ contents:
             index:      app-search-docs/index.asciidoc
             private:    1
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
+            branches:   [ {main: master}, main, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
             live:       *stacklivemain
             chunk:      1
             tags:       App Search/Guide
@@ -1115,7 +1111,7 @@ contents:
             index:      docs/sitesearch/index.asciidoc
             private:    1
             current:    main
-            branches:   [ {main: master} ]
+            branches:   [ {main: master}, main ]
             single:     1
             tags:       Site Search/Reference
             subject:    Swiftype
@@ -1193,7 +1189,7 @@ contents:
                   -
                     repo:   enterprise-search-php
                     path:   docs/guide/
-                    map_branches: *mapMasterToMain
+                    map_branches: *mapMainToMaster
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
@@ -1313,7 +1309,7 @@ contents:
                   - title:      APM Android Agent
                     prefix:     android
                     current:    main
-                    branches:   [ {main: master} ]
+                    branches:   [ {main: master}, main ]
                     live:       [ main ]
                     index:      docs/index.asciidoc
                     tags:       APM Android Agent/Reference
@@ -1497,7 +1493,7 @@ contents:
               - title:      APM AWS Lambda Extension
                 prefix:     lambda
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 tags:       APM AWS Lambda extension/Reference
@@ -1513,7 +1509,7 @@ contents:
               - title:      APM Attacher
                 prefix:     attacher
                 current:    main
-                branches:   [ {main: master} ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 tags:       APM Attacher/Reference
@@ -1567,7 +1563,7 @@ contents:
               - title:      ECS Logging Overview
                 prefix:     overview
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1588,7 +1584,7 @@ contents:
               - title:      ECS Logging Go (Logrus) Reference
                 prefix:     go-logrus
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1612,7 +1608,7 @@ contents:
               - title:      ECS Logging Go (Zap) Reference
                 prefix:     go-zap
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1637,7 +1633,7 @@ contents:
               - title:      ECS Logging Java Reference
                 prefix:     java
                 current:    1.x
-                branches:   [ main, 1.x, 0.x ]
+                branches:   [ {main: master}, main, 1.x, 0.x ]
                 live:       [ main, 1.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1664,7 +1660,7 @@ contents:
               - title:      ECS Logging .NET Reference
                 prefix:     dotnet
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1688,7 +1684,7 @@ contents:
               - title:      ECS Logging Node.js Reference
                 prefix:     nodejs
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1712,7 +1708,7 @@ contents:
               - title:      ECS Logging Ruby Reference
                 prefix:     ruby
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1736,7 +1732,7 @@ contents:
               - title:      ECS Logging PHP Reference
                 prefix:     php
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1760,7 +1756,7 @@ contents:
               - title:      ECS Logging Python Reference
                 prefix:     python
                 current:    main
-                branches:   [ main ]
+                branches:   [ {main: master}, main ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1824,13 +1820,9 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-                map_branches: *mapMasterToMain
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                map_branches: *mapMasterToMain
-
-
     -   title:      "Logstash: Collect, Enrich, and Transport"
         sections:
           - title:      Logstash Reference
@@ -1893,7 +1885,7 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
 
     -   title:      "Fleet: Install and Manage Elastic Agents"
         sections:
@@ -1926,7 +1918,7 @@ contents:
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    main
-            branches:   [ main ]
+            branches:   [ {main: master}, main ]
             live:       [ main ]
             index:      docs/en/integrations/index.asciidoc
             chunk:      1
@@ -2595,7 +2587,7 @@ contents:
             prefix:     en/elastic-platform-security
             current:    main
             index:      platform-security/index.asciidoc
-            branches:   [ main ]
+            branches:   [ {main: master}, main ]
             noindex:    1
             chunk:      1
             tags:       Elastic Platform/Security
@@ -2661,7 +2653,7 @@ contents:
             prefix:     en/elastic-stack-gke
             current:    main
             index:      docs/en/gke-on-prem/index.asciidoc
-            branches:   [ main ]
+            branches:   [ {main: master}, main ]
             private:    1
             noindex:    1
             chunk:      1
@@ -2860,12 +2852,12 @@ contents:
               -
                 repo:   guide
                 path:   /
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
               -
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches:   [ main, 2.x]
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
           - title:      Sense Editor for 4.x
             prefix:     en/sense
             current:    main
@@ -2879,7 +2871,7 @@ contents:
               -
                 repo:   sense
                 path:   docs
-                map_branches: *mapMasterToMain
+                map_branches: *mapMainToMaster
           - title:      Marvel Reference for 2.x and 1.x
             prefix:     en/marvel
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -76,7 +76,7 @@ contents_title:     Welcome to Elastic Docs
 variables:
   stackcurrent: &stackcurrent 8.5
   stacklivemain: &stacklivemain [ main, 8.5, 7.17 ]
-
+  stacklivemaster: &stacklivemaster [ master, 8.5, 7.17 ] 
   cloudSaasCurrent: &cloudSaasCurrent ms-82
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam

--- a/conf.yaml
+++ b/conf.yaml
@@ -2860,7 +2860,7 @@ contents:
                 map_branches: *mapMainToMaster
           - title:      Sense Editor for 4.x
             prefix:     en/sense
-            current:    main
+            current:    master
             branches:   [ {master: main} ]
             index:      docs/index.asciidoc
             noindex:    1

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -468,11 +468,11 @@ Legacy definitions
 :apm-get-started-ref:  https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-server-ref:       https://www.elastic.co/guide/en/apm/server/{branch}
 :apm-server-ref-v:     https://www.elastic.co/guide/en/apm/server/{branch}
-:apm-server-ref-m:     https://www.elastic.co/guide/en/apm/server/master
+:apm-server-ref-m:     https://www.elastic.co/guide/en/apm/server/main
 :apm-server-ref-62:    https://www.elastic.co/guide/en/apm/server/6.2
 :apm-server-ref-64:    https://www.elastic.co/guide/en/apm/server/6.4
 :apm-server-ref-70:    https://www.elastic.co/guide/en/apm/server/7.0
 :apm-overview-ref-v:   https://www.elastic.co/guide/en/apm/get-started/{branch}
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
-:apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
+:apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/main
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}

--- a/shared/versions/stack/main.asciidoc
+++ b/shared/versions/stack/main.asciidoc
@@ -1,1 +1,57 @@
-master.asciidoc
+:version:                8.5.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           8.5.0
+:logstash_version:       8.5.0
+:elasticsearch_version:  8.5.0
+:kibana_version:         8.5.0
+:apm_server_version:     8.5.0
+:branch:                 main
+:minor-version:          8.5
+:major-version:          8.x
+:prev-major-version:     7.x
+:prev-major-last:        7.17
+:major-version-only:     8
+:ecs_version:            8.5
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
+
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
+////
+APM Agent versions
+////
+:apm-go-branch:         2.x
+:apm-ios-branch:        0.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        5.x
+:apm-node-branch:       3.x
+:apm-php-branch:        1.x
+:apm-py-branch:         6.x
+:apm-ruby-branch:       4.x
+:apm-dotnet-branch:     1.12
+
+////
+ECS Logging
+////
+:ecs-logging:           main
+:ecs-logging-go-logrus: main
+:ecs-logging-go-zap:    main
+:ecs-logging-java:      1.x
+:ecs-logging-dotnet:    main
+:ecs-logging-nodejs:    main
+:ecs-logging-php:       main
+:ecs-logging-python:    main
+:ecs-logging-ruby:      main


### PR DESCRIPTION
This PR updates the conf.yaml to build both "main" and "master", so that we can move away from the latter.