### PR TITLE
Add K8s monitoring guide to docs landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -255,7 +255,17 @@
       </a>
     </div>
   </div>
-
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-kubernetes.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
+          Observe Kubernetes
+        </h4>
+        <p>Monitor your Kubernetes infrastructure with Elastic Observability.</p>
+      </div>
+    </a>
+  </div>
   <div class="row my-4">
    <div class="col-md-4 col-12 mb-2">
     <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">


### PR DESCRIPTION
This updates the [docs landing page](https://www.elastic.co/guide/index.html) with a card for the new [K8s monitoring onboarding guide](https://www.elastic.co/guide/en/welcome-to-elastic/8.7/getting-started-kubernetes.html).

Please don't merge until 8.7 GA. CI checks should pass once `current` is switched over to 8.7.