### PR TITLE
docs: move ingest docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1774,6 +1774,9 @@ contents:
             subject:    Fleet and Elastic Agent
             sources:
               -
+                repo:   ingest-docs
+                path:   docs/en
+              -
                 repo:   observability-docs
                 path:   docs/en
               -

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -160,7 +160,7 @@ alias docbldfnb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $G
 alias docbldjb='$GIT_HOME/docs/build_docs --respect_edit_url_overrides --doc $GIT_HOME/beats/journalbeat/docs/index.asciidoc --chunk 1'
 
 # Fleet and Elastic Agent guide
-alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/apm-server/docs --chunk 2'
+alias docbldim='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ingest-docs/docs/en/ingest-management/index.asciidoc --resource=$GIT_HOME/apm-server/docs --resource=$GIT_HOME/observability-docs/docs --chunk 2'
 
 # Integrations developer guide
 alias docbldidg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/integrations/index.asciidoc --resource=$GIT_HOME/package-spec/versions --chunk 2'


### PR DESCRIPTION
Moves the source of the ingest documentation.

Related: https://github.com/elastic/ingest-docs/pull/78

For: https://github.com/elastic/observability-docs/issues/2411