### PR TITLE
Fix race condition in link to current docs

### DIFF
--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -309,7 +309,8 @@ $(function() {
   // Empty column below TOC on small screens so the demand gen content can be positioned under the main content
   var bottom_left_col = $('#bottom_left_col');
 
-  $('.page_header > a[href="../current/index.html"]').click(function() {
+  $('.page_header > a[href="../current/index.html"]').click(function(e) {
+    e.preventDefault();
     utils.get_current_page_in_version('current');
   });
 

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -311,7 +311,9 @@ $(function() {
 
   $('.page_header > a[href="../current/index.html"]').click(function(e) {
     e.preventDefault();
-    utils.get_current_page_in_version('current');
+    utils.get_current_page_in_version('current').fail(function() {
+      location.href = "../current/index.html"
+    });
   });
 
   // Enable Sense widget


### PR DESCRIPTION
Fixes a race condition that would break the link to the current release documentation in the banner at the top of older docs. Thank you @jloleysens  !

I've tested this fix on a local build of the docs and haven't seen the race condition since.