### PR TITLE
Change key file permissions to `644`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM bitnami/minideb:buster AS base
 RUN install_packages apt-transport-https gnupg2 ca-certificates
 COPY .docker/apt/keys/nodesource.gpg /
 RUN apt-key add /nodesource.gpg
-COPY .docker/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/
+COPY --chmod=644 .docker/apt/sources.list.d/nodesource.list /etc/apt/sources.list.d/
 RUN install_packages \
   build-essential python2 \
     # needed for compiling native modules on ARM


### PR DESCRIPTION
### Summary

The doc build is failing with the following error:

```
09:33:47 INFO:docker build:#10 4.858 E: The repository 'https://deb.nodesource.com/node_12.x buster Release' does not have a Release file.
```

I found [this stackexchange answer](https://unix.stackexchange.com/questions/541939/whats-going-wrong-with-my-attempt-to-install-upgrade-node-js-in-linux) which explained that a permissions problem usually causes this problem. This PR changes the permissions for nodesource key-file to `-rw-r--r--` (`644`).