### PR TITLE
Bump docs version to 8.5.3

### DIFF
--- a/shared/versions/stack/8.5.asciidoc
+++ b/shared/versions/stack/8.5.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.5.2
+:version:                8.5.3
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.5.2
-:logstash_version:       8.5.2
-:elasticsearch_version:  8.5.2
-:kibana_version:         8.5.2
-:apm_server_version:     8.5.2
+:bare_version:           8.5.3
+:logstash_version:       8.5.3
+:elasticsearch_version:  8.5.3
+:kibana_version:         8.5.3
+:apm_server_version:     8.5.3
 :branch:                 8.5
 :minor-version:          8.5
 :major-version:          8.x


### PR DESCRIPTION
🛑 Do not merge until release day.

This updates the stack docs shared version attributes to `8.5.3`.

[docs release issue](https://github.com/elastic/dev/issues/2172)