### PR TITLE
Tell git to treat all directories as safe

### DIFF
--- a/build_docs
+++ b/build_docs
@@ -576,6 +576,8 @@ def standard_docker_args():
                         '--tmpfs', '/var/lib/nginx/proxy',
                         '--tmpfs', '/var/lib/nginx/uwsgi',
                         '--tmpfs', '/var/lib/nginx/scgi'])
+    # Mount in a custom gitconfig that treats all directories as safe
+    docker_args.extend(['-v', '%s/gitconfig:/.gitconfig' % DIR])
     return docker_args
 
 

--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,2 @@
+[safe]
+    directory = *


### PR DESCRIPTION
With a recent change to git [1], running commands like `git rev-parse --show-toplevel` will fail when different directories are owned by different users. Because of the complexity of how we use Docker and expect it to work across different operating systems, the easiest approach is to restore the prior behavior. [2]

Rather than trying to run `git config` from within the build process (which runs into its own file permission errors depending on who is running the command), instead we just hardcode the "global" gitconfig file (which is located at the root of the Docker container).

[1]: https://github.com/git/git/commit/8959555cee7ec045958f9b6dd62e541affb7e7d9
[2]: https://git-scm.com/docs/git-config#Documentation/git-config.txt-safedirectory

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
