### PR TITLE
Add glob include processor extension

### DIFF
--- a/resources/asciidoctor/lib/extensions.rb
+++ b/resources/asciidoctor/lib/extensions.rb
@@ -11,6 +11,7 @@ require_relative 'edit_me/extension'
 require_relative 'elastic_compat_tree_processor/extension'
 require_relative 'elastic_compat_preprocessor/extension'
 require_relative 'elastic_include_tagged/extension'
+require_relative 'glob_include_processor/extension'
 require_relative 'lang_override/extension'
 require_relative 'open_in_widget/extension'
 require_relative 'relativize_link/extension'
@@ -38,5 +39,6 @@ Asciidoctor::Extensions.register do
   # Everything after this must come after ElasticCompatTreeProcessor
   # or they won't see the right tree.
   include_processor ElasticIncludeTagged
+  include_processor GlobIncludeProcessor
 end
 Asciidoctor::Extensions.register AlternativeLanguageLookup

--- a/resources/asciidoctor/lib/glob_include_processor/extension.rb
+++ b/resources/asciidoctor/lib/glob_include_processor/extension.rb
@@ -4,16 +4,16 @@ require 'asciidoctor/extensions'
 ##
 # Include multiple files in a directory using globbing
 class GlobIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
-    def process doc, reader, target_glob, attributes
-      Dir[File.join reader.dir, target_glob].sort.reverse_each do |target|
-        content = IO.readlines target
-        content.unshift '' unless attributes['adjoin-option']
-        reader.push_include content, target, target, 1, attributes
-      end
-      reader
+  def process(_doc, reader, target_glob, attributes)
+    Dir[File.join reader.dir, target_glob].sort.reverse_each do |target|
+      content = IO.readlines target
+      content.unshift '' unless attributes['adjoin-option']
+      reader.push_include content, target, target, 1, attributes
     end
-  
-    def handles? target
-      target.include? '*'
-    end
+    reader
   end
+
+  def handles?(target)
+    target.include? '*'
+  end
+end

--- a/resources/asciidoctor/lib/glob_include_processor/extension.rb
+++ b/resources/asciidoctor/lib/glob_include_processor/extension.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'asciidoctor/extensions'
+##
+# Include multiple files in a directory using globbing
+class GlobIncludeProcessor < Asciidoctor::Extensions::IncludeProcessor
+    def process doc, reader, target_glob, attributes
+      Dir[File.join reader.dir, target_glob].sort.reverse_each do |target|
+        content = IO.readlines target
+        content.unshift '' unless attributes['adjoin-option']
+        reader.push_include content, target, target, 1, attributes
+      end
+      reader
+    end
+  
+    def handles? target
+      target.include? '*'
+    end
+  end


### PR DESCRIPTION
This PR adds an extension that enables the use of wildcards in include statements.