### PR TITLE
Add link in docs landing page to Elastic Stack components overview

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -68,6 +68,7 @@
       <td style="width: 50%">
         <div class="itemizedlist">
           <ul class="itemizedlist" type="disc">
+            <li class="listitem"><a href="en/welcome-to-elastic/current/stack-components.html">An overview of the Elastic Stack</a></li>
             <li class="listitem"><a href="en/cloud/current/ec-cloud-ingest-data.html">Add your data</a></li>
             <li class="listitem"><a href="en/cloud/current/ec-migrating-data.html">Migrate to Elastic Cloud</a></li>
             <li class="listitem"><a href="en/cloud/current/ec-planning.html">Plan for production</a></li>


### PR DESCRIPTION
This adds a link on the [docs landing page](https://www.elastic.co/guide/index.html), pointing to the new `An overview of the Elastic Stack` page, soon to come via https://github.com/elastic/tech-content/pull/240

@abdon and I aren't sure exactly where this link should go. It may not really belong in the "Featured topics" section of the landing page where I've put it, but the "Getting started" section is really for all the hands-on guides, so neither place seems ideal. Any suggestions are most welcome!

Rel: https://github.com/elastic/tech-content/issues/229