### PR TITLE
Fix GS guide cards arrangement on landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -255,17 +255,6 @@
       </a>
     </div>
   </div>
-  <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-kubernetes.html">
-      <div class="card h-100">
-        <h4 class="mt-3">
-          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
-          Observe Kubernetes
-        </h4>
-        <p>Monitor your Kubernetes infrastructure with Elastic Observability.</p>
-      </div>
-    </a>
-  </div>
   <div class="row my-4">
    <div class="col-md-4 col-12 mb-2">
     <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
@@ -275,6 +264,17 @@
           Security
         </h4>
         <p>Protect hosts with endpoint threat intelligence from Elastic Security.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-kubernetes.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
+          Observe Kubernetes
+        </h4>
+        <p>Monitor your Kubernetes infrastructure with Elastic Observability.</p>
       </div>
     </a>
   </div>


### PR DESCRIPTION
This should fix the arrangement of the GS Guide cards on the docs landing page.

![Screenshot 2023-03-30 at 12 11 18 PM](https://user-images.githubusercontent.com/41695641/228898874-3a046cfd-0e0d-4c8c-a60a-f57fcda05063.png)
