### PR TITLE
Add warnlinkcheck build option

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -1129,4 +1129,7 @@ sub check_opts {
         die('--reference only compatible with --all or --preview') if $Opts->{reference};
         die('--target_repo only compatible with --all or --preview') if $Opts->{target_repo};
     }
+    if ($Opts->{skiplinkcheck} && $Opts->{warnlinkcheck} ) {
+        die('--warnlinkcheck is incompatible with --skiplinkcheck');
+    }
 }

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -337,9 +337,13 @@ sub check_links {
         say $link_checker->report;
     }
     else {
+      if ( $Opts->{warnlinkcheck} ){
+        say $link_checker->report;
+      }
+      else {
         die $link_checker->report;
+      }
     }
-
 }
 
 #===================================
@@ -1007,6 +1011,7 @@ sub command_line_opts {
         'reference=s',
         'reposcache=s',
         'skiplinkcheck',
+        'warnlinkcheck',
         'sub_dir=s@',
         'user=s',
         # Options only compatible with --preview
@@ -1069,6 +1074,7 @@ sub usage {
           --repos_cache     Directory to which working repositories are cloned.
                             Defaults to `<script_dir>/.repos`.
           --skiplinkcheck   Omit the step that checks for broken links
+          --warnlinkcheck   Checks for broken links but does not fail if they exist
           --sub_dir         Use a directory as a branch of some repo
                             (eg --sub_dir elasticsearch:master:~/Code/elasticsearch)
           --target_repo     Repository to which to commit docs
@@ -1113,6 +1119,7 @@ sub check_opts {
         die('--rebuild only compatible with --all') if $Opts->{rebuild};
         die('--reposcache only compatible with --all') if $Opts->{reposcache};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
+        die('--warnlinkcheck only compatible with --all') if $Opts->{warnlinkcheck};
         die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
     }
     if ( !$Opts->{preview} ) {

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -333,16 +333,11 @@ sub check_links {
     check_kibana_links( $build_dir, $link_checker ) if exists $Conf->{repos}{kibana};
     # Comment out due to build errors
     # check_elasticsearch_links( $build_dir, $link_checker ) if exists $Conf->{repos}{elasticsearch};
-    if ( $link_checker->has_bad ) {
+    if ( $link_checker->has_bad || $Opts->{warnlinkcheck}) {
         say $link_checker->report;
     }
     else {
-      if ( $Opts->{warnlinkcheck} ){
-        say $link_checker->report;
-      }
-      else {
         die $link_checker->report;
-      }
     }
 }
 

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -235,6 +235,11 @@ class Dest
       self
     end
 
+    def warn_link_check
+      @cmd += ['--warnlinkcheck']
+      self
+    end
+
     def keep_hash
       @cmd += ['--keep_hash']
       self

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -235,11 +235,6 @@ class Dest
       self
     end
 
-    def warn_link_check
-      @cmd += ['--warnlinkcheck']
-      self
-    end
-
     def keep_hash
       @cmd += ['--keep_hash']
       self

--- a/lib/ES/LinkCheck.pm
+++ b/lib/ES/LinkCheck.pm
@@ -98,7 +98,7 @@ sub report {
         push @error, "  $file contains broken links to:";
         push @error, map {"   - $_"} sort keys %{ $bad->{$file} };
     }
-    die join "\n", @error, '';
+    return join "\n", @error, '';
 
 }
 


### PR DESCRIPTION
This PR adds an optional --warnlinkcheck option, which enables you to run the build without failing if there's a broken link. Unlike the `--skiplinkcheck` option, it still performs the check and prints the details in the log.

For example, in a local test with broken links, the output still contains info like this:

```
INFO:build_docs:Bad cross-document links:
INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/apm/agent/java/1.x/config-logging.html contains broken links to:
INFO:build_docs:   - en/ecs-logging/overview/master/intro.html
...
```