### PR TITLE
Add Elasticsearch link checking path

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -371,6 +371,10 @@ contents:
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
+                repo:   elasticsearch
+                path:   server/src/main/resources/org/elasticsearch/common
+                exclude_branches:   [ 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
           - title:      Elasticsearch Resiliency Status
             prefix:     en/elasticsearch/resiliency
             toc:        1


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/92802 

This PR attempts to address these doc build errors...

```
10:43:55 INFO:build_docs:Checking Elasticsearch links
10:43:55 INFO:build_docs:  Branch: 8.7, Version: 8.7
10:43:55 INFO:build_docs:  Branch: main, Version: master
10:43:55 INFO:build_docs:Can't read /doc/elastic+elasticsearch+pull-request+build-docs/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json: No such file or directory at lib/ES/Repo.pm line 363.
10:43:55 runbld>>> <<<<<<<<<<<< SCRIPT EXECUTION END <<<<<<<<<<<<
```
By adding this path to the list of sources for the Elasticsearch Guide:
https://github.com/elastic/elasticsearch/blob/8.7/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json