### PR TITLE
Bumps the version to 8.5.1

### DIFF
--- a/shared/versions/stack/8.5.asciidoc
+++ b/shared/versions/stack/8.5.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.5.0
+:version:                8.5.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.5.0
-:logstash_version:       8.5.0
-:elasticsearch_version:  8.5.0
-:kibana_version:         8.5.0
-:apm_server_version:     8.5.0
+:bare_version:           8.5.1
+:logstash_version:       8.5.1
+:elasticsearch_version:  8.5.1
+:kibana_version:         8.5.1
+:apm_server_version:     8.5.1
 :branch:                 8.5
 :minor-version:          8.5
 :major-version:          8.x


### PR DESCRIPTION
**DO NOT MERGE UNTIL RELEASE DAY**

[Doc release issue](https://github.com/elastic/dev/issues/2161)
