### PR TITLE
Promote ECK 2.6 branch to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -860,7 +860,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.5
+            current:    2.6
             branches:   [ {main: master}, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR sets the ECK 2.6 branch as the current version.

I am submitting this early to get approval. It should only be merged on Jan 10th after https://github.com/elastic/docs/pull/2590 is merged and ECK 2.6 is released.