### PR TITLE
Fix typo in esf version attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -45,7 +45,7 @@
 :apm-lambda-ref:       https://www.elastic.co/guide/en/apm/lambda/current
 :apm-attacher-ref:     https://www.elastic.co/guide/en/apm/attacher/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
-:esf-ref:              https://www.elastic.co/guide/en/esf/{esf-version}
+:esf-ref:              https://www.elastic.co/guide/en/esf/{esf_version}
 ///////
 Elastic-level pages
 ///////


### PR DESCRIPTION
Forgot that I used an underscore instead of dash to match the convention used for ECS. :-) 

This will fix the build error in https://github.com/elastic/observability-docs/pull/2853.
