### PR TITLE
ECE - Change current to 3.5.0

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,6 +83,7 @@ variables:
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-81: master
     ms-78: master
     ms-75: master
     ms-72: master
@@ -828,8 +829,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-78
+            current:    ms-81
             branches:
+              - ms-81: 3.5
               - ms-78: 3.4
               - ms-75: 3.3
               - ms-72: 3.2
@@ -867,6 +869,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-81: master
                   ms-78: master
                   ms-75: master
                   ms-72: master


### PR DESCRIPTION
This PR changes `current` for the Cloud ECE docs to `3.5.0` based off milestone release `ms-81`
To be merged on the release day, NOV 1.
Relates to https://github.com/elastic/dev/issues/2141
