### PR TITLE
Add master to welcome guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -127,8 +127,7 @@ contents:
             prefix:     en/welcome-to-elastic
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
-            branches:   [ 8.4 ]
-            live:       [ 8.4 ]
+            branches:   [ {main: master}, 8.4 ]
             chunk:      1
             tags:       Elastic/Welcome
             subject:    Welcome to Elastic


### PR DESCRIPTION
This PR updates the conf.yaml to include multiple versions for the welcome guide.  When the 8.5 release is underway, it will also be added to this list.