### PR TITLE
[Docs release] Bump current version to 8.6

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -75,10 +75,10 @@ contents_title:     Welcome to Elastic Docs
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.5
-  stacklive: &stacklive [ master, 8.5, 7.17 ]
+  stackcurrent: &stackcurrent 8.6
+  stacklive: &stacklive [ master, 8.6, 7.17 ]
 
-  stacklivemain: &stacklivemain [ main, 8.5, 7.17 ]
+  stacklivemain: &stacklivemain [ main, 8.6, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-84
 
@@ -129,7 +129,7 @@ contents:
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
             branches:   [ {main: master}, 8.6, 8.5, 8.4, 7.17 ]
-            live:       [ 8.5 ]
+            live:       [ 8.6 ]
             chunk:      1
             tags:       Elastic/Welcome
             subject:    Welcome to Elastic

--- a/shared/versions/stack/8.5.asciidoc
+++ b/shared/versions/stack/8.5.asciidoc
@@ -23,7 +23,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.6.asciidoc
+++ b/shared/versions/stack/8.6.asciidoc
@@ -18,12 +18,12 @@ bare_version never includes -alpha or -beta
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.5.asciidoc[]
+include::8.6.asciidoc[]


### PR DESCRIPTION
Changes the "current" version of Elastic documentation to 8.6.

DO NOT MERGE UNTIL RELEASE DAY