### PR TITLE
Remove client dependencies from ESS and ECH docs builds

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -81,32 +81,6 @@ variables:
 
   cloudSaasCurrent: &cloudSaasCurrent ms-82
 
-  mapCloudSaasToClientsTeam: &mapCloudSaasToClientsTeam
-    *cloudSaasCurrent : master
-  mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
-    ms-81: master
-    ms-78: master
-    ms-75: master
-    ms-72: master
-    ms-70: master
-    ms-69: master
-    ms-65: master
-    ms-62: master
-    ms-59: master
-    ms-57: master
-    ms-53: master
-    ms-49: master
-    ms-47: master
-    release-ms-41: master
-    2.5: master
-    2.4: master
-    2.3: master
-    2.2: master
-    2.1: master
-    2.0: master
-    1.1: master
-    1.0: master
-
   # Use this when you're building a book that uses a "main" branch, but it has a dependency on a repo with a "master" branch
   mapMainToMaster: &mapMainToMaster
     main: master

--- a/conf.yaml
+++ b/conf.yaml
@@ -81,6 +81,30 @@ variables:
 
   cloudSaasCurrent: &cloudSaasCurrent ms-82
 
+  mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-81: master
+    ms-78: master
+    ms-75: master
+    ms-72: master
+    ms-70: master
+    ms-69: master
+    ms-65: master
+    ms-62: master
+    ms-59: master
+    ms-57: master
+    ms-53: master
+    ms-49: master
+    ms-47: master
+    release-ms-41: master
+    2.5: master
+    2.4: master
+    2.3: master
+    2.2: master
+    2.1: master
+    2.0: master
+    1.1: master
+    1.0: master
+
   # Use this when you're building a book that uses a "main" branch, but it has a dependency on a repo with a "master" branch
   mapMainToMaster: &mapMainToMaster
     main: master

--- a/conf.yaml
+++ b/conf.yaml
@@ -736,41 +736,6 @@ contents:
               -
                 repo:   cloud
                 path:   docs/shared
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/go
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/ruby
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/java
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/javascript
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/python
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
           - title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
@@ -791,41 +756,6 @@ contents:
               -
                 repo:   cloud
                 path:   docs/heroku
-              -
-                alternatives: { source_lang: console, alternative_lang: php }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/php
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: go }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/go
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: ruby }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/ruby
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: java }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/java
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: javascript }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/javascript
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: python }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/python
-                map_branches: *mapCloudSaasToClientsTeam
-              -
-                alternatives: { source_lang: console, alternative_lang: csharp }
-                repo:   clients-team
-                path:   docs/examples/elastic-cloud/csharp
-                map_branches: *mapCloudSaasToClientsTeam
           - title:      Elastic Cloud Enterprise - Elastic Cloud on your Infrastructure
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference


### PR DESCRIPTION
Client docs have been moved out of the Cloud guides and into the Elasticsearch Reference. So, we can remove most of the dependencies on the `client-team` repo from the Cloud docs builds. 

Specifically, I removed the client dependencies for ESS (Elasticsearch Service) and ECH (Heroku) builds. Previous versions of ECE still include the client content so those dependencies are still in place.