### PR TITLE
Add `elastic` meta attributes to legacy doc build

### DIFF
--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -44,7 +44,6 @@ sub build_chunked {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
-    my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $resources = $opts{resource}      || [];
     my $noindex   = $opts{noindex}       || '';
@@ -121,7 +120,6 @@ sub build_chunked {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
-            '-a' => 'current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),
@@ -156,7 +154,6 @@ sub build_single {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
-    my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $noindex   = $opts{noindex}       || '';
     my $resources = $opts{resource}      || [];
@@ -226,7 +223,6 @@ sub build_single {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
-            '-a' => 'current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -44,6 +44,8 @@ sub build_chunked {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
+    my $prefix    = $opts{prefix}        || '';
+    my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $resources = $opts{resource}      || [];
     my $noindex   = $opts{noindex}       || '';
@@ -120,6 +122,8 @@ sub build_chunked {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
+            '-a' => 'dc.prefix=' . $prefix,
+            '-a' => 'dc.current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),
@@ -154,6 +158,8 @@ sub build_single {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
+    my $prefix    = $opts{prefix}        || '';
+    my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $noindex   = $opts{noindex}       || '';
     my $resources = $opts{resource}      || [];
@@ -223,6 +229,8 @@ sub build_single {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
+            '-a' => 'dc.prefix=' . $prefix,
+            '-a' => 'dc.current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),

--- a/lib/ES/Util.pm
+++ b/lib/ES/Util.pm
@@ -44,7 +44,6 @@ sub build_chunked {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
-    my $prefix    = $opts{prefix}        || '';
     my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $resources = $opts{resource}      || [];
@@ -122,8 +121,7 @@ sub build_chunked {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
-            '-a' => 'dc.prefix=' . $prefix,
-            '-a' => 'dc.current=' . $current,
+            '-a' => 'current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),
@@ -158,7 +156,6 @@ sub build_single {
     my $edit_urls = $opts{edit_urls};
     my $section   = $opts{section_title} || '';
     my $subject   = $opts{subject}       || '';
-    my $prefix    = $opts{prefix}        || '';
     my $current   = $opts{current}       || '';
     my $private   = $opts{private}       || '';
     my $noindex   = $opts{noindex}       || '';
@@ -229,8 +226,7 @@ sub build_single {
             '-a' => 'dc.type=Learn/Docs/' . $section,
             '-a' => 'dc.subject=' . $subject,
             '-a' => 'dc.identifier=' . $version,
-            '-a' => 'dc.prefix=' . $prefix,
-            '-a' => 'dc.current=' . $current,
+            '-a' => 'current=' . $current,
             $multi ? ( '-a' => "title-extra= [$version]" ) : (),
             $noindex ? ('-a' => 'noindex') : (),
             $page_header ? ('-a' => "page-header=$page_header") : (),

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -39,7 +39,9 @@ module DocbookCompat
     def munge_head(title_extra, title, html)
       html.gsub!(
         %r{<title>.+?</title>}m,
-        "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>"
+        "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>
+        <meta class=\"elastic\" name=\"content\" \
+        content=\"#{strip_tags title.main}#{title_extra}\">"
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -38,10 +38,11 @@ module DocbookCompat
 
     def munge_head(title_extra, title, html)
       html.gsub!(
-        %r{<title>.+?</title>}m,
-        "<title>#{strip_tags title.main}#{title_extra} | Elastic</title>
-        <meta class=\"elastic\" name=\"content\" \
-        content=\"#{strip_tags title.main}#{title_extra}\">"
+        %r{<title>.+?</title>}m, <<~HTML
+          <title>#{strip_tags title.main}#{title_extra} | Elastic</title>
+          <meta class=\"elastic\" name=\"content\" \
+          content=\"#{strip_tags title.main}#{title_extra}\">
+        HTML
       ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
     end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -31,7 +31,6 @@ module DocbookCompat
         elastic_compat_meta('is_current_product_version', current_version),
 
         # Not working
-        elastic_compat_meta('content', 'this is blank for now'),
         elastic_compat_meta('thumbnail_image', 'this is blank for now'),
       ]
     end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -18,11 +18,14 @@ module DocbookCompat
     def extra_docbook_compat_head
 
       # Allows :meta-product-name: to overwrite the product name
-      product_name = attributes['meta-product-name'] ? (attributes['meta-product-name']) : (attributes['dc.subject'])
+      product_name = attributes['meta-product-name'] ?
+        attributes['meta-product-name'] :
+        attributes['dc.subject']
       # Uses docdir attr to match final portion of string after `en/`
-      website_area = attributes['docdir'].scan(/(?<=en\/).*/i)[0].to_s
-      # Assigns the arbitrary value of 100 if the branch being built is "current"
-      current_version_val = attributes['source_branch'] == attributes['current'] ? (100) : (0)
+      website_area = attributes['docdir'].scan(%r{(?<=en\/).*}i)[0].to_s
+      # Assigns the arbitrary value of 100 if the branch built is "current"
+      current_version_val =
+        attributes['source_branch'] == attributes['current'] ? 100 : 0
       # Keeping this for now but will remove later
       # current_version_val = attributes['is-current-version'] ? (100) : (0)
 
@@ -34,8 +37,8 @@ module DocbookCompat
         elastic_compat_meta('is_current_product_version', current_version_val),
 
         # Not working
-        elastic_compat_meta('content', "this is blank for now"),
-        elastic_compat_meta('thumbnail_image', "this is blank for now"),
+        elastic_compat_meta('content', 'this is blank for now'),
+        elastic_compat_meta('thumbnail_image', 'this is blank for now'),
 
         # Legacy docbook meta
         docbook_compat_meta('DC.type', attributes['dc.type']),
@@ -50,6 +53,7 @@ module DocbookCompat
     def docbook_compat_meta(name, content)
       %(<meta name="#{name}" content="#{content}"/>)
     end
+
     def elastic_compat_meta(name, content)
       %(<meta class="elastic" name="#{name}" content="#{content}"/>)
     end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -7,7 +7,7 @@ module DocbookCompat
     def docinfo(location = :head, suffix = nil)
       case location
       when :head
-        [super, extra_docbook_compat_head].compact.join "\n"
+        [super, meta_head].compact.join "\n"
       else
         super
       end
@@ -15,31 +15,29 @@ module DocbookCompat
 
     private
 
-    def extra_docbook_compat_head
+    def meta_head
+      [
+        extra_elastic_head,
+        extra_docbook_compat_head,
+      ].compact.join "\n"
+    end
 
-      # Allows :meta-product-name: to overwrite the product name
-      product_name = attributes['meta-product-name'] ?
-        attributes['meta-product-name'] :
-        attributes['dc.subject']
-      # Uses docdir attr to match final portion of string after `en/`
-      website_area = attributes['docdir'].scan(%r{(?<=en\/).*}i)[0].to_s
-      # Assigns the arbitrary value of 100 if the branch built is "current"
-      current_version_val =
-        attributes['source_branch'] == attributes['current'] ? 100 : 0
-      # Keeping this for now but will remove later
-      # current_version_val = attributes['is-current-version'] ? (100) : (0)
-
+    def extra_elastic_head
       [
         # Working
         elastic_compat_meta('website_area', website_area),
         elastic_compat_meta('product_version', attributes['dc.identifier']),
         elastic_compat_meta('product_name', product_name),
-        elastic_compat_meta('is_current_product_version', current_version_val),
+        elastic_compat_meta('is_current_product_version', current_version),
 
         # Not working
         elastic_compat_meta('content', 'this is blank for now'),
         elastic_compat_meta('thumbnail_image', 'this is blank for now'),
+      ]
+    end
 
+    def extra_docbook_compat_head
+      [
         # Legacy docbook meta
         docbook_compat_meta('DC.type', attributes['dc.type']),
         docbook_compat_meta('DC.subject', attributes['dc.subject']),
@@ -56,6 +54,18 @@ module DocbookCompat
 
     def elastic_compat_meta(name, content)
       %(<meta class="elastic" name="#{name}" content="#{content}"/>)
+    end
+
+    def product_name
+      attributes['meta-product-name'] || attributes['dc.subject']
+    end
+
+    def website_area
+      attributes['docdir'].scan(%r{(?<=en\/).*}i)[0].to_s
+    end
+
+    def current_version
+      attributes['source_branch'] == attributes['current'] ? 100 : 0
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -25,7 +25,6 @@ module DocbookCompat
     def extra_elastic_head
       [
         # Elastic meta
-        elastic_compat_meta('content', page_title),
         elastic_compat_meta('product_version', attributes['dc.identifier']),
         elastic_compat_meta('product_name', product_name),
         elastic_compat_meta('website_area', 'documentation'),

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -24,14 +24,11 @@ module DocbookCompat
 
     def extra_elastic_head
       [
-        # Working
-        elastic_compat_meta('website_area', website_area),
+        # Elastic meta
+        elastic_compat_meta('content', page_title),
         elastic_compat_meta('product_version', attributes['dc.identifier']),
         elastic_compat_meta('product_name', product_name),
-        elastic_compat_meta('is_current_product_version', current_version),
-
-        # Not working
-        elastic_compat_meta('thumbnail_image', 'this is blank for now'),
+        elastic_compat_meta('website_area', 'documentation'),
       ]
     end
 
@@ -59,12 +56,8 @@ module DocbookCompat
       attributes['meta-product-name'] || attributes['dc.subject']
     end
 
-    def website_area
+    def page_title
       attributes['docdir'].scan(%r{(?<=en\/).*}i)[0].to_s
-    end
-
-    def current_version
-      attributes['source_branch'].to_s == attributes['current'].to_s ? 100 : 0
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -64,7 +64,7 @@ module DocbookCompat
     end
 
     def current_version
-      attributes['source_branch'] == attributes['current'] ? 100 : 0
+      attributes['source_branch'].to_s == attributes['current'].to_s ? 100 : 0
     end
   end
 end

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -16,20 +16,28 @@ module DocbookCompat
     private
 
     def extra_docbook_compat_head
+
+      # Allows :meta-product-name: to overwrite the product name
+      product_name = attributes['meta-product-name'] ? (attributes['meta-product-name']) : (attributes['dc.subject'])
+      # Uses docdir attr to match final portion of string after `en/`
+      website_area = attributes['docdir'].scan(/(?<=en\/).*/i)[0].to_s
+      # Assigns the arbitrary value of 100 if the branch being built is "current"
+      current_version_val = attributes['source_branch'] == attributes['current'] ? (100) : (0)
+      # Keeping this for now but will remove later
+      # current_version_val = attributes['is-current-version'] ? (100) : (0)
+
       [
-        # Elastic
-        elastic_compat_meta('product_name', attributes['dc.subject']),
+        # Working
+        elastic_compat_meta('website_area', website_area),
         elastic_compat_meta('product_version', attributes['dc.identifier']),
-        elastic_compat_meta('website_area', attributes['dc.prefix']),
-        elastic_compat_meta('source_branch', attributes['source_branch']),
-        elastic_compat_meta('current', attributes['current']),
+        elastic_compat_meta('product_name', product_name),
+        elastic_compat_meta('is_current_product_version', current_version_val),
 
-        if attributes['source_branch'] == attributes['current']
-          elastic_compat_meta('is_current_product_version', 100)
-        else
-          elastic_compat_meta('is_current_product_version', 0)
-        end,
+        # Not working
+        elastic_compat_meta('content', "this is blank for now"),
+        elastic_compat_meta('thumbnail_image', "this is blank for now"),
 
+        # Legacy docbook meta
         docbook_compat_meta('DC.type', attributes['dc.type']),
         docbook_compat_meta('DC.subject', attributes['dc.subject']),
         docbook_compat_meta('DC.identifier', attributes['dc.identifier']),

--- a/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extra_docinfo.rb
@@ -17,6 +17,19 @@ module DocbookCompat
 
     def extra_docbook_compat_head
       [
+        # Elastic
+        elastic_compat_meta('product_name', attributes['dc.subject']),
+        elastic_compat_meta('product_version', attributes['dc.identifier']),
+        elastic_compat_meta('website_area', attributes['dc.prefix']),
+        elastic_compat_meta('source_branch', attributes['source_branch']),
+        elastic_compat_meta('current', attributes['current']),
+
+        if attributes['source_branch'] == attributes['current']
+          elastic_compat_meta('is_current_product_version', 100)
+        else
+          elastic_compat_meta('is_current_product_version', 0)
+        end,
+
         docbook_compat_meta('DC.type', attributes['dc.type']),
         docbook_compat_meta('DC.subject', attributes['dc.subject']),
         docbook_compat_meta('DC.identifier', attributes['dc.identifier']),
@@ -28,6 +41,9 @@ module DocbookCompat
 
     def docbook_compat_meta(name, content)
       %(<meta name="#{name}" content="#{content}"/>)
+    end
+    def elastic_compat_meta(name, content)
+      %(<meta class="elastic" name="#{name}" content="#{content}"/>)
     end
   end
 end

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -501,9 +501,10 @@ RSpec.describe Chunker do
           include_examples 'standard page', 'index', nil
           include_examples 'subpage'
           it 'contains the correct title' do
-            expect(contents).to include(
-              '<title>Section: With subtitle | Title | Elastic</title>'
-            )
+            expect(contents).to include(<<~HTML.strip)
+              <title>Section: With subtitle | Title | Elastic</title>
+              <meta class="elastic" name="content" content="Section: With subtitle | Title">
+            HTML
           end
           it 'contains the heading' do
             expect(contents).to include(

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -53,11 +53,6 @@ RSpec.describe DocbookCompat do
     it "doesn't declare a generator" do
       expect(converted).not_to include('name="generator"')
     end
-    it 'has an elastic meta content tag' do
-      expect(converted).to include(<<~HTML)
-        <meta class="elastic" name="content" content="observability"/>
-      HTML
-    end
     it 'has an elastic meta product_name tag' do
       expect(converted).to include(<<~HTML)
         <meta class="elastic" name="product_name" content="BarSubject"/>

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe DocbookCompat do
         'dc.type' => 'FooType',
         'dc.subject' => 'BarSubject',
         'dc.identifier' => 'BazIdentifier',
+        'docdir' => '/doc/observability-docs/docs/en/observability',
       }
     end
     let(:input) do
@@ -52,6 +53,26 @@ RSpec.describe DocbookCompat do
     it "doesn't declare a generator" do
       expect(converted).not_to include('name="generator"')
     end
+    it 'has an elastic meta content tag' do
+      expect(converted).to include(<<~HTML)
+        <meta class="elastic" name="content" content="observability"/>
+      HTML
+    end
+    it 'has an elastic meta product_name tag' do
+      expect(converted).to include(<<~HTML)
+        <meta class="elastic" name="product_name" content="BarSubject"/>
+      HTML
+    end
+    it 'has an elastic meta product_version tag' do
+      expect(converted).to include(<<~HTML)
+        <meta class="elastic" name="product_version" content="BazIdentifier"/>
+      HTML
+    end
+    it 'has an elastic meta website_area tag' do
+      expect(converted).to include(<<~HTML)
+        <meta class="elastic" name="website_area" content="documentation"/>
+      HTML
+    end
     it 'has DC.type' do
       expect(converted).to include(<<~HTML)
         <meta name="DC.type" content="FooType"/>
@@ -74,7 +95,10 @@ RSpec.describe DocbookCompat do
     end
     context 'the title' do
       it 'includes Elastic' do
-        expect(converted).to include('<title>Title | Elastic</title>')
+        expect(converted).to include(<<~HTML)
+          <title>Title | Elastic</title>
+          <meta class="elastic" name="content" content="Title">
+        HTML
       end
     end
     context 'the body' do
@@ -356,7 +380,10 @@ RSpec.describe DocbookCompat do
       end
       context 'the title' do
         it "doesn't include the subtitle" do
-          expect(converted).to include('<title>Title | Elastic</title>')
+          expect(converted).to include(<<~HTML)
+            <title>Title | Elastic</title>
+            <meta class="elastic" name="content" content="Title">
+          HTML
         end
       end
       context 'the header' do
@@ -387,7 +414,10 @@ RSpec.describe DocbookCompat do
       end
       context 'the title' do
         it 'only includes the text of the title' do
-          expect(converted).to include('<title>foo | Elastic</title>')
+          expect(converted).to include(<<~HTML)
+            <title>foo | Elastic</title>
+            <meta class="elastic" name="content" content="foo">
+          HTML
         end
       end
       context 'the header' do
@@ -596,7 +626,10 @@ RSpec.describe DocbookCompat do
       end
       context 'the title' do
         it 'includes Elastic' do
-          expect(converted).to include('<title>Title [fooo] | Elastic</title>')
+          expect(converted).to include(<<~HTML)
+            <title>Title [fooo] | Elastic</title>
+            <meta class="elastic" name="content" content="Title [fooo]">
+          HTML
         end
       end
     end


### PR DESCRIPTION
### Summary

This PR adds the following Elastic meta attributes to the doc build:

- [x] `website_area`
- [x] `product_version`
- [x] `product_name`
- [x] `content`

For example, [this page](https://docs_2581.docs-preview.app.elstc.co/guide/en/observability/current/observability-introduction.html) in the preview has the following meta tags:

```html
<meta class="elastic" name="content" content="What is Elastic Observability? | Observability Guide [8.5]">
<meta class="elastic" name="product_name" content="Observability">
<meta class="elastic" name="product_version" content="8.5">
<meta class="elastic" name="website_area" content="documentation">
```

### How it works

I added to the existing DocBook compatibility components of our doc build:

`convert_document.rb` manipulates the page `<title>` using book attributes. I extended this functionality to add an Elastic meta tag using the same attributes.

`extra_docinfo.rb` adds DocBook compatibility meta tags to each page of the built docs. I extended this functionality to add Elastic meta tags using the same and new attributes.

### Out of scope

* Meta attribute overrides
* `is_current_product_version`
* `thumbnail_image`