### PR TITLE
Update attributes for rules and connectors

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -180,6 +180,8 @@ Kibana app and UI names
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
 :rules-ui:           Rules and Connectors
+:rac-ui:             Rules and Connectors
+:connectors-ui:      Connectors
 :connectors-feature: Actions and Connectors
 :user-experience:    User Experience
 :ems:                Elastic Maps Service


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/issues/143809

The Stack Management > "Rules and Connectors" app has split into separate "Rules" and "Connectors" apps. Since the "rules-ui" attribute is used in 8.0 and later docs, we must:

1) Create a new "rac-ui" attribute for the old app name for use in 8.0-8.5 docs
2) Create a new "connectors-ui" attribute for the new Connectors app
3) Change the "rules-ui" attribute to use the appropriate label for the new Rules app

This PR accomplishes (1) and (2).  (3) is accomplished in https://github.com/elastic/docs/pull/2568