### PR TITLE
Add dropdowns for Ent Search, App Search, Workplace Search books

### DIFF
--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -37,7 +37,7 @@ module Chunker
       cases.each do |c, method|
         next unless result[2].to_s.include?(c)
 
-        if method == 'generate_search_breadcrumbs'
+        result = if method == 'generate_search_breadcrumbs'
           result[2] = chev + send(method, doc, c)
         else
           result[2] = chev + send(method, doc)

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -23,13 +23,13 @@ module Chunker
         result[2] = chev + generate_ecslogging_breadcrumbs(doc)
       end
       if result[2].to_s.include? 'Enterprise Search'
-        result[2] = chev + generate_enterprise_search_breadcrumbs(doc)
+        result[2] = chev + generate_search_breadcrumbs(doc, 'Enterprise Search')
       end
       if result[2].to_s.include? 'App Search'
-        result[2] = chev + generate_app_search_breadcrumbs(doc)
+        result[2] = chev + generate_search_breadcrumbs(doc, 'App Search')
       end
       if result[2].to_s.include? 'Workplace Search'
-        result[2] = chev + generate_workplace_search_breadcrumbs(doc)
+        result[2] = chev + generate_search_breadcrumbs(doc, 'Workplace Search')
       end
       Asciidoctor::Block.new doc, :pass, source: result.join("\n")
     end
@@ -98,38 +98,20 @@ module Chunker
       HTML
     end
 
-    def generate_enterprise_search_breadcrumbs(doc)
+    def generate_search_breadcrumbs(doc, search_type)
       title = doc.title
       short = title.sub(/ documentation/, '')
-      <<~HTML.strip
-        <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-            <div class="related-products-title"></div>
-            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-            <div class="dropdown-content">
-              <ul>
-                <li class="dropdown-category">Enterprise Search</li>
-                <ul>
-                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
-                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
-                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
-                </ul>
-                <ul>
-                <li class="dropdown-category">Programming language clients</li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
-                </ul>
-            </div>
-          </div>
-        </span>
-      HTML
-    end
-
-    def generate_app_search_breadcrumbs(doc)
-      title = doc.title
-      short = title.sub(/ documentation/, '')
+      books = {
+        'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+        'App Search' => '/guide/en/app-search/current/index.html',
+        'Workplace Search' => '/guide/en/workplace-search/current/index.html'
+      }
+      clients = {
+        'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
+        'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
+        'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
+        'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html'
+      }
       <<~HTML.strip
         <span class="breadcrumb-link">
           <div id="related-products" class="dropdown">
@@ -139,46 +121,13 @@ module Chunker
               <ul>
                 <li class="dropdown-category">Enterprise Search guides</li>
                 <ul>
-                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
-                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
-                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
+                  #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
                 </ul>
-                <ul>
                 <li class="dropdown-category">Programming language clients</li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
-                </ul>
-            </div>
-          </div>
-        </span>
-      HTML
-    end
-
-    def generate_workplace_search_breadcrumbs(doc)
-      title = doc.title
-      short = title.gsub(/ documentation/, '')
-      <<~HTML.strip
-        <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-            <div class="related-products-title"></div>
-            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-            <div class="dropdown-content">
-              <ul>
-                <li class="dropdown-category">Enterprise Search guides</li>
                 <ul>
-                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
-                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
-                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
+                  #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
                 </ul>
-                <ul>
-                <li class="dropdown-category">Programming language clients</li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
-                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
-                </ul>
+              </ul>
             </div>
           </div>
         </span>

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -9,8 +9,8 @@ module Chunker
   # Builds the "breadcrumbs" at the top of the page.
   module Breadcrumbs
     include Link
-    include Search_breadcrumbs
-    include Obs_breadcrumbs
+    include Search_Breadcrumbs
+    include Obs_Breadcrumbs
 
     def generate_breadcrumbs(doc, section)
       chev = <<~HTML.strip
@@ -31,7 +31,7 @@ module Chunker
         'ECS Logging' => 'generate_ecslogging_breadcrumbs',
         'Enterprise Search' => 'generate_search_breadcrumbs',
         'App Search' => 'generate_search_breadcrumbs',
-        'Workplace Search' => 'generate_search_breadcrumbs'
+        'Workplace Search' => 'generate_search_breadcrumbs',
       }
 
       cases.each do |c, method|

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 require_relative 'link'
+require_relative 'search_breadcrumbs'
+require_relative 'obs_breadcrumbs'
 
 module Chunker
   ##
   # Builds the "breadcrumbs" at the top of the page.
   module Breadcrumbs
     include Link
+    include Search_breadcrumbs
+    include Obs_breadcrumbs
 
     def generate_breadcrumbs(doc, section)
       chev = <<~HTML.strip
@@ -16,122 +20,30 @@ module Chunker
       result += generate_breadcrumb_links(section, chev).reverse
       result << '</div>'
 
-      if result[2].to_s.include? 'APM'
-        result[2] = chev + generate_apm_breadcrumbs(doc)
-      end
-      if result[2].to_s.include? 'ECS Logging'
-        result[2] = chev + generate_ecslogging_breadcrumbs(doc)
-      end
-      if result[2].to_s.include? 'Enterprise Search'
-        result[2] = chev + generate_search_breadcrumbs(doc, 'Enterprise Search')
-      end
-      if result[2].to_s.include? 'App Search'
-        result[2] = chev + generate_search_breadcrumbs(doc, 'App Search')
-      end
-      if result[2].to_s.include? 'Workplace Search'
-        result[2] = chev + generate_search_breadcrumbs(doc, 'Workplace Search')
-      end
+      update_breadcrumbs_cases(result, chev, doc)
+
       Asciidoctor::Block.new doc, :pass, source: result.join("\n")
     end
 
-    def generate_apm_breadcrumbs(doc)
-      title = doc.title
-      short = title.sub(/APM /, '')
-      <<~HTML.strip
-        <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-            <div class="related-products-title">APM:</div>
-            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-            <div class="dropdown-content">
-              <ul>
-                <li class="dropdown-category">APM</li>
-                <ul>
-                  <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
-                </ul>
-                <li class="dropdown-category">APM agents</li>
-                <ul>
-                  <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
-                  <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
-                </ul>
-                <li class="dropdown-category">APM extensions</li>
-                <ul>
-                  <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
-                  <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
-                </ul>
-              </ul>
-            </div>
-          </div>
-        </span>
-      HTML
-    end
-
-    def generate_ecslogging_breadcrumbs(doc)
-      title = doc.title
-      short = title.sub(/ECS Logging /, '')
-      <<~HTML.strip
-        <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-            <div class="related-products-title">ECS Logging:</div>
-            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-            <div class="dropdown-content">
-              <ul>
-                <li><a href="/guide/en/ecs-logging/overview/current/intro.html">Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/go-logrus/current/intro.html">Go (Logrus) Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/go-zap/current/intro.html">Go (zap) Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/java/current/intro.html">Java Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/dotnet/current/intro.html">.NET Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/nodejs/current/intro.html">Node.js Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/ruby/current/intro.html">Ruby Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/php/current/intro.html">PHP Reference</a></li>
-                <li><a href="/guide/en/ecs-logging/python/current/intro.html">Python Reference</a></li>
-            </div>
-          </div>
-        </span>
-      HTML
-    end
-
-    def generate_search_breadcrumbs(doc, search_type)
-      title = doc.title
-      short = title.sub(/ documentation/, '')
-      books = {
-        'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
-        'App Search' => '/guide/en/app-search/current/index.html',
-        'Workplace Search' => '/guide/en/workplace-search/current/index.html'
+    def update_breadcrumbs_cases(result, chev, doc)
+      cases = {
+        'APM' => 'generate_apm_breadcrumbs',
+        'ECS Logging' => 'generate_ecslogging_breadcrumbs',
+        'Enterprise Search' => 'generate_search_breadcrumbs',
+        'App Search' => 'generate_search_breadcrumbs',
+        'Workplace Search' => 'generate_search_breadcrumbs'
       }
-      clients = {
-        'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
-        'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
-        'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
-        'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html'
-      }
-      <<~HTML.strip
-        <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-            <div class="related-products-title"></div>
-            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-            <div class="dropdown-content">
-              <ul>
-                <li class="dropdown-category">Enterprise Search guides</li>
-                <ul>
-                  #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-                </ul>
-                <li class="dropdown-category">Programming language clients</li>
-                <ul>
-                  #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-                </ul>
-              </ul>
-            </div>
-          </div>
-        </span>
-      HTML
+
+      cases.each do |c, method|
+        if result[2].to_s.include?(c)
+          if method == 'generate_search_breadcrumbs'
+            result[2] = chev + send(method, doc, c)
+          else
+            result[2] = chev + send(method, doc)
+          end
+          break
+        end
+      end
     end
 
     def generate_breadcrumb_links(section, chev)

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -37,11 +37,11 @@ module Chunker
       cases.each do |c, method|
         next unless result[2].to_s.include?(c)
 
-        result = if method == 'generate_search_breadcrumbs'
-          result[2] = chev + send(method, doc, c)
-        else
-          result[2] = chev + send(method, doc)
-        end
+        result = result[2] = if method == 'generate_search_breadcrumbs'
+                               chev + send(method, doc, c)
+                             else
+                               chev + send(method, doc)
+                             end
         break
       end
     end

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -35,7 +35,7 @@ module Chunker
       }
 
       cases.each do |c, method|
-        if result[2].to_s.include?(c)
+        next unless result[2].to_s.include?(c)
           if method == 'generate_search_breadcrumbs'
             result[2] = chev + send(method, doc, c)
           else
@@ -44,7 +44,7 @@ module Chunker
           break
         end
       end
-    end
+
 
     def generate_breadcrumb_links(section, chev)
       result = []
@@ -56,7 +56,7 @@ module Chunker
         HTML
         links = chev + link
         result << links
-      end
+    end
       result << <<~HTML.strip
         <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
       HTML

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -15,11 +15,21 @@ module Chunker
       result = ['<div class="breadcrumbs">']
       result += generate_breadcrumb_links(section, chev).reverse
       result << '</div>'
+
       if result[2].to_s.include? 'APM'
         result[2] = chev + generate_apm_breadcrumbs(doc)
       end
       if result[2].to_s.include? 'ECS Logging'
         result[2] = chev + generate_ecslogging_breadcrumbs(doc)
+      end
+      if result[2].to_s.include? 'Enterprise Search'
+        result[2] = chev + generate_enterprise_search_breadcrumbs(doc)
+      end
+      if result[2].to_s.include? 'App Search'
+        result[2] = chev + generate_app_search_breadcrumbs(doc)
+      end
+      if result[2].to_s.include? 'Workplace Search'
+        result[2] = chev + generate_workplace_search_breadcrumbs(doc)
       end
       Asciidoctor::Block.new doc, :pass, source: result.join("\n")
     end
@@ -82,6 +92,93 @@ module Chunker
                 <li><a href="/guide/en/ecs-logging/ruby/current/intro.html">Ruby Reference</a></li>
                 <li><a href="/guide/en/ecs-logging/php/current/intro.html">PHP Reference</a></li>
                 <li><a href="/guide/en/ecs-logging/python/current/intro.html">Python Reference</a></li>
+            </div>
+          </div>
+        </span>
+      HTML
+    end
+
+    def generate_enterprise_search_breadcrumbs(doc)
+      title = doc.title
+      short = title.sub(/ documentation/, '')
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+            <div class="related-products-title"></div>
+            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+            <div class="dropdown-content">
+              <ul>
+                <li class="dropdown-category">Enterprise Search</li>
+                <ul>
+                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
+                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
+                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
+                </ul>
+                <ul>
+                <li class="dropdown-category">Programming language clients</li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
+                </ul>
+            </div>
+          </div>
+        </span>
+      HTML
+    end
+
+    def generate_app_search_breadcrumbs(doc)
+      title = doc.title
+      short = title.sub(/ documentation/, '')
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+            <div class="related-products-title"></div>
+            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+            <div class="dropdown-content">
+              <ul>
+                <li class="dropdown-category">Enterprise Search guides</li>
+                <ul>
+                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
+                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
+                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
+                </ul>
+                <ul>
+                <li class="dropdown-category">Programming language clients</li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
+                </ul>
+            </div>
+          </div>
+        </span>
+      HTML
+    end
+
+    def generate_workplace_search_breadcrumbs(doc)
+      title = doc.title
+      short = title.gsub(/ documentation/, '')
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+            <div class="related-products-title"></div>
+            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+            <div class="dropdown-content">
+              <ul>
+                <li class="dropdown-category">Enterprise Search guides</li>
+                <ul>
+                <li><a href="/guide/en/enterprise-search/current/index.html">Enterprise Search</a></li>
+                <li><a href="/guide/en/app-search/current/index.html" target="_blank">App Search</a></li>
+                <li><a href="/guide/en/workplace-search/current/index.html" target="_blank">Workplace Search</a></li>
+                </ul>
+                <ul>
+                <li class="dropdown-category">Programming language clients</li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html" target="_blank">Node.js client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html" target="_blank">PHP client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html" target="_blank">Python client</a></li>
+                <li><a href="https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html" target="_blank">Ruby client</a></li>
+                </ul>
             </div>
           </div>
         </span>

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -9,8 +9,8 @@ module Chunker
   # Builds the "breadcrumbs" at the top of the page.
   module Breadcrumbs
     include Link
-    include Search_Breadcrumbs
-    include Obs_Breadcrumbs
+    include SearchBreadcrumbs
+    include ObsBreadcrumbs
 
     def generate_breadcrumbs(doc, section)
       chev = <<~HTML.strip
@@ -36,15 +36,15 @@ module Chunker
 
       cases.each do |c, method|
         next unless result[2].to_s.include?(c)
-          if method == 'generate_search_breadcrumbs'
-            result[2] = chev + send(method, doc, c)
-          else
-            result[2] = chev + send(method, doc)
-          end
-          break
-        end
-      end
 
+        if method == 'generate_search_breadcrumbs'
+          result[2] = chev + send(method, doc, c)
+        else
+          result[2] = chev + send(method, doc)
+        end
+        break
+      end
+    end
 
     def generate_breadcrumb_links(section, chev)
       result = []
@@ -56,7 +56,7 @@ module Chunker
         HTML
         links = chev + link
         result << links
-    end
+      end
       result << <<~HTML.strip
         <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
       HTML

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -3,12 +3,12 @@
 module Chunker
     ##
     # methods for generating breadcrumbs for Obs docs books
-    module ObsBreadcrumbs
-      def generate_apm_breadcrumbs(doc)
+  module ObsBreadcrumbs
+    def generate_apm_breadcrumbs(doc)
         title = doc.title
         short = title.sub(/APM /, '')
         <<~HTML.strip
-          <span class="breadcrumb-link">
+        <span class="breadcrumb-link">
           <div id="related-products" class="dropdown">
           <div class="related-products-title">APM:</div>
           <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
@@ -39,7 +39,7 @@ module Chunker
           </ul>
           </div>
           </div>
-          HTML
+        HTML
       end
 
       def generate_ecslogging_breadcrumbs(doc)

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+module Chunker
+    ##
+    # methods for generating breadcrumbs for Obs docs books
+    module Obs_breadcrumbs
+      def generate_apm_breadcrumbs(doc)
+        title = doc.title
+        short = title.sub(/APM /, '')
+        <<~HTML.strip
+          <span class="breadcrumb-link">
+            <div id="related-products" class="dropdown">
+              <div class="related-products-title">APM:</div>
+              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+              <div class="dropdown-content">
+                <ul>
+                  <li class="dropdown-category">APM</li>
+                  <ul>
+                    <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
+                  </ul>
+                  <li class="dropdown-category">APM agents</li>
+                  <ul>
+                    <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
+                    <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
+                  </ul>
+                  <li class="dropdown-category">APM extensions</li>
+                  <ul>
+                    <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
+                    <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
+                  </ul>
+                </ul>
+              </div>
+            </div>
+          </span>
+        HTML
+      end
+
+      def generate_ecslogging_breadcrumbs(doc)
+        title = doc.title
+        short = title.sub(/ECS Logging /, '')
+        <<~HTML.strip
+          <span class="breadcrumb-link">
+            <div id="related-products" class="dropdown">
+              <div class="related-products-title">ECS Logging:</div>
+              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+              <div class="dropdown-content">
+                <ul>
+                  <li><a href="/guide/en/ecs-logging/overview/current/intro.html">Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/go-logrus/current/intro.html">Go (Logrus) Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/go-zap/current/intro.html">Go (zap) Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/java/current/intro.html">Java Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/dotnet/current/intro.html">.NET Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/nodejs/current/intro.html">Node.js Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/ruby/current/intro.html">Ruby Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/php/current/intro.html">PHP Reference</a></li>
+                  <li><a href="/guide/en/ecs-logging/python/current/intro.html">Python Reference</a></li>
+                </ul>
+              </div>
+            </div>
+          </span>
+        HTML
+      end
+    end
+    end

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module Chunker
-    ##
-    # methods for generating breadcrumbs for Obs docs books
+  ##
+  # methods for generating breadcrumbs for Obs docs books
   module Obs_Breadcrumbs
     def generate_apm_breadcrumbs(doc)
         title = doc.title

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
 
 module Chunker
-  ##
-  # methods for generating breadcrumbs for Obs docs books
-  module Obs_Breadcrumbs
-    def generate_apm_breadcrumbs(doc)
+    ##
+    # methods for generating breadcrumbs for Obs docs books
+    module ObsBreadcrumbs
+      def generate_apm_breadcrumbs(doc)
         title = doc.title
         short = title.sub(/APM /, '')
         <<~HTML.strip
-        <span class="breadcrumb-link">
-        <div id="related-products" class="dropdown">
-        <div class="related-products-title">APM:</div>
-        <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-        <div class="dropdown-content">
-        <ul>
-        <li class="dropdown-category">APM</li>
-        <ul>
-        <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
-        </ul>
-        <li class="dropdown-category">APM agents</li>
-        <ul>
-        <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
-        <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
-        </ul>
-        <li class="dropdown-category">APM extensions</li>
-        <ul>
-        <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
-        <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
-        </ul>
-        </ul>
-        </div>
-        </div>
-        HTML
-    end
+          <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+          <div class="related-products-title">APM:</div>
+          <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+          <div class="dropdown-content">
+          <ul>
+          <li class="dropdown-category">APM</li>
+          <ul>
+          <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
+          </ul>
+          <li class="dropdown-category">APM agents</li>
+          <ul>
+          <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
+          <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
+          </ul>
+          <li class="dropdown-category">APM extensions</li>
+          <ul>
+          <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
+          <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
+          </ul>
+          </ul>
+          </div>
+          </div>
+          HTML
+      end
 
       def generate_ecslogging_breadcrumbs(doc)
         title = doc.title
@@ -66,6 +66,6 @@ module Chunker
             </div>
           </span>
         HTML
+      end
     end
-end
 end

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -68,3 +68,4 @@ module Chunker
         HTML
     end
 end
+end

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
 module Chunker
-    ##
-    # methods for generating breadcrumbs for Obs docs books
+  ##
+  # methods for generating breadcrumbs for Obs docs books
   module ObsBreadcrumbs
     def generate_apm_breadcrumbs(doc)
-        title = doc.title
-        short = title.sub(/APM /, '')
-        <<~HTML.strip
+      title = doc.title
+      short = title.sub(/APM /, '')
+      <<~HTML.strip
         <span class="breadcrumb-link">
           <div id="related-products" class="dropdown">
           <div class="related-products-title">APM:</div>
@@ -39,33 +39,33 @@ module Chunker
           </ul>
           </div>
           </div>
-        HTML
-      end
-
-      def generate_ecslogging_breadcrumbs(doc)
-        title = doc.title
-        short = title.sub(/ECS Logging /, '')
-        <<~HTML.strip
-          <span class="breadcrumb-link">
-            <div id="related-products" class="dropdown">
-              <div class="related-products-title">ECS Logging:</div>
-              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-              <div class="dropdown-content">
-                <ul>
-                  <li><a href="/guide/en/ecs-logging/overview/current/intro.html">Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/go-logrus/current/intro.html">Go (Logrus) Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/go-zap/current/intro.html">Go (zap) Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/java/current/intro.html">Java Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/dotnet/current/intro.html">.NET Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/nodejs/current/intro.html">Node.js Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/ruby/current/intro.html">Ruby Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/php/current/intro.html">PHP Reference</a></li>
-                  <li><a href="/guide/en/ecs-logging/python/current/intro.html">Python Reference</a></li>
-                </ul>
-              </div>
-            </div>
-          </span>
-        HTML
-      end
+      HTML
     end
+
+    def generate_ecslogging_breadcrumbs(doc)
+      title = doc.title
+      short = title.sub(/ECS Logging /, '')
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+            <div class="related-products-title">ECS Logging:</div>
+            <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+            <div class="dropdown-content">
+              <ul>
+                <li><a href="/guide/en/ecs-logging/overview/current/intro.html">Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/go-logrus/current/intro.html">Go (Logrus) Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/go-zap/current/intro.html">Go (zap) Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/java/current/intro.html">Java Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/dotnet/current/intro.html">.NET Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/nodejs/current/intro.html">Node.js Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/ruby/current/intro.html">Ruby Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/php/current/intro.html">PHP Reference</a></li>
+                <li><a href="/guide/en/ecs-logging/python/current/intro.html">Python Reference</a></li>
+              </ul>
+            </div>
+          </div>
+        </span>
+      HTML
+    end
+  end
 end

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -1,46 +1,46 @@
 # frozen_string_literal: true
+
 module Chunker
     ##
     # methods for generating breadcrumbs for Obs docs books
-    module Obs_breadcrumbs
-      def generate_apm_breadcrumbs(doc)
+  module Obs_Breadcrumbs
+    def generate_apm_breadcrumbs(doc)
         title = doc.title
         short = title.sub(/APM /, '')
         <<~HTML.strip
-          <span class="breadcrumb-link">
-            <div id="related-products" class="dropdown">
-              <div class="related-products-title">APM:</div>
-              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-              <div class="dropdown-content">
-                <ul>
-                  <li class="dropdown-category">APM</li>
-                  <ul>
-                    <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
-                  </ul>
-                  <li class="dropdown-category">APM agents</li>
-                  <ul>
-                    <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
-                    <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
-                  </ul>
-                  <li class="dropdown-category">APM extensions</li>
-                  <ul>
-                    <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
-                    <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
-                  </ul>
-                </ul>
-              </div>
-            </div>
-          </span>
+        <span class="breadcrumb-link">
+        <div id="related-products" class="dropdown">
+        <div class="related-products-title">APM:</div>
+        <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+        <div class="dropdown-content">
+        <ul>
+        <li class="dropdown-category">APM</li>
+        <ul>
+        <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
+        </ul>
+        <li class="dropdown-category">APM agents</li>
+        <ul>
+        <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
+        <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
+        </ul>
+        <li class="dropdown-category">APM extensions</li>
+        <ul>
+        <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
+        <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
+        </ul>
+        </ul>
+        </div>
+        </div>
         HTML
-      end
+    end
 
       def generate_ecslogging_breadcrumbs(doc)
         title = doc.title
@@ -66,6 +66,5 @@ module Chunker
             </div>
           </span>
         HTML
-      end
     end
-    end
+end

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
 module Chunker
-    ##
-    # methods for generating breadcrumbs for Enterprise Search book
-    module SearchBreadcrumbs
-      def generate_search_breadcrumbs(doc, _search_type)
+  ##
+  # methods for generating breadcrumbs for Enterprise Search book
+  module SearchBreadcrumbs
+    def generate_search_breadcrumbs(doc, _search_type)
         title = doc.title
         short = title.sub(/ documentation/, '')
         books = {
-          'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
-          'App Search' => '/guide/en/app-search/current/index.html',
-          'Workplace Search' => '/guide/en/workplace-search/current/index.html'
+            'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+            'App Search' => '/guide/en/app-search/current/index.html',
+            'Workplace Search' => '/guide/en/workplace-search/current/index.html',
         }
         clients = {
           'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
           'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
           'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
-          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html'
+          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
         }
         <<~HTML.strip
           <span class="breadcrumb-link">

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -8,36 +8,36 @@ module Chunker
       title = doc.title
       short = title.sub(/ documentation/, '')
       books = {
-          'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
-          'App Search' => '/guide/en/app-search/current/index.html',
-          'Workplace Search' => '/guide/en/workplace-search/current/index.html',
-        }
-        clients = {
-          'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
-          'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
-          'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
-          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
-        }
-        <<~HTML.strip
-          <span class="breadcrumb-link">
-            <div id="related-products" class="dropdown">
-              <div class="related-products-title"></div>
-              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-              <div class="dropdown-content">
-                <ul>
-                  <li class="dropdown-category">Enterprise Search guides</li>
-                  <ul>
-                    #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-                  </ul>
-                  <li class="dropdown-category">Programming language clients</li>
-                  <ul>
-                    #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-                  </ul>
-                </ul>
-              </div>
-            </div>
-          </span>
-        HTML
+        'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+        'App Search' => '/guide/en/app-search/current/index.html',
+        'Workplace Search' => '/guide/en/workplace-search/current/index.html',
+    }
+    clients = {
+        'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
+        'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
+        'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
+        'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
+    }
+    <<~HTML.strip
+    <span class="breadcrumb-link">
+    <div id="related-products" class="dropdown">
+    <div class="related-products-title"></div>
+    <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+    <div class="dropdown-content">
+    <ul>
+    <li class="dropdown-category">Enterprise Search guides</li>
+    <ul>
+    #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+    </ul>
+    <li class="dropdown-category">Programming language clients</li>
+    <ul>
+    #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+    </ul>
+    </ul>
+    </div>
+    </div>
+    </span>
+    HTML
     end
-end
+  end
 end

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+module Chunker
+##
+# methods for generating breadcrumbs for Enterprise Search book
+  module Search_breadcrumbs
+    def generate_search_breadcrumbs(doc, _search_type)
+        title = doc.title
+        short = title.sub(/ documentation/, '')
+        books = {
+          'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+          'App Search' => '/guide/en/app-search/current/index.html',
+          'Workplace Search' => '/guide/en/workplace-search/current/index.html',
+        }
+        clients = {
+          'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
+          'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
+          'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
+          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
+        }
+        <<~HTML.strip
+          <span class="breadcrumb-link">
+            <div id="related-products" class="dropdown">
+              <div class="related-products-title"></div>
+              <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+              <div class="dropdown-content">
+                <ul>
+                  <li class="dropdown-category">Enterprise Search guides</li>
+                  <ul>
+                    #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+                  </ul>
+                  <li class="dropdown-category">Programming language clients</li>
+                  <ul>
+                    #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+                  </ul>
+                </ul>
+              </div>
+            </div>
+          </span>
+        HTML
+      end
+    end
+    end

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
+
 module Chunker
-##
-# methods for generating breadcrumbs for Enterprise Search book
-  module Search_breadcrumbs
+  ##
+  # methods for generating breadcrumbs for Enterprise Search book
+  module Search_Breadcrumbs
     def generate_search_breadcrumbs(doc, _search_type)
-        title = doc.title
-        short = title.sub(/ documentation/, '')
-        books = {
+      title = doc.title
+      short = title.sub(/ documentation/, '')
+      books = {
           'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
           'App Search' => '/guide/en/app-search/current/index.html',
           'Workplace Search' => '/guide/en/workplace-search/current/index.html',
@@ -37,6 +38,6 @@ module Chunker
             </div>
           </span>
         HTML
-      end
     end
-    end
+end
+end

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -5,39 +5,39 @@ module Chunker
   # methods for generating breadcrumbs for Enterprise Search book
   module SearchBreadcrumbs
     def generate_search_breadcrumbs(doc, _search_type)
-        title = doc.title
-        short = title.sub(/ documentation/, '')
-        books = {
-            'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
-            'App Search' => '/guide/en/app-search/current/index.html',
-            'Workplace Search' => '/guide/en/workplace-search/current/index.html',
-        }
-        clients = {
-          'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
-          'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
-          'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
-          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
-        }
-        <<~HTML.strip
-          <span class="breadcrumb-link">
-          <div id="related-products" class="dropdown">
-          <div class="related-products-title"></div>
-          <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-          <div class="dropdown-content">
-          <ul>
-          <li class="dropdown-category">Enterprise Search guides</li>
-          <ul>
-          #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-          </ul>
-          <li class="dropdown-category">Programming language clients</li>
-          <ul>
-          #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-          </ul>
-          </ul>
-          </div>
-          </div>
-          </span>
-        HTML
-      end
+      title = doc.title
+      short = title.sub(/ documentation/, '')
+      books = {
+        'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+        'App Search' => '/guide/en/app-search/current/index.html',
+        'Workplace Search' => '/guide/en/workplace-search/current/index.html',
+      }
+      clients = {
+        'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
+        'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
+        'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
+        'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
+      }
+      <<~HTML.strip
+        <span class="breadcrumb-link">
+        <div id="related-products" class="dropdown">
+        <div class="related-products-title"></div>
+        <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+        <div class="dropdown-content">
+        <ul>
+        <li class="dropdown-category">Enterprise Search guides</li>
+        <ul>
+        #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+        </ul>
+        <li class="dropdown-category">Programming language clients</li>
+        <ul>
+        #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+        </ul>
+        </ul>
+        </div>
+        </div>
+        </span>
+      HTML
     end
   end
+end

--- a/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/search_breadcrumbs.rb
@@ -1,43 +1,43 @@
 # frozen_string_literal: true
 
 module Chunker
-  ##
-  # methods for generating breadcrumbs for Enterprise Search book
-  module Search_Breadcrumbs
-    def generate_search_breadcrumbs(doc, _search_type)
-      title = doc.title
-      short = title.sub(/ documentation/, '')
-      books = {
-        'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
-        'App Search' => '/guide/en/app-search/current/index.html',
-        'Workplace Search' => '/guide/en/workplace-search/current/index.html',
-    }
-    clients = {
-        'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
-        'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
-        'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
-        'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html',
-    }
-    <<~HTML.strip
-    <span class="breadcrumb-link">
-    <div id="related-products" class="dropdown">
-    <div class="related-products-title"></div>
-    <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
-    <div class="dropdown-content">
-    <ul>
-    <li class="dropdown-category">Enterprise Search guides</li>
-    <ul>
-    #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-    </ul>
-    <li class="dropdown-category">Programming language clients</li>
-    <ul>
-    #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
-    </ul>
-    </ul>
-    </div>
-    </div>
-    </span>
-    HTML
+    ##
+    # methods for generating breadcrumbs for Enterprise Search book
+    module SearchBreadcrumbs
+      def generate_search_breadcrumbs(doc, _search_type)
+        title = doc.title
+        short = title.sub(/ documentation/, '')
+        books = {
+          'Enterprise Search' => '/guide/en/enterprise-search/current/index.html',
+          'App Search' => '/guide/en/app-search/current/index.html',
+          'Workplace Search' => '/guide/en/workplace-search/current/index.html'
+        }
+        clients = {
+          'Node.js client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html',
+          'PHP client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/php/current/index.html',
+          'Python client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/python/current/index.html',
+          'Ruby client' => 'https://www.elastic.co/guide/en/enterprise-search-clients/ruby/current/index.html'
+        }
+        <<~HTML.strip
+          <span class="breadcrumb-link">
+          <div id="related-products" class="dropdown">
+          <div class="related-products-title"></div>
+          <div class="dropdown-anchor" tabindex="0">#{short}<span class="dropdown-icon"></span></div>
+          <div class="dropdown-content">
+          <ul>
+          <li class="dropdown-category">Enterprise Search guides</li>
+          <ul>
+          #{books.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+          </ul>
+          <li class="dropdown-category">Programming language clients</li>
+          <ul>
+          #{clients.map { |name, link| "<li><a href=\"#{link}\" target=\"_blank\">#{name}</a></li>" }.join("\n")}
+          </ul>
+          </ul>
+          </div>
+          </div>
+          </span>
+        HTML
+      end
     end
   end
-end


### PR DESCRIPTION
Adds dropdown for the 3 principal Enterprise Search books to help users toggle books.

- Naive copy/paste of https://github.com/elastic/docs/pull/2619 😄. 
- ⚠️ Unlikely not to have side effects.
- Not sure what protocol is for tests

### Screenshots 

<img width="866" alt="dropdown-app" src="https://user-images.githubusercontent.com/32779855/230440924-3be3e80a-c4c2-4761-a914-d1fb9307bd3c.png">
<img width="892" alt="dropdown-workplace" src="https://user-images.githubusercontent.com/32779855/230440951-4a45ea4a-a911-400e-926b-648b9d82a2ca.png">
<img width="879" alt="dropdown-enterprise" src="https://user-images.githubusercontent.com/32779855/230440955-723b2f19-9b81-4d10-9ae0-ce4c69c3ef12.png">


