### PR TITLE
Add attribute for stack rules feature

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -184,6 +184,7 @@ Kibana app and UI names
 :rac-ui:             Rules and Connectors
 :connectors-ui:      Connectors
 :connectors-feature: Actions and Connectors
+:stack-rules-feature: Stack Rules
 :user-experience:    User Experience
 :ems:                Elastic Maps Service
 :ems-init:           EMS


### PR DESCRIPTION
This PR adds a shared attribute for the "Stack Rules" feature, which is one of the groupings in Kibana feature privileges and referenced in the prerequisites of many rule APIs.