### PR TITLE
Bumps docs version to 8.7.1

### DIFF
--- a/shared/versions/stack/8.7.asciidoc
+++ b/shared/versions/stack/8.7.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.7.0
+:version:                8.7.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.7.0
-:logstash_version:       8.7.0
-:elasticsearch_version:  8.7.0
-:kibana_version:         8.7.0
-:apm_server_version:     8.7.0
+:bare_version:           8.7.1
+:logstash_version:       8.7.1
+:elasticsearch_version:  8.7.1
+:kibana_version:         8.7.1
+:apm_server_version:     8.7.1
 :branch:                 8.7
 :minor-version:          8.7
 :major-version:          8.x


### PR DESCRIPTION
**Do not merge until release day.**

This updates the stack docs shared version attributes to 8.7.1.

[Docs release issue]()