### PR TITLE
Add noindex tag to Azure Marketplace docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -261,6 +261,7 @@ contents:
             index:      docs/index.asciidoc
             branches:   [ master, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
+            noindex:    1
             tags:       Elastic Stack/Azure
             subject:    Azure Marketplace and Resource Manager (ARM) template
             sources:


### PR DESCRIPTION
We've been requested by the marketing team working with MS Azure to help reduce the prominence of the [Azure Marketplace Solution](https://www.elastic.co/guide/en/elastic-stack-deploy/master/azure-marketplace.html) docs in the Google search results. The change here will help with that.

Separately, I've added a recommendation notice at the top of those docs guiding people toward the newer Elastic Cloud offering in Azure Marketplace, as well as the associated docs.