### PR TITLE
remove APM Guide includes

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1259,16 +1259,6 @@ contents:
                     path:   docs/en
                     exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
                     map_branches: *mapMasterToMain
-                  -
-                    repo:   apm-aws-lambda
-                    path:   docs
-                    exclude_branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMasterToMain
-                  -
-                    repo:   apm-mutating-webhook
-                    path:   docs
-                    exclude_branches:   [ 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-                    map_branches: *mapMasterToMain
               - title:      APM Agents
                 base_dir:   agent
                 sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -162,7 +162,7 @@ alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/doc
 alias docbldidg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/integrations/index.asciidoc --resource=$GIT_HOME/package-spec/versions --chunk 2'
 
 # APM Guide
-alias docbldapm=' $GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/integrations-index.asciidoc --resource=$GIT_HOME/observability-docs/ --resource=$GIT_HOME/apm-aws-lambda/ --resource=$GIT_HOME/apm-mutating-webhook/ --chunk 2 --open'
+alias docbldapm=' $GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/integrations-index.asciidoc --resource=$GIT_HOME/observability-docs/ --chunk 2 --open'
 
 # APM Agents
 alias docbldamn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-agent-nodejs/docs/index.asciidoc --chunk 1 --resource $GIT_HOME/apm-aws-lambda/docs'


### PR DESCRIPTION
In https://github.com/elastic/docs/pull/2535, we created standalone documentation books for APM extensions. This PR is a follow-up PR that removes old cross-repo dependencies from the APM Guide. 

Closes https://github.com/elastic/observability-docs/issues/2207.

~This PR will not pass ci yet. Still waiting for the following PRs to be merged and backported:~

- [x] https://github.com/elastic/apm-server/pull/9252
- [x] https://github.com/elastic/apm-server/pull/9253