### PR TITLE
Promote ECK 2.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -859,7 +859,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.6
+            current:    2.7
             branches:   [ {main: master}, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This promotes ECK 2.7 branch to current.

It should be merged:
- after https://github.com/elastic/docs/pull/2632
- once ECK 2.7 is released