### PR TITLE
Add kibana dependency to Observability Guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1163,6 +1163,10 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+              -
+                repo:   kibana
+                path:   docs
+                exclude_branches: [ 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -102,7 +102,7 @@ alias docbldeesr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-ru
 alias docbldewsn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/client-docs/workplace-search-node/index.asciidoc --single'
 
 # Observability Guide
-alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide'
+alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/kibana/docs'
 
 # Observability Legacy
 alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/metrics/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR updates the Observability Guide to pull content from the kibana repo so that we can re-use some tagged regions.