### PR TITLE
Update attribute for Rules UI

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -179,7 +179,7 @@ Kibana app and UI names
 :stack-manage-app:   Stack Management
 :stack-monitor-app:  Stack Monitoring
 :alerts-ui:          Alerts and Actions
-:rules-ui:           Rules and Connectors
+:rules-ui:           Rules
 :connectors-feature: Actions and Connectors
 :user-experience:    User Experience
 :ems:                Elastic Maps Service


### PR DESCRIPTION
This PR must be merged *after* https://github.com/elastic/docs/pull/2567 and https://github.com/elastic/kibana/pull/145500

It updates the "rules-ui" attribute to reflect the new name for the "Rules" app in 8.6+