### PR TITLE
[Docs release] Bump current version to 8.5

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1128,7 +1128,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.5, 8.4, 8.3, 8.2, 8.1 ]
-                live:       [ main, 8.4 ]
+                live:       [ main, 8.5 ]
                 index:      client-docs/enterprise-search-node/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -73,10 +73,10 @@ contents_title:     Welcome to Elastic Docs
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.4
-  stacklive: &stacklive [ master, 8.4, 7.17 ]
+  stackcurrent: &stackcurrent 8.5
+  stacklive: &stacklive [ master, 8.5, 7.17 ]
 
-  stacklivemain: &stacklivemain [ main, 8.4, 7.17 ]
+  stacklivemain: &stacklivemain [ main, 8.5, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-82
 
@@ -128,7 +128,7 @@ contents:
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
             branches:   [ {main: master}, 8.5, 8.4, 7.17 ]
-            live:       [ 8.4 ]
+            live:       [ 8.5 ]
             chunk:      1
             tags:       Elastic/Welcome
             subject:    Welcome to Elastic

--- a/shared/versions/stack/8.4.asciidoc
+++ b/shared/versions/stack/8.4.asciidoc
@@ -23,7 +23,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.5.asciidoc
+++ b/shared/versions/stack/8.5.asciidoc
@@ -18,12 +18,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.4.asciidoc[]
+include::8.5.asciidoc[]

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.5.0
+:version:                8.6.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.5.0
-:logstash_version:       8.5.0
-:elasticsearch_version:  8.5.0
-:kibana_version:         8.5.0
-:apm_server_version:     8.5.0
+:bare_version:           8.6.0
+:logstash_version:       8.6.0
+:elasticsearch_version:  8.6.0
+:kibana_version:         8.6.0
+:apm_server_version:     8.6.0
 :branch:                 master
-:minor-version:          8.5
+:minor-version:          8.6
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17


### PR DESCRIPTION
Changes the "current" version of Elastic documentation to 8.5.

DO NOT MERGE UNTIL RELEASE DAY