### PR TITLE
Add kibana repo dependency to Security Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1672,6 +1672,10 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
+              -
+                repo:   kibana
+                path:   docs
+                exclude_branches: [ 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -79,7 +79,7 @@ alias docbldsoold=docbldso
 alias docbldaz='$GIT_HOME/docs/build_docs --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/security-docs/docs/index.asciidoc --resource $GIT_HOME/stack-docs/docs --chunk 1'
+alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/security-docs/docs/index.asciidoc --resource $GIT_HOME/stack-docs/docs --resource=$GIT_HOME/kibana/docs --chunk 1'
 
 alias docbldepd='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/endpoint/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
This PR updates the Elastic Security Guide to pull content from the kibana repo so that we can re-use some tagged regions.