### PR TITLE
Modify attribute for Ingest Guide

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -23,7 +23,7 @@
 :winlogbeat-ref:       https://www.elastic.co/guide/en/beats/winlogbeat/{branch}
 :heartbeat-ref:        https://www.elastic.co/guide/en/beats/heartbeat/{branch}
 :journalbeat-ref:      https://www.elastic.co/guide/en/beats/journalbeat/{branch}
-:ingest-guide:         https://www.elastic.co/guide/en/fleet/{branch}
+:ingest-guide:         https://www.elastic.co/guide/en/ingest/{branch}
 :fleet-guide:          https://www.elastic.co/guide/en/fleet/{branch}
 :apm-guide-ref:        https://www.elastic.co/guide/en/apm/guide/{branch}
 :apm-guide-7x:         https://www.elastic.co/guide/en/apm/guide/7.17


### PR DESCRIPTION
The `:ingest-guide:` attribute is set to resolve to `https://www.elastic.co/guide/en/fleet/{branch}`.  This PR updates the attribute.

Is the `:ingest-guide:` attribute currently in use anywhere?  Docs-ci will tell us... but we might have to wait until after #2578 is merged. 

UPDATE: Yes!  The attribute is in use for some 7.x branches.  See comments.

DO NOT MERGE until after #2578 has been merged.  