### PR TITLE
Update current version for .NET client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -527,7 +527,7 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                current:    8.0
+                current:    8.1
                 branches:   [ {main: master}, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -529,7 +529,7 @@ contents:
                 prefix:     net-api
                 current:    8.1
                 branches:   [ {main: master}, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ main, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ main, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients


### PR DESCRIPTION
We have now released 8.1.0 of the client and, therefore, should direct the current version in the docs to that branch.