### PR TITLE
Updates landing page for 8.6

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -65,13 +65,87 @@
     </div>
    </div>
    <div class="col-md-6 col-12">
-    <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt7bfdcb935bfc0044/6377b71862965b10fea0ba06/components-elastic-stack-color-32px.png" />
+    <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
   </div>
-  <h3>What exactly is the "Elastic Stack"?</h3>
-  <p>It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
-  <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
-  <details>
-    <summary class="title">About the Elastic Stack components</summary>    
+    <details>
+      <summary class="title">About the Elastic Stack</summary>
+
+      <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+      <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
+
+      <!-- This SVG was created in Figma. Find the source in the Platform Docs Team section in Figma, and in /tech-content/welcome-to-elastic/diagrams' in the tech-content repo. -->
+
+      <svg viewBox="0 0 1125 547" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="868" y="95" width="250" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="949.891" y="124.318">Administer </tspan><tspan x="957.141" y="143.318">Visualize </tspan><tspan x="973.453" y="162.318">Alert </tspan><tspan x="961.305" y="181.318">Analyze</tspan></text>
+        <rect x="575" y="95" width="251" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="679.398" y="127.318">Index </tspan><tspan x="679.938" y="146.318">Store </tspan><tspan x="673.578" y="165.318">Search </tspan><tspan x="669.305" y="184.318">Analyze</tspan></text>
+        <rect x="283.286" y="95" width="250" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="358.773" y="127.318">Consolidate </tspan><tspan x="365.445" y="146.318">Transform </tspan><tspan x="380.984" y="165.318">Enrich</tspan></text>
+        <rect y="95" width="251" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="96.6953" y="128.318">Protect </tspan><tspan x="97.6328" y="147.318">Collect </tspan><tspan x="80.9688" y="166.318">Preprocess </tspan><tspan x="108.023" y="185.318">Ship</tspan></text>
+        <rect x="37" y="214" width="177" height="228" rx="9" stroke="#434646" stroke-width="2"/>
+        <rect x="920" y="359" width="146" height="52.0179" rx="9" fill="#FFB7B3" stroke="#BD271E" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="940.133" y="380.318">Elasticsearch </tspan><tspan x="966.641" y="399.318">clients</tspan></text>
+        <rect x="51" y="223" width="148" height="71.4366" rx="9" fill="#EFC586" stroke="#FE6E05" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="103.469" y="243.318">Fleet&#10;</tspan><tspan x="108.297" y="262.318">and&#10;</tspan><tspan x="71.2422" y="281.318">Elastic Agent</tspan></text>
+        <mask id="path-14-inside-1_54_17" fill="white">
+        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z"/>
+        </mask>
+        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z" fill="#FFEFBF" stroke="#FEC514" stroke-width="4" mask="url(#path-14-inside-1_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="365" y="353.612">Logstash</tspan></text>
+        <mask id="path-16-inside-2_54_17" fill="white">
+        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z"/>
+        </mask>
+        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z" fill="#DBF0FF" stroke="#1447FE" stroke-width="4" mask="url(#path-16-inside-2_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="963" y="272.318">Kibana</tspan></text>
+        <mask id="path-18-inside-3_54_17" fill="white">
+        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z"/>
+        </mask>
+        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z" fill="#DDFDFF" stroke="#05A1B6" stroke-width="4" mask="url(#path-18-inside-3_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="351.133" y="243.498">Elasticsearch </tspan><tspan x="341.852" y="262.498">ingest pipelines</tspan></text>
+        <rect x="627" y="214" width="148" height="316" rx="9" fill="#DDFDFF" stroke="#05A1B6" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="646" y="363.717">Elasticsearch</tspan></text>
+        <rect x="49" y="374" width="148" height="59" rx="9" fill="#E1DCFF" stroke="#3404F3" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="97" y="409.318">Beats</tspan></text>
+        <rect x="49" y="307" width="148" height="55" rx="9" fill="#CFFFD4" stroke="#019822" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="105" y="341.318">APM</tspan></text>
+        <mask id="path-26-inside-4_54_17" fill="white">
+        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z"/>
+        </mask>
+        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-26-inside-4_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="350.57" y="486.318">Other queues&#10;</tspan><tspan x="343.273" y="505.318">and processors</tspan></text>
+        <mask id="path-28-inside-5_54_17" fill="white">
+        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z"/>
+        </mask>
+        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-28-inside-5_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="955.758" y="470.318">Interfaces, </tspan><tspan x="947.727" y="489.318">applications, </tspan><tspan x="951.961" y="508.318">consumers, </tspan><tspan x="962.43" y="527.318">websites</tspan></text>
+        <mask id="path-30-inside-6_54_17" fill="white">
+        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z"/>
+        </mask>
+        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-30-inside-6_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="64.3047" y="488.318">Other shippers </tspan><tspan x="75.0312" y="507.318">and sources</tspan></text>
+        <rect x="868.5" y="41.5" width="249" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="940.655" y="69.3182">Consume&#10;</tspan></text>
+        <rect x="575.5" y="41.5" width="250" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="670.337" y="69.3182">Store</tspan></text>
+        <rect x="2.5" y="41.5" width="532" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="229.151" y="69.3182">Ingest</tspan></text>
+        <path d="M311.704 492.71C312.096 492.321 312.099 491.688 311.71 491.296L305.37 484.908C304.981 484.516 304.347 484.513 303.955 484.903C303.563 485.292 303.561 485.925 303.95 486.317L309.586 491.995L303.908 497.63C303.516 498.019 303.513 498.653 303.903 499.045C304.292 499.437 304.925 499.439 305.317 499.05L311.704 492.71ZM213.007 492.633L310.996 493L311.004 491L213.014 490.633L213.007 492.633Z" fill="#BD271E"/>
+        <path d="M612.707 419.707C613.098 419.316 613.098 418.683 612.707 418.293L606.343 411.929C605.953 411.538 605.319 411.538 604.929 411.929C604.538 412.319 604.538 412.952 604.929 413.343L610.586 419L604.929 424.657C604.538 425.047 604.538 425.68 604.929 426.071C605.319 426.461 605.953 426.461 606.343 426.071L612.707 419.707ZM229 420L612 420L612 418L229 418L229 420Z" fill="#BD271E"/>
+        <path d="M904.707 301.707C905.098 301.317 905.098 300.683 904.707 300.293L898.343 293.929C897.953 293.538 897.319 293.538 896.929 293.929C896.538 294.319 896.538 294.953 896.929 295.343L902.586 301L896.929 306.657C896.538 307.047 896.538 307.681 896.929 308.071C897.319 308.462 897.953 308.462 898.343 308.071L904.707 301.707ZM790 302H904V300H790V302Z" fill="#BD271E"/>
+        <path d="M612.707 346.707C613.098 346.317 613.098 345.683 612.707 345.293L606.343 338.929C605.953 338.538 605.319 338.538 604.929 338.929C604.538 339.319 604.538 339.953 604.929 340.343L610.586 346L604.929 351.657C604.538 352.047 604.538 352.681 604.929 353.071C605.319 353.462 605.953 353.462 606.343 353.071L612.707 346.707ZM501 347L612 347L612 345L501 345V347Z" fill="#BD271E"/>
+        <path d="M612.707 486.707C613.098 486.317 613.098 485.683 612.707 485.293L606.343 478.929C605.953 478.538 605.319 478.538 604.929 478.929C604.538 479.319 604.538 479.953 604.929 480.343L610.586 486L604.929 491.657C604.538 492.047 604.538 492.681 604.929 493.071C605.319 493.462 605.953 493.462 606.343 493.071L612.707 486.707ZM501 487L612 487L612 485L501 485V487Z" fill="#BD271E"/>
+        <path d="M611.707 255.707C612.098 255.317 612.098 254.683 611.707 254.293L605.343 247.929C604.953 247.538 604.319 247.538 603.929 247.929C603.538 248.319 603.538 248.953 603.929 249.343L609.586 255L603.929 260.657C603.538 261.047 603.538 261.681 603.929 262.071C604.319 262.462 604.953 262.462 605.343 262.071L611.707 255.707ZM500 256L611 256L611 254L500 254V256Z" fill="#BD271E"/>
+        <path d="M317.707 345.707C318.098 345.317 318.098 344.683 317.707 344.293L311.343 337.929C310.953 337.538 310.319 337.538 309.929 337.929C309.538 338.319 309.538 338.953 309.929 339.343L315.586 345L309.929 350.657C309.538 351.047 309.538 351.681 309.929 352.071C310.319 352.462 310.953 352.462 311.343 352.071L317.707 345.707ZM229 346H317V344H229V346Z" fill="#BD271E"/>
+        <path d="M316.707 255.707C317.098 255.317 317.098 254.683 316.707 254.293L310.343 247.929C309.953 247.538 309.319 247.538 308.929 247.929C308.538 248.319 308.538 248.953 308.929 249.343L314.586 255L308.929 260.657C308.538 261.047 308.538 261.681 308.929 262.071C309.319 262.462 309.953 262.462 310.343 262.071L316.707 255.707ZM228 256L316 256V254L228 254V256Z" fill="#BD271E"/>
+        <path d="M789.293 254.293C788.902 254.683 788.902 255.317 789.293 255.707L795.657 262.071C796.047 262.462 796.681 262.462 797.071 262.071C797.462 261.681 797.462 261.047 797.071 260.657L791.414 255L797.071 249.343C797.462 248.953 797.462 248.319 797.071 247.929C796.681 247.538 796.047 247.538 795.657 247.929L789.293 254.293ZM790 256L904 256V254L790 254V256Z" fill="#BD271E"/>
+        <path d="M789.293 382.293C788.902 382.683 788.902 383.317 789.293 383.707L795.657 390.071C796.047 390.462 796.681 390.462 797.071 390.071C797.462 389.681 797.462 389.047 797.071 388.657L791.414 383L797.071 377.343C797.462 376.953 797.462 376.319 797.071 375.929C796.681 375.538 796.047 375.538 795.657 375.929L789.293 382.293ZM790 384L847 384L847 382L790 382L790 384ZM847 384L904 384L904 382L847 382L847 384Z" fill="#BD271E"/>
+        <path d="M789.293 485.293C788.902 485.683 788.902 486.317 789.293 486.707L795.657 493.071C796.047 493.462 796.681 493.462 797.071 493.071C797.462 492.681 797.462 492.047 797.071 491.657L791.414 486L797.071 480.343C797.462 479.953 797.462 479.319 797.071 478.929C796.681 478.538 796.047 478.538 795.657 478.929L789.293 485.293ZM790 487L847 487L847 485L790 485L790 487ZM847 487L904 487L904 485L847 485L847 487Z" fill="#BD271E"/>
+        <path d="M993.707 419.293C993.317 418.902 992.683 418.902 992.293 419.293L985.929 425.657C985.538 426.047 985.538 426.681 985.929 427.071C986.319 427.462 986.953 427.462 987.343 427.071L993 421.414L998.657 427.071C999.047 427.462 999.681 427.462 1000.07 427.071C1000.46 426.681 1000.46 426.047 1000.07 425.657L993.707 419.293ZM992 420V440H994V420H992Z" fill="#BD271E"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="26" font-weight="bold" letter-spacing="0em"><tspan x="9" y="24.9545">Components of the Elastic Stack</tspan></text>
+        </svg>
+    
     <h3 id="_ingest">Ingest</h3>
     <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
     <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -57,7 +57,7 @@
       Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
     </p>
     <details>
-      <summary class="title">Expand to learn about the Elastic Stack</summary>
+      <summary class="title">About the Elastic Stack</summary>
     
       <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
       <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
@@ -205,13 +205,13 @@
       </dl>
     </details>
     <p>
-       <a class="inline-block mr-3" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
-       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All docs</a>
-       <a class="inline-block mr-3" href="https://www.elastic.co/videos/training-how-to-series-stack">How-to videos</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a> 
+      <a class="inline-block mr-3" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
    </div>
    <div class="col-md-6 col-12">
-     <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt9068c0f145771649/633b72121434a77dfebf7301/kibana.png" />
+     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
    </div>
   </div>
 
@@ -226,7 +226,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
             Search my data
           </h4>
-          <p>Build a custom search engine experience with Elastic Enterprise Search.</p>
+          <p>Learn how to build a custom search engine experience with Elastic Enterprise Search.</p>
         </div>
       </a>
     </div>
@@ -237,7 +237,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
             Observe my data
           </h4>
-          <p>Monitor applications and systems with Elastic Observability.</p>
+          <p>Learn how to monitor applications and systems with Elastic Observability.</p>
         </div>
       </a>
     </div>
@@ -248,12 +248,14 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
             Protect my environment
           </h4>
-          <p>Learn how to use Elastic Security for SIEM.</p>
+          <p>Learn how to use detect, investigate, and respond to threats with Elastic Security for SIEM.</p>
         </div>
       </a>
     </div>
   </div>
-  <div class="col-md-4 col-12 mb-2">
+
+  <div class="row my-4">
+   <div class="col-md-4 col-12 mb-2">
     <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
       <div class="card h-100">
         <h4 class="mt-3">
@@ -268,7 +270,7 @@
       <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-general-purpose.html">
         <div class="card h-100">
           <h4 class="mt-3">
-            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
+            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltcb0e79820c355263/636c1905cbd6b84ecb4851b2/stack-logo-color-32px.png');"></span>
             Build a custom solution
           </h4>
           <p>Learn how to deploy your own platform to store, search, and visualize any data.</p>
@@ -282,7 +284,7 @@
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
-        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt339897734cf6f1a5/634d9d7aad35ab2389acb5f8/icon-visualizer-32-color.png');"></span>
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltfb840f627b5923e7/636c1b62358231185a7a8c11/featured-topics-logo-color-32px.png');"></span>
         Featured topics
       </h4>
     </div>
@@ -311,8 +313,8 @@
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
-        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltf6be06b964edf05e/634d9d7ab3f39b38fccfd0b4/icon-spaces-32-color.png');"></span>
-        Get organized
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltd8c4f9a116dd3ea5/636c1ca3a09a9e1155316094/subscribe-logo-color-32px.png');"></span>
+        Subscribe
       </h4>
     </div>
     <ul class="ul-col-md-2 ul-col-1">
@@ -337,7 +339,7 @@
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
-        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltf6be06b964edf05e/634d9d7ab3f39b38fccfd0b4/icon-spaces-32-color.png');"></span>
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt32521b6ce9c6b5ef/636c23102e673b30d507d84e/need-help-logo-color-32px.png');"></span>
         Need help?
       </h4>
     </div>
@@ -356,9 +358,6 @@
       </li>
       <li>
         <a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a>
-      </li>
-      <li>
-        <a href="https://www.elastic.co/videos/">Webinars</a>
       </li>
       <li>
         <a href="https://ela.st/slack">Community Slack</a>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -56,87 +56,90 @@
     <p>
       Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
     </p>
-    <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
-    <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
-    <details>
-      <summary class="title">About the Elastic Stack components</summary>    
-      <h3 id="_ingest">Ingest</h3>
-      <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
-      <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
-      <p>Trying to decide which ingest component to use? Refer to <a href="en/cloud/current/ec-cloud-ingest-data.html">Adding data to Elasticsearch</a> to help you decide.</p>
-      <dl>
-        <dt id="stack-components-agent">
-          Fleet and Elastic Agent
-        </dt>
-        <dd>
-          <p>
-            Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more. Each agent has a single policy to which you can add integrations for new data sources, security protections, and more.
-          </p>
-          <p>Fleet enables you to centrally manage Elastic Agents and their policies. Use Fleet to monitor the state of all your Elastic Agents, manage agent policies, and upgrade Elastic Agent binaries or integrations.</p>
-          <p><a href="en/fleet/current/fleet-overview.html">Learn more about Fleet and Elastic Agent</a>.</p>
-        </dd>
-        <dt id="stack-components-apm">
-          APM
-        </dt>
-        <dd>
-          Elastic APM is an application performance monitoring system built on the Elastic Stack. It allows you to monitor software services and applications in real-time, by collecting detailed performance information on response time for incoming requests, database queries, calls to caches, external HTTP requests, and more. This makes it easy to pinpoint and fix performance problems quickly. <a href="en/apm/guide/current/apm-overview.html">Learn more about APM</a>.
-        </dd>
-        <dt id="stack-components-beats">
-          Beats
-        </dt>
-        <dd>
-          Beats are data shippers that you install as agents on your servers to send operational data to Elasticsearch. Beats are available for many standard observability data scenarios, including audit data, log files and journals, cloud data, availability, metrics, network traffic, and Windows event logs. <a href="en/beats/libbeat/current/beats-reference.html">Learn more about Beats</a>.
-        </dd>
-        <dt id="stack-components-ingest-pipelines">
-          Elasticsearch ingest pipelines
-        </dt>
-        <dd>
-          Ingest pipelines let you perform common transformations on your data before indexing them into Elasticsearch. You can configure one or more "processor" tasks to run sequentially, making specific changes to your documents before storing them in Elasticsearch. <a href="en/elasticsearch/reference/current/ingest.html">Learn more about ingest pipelines</a>.
-        </dd>
-        <dt id="stack-components-logstash">
-          Logstash
-        </dt>
-        <dd>
-          Logstash is a data collection engine with real-time pipelining capabilities. It can dynamically unify data from disparate sources and normalize the data into destinations of your choice. Logstash supports a broad array of input, filter, and output plugins, with many native codecs further simplifying the ingestion process. <a href="en/logstash/current/introduction.html">Learn more about Logstash</a>.
-        </dd>
-      </dl>
-      
-      <h3 id="_store">Store</h3>
-      <dl>
-        <dt id="stack-components-elasticsearch">
-          Elasticsearch
-        </dt>
-        <dd>
-          Elasticsearch is the distributed search and analytics engine at the heart of the Elastic Stack. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches. Elasticsearch provides a REST API that enables you to store data in Elasticsearch and retrieve it. The REST API also provides access to Elasticsearch&#8217;s search and analytics capabilities. <a href="en/elasticsearch/reference/current/elasticsearch-intro.html">Learn more about Elasticsearch</a>.
-        </dd>
-      </dl>
-      
-      <h3 id="_consume">Consume</h3>
-      <p>Use Kibana to query and visualize the data that&#8217;s stored in Elasticsearch. Or, use the Elasticsearch clients to access data in Elasticsearch directly from common programming languages.</p>
-      <dl>
-        <dt id="stack-components-kibana">
-          Kibana
-        </dt>
-        <dd>
-          Kibana is the tool to harness your Elasticsearch data and to manage the Elastic Stack. Use it to analyze and visualize the data that&#8217;s stored in Elasticsearch. Kibana is also the home for the Elastic Enterprise Search, Elastic Observability and Elastic Security solutions. <a href="en/kibana/current/introduction.html">Learn more about Kibana</a>.
-        </dd>
-        <dt id="stack-components-elasticsearch-clients">
-          Elasticsearch clients
-        </dt>
-        <dd>
-          The clients provide a convenient mechanism to manage API requests and responses to and from Elasticsearch from popular languages such as Java, Ruby, Go, Python, and others. Both official and community contributed clients are available. <a href="en/elasticsearch/client/index.html">Learn more about the Elasticsearch clients</a>.
-        </dd>
-      </dl>
-    </details>
+    <div class="col-md-6 col-12">
     <p>
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a> 
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
+    </div>
    </div>
    <div class="col-md-6 col-12">
     <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt7bfdcb935bfc0044/6377b71862965b10fea0ba06/components-elastic-stack-color-32px.png" />
   </div>
+  <h3>What exactly is the "Elastic Stack"?</h3>
+  <p>It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+  <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
+  <details>
+    <summary class="title">About the Elastic Stack components</summary>    
+    <h3 id="_ingest">Ingest</h3>
+    <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
+    <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
+    <p>Trying to decide which ingest component to use? Refer to <a href="en/cloud/current/ec-cloud-ingest-data.html">Adding data to Elasticsearch</a> to help you decide.</p>
+    <dl>
+      <dt id="stack-components-agent">
+        Fleet and Elastic Agent
+      </dt>
+      <dd>
+        <p>
+          Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more. Each agent has a single policy to which you can add integrations for new data sources, security protections, and more.
+        </p>
+        <p>Fleet enables you to centrally manage Elastic Agents and their policies. Use Fleet to monitor the state of all your Elastic Agents, manage agent policies, and upgrade Elastic Agent binaries or integrations.</p>
+        <p><a href="en/fleet/current/fleet-overview.html">Learn more about Fleet and Elastic Agent</a>.</p>
+      </dd>
+      <dt id="stack-components-apm">
+        APM
+      </dt>
+      <dd>
+        Elastic APM is an application performance monitoring system built on the Elastic Stack. It allows you to monitor software services and applications in real-time, by collecting detailed performance information on response time for incoming requests, database queries, calls to caches, external HTTP requests, and more. This makes it easy to pinpoint and fix performance problems quickly. <a href="en/apm/guide/current/apm-overview.html">Learn more about APM</a>.
+      </dd>
+      <dt id="stack-components-beats">
+        Beats
+      </dt>
+      <dd>
+        Beats are data shippers that you install as agents on your servers to send operational data to Elasticsearch. Beats are available for many standard observability data scenarios, including audit data, log files and journals, cloud data, availability, metrics, network traffic, and Windows event logs. <a href="en/beats/libbeat/current/beats-reference.html">Learn more about Beats</a>.
+      </dd>
+      <dt id="stack-components-ingest-pipelines">
+        Elasticsearch ingest pipelines
+      </dt>
+      <dd>
+        Ingest pipelines let you perform common transformations on your data before indexing them into Elasticsearch. You can configure one or more "processor" tasks to run sequentially, making specific changes to your documents before storing them in Elasticsearch. <a href="en/elasticsearch/reference/current/ingest.html">Learn more about ingest pipelines</a>.
+      </dd>
+      <dt id="stack-components-logstash">
+        Logstash
+      </dt>
+      <dd>
+        Logstash is a data collection engine with real-time pipelining capabilities. It can dynamically unify data from disparate sources and normalize the data into destinations of your choice. Logstash supports a broad array of input, filter, and output plugins, with many native codecs further simplifying the ingestion process. <a href="en/logstash/current/introduction.html">Learn more about Logstash</a>.
+      </dd>
+    </dl>
+    
+    <h3 id="_store">Store</h3>
+    <dl>
+      <dt id="stack-components-elasticsearch">
+        Elasticsearch
+      </dt>
+      <dd>
+        Elasticsearch is the distributed search and analytics engine at the heart of the Elastic Stack. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches. Elasticsearch provides a REST API that enables you to store data in Elasticsearch and retrieve it. The REST API also provides access to Elasticsearch&#8217;s search and analytics capabilities. <a href="en/elasticsearch/reference/current/elasticsearch-intro.html">Learn more about Elasticsearch</a>.
+      </dd>
+    </dl>
+    
+    <h3 id="_consume">Consume</h3>
+    <p>Use Kibana to query and visualize the data that&#8217;s stored in Elasticsearch. Or, use the Elasticsearch clients to access data in Elasticsearch directly from common programming languages.</p>
+    <dl>
+      <dt id="stack-components-kibana">
+        Kibana
+      </dt>
+      <dd>
+        Kibana is the tool to harness your Elasticsearch data and to manage the Elastic Stack. Use it to analyze and visualize the data that&#8217;s stored in Elasticsearch. Kibana is also the home for the Elastic Enterprise Search, Elastic Observability and Elastic Security solutions. <a href="en/kibana/current/introduction.html">Learn more about Kibana</a>.
+      </dd>
+      <dt id="stack-components-elasticsearch-clients">
+        Elasticsearch clients
+      </dt>
+      <dd>
+        The clients provide a convenient mechanism to manage API requests and responses to and from Elasticsearch from popular languages such as Java, Ruby, Go, Python, and others. Both official and community contributed clients are available. <a href="en/elasticsearch/client/index.html">Learn more about the Elasticsearch clients</a>.
+      </dd>
+    </dl>
+  </details>
   </div>
 
   <h2>Get started</h2>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -68,9 +68,11 @@
   </div>
 
     <details>
-      <summary class="title">About the Elastic Stack</summary>
+      <p></p>
+    <h2>Learn about the Elastic Stack</h2>
+    <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+      <summary class="title">About the Elastic Stack components</summary>
 
-      <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
       <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
 
       <!-- This SVG was created in Figma. Find the source in the Platform Docs Team section in Figma, and in /tech-content/welcome-to-elastic/diagrams' in the tech-content repo. -->

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -211,7 +211,7 @@
    </p>
    </div>
    <div class="col-md-6 col-12">
-     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
+     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="940" height="660" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
    </div>
   </div>
 
@@ -278,8 +278,6 @@
       </a>
     </div>
   </div>
-
-  <h3>Get to know the Stack</h3>
 
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -67,10 +67,10 @@
    </div>
   </div>
 
+  <h2>Learn about the Elastic Stack</h2>
+  <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+
     <details>
-      <p></p>
-    <h2>Learn about the Elastic Stack</h2>
-    <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
       <summary class="title">About the Elastic Stack components</summary>
 
       <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -211,7 +211,7 @@
    </p>
    </div>
    <div class="col-md-6 col-12">
-     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="940" height="660" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
+     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
    </div>
   </div>
 

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -206,7 +206,7 @@
     </details>
     <p>
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a> 
-      <a class="inline-block mr-3" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
    </div>
@@ -256,7 +256,7 @@
 
   <div class="row my-4">
    <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
       <div class="card h-100">
         <h4 class="mt-3">
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
@@ -267,7 +267,7 @@
     </a>
   </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-general-purpose.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-general-purpose.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltcb0e79820c355263/636c1905cbd6b84ecb4851b2/stack-logo-color-32px.png');"></span>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -65,6 +65,7 @@
    </div>
    <div class="col-md-6 col-12">
     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
+   </div>
   </div>
 
     <details>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -47,7 +47,7 @@
   }
 </style>
 
-<div class="legalnotice">
+<div class="legalnotice"></div>
 
 <div class="row my-4">
   <div class="col-md-6 col-12">
@@ -61,7 +61,6 @@
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
-   </div>
    </div>
    <div class="col-md-6 col-12">
     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -56,17 +56,17 @@
     <p>
       Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
     </p>
-    <div class="col-md-6 col-12">
     <p>
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a> 
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
-    </div>
+   </div>
    </div>
    <div class="col-md-6 col-12">
     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
   </div>
+
     <details>
       <summary class="title">About the Elastic Stack</summary>
 
@@ -214,7 +214,6 @@
       </dd>
     </dl>
   </details>
-  </div>
 
   <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -1,238 +1,369 @@
+<style>
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
+  .card {
+    cursor: pointer;
+    padding: 16px;
+    text-align: left;
+    color: #000;
+  }
+
+  .card:hover {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+    padding: 16px;
+    text-align: left;
+  }
+
+  #guide a.no-text-decoration:hover {
+    text-decoration: none!important;
+  }
+
+  .icon {
+    width: 24px;
+    height: 24px;
+    background-position: bottom;
+    background-size: contain;
+    background-repeat: no-repeat;
+  }
+
+  .ul-col-1 {
+    columns: 1;
+    -webkit-columns: 1;
+    -moz-columns: 1;
+  }
+
+  @media (min-width:769px) {
+    .ul-col-md-2 {
+      columns: 2;
+      -webkit-columns: 2;
+      -moz-columns: 2;
+    }
+  }
+</style>
+
 <div class="legalnotice">
-  <p style="font-size:small"><a href="#viewall">View all docs</a> | <a href="en/welcome-to-elastic/current/new.html">Check out the latest from Elastic</a></p>
-  <p>
-    Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
-  </p>
-  <details>
-    <summary class="title">About the Elastic Stack</summary>
-  
-    <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
-    <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
-  
-    <!-- This SVG was created in Figma. Find the source in the Platform Docs Team section in Figma, and in /tech-content/welcome-to-elastic/diagrams' in the tech-content repo. -->
 
-    <svg viewBox="0 0 1125 547" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="868" y="95" width="250" height="452" fill="#E8E8E8"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="949.891" y="124.318">Administer </tspan><tspan x="957.141" y="143.318">Visualize </tspan><tspan x="973.453" y="162.318">Alert </tspan><tspan x="961.305" y="181.318">Analyze</tspan></text>
-      <rect x="575" y="95" width="251" height="452" fill="#E8E8E8"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="679.398" y="127.318">Index </tspan><tspan x="679.938" y="146.318">Store </tspan><tspan x="673.578" y="165.318">Search </tspan><tspan x="669.305" y="184.318">Analyze</tspan></text>
-      <rect x="283.286" y="95" width="250" height="452" fill="#E8E8E8"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="358.773" y="127.318">Consolidate </tspan><tspan x="365.445" y="146.318">Transform </tspan><tspan x="380.984" y="165.318">Enrich</tspan></text>
-      <rect y="95" width="251" height="452" fill="#E8E8E8"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="96.6953" y="128.318">Protect </tspan><tspan x="97.6328" y="147.318">Collect </tspan><tspan x="80.9688" y="166.318">Preprocess </tspan><tspan x="108.023" y="185.318">Ship</tspan></text>
-      <rect x="37" y="214" width="177" height="228" rx="9" stroke="#434646" stroke-width="2"/>
-      <rect x="920" y="359" width="146" height="52.0179" rx="9" fill="#FFB7B3" stroke="#BD271E" stroke-width="2"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="940.133" y="380.318">Elasticsearch </tspan><tspan x="966.641" y="399.318">clients</tspan></text>
-      <rect x="51" y="223" width="148" height="71.4366" rx="9" fill="#EFC586" stroke="#FE6E05" stroke-width="2"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="103.469" y="243.318">Fleet&#10;</tspan><tspan x="108.297" y="262.318">and&#10;</tspan><tspan x="71.2422" y="281.318">Elastic Agent</tspan></text>
-      <mask id="path-14-inside-1_54_17" fill="white">
-      <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z"/>
-      </mask>
-      <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z" fill="#FFEFBF" stroke="#FEC514" stroke-width="4" mask="url(#path-14-inside-1_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="365" y="353.612">Logstash</tspan></text>
-      <mask id="path-16-inside-2_54_17" fill="white">
-      <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z"/>
-      </mask>
-      <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z" fill="#DBF0FF" stroke="#1447FE" stroke-width="4" mask="url(#path-16-inside-2_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="963" y="272.318">Kibana</tspan></text>
-      <mask id="path-18-inside-3_54_17" fill="white">
-      <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z"/>
-      </mask>
-      <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z" fill="#DDFDFF" stroke="#05A1B6" stroke-width="4" mask="url(#path-18-inside-3_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="351.133" y="243.498">Elasticsearch </tspan><tspan x="341.852" y="262.498">ingest pipelines</tspan></text>
-      <rect x="627" y="214" width="148" height="316" rx="9" fill="#DDFDFF" stroke="#05A1B6" stroke-width="2"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="646" y="363.717">Elasticsearch</tspan></text>
-      <rect x="49" y="374" width="148" height="59" rx="9" fill="#E1DCFF" stroke="#3404F3" stroke-width="2"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="97" y="409.318">Beats</tspan></text>
-      <rect x="49" y="307" width="148" height="55" rx="9" fill="#CFFFD4" stroke="#019822" stroke-width="2"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="105" y="341.318">APM</tspan></text>
-      <mask id="path-26-inside-4_54_17" fill="white">
-      <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z"/>
-      </mask>
-      <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-26-inside-4_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="350.57" y="486.318">Other queues&#10;</tspan><tspan x="343.273" y="505.318">and processors</tspan></text>
-      <mask id="path-28-inside-5_54_17" fill="white">
-      <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z"/>
-      </mask>
-      <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-28-inside-5_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="955.758" y="470.318">Interfaces, </tspan><tspan x="947.727" y="489.318">applications, </tspan><tspan x="951.961" y="508.318">consumers, </tspan><tspan x="962.43" y="527.318">websites</tspan></text>
-      <mask id="path-30-inside-6_54_17" fill="white">
-      <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z"/>
-      </mask>
-      <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-30-inside-6_54_17)"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="64.3047" y="488.318">Other shippers </tspan><tspan x="75.0312" y="507.318">and sources</tspan></text>
-      <rect x="868.5" y="41.5" width="249" height="43" fill="#EFF2FF" stroke="black"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="940.655" y="69.3182">Consume&#10;</tspan></text>
-      <rect x="575.5" y="41.5" width="250" height="43" fill="#EFF2FF" stroke="black"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="670.337" y="69.3182">Store</tspan></text>
-      <rect x="2.5" y="41.5" width="532" height="43" fill="#EFF2FF" stroke="black"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="229.151" y="69.3182">Ingest</tspan></text>
-      <path d="M311.704 492.71C312.096 492.321 312.099 491.688 311.71 491.296L305.37 484.908C304.981 484.516 304.347 484.513 303.955 484.903C303.563 485.292 303.561 485.925 303.95 486.317L309.586 491.995L303.908 497.63C303.516 498.019 303.513 498.653 303.903 499.045C304.292 499.437 304.925 499.439 305.317 499.05L311.704 492.71ZM213.007 492.633L310.996 493L311.004 491L213.014 490.633L213.007 492.633Z" fill="#BD271E"/>
-      <path d="M612.707 419.707C613.098 419.316 613.098 418.683 612.707 418.293L606.343 411.929C605.953 411.538 605.319 411.538 604.929 411.929C604.538 412.319 604.538 412.952 604.929 413.343L610.586 419L604.929 424.657C604.538 425.047 604.538 425.68 604.929 426.071C605.319 426.461 605.953 426.461 606.343 426.071L612.707 419.707ZM229 420L612 420L612 418L229 418L229 420Z" fill="#BD271E"/>
-      <path d="M904.707 301.707C905.098 301.317 905.098 300.683 904.707 300.293L898.343 293.929C897.953 293.538 897.319 293.538 896.929 293.929C896.538 294.319 896.538 294.953 896.929 295.343L902.586 301L896.929 306.657C896.538 307.047 896.538 307.681 896.929 308.071C897.319 308.462 897.953 308.462 898.343 308.071L904.707 301.707ZM790 302H904V300H790V302Z" fill="#BD271E"/>
-      <path d="M612.707 346.707C613.098 346.317 613.098 345.683 612.707 345.293L606.343 338.929C605.953 338.538 605.319 338.538 604.929 338.929C604.538 339.319 604.538 339.953 604.929 340.343L610.586 346L604.929 351.657C604.538 352.047 604.538 352.681 604.929 353.071C605.319 353.462 605.953 353.462 606.343 353.071L612.707 346.707ZM501 347L612 347L612 345L501 345V347Z" fill="#BD271E"/>
-      <path d="M612.707 486.707C613.098 486.317 613.098 485.683 612.707 485.293L606.343 478.929C605.953 478.538 605.319 478.538 604.929 478.929C604.538 479.319 604.538 479.953 604.929 480.343L610.586 486L604.929 491.657C604.538 492.047 604.538 492.681 604.929 493.071C605.319 493.462 605.953 493.462 606.343 493.071L612.707 486.707ZM501 487L612 487L612 485L501 485V487Z" fill="#BD271E"/>
-      <path d="M611.707 255.707C612.098 255.317 612.098 254.683 611.707 254.293L605.343 247.929C604.953 247.538 604.319 247.538 603.929 247.929C603.538 248.319 603.538 248.953 603.929 249.343L609.586 255L603.929 260.657C603.538 261.047 603.538 261.681 603.929 262.071C604.319 262.462 604.953 262.462 605.343 262.071L611.707 255.707ZM500 256L611 256L611 254L500 254V256Z" fill="#BD271E"/>
-      <path d="M317.707 345.707C318.098 345.317 318.098 344.683 317.707 344.293L311.343 337.929C310.953 337.538 310.319 337.538 309.929 337.929C309.538 338.319 309.538 338.953 309.929 339.343L315.586 345L309.929 350.657C309.538 351.047 309.538 351.681 309.929 352.071C310.319 352.462 310.953 352.462 311.343 352.071L317.707 345.707ZM229 346H317V344H229V346Z" fill="#BD271E"/>
-      <path d="M316.707 255.707C317.098 255.317 317.098 254.683 316.707 254.293L310.343 247.929C309.953 247.538 309.319 247.538 308.929 247.929C308.538 248.319 308.538 248.953 308.929 249.343L314.586 255L308.929 260.657C308.538 261.047 308.538 261.681 308.929 262.071C309.319 262.462 309.953 262.462 310.343 262.071L316.707 255.707ZM228 256L316 256V254L228 254V256Z" fill="#BD271E"/>
-      <path d="M789.293 254.293C788.902 254.683 788.902 255.317 789.293 255.707L795.657 262.071C796.047 262.462 796.681 262.462 797.071 262.071C797.462 261.681 797.462 261.047 797.071 260.657L791.414 255L797.071 249.343C797.462 248.953 797.462 248.319 797.071 247.929C796.681 247.538 796.047 247.538 795.657 247.929L789.293 254.293ZM790 256L904 256V254L790 254V256Z" fill="#BD271E"/>
-      <path d="M789.293 382.293C788.902 382.683 788.902 383.317 789.293 383.707L795.657 390.071C796.047 390.462 796.681 390.462 797.071 390.071C797.462 389.681 797.462 389.047 797.071 388.657L791.414 383L797.071 377.343C797.462 376.953 797.462 376.319 797.071 375.929C796.681 375.538 796.047 375.538 795.657 375.929L789.293 382.293ZM790 384L847 384L847 382L790 382L790 384ZM847 384L904 384L904 382L847 382L847 384Z" fill="#BD271E"/>
-      <path d="M789.293 485.293C788.902 485.683 788.902 486.317 789.293 486.707L795.657 493.071C796.047 493.462 796.681 493.462 797.071 493.071C797.462 492.681 797.462 492.047 797.071 491.657L791.414 486L797.071 480.343C797.462 479.953 797.462 479.319 797.071 478.929C796.681 478.538 796.047 478.538 795.657 478.929L789.293 485.293ZM790 487L847 487L847 485L790 485L790 487ZM847 487L904 487L904 485L847 485L847 487Z" fill="#BD271E"/>
-      <path d="M993.707 419.293C993.317 418.902 992.683 418.902 992.293 419.293L985.929 425.657C985.538 426.047 985.538 426.681 985.929 427.071C986.319 427.462 986.953 427.462 987.343 427.071L993 421.414L998.657 427.071C999.047 427.462 999.681 427.462 1000.07 427.071C1000.46 426.681 1000.46 426.047 1000.07 425.657L993.707 419.293ZM992 420V440H994V420H992Z" fill="#BD271E"/>
-      <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="26" font-weight="bold" letter-spacing="0em"><tspan x="9" y="24.9545">Components of the Elastic Stack</tspan></text>
-      </svg>
+<div class="row my-4">
+  <div class="col-md-6 col-12">
+    <p></p>
+    <h2>Learn about Elastic</h2>
+    <p>
+      Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
+    </p>
+    <details>
+      <summary class="title">Expand to learn about the Elastic Stack</summary>
+    
+      <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+      <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
+    
+      <!-- This SVG was created in Figma. Find the source in the Platform Docs Team section in Figma, and in /tech-content/welcome-to-elastic/diagrams' in the tech-content repo. -->
+  
+      <svg viewBox="0 0 1125 547" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <rect x="868" y="95" width="250" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="949.891" y="124.318">Administer </tspan><tspan x="957.141" y="143.318">Visualize </tspan><tspan x="973.453" y="162.318">Alert </tspan><tspan x="961.305" y="181.318">Analyze</tspan></text>
+        <rect x="575" y="95" width="251" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="679.398" y="127.318">Index </tspan><tspan x="679.938" y="146.318">Store </tspan><tspan x="673.578" y="165.318">Search </tspan><tspan x="669.305" y="184.318">Analyze</tspan></text>
+        <rect x="283.286" y="95" width="250" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="358.773" y="127.318">Consolidate </tspan><tspan x="365.445" y="146.318">Transform </tspan><tspan x="380.984" y="165.318">Enrich</tspan></text>
+        <rect y="95" width="251" height="452" fill="#E8E8E8"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="96.6953" y="128.318">Protect </tspan><tspan x="97.6328" y="147.318">Collect </tspan><tspan x="80.9688" y="166.318">Preprocess </tspan><tspan x="108.023" y="185.318">Ship</tspan></text>
+        <rect x="37" y="214" width="177" height="228" rx="9" stroke="#434646" stroke-width="2"/>
+        <rect x="920" y="359" width="146" height="52.0179" rx="9" fill="#FFB7B3" stroke="#BD271E" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="940.133" y="380.318">Elasticsearch </tspan><tspan x="966.641" y="399.318">clients</tspan></text>
+        <rect x="51" y="223" width="148" height="71.4366" rx="9" fill="#EFC586" stroke="#FE6E05" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="103.469" y="243.318">Fleet&#10;</tspan><tspan x="108.297" y="262.318">and&#10;</tspan><tspan x="71.2422" y="281.318">Elastic Agent</tspan></text>
+        <mask id="path-14-inside-1_54_17" fill="white">
+        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z"/>
+        </mask>
+        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z" fill="#FFEFBF" stroke="#FEC514" stroke-width="4" mask="url(#path-14-inside-1_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="365" y="353.612">Logstash</tspan></text>
+        <mask id="path-16-inside-2_54_17" fill="white">
+        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z"/>
+        </mask>
+        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z" fill="#DBF0FF" stroke="#1447FE" stroke-width="4" mask="url(#path-16-inside-2_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="963" y="272.318">Kibana</tspan></text>
+        <mask id="path-18-inside-3_54_17" fill="white">
+        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z"/>
+        </mask>
+        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z" fill="#DDFDFF" stroke="#05A1B6" stroke-width="4" mask="url(#path-18-inside-3_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="351.133" y="243.498">Elasticsearch </tspan><tspan x="341.852" y="262.498">ingest pipelines</tspan></text>
+        <rect x="627" y="214" width="148" height="316" rx="9" fill="#DDFDFF" stroke="#05A1B6" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="646" y="363.717">Elasticsearch</tspan></text>
+        <rect x="49" y="374" width="148" height="59" rx="9" fill="#E1DCFF" stroke="#3404F3" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="97" y="409.318">Beats</tspan></text>
+        <rect x="49" y="307" width="148" height="55" rx="9" fill="#CFFFD4" stroke="#019822" stroke-width="2"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="105" y="341.318">APM</tspan></text>
+        <mask id="path-26-inside-4_54_17" fill="white">
+        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z"/>
+        </mask>
+        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-26-inside-4_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="350.57" y="486.318">Other queues&#10;</tspan><tspan x="343.273" y="505.318">and processors</tspan></text>
+        <mask id="path-28-inside-5_54_17" fill="white">
+        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z"/>
+        </mask>
+        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-28-inside-5_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="955.758" y="470.318">Interfaces, </tspan><tspan x="947.727" y="489.318">applications, </tspan><tspan x="951.961" y="508.318">consumers, </tspan><tspan x="962.43" y="527.318">websites</tspan></text>
+        <mask id="path-30-inside-6_54_17" fill="white">
+        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z"/>
+        </mask>
+        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-30-inside-6_54_17)"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="64.3047" y="488.318">Other shippers </tspan><tspan x="75.0312" y="507.318">and sources</tspan></text>
+        <rect x="868.5" y="41.5" width="249" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="940.655" y="69.3182">Consume&#10;</tspan></text>
+        <rect x="575.5" y="41.5" width="250" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="670.337" y="69.3182">Store</tspan></text>
+        <rect x="2.5" y="41.5" width="532" height="43" fill="#EFF2FF" stroke="black"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="229.151" y="69.3182">Ingest</tspan></text>
+        <path d="M311.704 492.71C312.096 492.321 312.099 491.688 311.71 491.296L305.37 484.908C304.981 484.516 304.347 484.513 303.955 484.903C303.563 485.292 303.561 485.925 303.95 486.317L309.586 491.995L303.908 497.63C303.516 498.019 303.513 498.653 303.903 499.045C304.292 499.437 304.925 499.439 305.317 499.05L311.704 492.71ZM213.007 492.633L310.996 493L311.004 491L213.014 490.633L213.007 492.633Z" fill="#BD271E"/>
+        <path d="M612.707 419.707C613.098 419.316 613.098 418.683 612.707 418.293L606.343 411.929C605.953 411.538 605.319 411.538 604.929 411.929C604.538 412.319 604.538 412.952 604.929 413.343L610.586 419L604.929 424.657C604.538 425.047 604.538 425.68 604.929 426.071C605.319 426.461 605.953 426.461 606.343 426.071L612.707 419.707ZM229 420L612 420L612 418L229 418L229 420Z" fill="#BD271E"/>
+        <path d="M904.707 301.707C905.098 301.317 905.098 300.683 904.707 300.293L898.343 293.929C897.953 293.538 897.319 293.538 896.929 293.929C896.538 294.319 896.538 294.953 896.929 295.343L902.586 301L896.929 306.657C896.538 307.047 896.538 307.681 896.929 308.071C897.319 308.462 897.953 308.462 898.343 308.071L904.707 301.707ZM790 302H904V300H790V302Z" fill="#BD271E"/>
+        <path d="M612.707 346.707C613.098 346.317 613.098 345.683 612.707 345.293L606.343 338.929C605.953 338.538 605.319 338.538 604.929 338.929C604.538 339.319 604.538 339.953 604.929 340.343L610.586 346L604.929 351.657C604.538 352.047 604.538 352.681 604.929 353.071C605.319 353.462 605.953 353.462 606.343 353.071L612.707 346.707ZM501 347L612 347L612 345L501 345V347Z" fill="#BD271E"/>
+        <path d="M612.707 486.707C613.098 486.317 613.098 485.683 612.707 485.293L606.343 478.929C605.953 478.538 605.319 478.538 604.929 478.929C604.538 479.319 604.538 479.953 604.929 480.343L610.586 486L604.929 491.657C604.538 492.047 604.538 492.681 604.929 493.071C605.319 493.462 605.953 493.462 606.343 493.071L612.707 486.707ZM501 487L612 487L612 485L501 485V487Z" fill="#BD271E"/>
+        <path d="M611.707 255.707C612.098 255.317 612.098 254.683 611.707 254.293L605.343 247.929C604.953 247.538 604.319 247.538 603.929 247.929C603.538 248.319 603.538 248.953 603.929 249.343L609.586 255L603.929 260.657C603.538 261.047 603.538 261.681 603.929 262.071C604.319 262.462 604.953 262.462 605.343 262.071L611.707 255.707ZM500 256L611 256L611 254L500 254V256Z" fill="#BD271E"/>
+        <path d="M317.707 345.707C318.098 345.317 318.098 344.683 317.707 344.293L311.343 337.929C310.953 337.538 310.319 337.538 309.929 337.929C309.538 338.319 309.538 338.953 309.929 339.343L315.586 345L309.929 350.657C309.538 351.047 309.538 351.681 309.929 352.071C310.319 352.462 310.953 352.462 311.343 352.071L317.707 345.707ZM229 346H317V344H229V346Z" fill="#BD271E"/>
+        <path d="M316.707 255.707C317.098 255.317 317.098 254.683 316.707 254.293L310.343 247.929C309.953 247.538 309.319 247.538 308.929 247.929C308.538 248.319 308.538 248.953 308.929 249.343L314.586 255L308.929 260.657C308.538 261.047 308.538 261.681 308.929 262.071C309.319 262.462 309.953 262.462 310.343 262.071L316.707 255.707ZM228 256L316 256V254L228 254V256Z" fill="#BD271E"/>
+        <path d="M789.293 254.293C788.902 254.683 788.902 255.317 789.293 255.707L795.657 262.071C796.047 262.462 796.681 262.462 797.071 262.071C797.462 261.681 797.462 261.047 797.071 260.657L791.414 255L797.071 249.343C797.462 248.953 797.462 248.319 797.071 247.929C796.681 247.538 796.047 247.538 795.657 247.929L789.293 254.293ZM790 256L904 256V254L790 254V256Z" fill="#BD271E"/>
+        <path d="M789.293 382.293C788.902 382.683 788.902 383.317 789.293 383.707L795.657 390.071C796.047 390.462 796.681 390.462 797.071 390.071C797.462 389.681 797.462 389.047 797.071 388.657L791.414 383L797.071 377.343C797.462 376.953 797.462 376.319 797.071 375.929C796.681 375.538 796.047 375.538 795.657 375.929L789.293 382.293ZM790 384L847 384L847 382L790 382L790 384ZM847 384L904 384L904 382L847 382L847 384Z" fill="#BD271E"/>
+        <path d="M789.293 485.293C788.902 485.683 788.902 486.317 789.293 486.707L795.657 493.071C796.047 493.462 796.681 493.462 797.071 493.071C797.462 492.681 797.462 492.047 797.071 491.657L791.414 486L797.071 480.343C797.462 479.953 797.462 479.319 797.071 478.929C796.681 478.538 796.047 478.538 795.657 478.929L789.293 485.293ZM790 487L847 487L847 485L790 485L790 487ZM847 487L904 487L904 485L847 485L847 487Z" fill="#BD271E"/>
+        <path d="M993.707 419.293C993.317 418.902 992.683 418.902 992.293 419.293L985.929 425.657C985.538 426.047 985.538 426.681 985.929 427.071C986.319 427.462 986.953 427.462 987.343 427.071L993 421.414L998.657 427.071C999.047 427.462 999.681 427.462 1000.07 427.071C1000.46 426.681 1000.46 426.047 1000.07 425.657L993.707 419.293ZM992 420V440H994V420H992Z" fill="#BD271E"/>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="26" font-weight="bold" letter-spacing="0em"><tspan x="9" y="24.9545">Components of the Elastic Stack</tspan></text>
+        </svg>
+        
       
-    
-    <h3 id="_ingest">Ingest</h3>
-    <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
-    <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
-    <p>Trying to decide which ingest component to use? Refer to <a href="en/cloud/current/ec-cloud-ingest-data.html">Adding data to Elasticsearch</a> to help you decide.</p>
-    <dl>
-      <dt id="stack-components-agent">
-        Fleet and Elastic Agent
-      </dt>
-      <dd>
-        <p>
-          Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more. Each agent has a single policy to which you can add integrations for new data sources, security protections, and more.
-        </p>
-        <p>Fleet enables you to centrally manage Elastic Agents and their policies. Use Fleet to monitor the state of all your Elastic Agents, manage agent policies, and upgrade Elastic Agent binaries or integrations.</p>
-        <p><a href="en/fleet/current/fleet-overview.html">Learn more about Fleet and Elastic Agent</a>.</p>
-      </dd>
-      <dt id="stack-components-apm">
-        APM
-      </dt>
-      <dd>
-        Elastic APM is an application performance monitoring system built on the Elastic Stack. It allows you to monitor software services and applications in real-time, by collecting detailed performance information on response time for incoming requests, database queries, calls to caches, external HTTP requests, and more. This makes it easy to pinpoint and fix performance problems quickly. <a href="en/apm/guide/current/apm-overview.html">Learn more about APM</a>.
-      </dd>
-      <dt id="stack-components-beats">
-        Beats
-      </dt>
-      <dd>
-        Beats are data shippers that you install as agents on your servers to send operational data to Elasticsearch. Beats are available for many standard observability data scenarios, including audit data, log files and journals, cloud data, availability, metrics, network traffic, and Windows event logs. <a href="en/beats/libbeat/current/beats-reference.html">Learn more about Beats</a>.
-      </dd>
-      <dt id="stack-components-ingest-pipelines">
-        Elasticsearch ingest pipelines
-      </dt>
-      <dd>
-        Ingest pipelines let you perform common transformations on your data before indexing them into Elasticsearch. You can configure one or more "processor" tasks to run sequentially, making specific changes to your documents before storing them in Elasticsearch. <a href="en/elasticsearch/reference/current/ingest.html">Learn more about ingest pipelines</a>.
-      </dd>
-      <dt id="stack-components-logstash">
-        Logstash
-      </dt>
-      <dd>
-        Logstash is a data collection engine with real-time pipelining capabilities. It can dynamically unify data from disparate sources and normalize the data into destinations of your choice. Logstash supports a broad array of input, filter, and output plugins, with many native codecs further simplifying the ingestion process. <a href="en/logstash/current/introduction.html">Learn more about Logstash</a>.
-      </dd>
-    </dl>
-    
-    <h3 id="_store">Store</h3>
-    <dl>
-      <dt id="stack-components-elasticsearch">
-        Elasticsearch
-      </dt>
-      <dd>
-        Elasticsearch is the distributed search and analytics engine at the heart of the Elastic Stack. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches. Elasticsearch provides a REST API that enables you to store data in Elasticsearch and retrieve it. The REST API also provides access to Elasticsearch&#8217;s search and analytics capabilities. <a href="en/elasticsearch/reference/current/elasticsearch-intro.html">Learn more about Elasticsearch</a>.
-      </dd>
-    </dl>
-    
-    <h3 id="_consume">Consume</h3>
-    <p>Use Kibana to query and visualize the data that&#8217;s stored in Elasticsearch. Or, use the Elasticsearch clients to access data in Elasticsearch directly from common programming languages.</p>
-    <dl>
-      <dt id="stack-components-kibana">
-        Kibana
-      </dt>
-      <dd>
-        Kibana is the tool to harness your Elasticsearch data and to manage the Elastic Stack. Use it to analyze and visualize the data that&#8217;s stored in Elasticsearch. Kibana is also the home for the Elastic Enterprise Search, Elastic Observability and Elastic Security solutions. <a href="en/kibana/current/introduction.html">Learn more about Kibana</a>.
-      </dd>
-      <dt id="stack-components-elasticsearch-clients">
-        Elasticsearch clients
-      </dt>
-      <dd>
-        The clients provide a convenient mechanism to manage API requests and responses to and from Elasticsearch from popular languages such as Java, Ruby, Go, Python, and others. Both official and community contributed clients are available. <a href="en/elasticsearch/client/index.html">Learn more about the Elasticsearch clients</a>.
-      </dd>
-    </dl>
-  </details>
+      <h3 id="_ingest">Ingest</h3>
+      <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
+      <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
+      <p>Trying to decide which ingest component to use? Refer to <a href="en/cloud/current/ec-cloud-ingest-data.html">Adding data to Elasticsearch</a> to help you decide.</p>
+      <dl>
+        <dt id="stack-components-agent">
+          Fleet and Elastic Agent
+        </dt>
+        <dd>
+          <p>
+            Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to a host. It can also protect hosts from security threats, query data from operating systems, forward data from remote services or hardware, and more. Each agent has a single policy to which you can add integrations for new data sources, security protections, and more.
+          </p>
+          <p>Fleet enables you to centrally manage Elastic Agents and their policies. Use Fleet to monitor the state of all your Elastic Agents, manage agent policies, and upgrade Elastic Agent binaries or integrations.</p>
+          <p><a href="en/fleet/current/fleet-overview.html">Learn more about Fleet and Elastic Agent</a>.</p>
+        </dd>
+        <dt id="stack-components-apm">
+          APM
+        </dt>
+        <dd>
+          Elastic APM is an application performance monitoring system built on the Elastic Stack. It allows you to monitor software services and applications in real-time, by collecting detailed performance information on response time for incoming requests, database queries, calls to caches, external HTTP requests, and more. This makes it easy to pinpoint and fix performance problems quickly. <a href="en/apm/guide/current/apm-overview.html">Learn more about APM</a>.
+        </dd>
+        <dt id="stack-components-beats">
+          Beats
+        </dt>
+        <dd>
+          Beats are data shippers that you install as agents on your servers to send operational data to Elasticsearch. Beats are available for many standard observability data scenarios, including audit data, log files and journals, cloud data, availability, metrics, network traffic, and Windows event logs. <a href="en/beats/libbeat/current/beats-reference.html">Learn more about Beats</a>.
+        </dd>
+        <dt id="stack-components-ingest-pipelines">
+          Elasticsearch ingest pipelines
+        </dt>
+        <dd>
+          Ingest pipelines let you perform common transformations on your data before indexing them into Elasticsearch. You can configure one or more "processor" tasks to run sequentially, making specific changes to your documents before storing them in Elasticsearch. <a href="en/elasticsearch/reference/current/ingest.html">Learn more about ingest pipelines</a>.
+        </dd>
+        <dt id="stack-components-logstash">
+          Logstash
+        </dt>
+        <dd>
+          Logstash is a data collection engine with real-time pipelining capabilities. It can dynamically unify data from disparate sources and normalize the data into destinations of your choice. Logstash supports a broad array of input, filter, and output plugins, with many native codecs further simplifying the ingestion process. <a href="en/logstash/current/introduction.html">Learn more about Logstash</a>.
+        </dd>
+      </dl>
+      
+      <h3 id="_store">Store</h3>
+      <dl>
+        <dt id="stack-components-elasticsearch">
+          Elasticsearch
+        </dt>
+        <dd>
+          Elasticsearch is the distributed search and analytics engine at the heart of the Elastic Stack. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches. Elasticsearch provides a REST API that enables you to store data in Elasticsearch and retrieve it. The REST API also provides access to Elasticsearch&#8217;s search and analytics capabilities. <a href="en/elasticsearch/reference/current/elasticsearch-intro.html">Learn more about Elasticsearch</a>.
+        </dd>
+      </dl>
+      
+      <h3 id="_consume">Consume</h3>
+      <p>Use Kibana to query and visualize the data that&#8217;s stored in Elasticsearch. Or, use the Elasticsearch clients to access data in Elasticsearch directly from common programming languages.</p>
+      <dl>
+        <dt id="stack-components-kibana">
+          Kibana
+        </dt>
+        <dd>
+          Kibana is the tool to harness your Elasticsearch data and to manage the Elastic Stack. Use it to analyze and visualize the data that&#8217;s stored in Elasticsearch. Kibana is also the home for the Elastic Enterprise Search, Elastic Observability and Elastic Security solutions. <a href="en/kibana/current/introduction.html">Learn more about Kibana</a>.
+        </dd>
+        <dt id="stack-components-elasticsearch-clients">
+          Elasticsearch clients
+        </dt>
+        <dd>
+          The clients provide a convenient mechanism to manage API requests and responses to and from Elasticsearch from popular languages such as Java, Ruby, Go, Python, and others. Both official and community contributed clients are available. <a href="en/elasticsearch/client/index.html">Learn more about the Elasticsearch clients</a>.
+        </dd>
+      </dl>
+    </details>
+    <p>
+       <a class="inline-block mr-3" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
+       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All docs</a>
+       <a class="inline-block mr-3" href="https://www.elastic.co/videos/training-how-to-series-stack">How-to videos</a>
+   </p>
+   </div>
+   <div class="col-md-6 col-12">
+     <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt9068c0f145771649/633b72121434a77dfebf7301/kibana.png" />
+   </div>
+  </div>
 
-  <h2>Get started</h2>
+  <h3>Get started</h3>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
-  <table style="width: 100%;margin-bottom: 5px !important;">
-    <tr>
-      <td style="width: 50%; padding-top: 0px !important;">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-observability.html">Monitor applications and systems with Elastic Observability</a></li>
-            <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-siem-security.html">Use Elastic Security for SIEM</a></li>
-            <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-endpoint-security.html">Protect hosts with endpoint threat intelligence from Elastic Security</a></li>
-          </ul>
+  <div class="row my-4">
+    <div class="col-md-4 col-12 mb-2">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
+        <div class="card h-100">
+          <h4 class="mt-3">
+            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
+            Search my data
+          </h4>
+          <p>Build a custom search engine experience with Elastic Enterprise Search.</p>
         </div>
-      </td>
-      <td style="width: 50%; padding-top: 0px !important;">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/enterprise-search/current/start.html">Build a custom search engine experience with Elastic Enterprise Search</a></li>
-            <li class="listitem"><a href="en/welcome-to-elastic/current/getting-started-general-purpose.html">Deploy your own platform to store, search, and visualize any data</a></li>
-          </ul>
+      </a>
+    </div>
+    <div class="col-md-4 col-12 mb-2">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+        <div class="card h-100">
+          <h4 class="mt-3">
+            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
+            Observe my data
+          </h4>
+          <p>Monitor applications and systems with Elastic Observability.</p>
         </div>
-      </td>
-    </tr>
-  </table>
+      </a>
+    </div>
+    <div class="col-md-4 col-12 mb-2">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-siem-security.html">
+        <div class="card h-100">
+          <h4 class="mt-3">
+            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
+            Protect my environment
+          </h4>
+          <p>Learn how to use Elastic Security for SIEM.</p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
+          Protect my environment
+        </h4>
+        <p>Learn how to protect your hosts with endpoint threat intelligence from Elastic Security.</p>
+      </div>
+    </a>
+  </div>
+    <div class="col-md-4 col-12 mb-2">
+      <a class="no-text-decoration" href="https://www.https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-general-purpose.html">
+        <div class="card h-100">
+          <h4 class="mt-3">
+            <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
+            Build a custom solution
+          </h4>
+          <p>Learn how to deploy your own platform to store, search, and visualize any data.</p>
+        </div>
+      </a>
+    </div>
+  </div>
 
-  <table style="width: 100%;margin-bottom: 5px !important;">
-    <tr>
-      <th style="width: 50%; padding-top: 0px !important;"><h3 style="margin-top: 0px !important">Featured topics</h3></th>
-      <th style="width: 50%; padding-top: 0px !important;"><h3 style="margin-top: 0px !important">Subscribe</h3></th>
-    </tr>
-    <tr>
-      <td style="width: 50%">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/cloud/current/ec-cloud-ingest-data.html">Add your data</a></li>
-            <li class="listitem"><a href="en/cloud/current/ec-migrating-data.html">Migrate to Elastic Cloud</a></li>
-            <li class="listitem"><a href="en/cloud/current/ec-planning.html">Plan for production</a></li>
-            <li class="listitem"><a href="en/cloud/current/ec-monitoring.html">Keep your deployment healthy</a></li>
-            <li class="listitem"><a href="en/elasticsearch/reference/current/example-using-index-lifecycle-policy.html">Manage data retention</a></li>
-            <li class="listitem"><a href="en/kibana/current/dashboard.html">Visualize data with dashboards</a></li>
-          </ul>
-        </div>
-      </td>
-      <td style="width: 50%">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/cloud/current/ec-billing-models.html">Elastic Cloud</a></li>
-            <li class="listitem"><a href="https://aws.amazon.com/marketplace/pp/prodview-voru33wi6xs7k">AWS Marketplace</a></li>
-            <li class="listitem"><a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp">Azure Marketplace</a></li>
-            <li class="listitem"><a href="https://console.cloud.google.com/marketplace/product/endpoints/elasticsearch-service.gcpmarketplace.elastic.co">GCP Marketplace</a></li>
-            <li class="listitem"><a href="https://cloud.elastic.co/pricing">Review pricing using our calculator</a></li>
-          </ul>
-        </div>
-      </td>
-    </tr>
-  </table>
+  <h3>Get to know the Stack</h3>
 
-  <h3 style="margin-top: 0px !important">Need help?</h3>
-  <table width="100%;margin-bottom: 5px !important;">
-    <tr>
-      <td style="width: 50%; padding-top: 0px !important;">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a></li>
-            <li class="listitem"><a href="https://discuss.elastic.co/">Forums</a></li>
-            <li class="listitem"><a href="https://www.elastic.co/training/">Training</a></li>
-            <li class="listitem"><a href="en/welcome-to-elastic/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a></li>
-          </ul>
-        </div>
-      </td>
-      <td style="width: 50%; padding-top: 0px !important;">
-        <div class="itemizedlist">
-          <ul class="itemizedlist" type="disc">
-            <li class="listitem"><a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a></li>
-            <li class="listitem"><a href="https://www.elastic.co/videos/">Webinars</a></li>
-            <li class="listitem"><a href="https://ela.st/slack">Community Slack</a></li>
-          </ul>
-        </div>
-      </td>
-    </tr>
-  </table>
-</div>
+  <div class="my-5">
+    <div class="d-flex align-items-center mb-3">
+      <h4 class="mt-3">
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt339897734cf6f1a5/634d9d7aad35ab2389acb5f8/icon-visualizer-32-color.png');"></span>
+        Featured topics
+      </h4>
+    </div>
+    <ul class="ul-col-md-2 ul-col-1">
+      <li>
+        <a href="en/cloud/current/ec-cloud-ingest-data.html">Add your data</a>
+      </li>
+      <li>
+        <a href="en/cloud/current/ec-migrating-data.html">Migrate to Elastic Cloud</a>
+      </li>
+      <li>
+        <a href="en/cloud/current/ec-planning.html">Plan for production</a>
+      </li>
+      <li>
+        <a href="en/cloud/current/ec-monitoring.html">Keep your deployment healthy</a>
+      </li>
+      <li>
+        <a href="en/elasticsearch/reference/current/example-using-index-lifecycle-policy.html">Manage data retention</a>
+      </li>
+      <li>
+        <a href="en/kibana/current/dashboard.html">Visualize data with dashboards</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="my-5">
+    <div class="d-flex align-items-center mb-3">
+      <h4 class="mt-3">
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltf6be06b964edf05e/634d9d7ab3f39b38fccfd0b4/icon-spaces-32-color.png');"></span>
+        Get organized
+      </h4>
+    </div>
+    <ul class="ul-col-md-2 ul-col-1">
+      <li>
+        <a href="en/cloud/current/ec-billing-models.html">Elastic Cloud</a>
+      </li>
+      <li>
+        <a href="https://aws.amazon.com/marketplace/pp/prodview-voru33wi6xs7k">AWS Marketplace</a>
+      </li>
+      <li>
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp">Azure Marketplace</a>
+      </li>
+      <li>
+        <a href="https://console.cloud.google.com/marketplace/product/endpoints/elasticsearch-service.gcpmarketplace.elastic.co">GCP Marketplace</a>
+      </li>
+      <li>
+        <a href="https://cloud.elastic.co/pricing">Review pricing using our calculator</a>
+      </li>
+    </ul>
+  </div>
+
+  <div class="my-5">
+    <div class="d-flex align-items-center mb-3">
+      <h4 class="mt-3">
+        <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltf6be06b964edf05e/634d9d7ab3f39b38fccfd0b4/icon-spaces-32-color.png');"></span>
+        Need help?
+      </h4>
+    </div>
+    <ul class="ul-col-md-2 ul-col-1">
+      <li>
+        <a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a>
+      </li>
+      <li>
+        <a href="https://discuss.elastic.co/">Forums</a>
+      </li>
+      <li>
+        <a href="https://www.elastic.co/training/">Training</a>
+      </li>
+      <li>
+        <a href="en/welcome-to-elastic/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a>
+      </li>
+      <li>
+        <a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a>
+      </li>
+      <li>
+        <a href="https://www.elastic.co/videos/">Webinars</a>
+      </li>
+      <li>
+        <a href="https://ela.st/slack">Community Slack</a>
+      </li>
+    </ul>
+  </div>
 
 <hr id="viewall" style="margin-top: 0px;margin-bottom: 0px !important;"/>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -56,86 +56,10 @@
     <p>
       Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
     </p>
+    <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
+    <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
     <details>
-      <summary class="title">About the Elastic Stack</summary>
-    
-      <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
-      <p>You can deploy the Elastic Stack as a Cloud service supported on AWS, Google Cloud, and Azure, or as an on-prem installation on your own hardware.</p>
-    
-      <!-- This SVG was created in Figma. Find the source in the Platform Docs Team section in Figma, and in /tech-content/welcome-to-elastic/diagrams' in the tech-content repo. -->
-  
-      <svg viewBox="0 0 1125 547" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <rect x="868" y="95" width="250" height="452" fill="#E8E8E8"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="949.891" y="124.318">Administer </tspan><tspan x="957.141" y="143.318">Visualize </tspan><tspan x="973.453" y="162.318">Alert </tspan><tspan x="961.305" y="181.318">Analyze</tspan></text>
-        <rect x="575" y="95" width="251" height="452" fill="#E8E8E8"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="679.398" y="127.318">Index </tspan><tspan x="679.938" y="146.318">Store </tspan><tspan x="673.578" y="165.318">Search </tspan><tspan x="669.305" y="184.318">Analyze</tspan></text>
-        <rect x="283.286" y="95" width="250" height="452" fill="#E8E8E8"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="358.773" y="127.318">Consolidate </tspan><tspan x="365.445" y="146.318">Transform </tspan><tspan x="380.984" y="165.318">Enrich</tspan></text>
-        <rect y="95" width="251" height="452" fill="#E8E8E8"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="96.6953" y="128.318">Protect </tspan><tspan x="97.6328" y="147.318">Collect </tspan><tspan x="80.9688" y="166.318">Preprocess </tspan><tspan x="108.023" y="185.318">Ship</tspan></text>
-        <rect x="37" y="214" width="177" height="228" rx="9" stroke="#434646" stroke-width="2"/>
-        <rect x="920" y="359" width="146" height="52.0179" rx="9" fill="#FFB7B3" stroke="#BD271E" stroke-width="2"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="940.133" y="380.318">Elasticsearch </tspan><tspan x="966.641" y="399.318">clients</tspan></text>
-        <rect x="51" y="223" width="148" height="71.4366" rx="9" fill="#EFC586" stroke="#FE6E05" stroke-width="2"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="103.469" y="243.318">Fleet&#10;</tspan><tspan x="108.297" y="262.318">and&#10;</tspan><tspan x="71.2422" y="281.318">Elastic Agent</tspan></text>
-        <mask id="path-14-inside-1_54_17" fill="white">
-        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z"/>
-        </mask>
-        <path d="M330 322C330 316.477 334.477 312 340 312H470C475.523 312 480 316.477 480 322V370C480 375.523 475.523 380 470 380H340C334.477 380 330 375.523 330 370V322Z" fill="#FFEFBF" stroke="#FEC514" stroke-width="4" mask="url(#path-14-inside-1_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="365" y="353.612">Logstash</tspan></text>
-        <mask id="path-16-inside-2_54_17" fill="white">
-        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z"/>
-        </mask>
-        <path d="M918 223C918 217.477 922.477 213 928 213H1058C1063.52 213 1068 217.477 1068 223V319C1068 324.523 1063.52 329 1058 329H928C922.477 329 918 324.523 918 319V223Z" fill="#DBF0FF" stroke="#1447FE" stroke-width="4" mask="url(#path-16-inside-2_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="963" y="272.318">Kibana</tspan></text>
-        <mask id="path-18-inside-3_54_17" fill="white">
-        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z"/>
-        </mask>
-        <path d="M330 223C330 217.477 334.477 213 340 213H468C473.523 213 478 217.477 478 223V277C478 282.523 473.523 287 468 287H404H340C334.477 287 330 282.523 330 277V223Z" fill="#DDFDFF" stroke="#05A1B6" stroke-width="4" mask="url(#path-18-inside-3_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="351.133" y="243.498">Elasticsearch </tspan><tspan x="341.852" y="262.498">ingest pipelines</tspan></text>
-        <rect x="627" y="214" width="148" height="316" rx="9" fill="#DDFDFF" stroke="#05A1B6" stroke-width="2"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="646" y="363.717">Elasticsearch</tspan></text>
-        <rect x="49" y="374" width="148" height="59" rx="9" fill="#E1DCFF" stroke="#3404F3" stroke-width="2"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="97" y="409.318">Beats</tspan></text>
-        <rect x="49" y="307" width="148" height="55" rx="9" fill="#CFFFD4" stroke="#019822" stroke-width="2"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="105" y="341.318">APM</tspan></text>
-        <mask id="path-26-inside-4_54_17" fill="white">
-        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z"/>
-        </mask>
-        <path d="M329 465C329 459.477 333.477 455 339 455H469C474.523 455 479 459.477 479 465V512C479 517.523 474.523 522 469 522H339C333.477 522 329 517.523 329 512V465Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-26-inside-4_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="350.57" y="486.318">Other queues&#10;</tspan><tspan x="343.273" y="505.318">and processors</tspan></text>
-        <mask id="path-28-inside-5_54_17" fill="white">
-        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z"/>
-        </mask>
-        <path d="M920 458C920 452.477 924.477 448 930 448H1056C1061.52 448 1066 452.477 1066 458V523C1066 528.523 1061.52 533 1056 533H930C924.477 533 920 528.523 920 523V458Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-28-inside-5_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="955.758" y="470.318">Interfaces, </tspan><tspan x="947.727" y="489.318">applications, </tspan><tspan x="951.961" y="508.318">consumers, </tspan><tspan x="962.43" y="527.318">websites</tspan></text>
-        <mask id="path-30-inside-6_54_17" fill="white">
-        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z"/>
-        </mask>
-        <path d="M48 466C48 460.477 52.4772 456 58 456H188C193.523 456 198 460.477 198 466V515C198 520.523 193.523 525 188 525H58C52.4772 525 48 520.523 48 515V466Z" fill="white" stroke="#8C8C8C" stroke-width="4" stroke-dasharray="4 4" mask="url(#path-30-inside-6_54_17)"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0em"><tspan x="64.3047" y="488.318">Other shippers </tspan><tspan x="75.0312" y="507.318">and sources</tspan></text>
-        <rect x="868.5" y="41.5" width="249" height="43" fill="#EFF2FF" stroke="black"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="940.655" y="69.3182">Consume&#10;</tspan></text>
-        <rect x="575.5" y="41.5" width="250" height="43" fill="#EFF2FF" stroke="black"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="670.337" y="69.3182">Store</tspan></text>
-        <rect x="2.5" y="41.5" width="532" height="43" fill="#EFF2FF" stroke="black"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="16" font-weight="bold" letter-spacing="0.3em"><tspan x="229.151" y="69.3182">Ingest</tspan></text>
-        <path d="M311.704 492.71C312.096 492.321 312.099 491.688 311.71 491.296L305.37 484.908C304.981 484.516 304.347 484.513 303.955 484.903C303.563 485.292 303.561 485.925 303.95 486.317L309.586 491.995L303.908 497.63C303.516 498.019 303.513 498.653 303.903 499.045C304.292 499.437 304.925 499.439 305.317 499.05L311.704 492.71ZM213.007 492.633L310.996 493L311.004 491L213.014 490.633L213.007 492.633Z" fill="#BD271E"/>
-        <path d="M612.707 419.707C613.098 419.316 613.098 418.683 612.707 418.293L606.343 411.929C605.953 411.538 605.319 411.538 604.929 411.929C604.538 412.319 604.538 412.952 604.929 413.343L610.586 419L604.929 424.657C604.538 425.047 604.538 425.68 604.929 426.071C605.319 426.461 605.953 426.461 606.343 426.071L612.707 419.707ZM229 420L612 420L612 418L229 418L229 420Z" fill="#BD271E"/>
-        <path d="M904.707 301.707C905.098 301.317 905.098 300.683 904.707 300.293L898.343 293.929C897.953 293.538 897.319 293.538 896.929 293.929C896.538 294.319 896.538 294.953 896.929 295.343L902.586 301L896.929 306.657C896.538 307.047 896.538 307.681 896.929 308.071C897.319 308.462 897.953 308.462 898.343 308.071L904.707 301.707ZM790 302H904V300H790V302Z" fill="#BD271E"/>
-        <path d="M612.707 346.707C613.098 346.317 613.098 345.683 612.707 345.293L606.343 338.929C605.953 338.538 605.319 338.538 604.929 338.929C604.538 339.319 604.538 339.953 604.929 340.343L610.586 346L604.929 351.657C604.538 352.047 604.538 352.681 604.929 353.071C605.319 353.462 605.953 353.462 606.343 353.071L612.707 346.707ZM501 347L612 347L612 345L501 345V347Z" fill="#BD271E"/>
-        <path d="M612.707 486.707C613.098 486.317 613.098 485.683 612.707 485.293L606.343 478.929C605.953 478.538 605.319 478.538 604.929 478.929C604.538 479.319 604.538 479.953 604.929 480.343L610.586 486L604.929 491.657C604.538 492.047 604.538 492.681 604.929 493.071C605.319 493.462 605.953 493.462 606.343 493.071L612.707 486.707ZM501 487L612 487L612 485L501 485V487Z" fill="#BD271E"/>
-        <path d="M611.707 255.707C612.098 255.317 612.098 254.683 611.707 254.293L605.343 247.929C604.953 247.538 604.319 247.538 603.929 247.929C603.538 248.319 603.538 248.953 603.929 249.343L609.586 255L603.929 260.657C603.538 261.047 603.538 261.681 603.929 262.071C604.319 262.462 604.953 262.462 605.343 262.071L611.707 255.707ZM500 256L611 256L611 254L500 254V256Z" fill="#BD271E"/>
-        <path d="M317.707 345.707C318.098 345.317 318.098 344.683 317.707 344.293L311.343 337.929C310.953 337.538 310.319 337.538 309.929 337.929C309.538 338.319 309.538 338.953 309.929 339.343L315.586 345L309.929 350.657C309.538 351.047 309.538 351.681 309.929 352.071C310.319 352.462 310.953 352.462 311.343 352.071L317.707 345.707ZM229 346H317V344H229V346Z" fill="#BD271E"/>
-        <path d="M316.707 255.707C317.098 255.317 317.098 254.683 316.707 254.293L310.343 247.929C309.953 247.538 309.319 247.538 308.929 247.929C308.538 248.319 308.538 248.953 308.929 249.343L314.586 255L308.929 260.657C308.538 261.047 308.538 261.681 308.929 262.071C309.319 262.462 309.953 262.462 310.343 262.071L316.707 255.707ZM228 256L316 256V254L228 254V256Z" fill="#BD271E"/>
-        <path d="M789.293 254.293C788.902 254.683 788.902 255.317 789.293 255.707L795.657 262.071C796.047 262.462 796.681 262.462 797.071 262.071C797.462 261.681 797.462 261.047 797.071 260.657L791.414 255L797.071 249.343C797.462 248.953 797.462 248.319 797.071 247.929C796.681 247.538 796.047 247.538 795.657 247.929L789.293 254.293ZM790 256L904 256V254L790 254V256Z" fill="#BD271E"/>
-        <path d="M789.293 382.293C788.902 382.683 788.902 383.317 789.293 383.707L795.657 390.071C796.047 390.462 796.681 390.462 797.071 390.071C797.462 389.681 797.462 389.047 797.071 388.657L791.414 383L797.071 377.343C797.462 376.953 797.462 376.319 797.071 375.929C796.681 375.538 796.047 375.538 795.657 375.929L789.293 382.293ZM790 384L847 384L847 382L790 382L790 384ZM847 384L904 384L904 382L847 382L847 384Z" fill="#BD271E"/>
-        <path d="M789.293 485.293C788.902 485.683 788.902 486.317 789.293 486.707L795.657 493.071C796.047 493.462 796.681 493.462 797.071 493.071C797.462 492.681 797.462 492.047 797.071 491.657L791.414 486L797.071 480.343C797.462 479.953 797.462 479.319 797.071 478.929C796.681 478.538 796.047 478.538 795.657 478.929L789.293 485.293ZM790 487L847 487L847 485L790 485L790 487ZM847 487L904 487L904 485L847 485L847 487Z" fill="#BD271E"/>
-        <path d="M993.707 419.293C993.317 418.902 992.683 418.902 992.293 419.293L985.929 425.657C985.538 426.047 985.538 426.681 985.929 427.071C986.319 427.462 986.953 427.462 987.343 427.071L993 421.414L998.657 427.071C999.047 427.462 999.681 427.462 1000.07 427.071C1000.46 426.681 1000.46 426.047 1000.07 425.657L993.707 419.293ZM992 420V440H994V420H992Z" fill="#BD271E"/>
-        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="26" font-weight="bold" letter-spacing="0em"><tspan x="9" y="24.9545">Components of the Elastic Stack</tspan></text>
-        </svg>
-        
-      
+      <summary class="title">About the Elastic Stack components</summary>    
       <h3 id="_ingest">Ingest</h3>
       <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
       <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
@@ -211,11 +135,11 @@
    </p>
    </div>
    <div class="col-md-6 col-12">
-     <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
-   </div>
+    <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt7bfdcb935bfc0044/6377b71862965b10fea0ba06/components-elastic-stack-color-32px.png" />
+  </div>
   </div>
 
-  <h3>Get started</h3>
+  <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
   <div class="row my-4">
@@ -226,7 +150,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
             Search my data
           </h4>
-          <p>Learn how to build a custom search engine experience with Elastic Enterprise Search.</p>
+          <p>Build a custom search engine experience with Elastic Enterprise Search.</p>
         </div>
       </a>
     </div>
@@ -237,7 +161,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
             Observe my data
           </h4>
-          <p>Learn how to monitor applications and systems with Elastic Observability.</p>
+          <p>Monitor applications and systems with Elastic Observability.</p>
         </div>
       </a>
     </div>
@@ -248,7 +172,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
             Protect my environment
           </h4>
-          <p>Learn how to use detect, investigate, and respond to threats with Elastic Security for SIEM.</p>
+          <p>Use detect, investigate, and respond to threats with Elastic Security for SIEM.</p>
         </div>
       </a>
     </div>
@@ -262,7 +186,7 @@
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
           Protect my environment
         </h4>
-        <p>Learn how to protect your hosts with endpoint threat intelligence from Elastic Security.</p>
+        <p>Protect your hosts with endpoint threat intelligence from Elastic Security.</p>
       </div>
     </a>
   </div>
@@ -273,13 +197,13 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltcb0e79820c355263/636c1905cbd6b84ecb4851b2/stack-logo-color-32px.png');"></span>
             Build a custom solution
           </h4>
-          <p>Learn how to deploy your own platform to store, search, and visualize any data.</p>
+          <p>Deploy your own platform to store, search, and visualize any data.</p>
         </div>
       </a>
     </div>
   </div>
 
-  <div class="my-5">
+  <div class="my-4">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
         <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltfb840f627b5923e7/636c1b62358231185a7a8c11/featured-topics-logo-color-32px.png');"></span>
@@ -308,7 +232,7 @@
     </ul>
   </div>
 
-  <div class="my-5">
+  <div class="4">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
         <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltd8c4f9a116dd3ea5/636c1ca3a09a9e1155316094/subscribe-logo-color-32px.png');"></span>
@@ -334,7 +258,7 @@
     </ul>
   </div>
 
-  <div class="my-5">
+  <div class="my-4">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
         <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt32521b6ce9c6b5ef/636c23102e673b30d507d84e/need-help-logo-color-32px.png');"></span>


### PR DESCRIPTION
## Summary

Addresses #242 to update the Welcome to Elastic Docs page and make it more visually appealing. 

[Preview](https://docs_2559.docs-preview.app.elstc.co/guide/index.html)

![Welcome to Elastic Docs](https://user-images.githubusercontent.com/38990715/202272019-91d0de1b-59a8-4b98-ba20-9abf52dad6f8.gif)

## Ask

I want to make sure we're all aligned on the changes, so please leave any feedback, make updates, etc. 

## Plan

Let's wrap this up in time to merge for 8.6.0.