### PR TITLE
Adding Curator 8.0 as current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -707,8 +707,8 @@ contents:
                 path:   docs/src/reference/asciidoc
           - title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
-            current:    5.8
-            branches:   [ 5.x, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
+            current:    8.0
+            branches:   [ 8.0, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
             subject:    Clients


### PR DESCRIPTION
Will add 7 and 6 afterwards as single steps to avoid losing all at once.

