### PR TITLE
Add elasticsearch-net doc code snippets directory

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -538,6 +538,9 @@ contents:
                   -
                     repo:   elasticsearch-net
                     path:   docs/
+                  -
+                    repo:   elasticsearch-net
+                    path:   tests/Tests/Documentation
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent


### PR DESCRIPTION
As with #2308 - This PR adds the path to test source code in the `elasticsearch-net` configuration.

https://github.com/elastic/elasticsearch-net/pull/7272 pulls code snippets in the document from test source code, which is not checked out by the docs build process.
