### PR TITLE
Make the ECK 2.5 the current branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -928,7 +928,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.4
-            branches:   [ {main: master}, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -927,7 +927,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.4
+            current:    2.5
             branches:   [ {main: master}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
To be merged on release day Elastic Stack 8.5/ECK 2.5