### PR TITLE
Add APM extension books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1440,6 +1440,32 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
+              - title:      APM AWS Lambda extension
+                prefix:     lambda
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                tags:       APM AWS Lambda extension/Reference
+                subject:    APM
+                chunk:      1
+                sources:
+                  -
+                    repo:   apm-aws-lambda
+                    path:   docs
+              - title:      APM Mutating Webhook
+                prefix:     webhook
+                current:    main
+                branches:   [ {main: master} ]
+                live:       [ main ]
+                index:      docs/index.asciidoc
+                tags:       APM Mutating Webhook/Reference
+                subject:    APM
+                chunk:      1
+                sources:
+                  -
+                    repo:   apm-mutating-webhook
+                    path:   docs
               - title:      Legacy APM (standalone)
                 sections:
                   - title:      Legacy APM Overview

--- a/conf.yaml
+++ b/conf.yaml
@@ -1440,7 +1440,7 @@ contents:
                         repo:   apm-agent-rum-js
                         path:   CHANGELOG.asciidoc
                         exclude_branches:   [ 3.x, 2.x, 1.x, 0.x ]
-              - title:      APM AWS Lambda extension
+              - title:      APM AWS Lambda Extension
                 prefix:     lambda
                 current:    main
                 branches:   [ {main: master} ]
@@ -1453,13 +1453,13 @@ contents:
                   -
                     repo:   apm-aws-lambda
                     path:   docs
-              - title:      APM Mutating Webhook
-                prefix:     webhook
+              - title:      APM Attacher
+                prefix:     attacher
                 current:    main
                 branches:   [ {main: master} ]
                 live:       [ main ]
                 index:      docs/index.asciidoc
-                tags:       APM Mutating Webhook/Reference
+                tags:       APM Attacher/Reference
                 subject:    APM
                 chunk:      1
                 sources:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -183,6 +183,10 @@ alias docbldamphp='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-php/docs/
 
 alias docbldamios='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-ios/docs/index.asciidoc --chunk 1'
 
+alias docbldaws='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-aws-lambda/docs/index.asciidoc --chunk 1'
+
+alias docbldamw='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-mutating-webhook/docs/index.asciidoc --chunk 1'
+
 # APM Legacy
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -41,6 +41,8 @@
 :apm-dotnet-ref:       https://www.elastic.co/guide/en/apm/agent/dotnet/current
 :apm-php-ref:          https://www.elastic.co/guide/en/apm/agent/php/current
 :apm-ios-ref:          https://www.elastic.co/guide/en/apm/agent/swift/current
+:apm-lambda-ref:       https://www.elastic.co/guide/en/apm/lambda/current
+:apm-webhook-ref:      https://www.elastic.co/guide/en/apm/webhook/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 ///////
 Elastic-level pages

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -42,7 +42,7 @@
 :apm-php-ref:          https://www.elastic.co/guide/en/apm/agent/php/current
 :apm-ios-ref:          https://www.elastic.co/guide/en/apm/agent/swift/current
 :apm-lambda-ref:       https://www.elastic.co/guide/en/apm/lambda/current
-:apm-webhook-ref:      https://www.elastic.co/guide/en/apm/webhook/current
+:apm-attacher-ref:     https://www.elastic.co/guide/en/apm/attacher/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 ///////
 Elastic-level pages


### PR DESCRIPTION
Adds new APM extension books. Why? See https://github.com/elastic/observability-docs/issues/2207.