### PR TITLE
Removed Perl client branches in favor of 8.x and 7.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -557,8 +557,8 @@ contents:
               - title:      Perl Client
                 prefix:     perl-api
                 current:    master
-                branches:   [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ master, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                branches:   [ master, 8.x, 7.x ]
+                live:       [ master, 8.x, 7.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Perl


### PR DESCRIPTION
This PR removes the `branches` and `live` for Perl Client in favor of `8.x` and `7.x` only. This change is required since the Perl client announced [End-of-Life for version 8](https://github.com/elastic/elasticsearch-perl/issues/220) and we are not going to branch anymore with the stack version. Moreover, the old 8.0 to 8.6 branches are going to be removed.