### PR TITLE
Update Preview image

### DIFF
--- a/preview/build.sh
+++ b/preview/build.sh
@@ -4,9 +4,14 @@
 
 set -eo pipefail
 
-export PREVIEW=docker.elastic.co/docs/preview:15
+export IMAGE=docker.elastic.co/docs/preview
+export VERSION=17
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --docker-build build
-DOCKER_BUILDKIT=1 docker build -t $PREVIEW -f preview/Dockerfile .
+DOCKER_BUILDKIT=1 docker build -t $IMAGE:$VERSION -f preview/Dockerfile .
 
+docker tag $IMAGE:$VERSION $IMAGE:latest
+
+# docker push $IMAGE:$VERSION
+# docker push $IMAGE:latest


### PR DESCRIPTION
We need a new image with the latest GitHub RSA SSH public key in order to fetch docs with Git in order to preview them.

Update the scripts a bit in the meantime to reflect what I did when building/testing/pushing this.

This doesn't need to get merged for the new image to get deployed (it already exists), but I wanted to keep this up to date with the current tagged version ("17") of the image.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
