### PR TITLE
Update auditbeat doc build alias

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -151,8 +151,9 @@ alias docbldmb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GI
 
 alias docbldhb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/heartbeat/docs/index.asciidoc --chunk 1'
 
-alias docbldab='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --chunk 1'
 alias docbldabx='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/auditbeat/docs/index.asciidoc --resource=$GIT_HOME/beats/x-pack/auditbeat --chunk 1'
+
+alias docbldab=docbldabx
 
 alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/x-pack/functionbeat/docs/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
The `docbldab` alias does not work. The files in the x-pack directory are required to build the Auditbeat Reference.