### PR TITLE
Bump docs version to 8.6.1

### DIFF
--- a/shared/versions/stack/8.6.asciidoc
+++ b/shared/versions/stack/8.6.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.6.0
+:version:                8.6.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.6.0
-:logstash_version:       8.6.0
-:elasticsearch_version:  8.6.0
-:kibana_version:         8.6.0
-:apm_server_version:     8.6.0
+:bare_version:           8.6.1
+:logstash_version:       8.6.1
+:elasticsearch_version:  8.6.1
+:kibana_version:         8.6.1
+:apm_server_version:     8.6.1
 :branch:                 8.6
 :minor-version:          8.6
 :major-version:          8.x


### PR DESCRIPTION
This updates the stack docs shared version attributes to `8.6.1`.

[docs release issue](https://github.com/elastic/dev/issues/2195)

Note that this is a replacement for #2598 that strangely started to repeatedly fail the `self-check` CI check.