### PR TITLE
Add shared attribute for kibana blob

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -163,7 +163,6 @@ Commonly referenced paths in commonly referenced repositories.
 ifdef::elasticsearch-root[]
 :es-ref-dir: {elasticsearch-root}/docs/reference
 endif::elasticsearch-root[]
-
 //////////
 Kibana app and UI names
 //////////
@@ -466,7 +465,7 @@ Issue and pull request URLs
 :apm-repo:     https://github.com/elastic/apm-server/
 :apm-issue:    {apm-repo}issues/
 :apm-pull:     {apm-repo}pull/
-
+:kibana-blob:  {kib-repo}blob/{branch}/
 //////////
 Legacy definitions
 //////////


### PR DESCRIPTION
This PR updates https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc in order to remove the book-scoped `blob` attribute from https://github.com/elastic/kibana/blob/main/docs/index.asciidoc