### PR TITLE
Warn on master links

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -1129,4 +1129,7 @@ sub check_opts {
         die('--reference only compatible with --all or --preview') if $Opts->{reference};
         die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
     }
+    if ($Opts->{skiplinkcheck} && $Opts->{warnlinkcheck} ) {
+        die('--warnlinkcheck is incompatible with --skiplinkcheck');
+    }
 }

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -337,9 +337,13 @@ sub check_links {
         say $link_checker->report;
     }
     else {
+      if ( $Opts->{warnlinkcheck} ){
+        say $link_checker->report;
+      }
+      else {
         die $link_checker->report;
+      }
     }
-
 }
 
 #===================================
@@ -1007,6 +1011,7 @@ sub command_line_opts {
         'reference=s',
         'reposcache=s',
         'skiplinkcheck',
+        'warnlinkcheck',
         'sub_dir=s@',
         'user=s',
         # Options only compatible with --preview
@@ -1069,6 +1074,7 @@ sub usage {
           --repos_cache     Directory to which working repositories are cloned.
                             Defaults to `<script_dir>/.repos`.
           --skiplinkcheck   Omit the step that checks for broken links
+          --warnlinkcheck   Checks for broken links but does not fail if they exist
           --sub_dir         Use a directory as a branch of some repo
                             (eg --sub_dir elasticsearch:master:~/Code/elasticsearch)
           --target_repo     Repository to which to commit docs
@@ -1113,6 +1119,7 @@ sub check_opts {
         die('--rebuild only compatible with --all') if $Opts->{rebuild};
         die('--reposcache only compatible with --all') if $Opts->{reposcache};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
+        die('--warnlinkcheck only compatible with --all') if $Opts->{warnlinkcheck};
         die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
     }
     if ( !$Opts->{preview} ) {

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -333,16 +333,11 @@ sub check_links {
     check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
     # Comment out due to build errors
     # check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
-    if ( $link_checker->has_bad ) {
+    if ( $link_checker->has_bad || $Opts->{warnlinkcheck}) {
         say $link_checker->report;
     }
     else {
-      if ( $Opts->{warnlinkcheck} ){
-        say $link_checker->report;
-      }
-      else {
         die $link_checker->report;
-      }
     }
 }
 

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -333,7 +333,7 @@ sub check_links {
     check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
     # Comment out due to build errors
     # check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
-    if ( $link_checker->has_bad || $Opts->{warnlinkcheck}) {
+    if ( $link_checker->has_bad || $link_checker->has_warn || $Opts->{warnlinkcheck}) {
         say $link_checker->report;
     }
     else {

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -333,11 +333,19 @@ sub check_links {
     check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
     # Comment out due to build errors
     # check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
-    if ( $link_checker->has_bad || $link_checker->has_warn || $Opts->{warnlinkcheck}) {
+    if ( $Opts->{warnlinkcheck} || ($link_checker->has_bad && !$link_checker->has_warn)) {
+        #If --warnlinkcheck was specified or there are neither failing links nor warning links... don't die
         say $link_checker->report;
     }
     else {
-        die $link_checker->report;
+        if (!$link_checker->has_bad) {
+        # If --warnlinkcheck was not specified and there are failing links... die
+          die $link_checker->report;
+        }
+        else {
+        # If --warnlinkcheck was not specified and there are no failing links but there are warning links... don't die
+          say $link_checker->report;
+        }
     }
 }
 

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -118,10 +118,10 @@ RSpec.describe 'building all books' do
       it 'logs there are master links' do
         expect(outputs[-1]).to include('Bad master links')
       end
-      it 'logs the bad link' do
+      it 'logs the bad link to master' do
         expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
           /tmp/docsbuild/target_repo/html/test/current/chapter.html contains broken links to:
-           - foo
+           - master/foo
         LOG
       end
     end
@@ -181,7 +181,8 @@ RSpec.describe 'building all books' do
     end
     describe 'when there is a broken link in kibana to master' do
       include_context 'there is a broken link in kibana to master', true, false
-      include_examples 'there are broken links in kibana to master', 'foo'
+      include_examples 'there are broken links in kibana to master',
+                       'master/foo'
     end
     describe 'when a link in kibana goes to the website outside the guide' do
       include_context 'there is a kibana link', true,
@@ -214,8 +215,8 @@ RSpec.describe 'building all books' do
     end
     describe 'when there is a broken APM link' do
       include_context 'there is a kibana link', true,
-                      '${APM_DOCS}not-an-apm-page.html', false
-      include_examples 'there are broken links in kibana to master',
+                      '${APM_DOCS}not-an-apm-page.html', true
+      include_examples 'there are broken links in kibana',
                        'en/apm/not-an-apm-page.html'
     end
     describe 'when there is a broken Stack link' do

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -21,7 +21,15 @@ RSpec.describe 'building all books' do
     include_context 'there is a broken link in the docs',
                     'https://www.elastic.co/guide/foo', check_links
   end
+  shared_context 'there is a broken absolute link to master' do |check_links|
+    include_context 'there is a broken link in the docs',
+                    'https://www.elastic.co/guide/foo', check_links
+  end
   shared_context 'there is a broken relative link in the docs' do |check_links|
+    include_context 'there is a broken link in the docs',
+                    'link:/guide/foo[]', check_links
+  end
+  shared_context 'there is a broken relative link to master' do |check_links|
     include_context 'there is a broken link in the docs',
                     'link:/guide/foo[]', check_links
   end
@@ -82,6 +90,18 @@ RSpec.describe 'building all books' do
         expect(outputs[0]).to include('Skipped Checking links')
       end
     end
+    describe 'when there is a broken absolute link to master' do
+      include_context 'there is a broken absolute link to master', false
+      it 'logs but does not fail on master links' do
+        expect(outputs[0]).to include('Bad master links')
+      end
+    end
+    describe 'when there is a broken relative link to master' do
+      include_context 'there is a broken relative link to master', false
+      it 'logs but does not fail on master links' do
+        expect(outputs[0]).to include('Bad master links')
+      end
+    end
     describe 'when there is a broken link in kibana' do
       include_context 'there is a broken link in kibana', false
       it 'logs that it skipped link checking' do
@@ -102,6 +122,17 @@ RSpec.describe 'building all books' do
       it 'logs the bad link' do
         expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
           /tmp/docsbuild/target_repo/html/test/current/chapter.html contains broken links to:
+           - foo
+        LOG
+      end
+    end
+    shared_examples 'there are links to master in the docs' do
+      it 'logs there are master links' do
+        expect(outputs[-1]).to include('Bad master links')
+      end
+      it 'logs the bad link' do
+        expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
+          /tmp/docsbuild/target_repo/html/test/current/chapter.html contains broken master links to:
            - foo
         LOG
       end
@@ -137,6 +168,14 @@ RSpec.describe 'building all books' do
       include_context 'there is a broken relative link in the docs', true
       include_examples 'there are broken links in the docs'
     end
+    describe 'when there is a broken absolute link to master' do
+      include_context 'there is a broken absolute link to master', false
+      include_examples 'there are links to master in the docs'
+    end
+    describe 'when there is a broken relative link to master' do
+      include_context 'there is a broken relative link to master', false
+      include_examples 'there are broken links in the docs'
+    end
     describe 'when there is a broken link in kibana' do
       include_context 'there is a broken link in kibana', true
       include_examples 'there are broken links in kibana', 'foo'
@@ -150,25 +189,25 @@ RSpec.describe 'building all books' do
       include_context 'there is a kibana link', true,
                       '${ELASTICSEARCH_DOCS}missing-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elasticsearch/reference/master/missing-page.html'
+                       'en/elasticsearch/reference/current/missing-page.html'
     end
     describe 'when there is a broken Kibana guide link' do
       include_context 'there is a kibana link', true,
                       '${KIBANA_DOCS}not-a-kibana-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/kibana/master/not-a-kibana-page.html'
+                       'en/kibana/current/not-a-kibana-page.html'
     end
     describe 'when there is a broken ES Plugin link' do
       include_context 'there is a kibana link', true,
                       '${PLUGIN_DOCS}not-valid-plugin.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elasticsearch/plugins/master/not-valid-plugin.html'
+                       'en/elasticsearch/plugins/current/not-valid-plugin.html'
     end
     describe 'when there is a broken Fleet link' do
       include_context 'there is a kibana link', true,
                       '${FLEET_DOCS}not-a-fleet-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/fleet/master/not-a-fleet-page.html'
+                       'en/fleet/current/not-a-fleet-page.html'
     end
     describe 'when there is a broken APM link' do
       include_context 'there is a kibana link', true,
@@ -180,37 +219,37 @@ RSpec.describe 'building all books' do
       include_context 'there is a kibana link', true,
                       '${STACK_DOCS}not-a-stack-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elastic-stack/master/not-a-stack-page.html'
+                       'en/elastic-stack/current/not-a-stack-page.html'
     end
     describe 'when there is a broken Security link' do
       include_context 'there is a kibana link', true,
                       '${SECURITY_SOLUTION_DOCS}not-a-security-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/security/master/not-a-security-page.html'
+                       'en/security/current/not-a-security-page.html'
     end
     describe 'when there is a broken Stack Getting Started link' do
       include_context 'there is a kibana link', true,
                       '${STACK_GETTING_STARTED}not-a-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/elastic-stack-get-started/master/not-a-page.html'
+                       'en/elastic-stack-get-started/current/not-a-page.html'
     end
     describe 'when there is a broken App Search link' do
       include_context 'there is a kibana link', true,
                       '${APP_SEARCH_DOCS}not-a-search-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/app-search/master/not-a-search-page.html'
+                       'en/app-search/current/not-a-search-page.html'
     end
     describe 'when there is a broken Enterprise Search link' do
       include_context 'there is a kibana link', true,
                       '${ENTERPRISE_SEARCH_DOCS}not-a-search-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/enterprise-search/master/not-a-search-page.html'
+                       'en/enterprise-search/current/not-a-search-page.html'
     end
     describe 'when there is a broken Workplace Search link' do
       include_context 'there is a kibana link', true,
                       '${WORKPLACE_SEARCH_DOCS}not-a-search-page.html', true
       include_examples 'there are broken links in kibana',
-                       'en/workplace-search/master/not-a-search-page.html'
+                       'en/workplace-search/current/not-a-search-page.html'
     end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do

--- a/integtest/spec/all_books_broken_link_detection_spec.rb
+++ b/integtest/spec/all_books_broken_link_detection_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe 'building all books' do
     include_context 'there is a broken link',
                     'link:/guide/foo[]', check, fail
   end
+  shared_context 'there is a broken absolute link to master' do |check, fail|
+    include_context 'there is a broken link',
+                    'https://www.elastic.co/guide/master/foo', check, fail
+  end
+  shared_context 'there is a broken relative link to master' do |check, fail|
+    include_context 'there is a broken link',
+                    'link:/guide/master/foo[]', check, fail
+  end
   shared_context 'there is a kibana link' do |check, url, fail|
     convert_before do |src, dest|
       # Kibana is special and we check links in it with a little magic
@@ -65,7 +73,10 @@ RSpec.describe 'building all books' do
     include_context 'there is a kibana link', check,
                     '${ELASTIC_WEBSITE_URL}guide/foo', fail
   end
-
+  shared_context 'there is a broken link in kibana to master' do |check, fail|
+    include_context 'there is a kibana link', check,
+                    '${ELASTIC_WEBSITE_URL}guide/master/foo', fail
+  end
   describe 'when broken link detection is disabled' do
     describe 'when there is a broken absolute link' do
       include_context 'there is a broken absolute link', false, false
@@ -125,6 +136,17 @@ RSpec.describe 'building all books' do
         LOG
       end
     end
+    shared_examples 'there are broken links in kibana to master' do |url|
+      it 'logs there are bad cross document links' do
+        expect(outputs[-1]).to include('Bad master links:')
+      end
+      it 'logs the bad link' do
+        expect(outputs[-1]).to include(indent(<<~LOG.strip, '  '))
+          Kibana [master]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
+           - #{url}
+        LOG
+      end
+    end
     describe 'when all of the links are intact' do
       convert_before do |src, dest|
         repo = src.repo_with_index(
@@ -146,16 +168,20 @@ RSpec.describe 'building all books' do
       include_examples 'there are broken links'
     end
     describe 'when there is a broken absolute link to master' do
-      include_context 'there is a broken absolute link', true, false
+      include_context 'there is a broken absolute link to master', true, false
       include_examples 'there are broken links to master'
     end
     describe 'when there is a broken relative link to master' do
-      include_context 'there is a broken relative link', true, false
+      include_context 'there is a broken relative link to master', true, false
       include_examples 'there are broken links to master'
     end
     describe 'when there is a broken link in kibana' do
       include_context 'there is a broken link in kibana', true, true
       include_examples 'there are broken links in kibana', 'foo'
+    end
+    describe 'when there is a broken link in kibana to master' do
+      include_context 'there is a broken link in kibana to master', true, false
+      include_examples 'there are broken links in kibana to master', 'foo'
     end
     describe 'when a link in kibana goes to the website outside the guide' do
       include_context 'there is a kibana link', true,
@@ -164,69 +190,69 @@ RSpec.describe 'building all books' do
     end
     describe 'when there is a broken Elasticsearch Guide link in Kibana' do
       include_context 'there is a kibana link', true,
-                      '${ELASTICSEARCH_DOCS}missing-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/elasticsearch/reference/current/missing-page.html'
+                      '${ELASTICSEARCH_DOCS}missing-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/elasticsearch/reference/master/missing-page.html'
     end
     describe 'when there is a broken Kibana guide link' do
       include_context 'there is a kibana link', true,
-                      '${KIBANA_DOCS}not-a-kibana-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/kibana/current/not-a-kibana-page.html'
+                      '${KIBANA_DOCS}not-a-kibana-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/kibana/master/not-a-kibana-page.html'
     end
     describe 'when there is a broken ES Plugin link' do
       include_context 'there is a kibana link', true,
-                      '${PLUGIN_DOCS}not-valid-plugin.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/elasticsearch/plugins/current/not-valid-plugin.html'
+                      '${PLUGIN_DOCS}not-valid-plugin.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/elasticsearch/plugins/master/not-valid-plugin.html'
     end
     describe 'when there is a broken Fleet link' do
       include_context 'there is a kibana link', true,
-                      '${FLEET_DOCS}not-a-fleet-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/fleet/current/not-a-fleet-page.html'
+                      '${FLEET_DOCS}not-a-fleet-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/fleet/master/not-a-fleet-page.html'
     end
     describe 'when there is a broken APM link' do
       include_context 'there is a kibana link', true,
-                      '${APM_DOCS}not-an-apm-page.html', true
-      include_examples 'there are broken links in kibana',
+                      '${APM_DOCS}not-an-apm-page.html', false
+      include_examples 'there are broken links in kibana to master',
                        'en/apm/not-an-apm-page.html'
     end
     describe 'when there is a broken Stack link' do
       include_context 'there is a kibana link', true,
-                      '${STACK_DOCS}not-a-stack-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/elastic-stack/current/not-a-stack-page.html'
+                      '${STACK_DOCS}not-a-stack-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/elastic-stack/master/not-a-stack-page.html'
     end
     describe 'when there is a broken Security link' do
       include_context 'there is a kibana link', true,
-                      '${SECURITY_SOLUTION_DOCS}not-a-security-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/security/current/not-a-security-page.html'
+                      '${SECURITY_SOLUTION_DOCS}not-a-security-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/security/master/not-a-security-page.html'
     end
     describe 'when there is a broken Stack Getting Started link' do
       include_context 'there is a kibana link', true,
-                      '${STACK_GETTING_STARTED}not-a-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/elastic-stack-get-started/current/not-a-page.html'
+                      '${STACK_GETTING_STARTED}not-a-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/elastic-stack-get-started/master/not-a-page.html'
     end
     describe 'when there is a broken App Search link' do
       include_context 'there is a kibana link', true,
-                      '${APP_SEARCH_DOCS}not-a-search-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/app-search/current/not-a-search-page.html'
+                      '${APP_SEARCH_DOCS}not-a-search-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/app-search/master/not-a-search-page.html'
     end
     describe 'when there is a broken Enterprise Search link' do
       include_context 'there is a kibana link', true,
-                      '${ENTERPRISE_SEARCH_DOCS}not-a-search-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/enterprise-search/current/not-a-search-page.html'
+                      '${ENTERPRISE_SEARCH_DOCS}not-a-search-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/enterprise-search/master/not-a-search-page.html'
     end
     describe 'when there is a broken Workplace Search link' do
       include_context 'there is a kibana link', true,
-                      '${WORKPLACE_SEARCH_DOCS}not-a-search-page.html', true
-      include_examples 'there are broken links in kibana',
-                       'en/workplace-search/current/not-a-search-page.html'
+                      '${WORKPLACE_SEARCH_DOCS}not-a-search-page.html', false
+      include_examples 'there are broken links in kibana to master',
+                       'en/workplace-search/master/not-a-search-page.html'
     end
     describe 'when using --keep_hash and --sub_dir together like a PR test' do
       describe 'when there is a broken link in one of the books being built' do

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -235,6 +235,11 @@ class Dest
       self
     end
 
+    def warn_link_check
+      @cmd += ['--warnlinkcheck']
+      self
+    end
+
     def keep_hash
       @cmd += ['--keep_hash']
       self

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -235,11 +235,6 @@ class Dest
       self
     end
 
-    def warn_link_check
-      @cmd += ['--warnlinkcheck']
-      self
-    end
-
     def keep_hash
       @cmd += ['--keep_hash']
       self

--- a/lib/ES/LinkCheck.pm
+++ b/lib/ES/LinkCheck.pm
@@ -104,7 +104,7 @@ sub report {
         push @error, "  $file contains broken links to:";
         push @error, map {"   - $_"} sort keys %{ $bad->{$file} };
       }
-      die join "\n", @error, '';
+      return join "\n", @error, '';
     }
     if (keys %$warn) {
       my @warning = "Bad master links:";

--- a/lib/ES/LinkCheck.pm
+++ b/lib/ES/LinkCheck.pm
@@ -104,7 +104,7 @@ sub report {
         push @error, "  $file contains broken links to:";
         push @error, map {"   - $_"} sort keys %{ $bad->{$file} };
       }
-      return join "\n", @error, '';
+      die join "\n", @error, '';
     }
     if (keys %$warn) {
       my @warning = "Bad master links:";

--- a/lib/ES/LinkCheck.pm
+++ b/lib/ES/LinkCheck.pm
@@ -98,7 +98,7 @@ sub report {
         push @error, "  $file contains broken links to:";
         push @error, map {"   - $_"} sort keys %{ $bad->{$file} };
     }
-    die join "\n", @error, '';
+    return join "\n", @error, '';
 
 }
 


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2521

The idea is that we'd generate warnings rather than errors if the link checker hits URLs that contain "master" and address them via redirects instead.

This PR should be merged after https://github.com/elastic/docs/pull/2670, which contains some of the foundational commits.