### PR TITLE
Changes current and live for .NET Client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -529,7 +529,7 @@ contents:
                 prefix:     net-api
                 current:    8.0
                 branches:   [ {main: master}, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ {main: master}, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -527,9 +527,9 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                current:    *stackcurrent
+                current:    8.0
                 branches:   [ {main: master}, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                live:       *stacklivemain
+                live:       [ {main: master}, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients


### PR DESCRIPTION
## Overview

This PR changes the `current` branch and the `live` branches for the .NET docs. As the 8.0 client is not GA now, it might be confusing for the users to expose 8.1+ versions for the docs. For this reason, this PR sets `current` to 8.0 and stops exposing branches newer than 8.0 in `live`. When the client versioning and stack versioning are aligned, we start exposing those branches again.

DO NOT MERGE BEFORE https://github.com/elastic/elasticsearch-net/pull/6658