### PR TITLE
Update build config for Enterprise Search Node.js client

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1060,7 +1060,7 @@ contents:
                 private:    1
                 single:     1
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1 ]
+                branches:   [ {main: master}, 8.6]
                 live:       [ main, 8.6 ]
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js

--- a/conf.yaml
+++ b/conf.yaml
@@ -1038,6 +1038,23 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
+              - title:      App Search Node.js client
+                prefix:     app-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      client-docs/app-search-node/index.asciidoc
+                tags:       App Search Clients/Node.js
+                subject:    App Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/app-search-node
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 private:    1
@@ -1097,6 +1114,23 @@ contents:
                   -
                     repo:   enterprise-search-ruby
                     path:   docs/guide/
+                  -
+                    repo:   docs
+                    path:   shared/versions/stack/{version}.asciidoc
+              - title:      Workplace Search Node.js client
+                prefix:     workplace-search-node
+                private:    1
+                single:     1
+                current:    *stackcurrent
+                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                live:       *stacklivemain
+                index:      client-docs/workplace-search-node/index.asciidoc
+                tags:       Workplace Search Clients/Node.js
+                subject:    Workplace Search Clients
+                sources:
+                  -
+                    repo:   enterprise-search-pubs
+                    path:   client-docs/workplace-search-node
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1061,7 +1061,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
-                live:       [ main, 8.6 ]
+                live:       *stacklivemain
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -1062,13 +1062,13 @@ contents:
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
                 live:       [ main, 8.6 ]
-                index:      docs/guide/index.asciidoc
+                index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients
                 sources:
                   -
                     repo:   enterprise-search-js
-                    path:   docs/guide
+                    path:   packages/enterprise-search/docs
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1062,7 +1062,7 @@ contents:
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
                 live:       [ main, 8.6 ]
-                chunk:      1
+                chunk:      2
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -1061,14 +1061,14 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1 ]
-                live:       [ main, 8.5 ]
-                index:      client-docs/enterprise-search-node/index.asciidoc
+                live:       [ main, 8.6 ]
+                index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients
                 sources:
                   -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/enterprise-search-node
+                    repo:   enterprise-search-node-js
+                    path:   docs/guide
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1062,6 +1062,7 @@ contents:
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
                 live:       [ main, 8.6 ]
+                chunk:      1
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -1038,23 +1038,6 @@ contents:
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc
-              - title:      App Search Node.js client
-                prefix:     app-search-node
-                private:    1
-                single:     1
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      client-docs/app-search-node/index.asciidoc
-                tags:       App Search Clients/Node.js
-                subject:    App Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/app-search-node
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 private:    1
@@ -1114,23 +1097,6 @@ contents:
                   -
                     repo:   enterprise-search-ruby
                     path:   docs/guide/
-                  -
-                    repo:   docs
-                    path:   shared/versions/stack/{version}.asciidoc
-              - title:      Workplace Search Node.js client
-                prefix:     workplace-search-node
-                private:    1
-                single:     1
-                current:    *stackcurrent
-                branches:   [ {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
-                index:      client-docs/workplace-search-node/index.asciidoc
-                tags:       Workplace Search Clients/Node.js
-                subject:    Workplace Search Clients
-                sources:
-                  -
-                    repo:   enterprise-search-pubs
-                    path:   client-docs/workplace-search-node
                   -
                     repo:   docs
                     path:   shared/versions/stack/{version}.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1067,7 +1067,7 @@ contents:
                 subject:    Enterprise Search Clients
                 sources:
                   -
-                    repo:   enterprise-search-node-js
+                    repo:   enterprise-search-js
                     path:   docs/guide
                   -
                     repo:   docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1061,7 +1061,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
-                live:       *stacklivemain
+                live:       [ main, 8.6 ]
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/conf.yaml
+++ b/conf.yaml
@@ -1057,12 +1057,9 @@ contents:
                     path:   shared/versions/stack/{version}.asciidoc
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
-                private:    1
-                single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.6]
                 live:       [ main, 8.6 ]
-                chunk:      2
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -117,6 +117,7 @@ Elastic-level pages
 :enterprise-search-ref: https://www.elastic.co/guide/en/enterprise-search/{branch}
 :app-search-ref:       https://www.elastic.co/guide/en/app-search/{branch}
 :workplace-search-ref: https://www.elastic.co/guide/en/workplace-search/{branch}
+:enterprise-search-node-ref: https://www.elastic.co/guide/en/enterprise-search-clients/node/{branch}
 :enterprise-search-php-ref: https://www.elastic.co/guide/en/enterprise-search-clients/php/{branch}
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/{branch}
 :enterprise-search-ruby-ref: https://www.elastic.co/guide/en/enterprise-search-clients/ruby/{branch}


### PR DESCRIPTION
Updates build to generate Ent Search node client docs, added in this [PR](https://github.com/elastic/enterprise-search-js/pull/20) and to 8.6 branch in [this PR](https://github.com/elastic/enterprise-search-js/pull/21).

- Updates `conf.yaml` to build Enterprise Search Node.js client docs from the [GH repo](https://github.com/elastic/enterprise-search-js/tree/main/packages/enterprise-search)
   - Remove deprecated clients from build
- Adds `enterprise-search-node-ref` to shared attributes