### PR TITLE
ESS - Change current to ms-87

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.6, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-86
+  cloudSaasCurrent: &cloudSaasCurrent ms-87
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-81: master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-87.

Do not merge until release day.