### PR TITLE
fix: '_find_toplevel' fails due to "fatal: detected dubious ownership in repository" error from latest git

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -17,7 +17,7 @@
 
 import errno
 import logging
-from os import environ, getgid, getuid
+from os import environ
 from os.path import basename, dirname, exists, expanduser, isdir
 from os.path import join, normpath, realpath
 import re
@@ -551,12 +551,6 @@ def standard_docker_args():
     docker_args = []
     # Remove the container immediately when we're done building the docs
     docker_args.append('--rm')
-    # Make sure we create files as the current user because that is what
-    # folks that use build_docs.pl expect.
-    uid = getuid()
-    if uid == 0:
-        raise ArgError("This process isn't likely to suceed if run as root")
-    docker_args.extend(['--user', '%d:%d' % (uid, getgid())])
     # Mount the docs build code so we can run it!
     docker_args.extend(['-v', '%s:/docs_build:cached' % DIR])
     # Seccomp adds a *devestating* performance overhead if you happen


### PR DESCRIPTION
A recent git update: add an owner check for the top-level directoy
  https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
This was breaking `git rev-parse --show-toplevel` call made in
build_docs.pl's `sub _find_toplevel` with the message:
    INFO:build_docs:fatal: detected dubious ownership in repository at 'some dir'
for some (macos?) users.

Removing the `--user $localUid:$localGid` for the `docker run ...` that
runs the doc build avoids this error by running the build as root
instead of as the local user (which is some UID that doesn't necessarily
map to a user in the docker container).

I am not sure there isn't some fallout from this change.
