### PR TITLE
WIP: Add custom content to head of the clients page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -459,6 +459,8 @@ contents:
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           - title:      Elasticsearch Clients
             base_dir:   en/elasticsearch/client
+            # TODO: Add a new file and update the path here.
+            toc_extra:  extra/docs_landing.html
             sections:
               - title:      Java Client
                 prefix:     java-api-client

--- a/schema.yaml
+++ b/schema.yaml
@@ -41,6 +41,10 @@ subsection:
     # defined in each book?
     lang: str(required=False)
 
+    # toc_extra is supported on both individual books, and sub-TOCs (subpages
+    # with their own lists of books).
+    toc_extra: str(required=False)
+
 ---
 book:
     # Title of the book (used in headers, and in lists of books)


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/client/index.html

The code supports this, but I needed to make the YAML schema for conf.yaml support it too.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
