### PR TITLE
Bump docs version to 7.17.9

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.8
+:version:                7.17.9
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.8
-:logstash_version:       7.17.8
-:elasticsearch_version:  7.17.8
-:kibana_version:         7.17.8
-:apm_server_version:     7.17.8
+:bare_version:           7.17.9
+:logstash_version:       7.17.9
+:elasticsearch_version:  7.17.9
+:kibana_version:         7.17.9
+:apm_server_version:     7.17.9
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
🛑 Do not merge until release day.

This updates the stack docs shared version attributes to `7.17.9`.

[docs release issue](https://github.com/elastic/dev/issues/2195)