### PR TITLE
Adding Curator 6.0 and 7.0 doc branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -708,7 +708,7 @@ contents:
           - title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
             current:    8.0
-            branches:   [ 8.0, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
+            branches:   [ 8.0, 7.0, 6.0, 5.8, 5.7, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.3, 4.2, 4.1, 4.0, 3.5, 3.4, 3.3 ]
             index:      docs/asciidoc/index.asciidoc
             tags:       Clients/Curator
             subject:    Clients


### PR DESCRIPTION
I previously fixed these as well, but wanted 8.0 in for certain, rather than have it held up.
