### PR TITLE
Add dropdown for APM and ECS logging books

### DIFF
--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -12,7 +12,63 @@ module Chunker
       result = ['<div class="breadcrumbs">']
       result += generate_breadcrumb_links(section).reverse
       result << '</div>'
+      if result[2].to_s.include? 'APM'
+        result.insert(2, generate_apm_breadcrumbs)
+      end
+      if result[2].to_s.include? 'ECS Logging'
+        result.insert(2, generate_ecslogging_breadcrumbs)
+      end
       Asciidoctor::Block.new doc, :pass, source: result.join("\n")
+    end
+
+    def generate_apm_breadcrumbs
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div class="dropdown">
+            <span>APM ▾</span>
+              <div class="dropdown-content">
+                <strong>APM</strong></br>
+                <a href="https://www.elastic.co/guide/en/apm/guide/current/index.html">APM Guide</a></br>
+                <strong>APM agents</strong></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/android/current/index.html">Android agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/go/current/index.html">Go agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/swift/current/index.html">iOS agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/java/current/index.html">Java agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/dotnet/current/index.html">.NET agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/nodejs/current/index.html">Node.js agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/php/current/index.html">PHP agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/python/current/index.html">Python agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/ruby/current/index.html">Ruby agent</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html">RUM Agent</a></br>
+                <strong>APM extensions</strong></br>
+                <a href="https://www.elastic.co/guide/en/apm/lambda/current/index.html">AWS Lambda extension</a></br>
+                <a href="https://www.elastic.co/guide/en/apm/attacher/current/index.html">APM attacher</a>
+            </div>
+          </div>
+        <span class="chevron-right">›</span>
+      HTML
+    end
+
+    def generate_ecslogging_breadcrumbs
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div class="dropdown">
+            <span>ECS Logging ▾</span>
+              <div class="dropdown-content">
+                <strong>ECS Logging</strong></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/overview/current/index.html">Overview</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/go-logrus/current/index.html">Go (Logrus)</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/go-zap/current/index.html">Go (Zap)</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Java</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/dotnet/current/index.html">.NET</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/nodejs/current/index.html">Node.js</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/ruby/current/index.html">Ruby</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/php/current/index.html">PHP</a></br>
+                <a href="https://www.elastic.co/guide/en/ecs-logging/python/current/index.html">Python</a></br>
+            </div>
+          </div>
+        <span class="chevron-right">›</span>
+      HTML
     end
 
     def generate_breadcrumb_links(section)

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -28,21 +28,21 @@ module Chunker
             <span>APM ▾</span>
               <div class="dropdown-content">
                 <strong>APM</strong></br>
-                <a href="https://www.elastic.co/guide/en/apm/guide/current/index.html">APM Guide</a></br>
+                <a href="/guide/en/apm/guide/current/index.html">APM Guide</a></br>
                 <strong>APM agents</strong></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/android/current/index.html">Android agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/go/current/index.html">Go agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/swift/current/index.html">iOS agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/java/current/index.html">Java agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/dotnet/current/index.html">.NET agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/nodejs/current/index.html">Node.js agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/php/current/index.html">PHP agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/python/current/index.html">Python agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/ruby/current/index.html">Ruby agent</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/agent/rum-js/current/index.html">RUM Agent</a></br>
+                <a href="/guide/en/apm/agent/android/current/index.html">Android agent</a></br>
+                <a href="/guide/en/apm/agent/go/current/index.html">Go agent</a></br>
+                <a href="/guide/en/apm/agent/swift/current/index.html">iOS agent</a></br>
+                <a href="/guide/en/apm/agent/java/current/index.html">Java agent</a></br>
+                <a href="/guide/en/apm/agent/dotnet/current/index.html">.NET agent</a></br>
+                <a href="/guide/en/apm/agent/nodejs/current/index.html">Node.js agent</a></br>
+                <a href="/guide/en/apm/agent/php/current/index.html">PHP agent</a></br>
+                <a href="/guide/en/apm/agent/python/current/index.html">Python agent</a></br>
+                <a href="/guide/en/apm/agent/ruby/current/index.html">Ruby agent</a></br>
+                <a href="/guide/en/apm/agent/rum-js/current/index.html">RUM Agent</a></br>
                 <strong>APM extensions</strong></br>
-                <a href="https://www.elastic.co/guide/en/apm/lambda/current/index.html">AWS Lambda extension</a></br>
-                <a href="https://www.elastic.co/guide/en/apm/attacher/current/index.html">APM attacher</a>
+                <a href="/guide/en/apm/lambda/current/index.html">AWS Lambda extension</a></br>
+                <a href="/guide/en/apm/attacher/current/index.html">APM attacher</a>
             </div>
           </div>
         <span class="chevron-right">›</span>
@@ -56,15 +56,15 @@ module Chunker
             <span>ECS Logging ▾</span>
               <div class="dropdown-content">
                 <strong>ECS Logging</strong></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/overview/current/index.html">Overview</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/go-logrus/current/index.html">Go (Logrus)</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/go-zap/current/index.html">Go (Zap)</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/java/current/index.html">Java</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/dotnet/current/index.html">.NET</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/nodejs/current/index.html">Node.js</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/ruby/current/index.html">Ruby</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/php/current/index.html">PHP</a></br>
-                <a href="https://www.elastic.co/guide/en/ecs-logging/python/current/index.html">Python</a></br>
+                <a href="/guide/en/ecs-logging/overview/current/index.html">Overview</a></br>
+                <a href="/guide/en/ecs-logging/go-logrus/current/index.html">Go (Logrus)</a></br>
+                <a href="/guide/en/ecs-logging/go-zap/current/index.html">Go (Zap)</a></br>
+                <a href="/guide/en/ecs-logging/java/current/index.html">Java</a></br>
+                <a href="/guide/en/ecs-logging/dotnet/current/index.html">.NET</a></br>
+                <a href="/guide/en/ecs-logging/nodejs/current/index.html">Node.js</a></br>
+                <a href="/guide/en/ecs-logging/ruby/current/index.html">Ruby</a></br>
+                <a href="/guide/en/ecs-logging/php/current/index.html">PHP</a></br>
+                <a href="/guide/en/ecs-logging/python/current/index.html">Python</a></br>
             </div>
           </div>
         <span class="chevron-right">›</span>

--- a/resources/web/style/nav.pcss
+++ b/resources/web/style/nav.pcss
@@ -49,10 +49,30 @@
     display: none;
     width: 100%;
   }
+
   .navfooter {
     border-top: 1px dotted #E8E8E8;
     padding-top: 10px;
     margin: 60px 0 15px;
+  }
+
+  .dropdown {
+    position: relative;
+    display: inline-block;
+  }
+
+  .dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    min-width: 200px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    padding: 12px 16px;
+    z-index: 1;
+  }
+
+  .dropdown:hover .dropdown-content {
+    display: block;
   }
 }
 


### PR DESCRIPTION
### Summary

This PR adds a simple breadcrumb dropdown to the APM and ECS logging books. This dropdown makes it easier for users to navigate between books with related content.

<img width="1237" alt="Screenshot 2023-02-11 at 6 40 51 PM" src="https://user-images.githubusercontent.com/5618806/218289905-6f31389d-b3fb-4b32-b4a3-281322771d32.png">

### Preview

APM: https://docs_2617.docs-preview.app.elstc.co/guide/en/apm/guide/current/apm-components.html
ECS Logging: https://docs_2617.docs-preview.app.elstc.co/guide/en/ecs-logging/overview/current/intro.html

### Limitations

All navigation items are hardcoded, not generated. This means if a new APM or ECS logging book is added to the doc build, it will also need to be manually added to the dropdown array.

### Related

* Closes https://github.com/elastic/observability-docs/issues/2058.