### PR TITLE
Update Rust Client to build from main

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -595,8 +595,8 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    master
-                branches:   [ master, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
-                live:       [ master, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                branches:   [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                live:       [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1
                 tags:       Clients/Rust

--- a/conf.yaml
+++ b/conf.yaml
@@ -595,7 +595,7 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    main
-                branches:   [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                branches:   [ {main: master}, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 live:       [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1

--- a/conf.yaml
+++ b/conf.yaml
@@ -594,7 +594,7 @@ contents:
                     path:   docs/guide
               - title:      Rust Client
                 prefix:     rust-api
-                current:    master
+                current:    main
                 branches:   [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 live:       [ main, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc


### PR DESCRIPTION
The elasticsearch-rs repo now builds from main rather than master as a result of [this commit](https://github.com/elastic/elasticsearch-rs/commit/790d523e0b436da3765e80c4da6927814a58c2a1). This updates the doc builds accordingly.
