### PR TITLE
ESS - Changing current to ms-86

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.5, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-84
+  cloudSaasCurrent: &cloudSaasCurrent ms-86
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-81: master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-86.
Do not merge until release day.
