### PR TITLE
ESS - Change current to ms-82

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,7 +78,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.4, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-81
+  cloudSaasCurrent: &cloudSaasCurrent ms-82
 
   mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
     *cloudSaasCurrent : master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-82.
Do not merge until release day.