### PR TITLE
Fix text on landing page SIEM card

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -250,7 +250,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
             Protect my environment
           </h4>
-          <p>Use detect, investigate, and respond to threats with Elastic Security for SIEM.</p>
+          <p>Detect, investigate, and respond to threats with Elastic Security for SIEM.</p>
         </div>
       </a>
     </div>


### PR DESCRIPTION
I just noticed that the text on our [landing page](https://www.elastic.co/guide/index.html) for the SIEM getting started guide needs a small fix to remove the "Use".

![Screenshot 2023-02-06 at 3 47 42 PM](https://user-images.githubusercontent.com/41695641/217081914-b1dd0419-b9c6-41ce-888c-cc413963ebf0.png)



