### PR TITLE
Changes for ECS 8.7 SFF

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -245,8 +245,8 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    8.6
-            branches:   [  {main: master}, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.6, 8.5, 8.4, 8.3, 1.12 ]
+            branches:   [  {main: master}, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.6
+:ecs_version:            8.7
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
Related to ECS Soft Feature Freeze 8.7

PR Adds the new version 8.7 to the selector in conf.yaml.
PR does not update the current attribute
PR adds the new branch to the branches attribute and
also adds the upcoming release branch to the live attribute.

Maps the upcoming ecs_version to the next stack version in shared/versions/stack/master.asciidoc