### PR TITLE
Comment out elasticsearch link checker

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -331,7 +331,8 @@ sub check_links {
     $link_checker->check;
 
     check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
-    check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
+    # Comment out due to build errors
+    # check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
     if ( $link_checker->has_bad ) {
         say $link_checker->report;
     }


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/92802

https://github.com/elastic/docs/pull/2655 failed to resolve the build error in https://github.com/elastic/elasticsearch/pull/91491 so this PR temporarily comments out the link checker until it can be fixed.