### PR TITLE
Start building ESF documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -49,6 +49,7 @@ repos:
     enterprise-search-php: https://github.com/elastic/enterprise-search-php.git
     enterprise-search-python: https://github.com/elastic/enterprise-search-python.git
     enterprise-search-ruby: https://github.com/elastic/enterprise-search-ruby.git
+    esf:                  https://github.com/elastic/elastic-serverless-forwarder.git
     guide:                https://github.com/elastic/elasticsearch-definitive-guide.git
     guide-cn:             https://github.com/elasticsearch-cn/elasticsearch-definitive-guide.git
     ingest-docs:          https://github.com/elastic/ingest-docs.git
@@ -1808,6 +1809,22 @@ contents:
               -
                 repo:   package-spec
                 path:   spec
+
+    -   title:      "Cloud Native: Ship Data from your Cloud Provider"
+        sections:
+          - title:      Elastic Serverless Forwarder
+            prefix:     en/esf
+            index:      docs/index.asciidoc
+            current:    master
+            branches:   [ {main: master} ]
+            live:       master
+            chunk:      2
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   esf
+                path:   docs
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1810,14 +1810,14 @@ contents:
                 repo:   package-spec
                 path:   spec
 
-    -   title:      "Cloud Native: Ship Data from your Cloud Provider"
+    -   title:      "Cloud Native: Ship Data from Your Cloud Provider"
         sections:
           - title:      Elastic Serverless Forwarder
             prefix:     en/esf
-            index:      docs/index.asciidoc
-            current:    master
+            index:      docs/en/index.asciidoc
+            current:    main
             branches:   [ {main: master} ]
-            live:       master
+            live:       [ main ]
             chunk:      2
             tags:       Cloud Native Ingest/Reference
             subject:    cloud native ingest

--- a/conf.yaml
+++ b/conf.yaml
@@ -1824,7 +1824,13 @@ contents:
             sources:
               -
                 repo:   esf
-                path:   docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
     -   title:      "Beats: Collect, Parse, and Ship"
         sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -14,6 +14,9 @@ alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/re
 
 alias docbldes=docbldesx
 
+# Elasticsearch Serverless Forwarder
+alias docbldesf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-serverless-forwarder/docs/en/index.asciidoc --chunk 2'
+
 # Elasticsearch 6.2 and earlier
 
 alias docbldesold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -45,6 +45,7 @@
 :apm-lambda-ref:       https://www.elastic.co/guide/en/apm/lambda/current
 :apm-attacher-ref:     https://www.elastic.co/guide/en/apm/attacher/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
+:esf-ref:              https://www.elastic.co/guide/en/esf/{esf-version}
 ///////
 Elastic-level pages
 ///////
@@ -131,6 +132,7 @@ Elastic-level pages
 Elastic Cloud
 //////////
 :ecloud:      Elastic Cloud
+:esf:         Elastic Serverless Forwarder
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -15,7 +15,6 @@ bare_version never includes -alpha or -beta
 :major-version-only:     8
 :ecs_version:            8.7
 :esf_version:            master
-:esf_version:            master
 
 //////////
 release-state can be: released | prerelease | unreleased

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -14,6 +14,8 @@ bare_version never includes -alpha or -beta
 :prev-major-last:        7.17
 :major-version-only:     8
 :ecs_version:            8.7
+:esf_version:            master
+:esf_version:            master
 
 //////////
 release-state can be: released | prerelease | unreleased


### PR DESCRIPTION
### Related issues and PRs:

* https://github.com/elastic/observability-docs/issues/2716
* https://github.com/elastic/elastic-serverless-forwarder/pull/270
* https://github.com/elastic/elastic-serverless-forwarder/pull/311

Note that https://github.com/elastic/elastic-serverless-forwarder/pull/311 contains https://github.com/elastic/elastic-serverless-forwarder/pull/270. Just wanted to work in an isolated branch until [#270](https://github.com/elastic/elastic-serverless-forwarder/pull/270) is merged.

### Updated docs page (proposed--please opine)

![image](https://user-images.githubusercontent.com/14206422/231294760-5a18b6ff-d8ff-4118-9427-ce85cfac377f.png)


### TODOs

- [x] Update conf.yaml
- [x] Add shared attribute for esf-ref (path for new ESF docs).
- [x] Add shared attribute for esf (Elastic Serverless Forwarder).
- [ ] After merging this PR, stop building ESF docs from main in obs-docs repo.
- [ ] Set up global redirects for ESF links in master.
- [ ] Make sure any in-progress PRs in the obs-docs repo get handled correctly (for example, https://github.com/elastic/observability-docs/pull/2661)