### PR TITLE
ECS 8.6 Release - change the "current" version selector

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -244,7 +244,7 @@ contents:
                 path:   shared/settings.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.5
+            current:    8.6
             branches:   [  {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.6, 8.5, 8.4, 8.3, 1.12 ]
             index:      docs/index.asciidoc


### PR DESCRIPTION
Open a docs PR to change the "current" version selector.
