### PR TITLE
Change Enterprise Search link on docs landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -57,7 +57,7 @@
       Elastic provides flexible search, monitoring, and security solutions based on Elasticsearch.
     </p>
     <p>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a> 
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
@@ -147,7 +147,7 @@
         <path d="M993.707 419.293C993.317 418.902 992.683 418.902 992.293 419.293L985.929 425.657C985.538 426.047 985.538 426.681 985.929 427.071C986.319 427.462 986.953 427.462 987.343 427.071L993 421.414L998.657 427.071C999.047 427.462 999.681 427.462 1000.07 427.071C1000.46 426.681 1000.46 426.047 1000.07 425.657L993.707 419.293ZM992 420V440H994V420H992Z" fill="#BD271E"/>
         <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Inter" font-size="26" font-weight="bold" letter-spacing="0em"><tspan x="9" y="24.9545">Components of the Elastic Stack</tspan></text>
         </svg>
-    
+
     <h3 id="_ingest">Ingest</h3>
     <p>Elastic provides a number of components that ingest data. Collect and ship logs, metrics, and other types of data with Elastic Agent or Beats. Manage your Elastic Agents with Fleet. Collect detailed performance information with Elastic APM.</p>
     <p>If you want to transform or enrich data before it&#8217;s stored, you can use Elasticsearch ingest pipelines or Logstash.</p>
@@ -188,7 +188,7 @@
         Logstash is a data collection engine with real-time pipelining capabilities. It can dynamically unify data from disparate sources and normalize the data into destinations of your choice. Logstash supports a broad array of input, filter, and output plugins, with many native codecs further simplifying the ingestion process. <a href="en/logstash/current/introduction.html">Learn more about Logstash</a>.
       </dd>
     </dl>
-    
+
     <h3 id="_store">Store</h3>
     <dl>
       <dt id="stack-components-elasticsearch">
@@ -198,7 +198,7 @@
         Elasticsearch is the distributed search and analytics engine at the heart of the Elastic Stack. It provides near real-time search and analytics for all types of data. Whether you have structured or unstructured text, numerical data, or geospatial data, Elasticsearch can efficiently store and index it in a way that supports fast searches. Elasticsearch provides a REST API that enables you to store data in Elasticsearch and retrieve it. The REST API also provides access to Elasticsearch&#8217;s search and analytics capabilities. <a href="en/elasticsearch/reference/current/elasticsearch-intro.html">Learn more about Elasticsearch</a>.
       </dd>
     </dl>
-    
+
     <h3 id="_consume">Consume</h3>
     <p>Use Kibana to query and visualize the data that&#8217;s stored in Elasticsearch. Or, use the Elasticsearch clients to access data in Elasticsearch directly from common programming languages.</p>
     <dl>
@@ -222,7 +222,7 @@
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
   <div class="row my-4">
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/index.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>


### PR DESCRIPTION
Change link to land on new [Enterprise Search docs landing page](https://www.elastic.co/guide/en/enterprise-search/current/index.html) instead of [getting started](https://www.elastic.co/guide/en/enterprise-search/current/start.html) section.

_Not sure if we want to do this but it's quicker to open a PR than to ask the question :)_