### PR TITLE
Build Amazon Kinesis Firehose docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1852,7 +1852,7 @@ contents:
             current:    main
             branches:   [ {main: master} ]
             live:       [ main ]
-            chunk:      2
+            chunk:      1
             tags:       Cloud Native Ingest/Reference
             subject:    cloud native ingest
             sources:

--- a/conf.yaml
+++ b/conf.yaml
@@ -1848,7 +1848,7 @@ contents:
 
           - title:      Amazon Kinesis Data Firehose Ingestion Guide
             prefix:     en/kinesis
-            index:      docs/en/aws-firehose-index.asciidoc
+            index:      docs/en/observability/aws-firehose-index.asciidoc
             current:    main
             branches:   [ {main: master} ]
             live:       [ main ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -1826,7 +1826,7 @@ contents:
 
     -   title:      "Cloud Native: Ship Data from Your Cloud Provider"
         sections:
-          - title:      Elastic Serverless Forwarder
+          - title:      Elastic Serverless Forwarder Guide
             prefix:     en/esf
             index:      docs/en/index.asciidoc
             current:    main
@@ -1838,6 +1838,26 @@ contents:
             sources:
               -
                 repo:   esf
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+
+          - title:      Amazon Kinesis Data Firehose Ingestion Guide
+            prefix:     en/kinesis
+            index:      docs/en/aws-firehose-index.asciidoc
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            chunk:      2
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   observability-docs
                 path:   docs/en
               -
                 repo:   docs

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -17,6 +17,9 @@ alias docbldes=docbldesx
 # Elasticsearch Serverless Forwarder
 alias docbldesf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-serverless-forwarder/docs/en/index.asciidoc --chunk 2'
 
+# Amazon Kinesis Firehose
+alias docbldakf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/aws-firehose-index.asciidoc --chunk 2'
+
 # Elasticsearch 6.2 and earlier
 
 alias docbldesold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.x.asciidoc --resource=$GIT_HOME/elasticsearch-extra/x-pack-elasticsearch/docs/ --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -18,7 +18,7 @@ alias docbldes=docbldesx
 alias docbldesf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-serverless-forwarder/docs/en/index.asciidoc --chunk 2'
 
 # Amazon Kinesis Firehose
-alias docbldakf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/aws-firehose-index.asciidoc --chunk 2'
+alias docbldakf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/aws-firehose-index.asciidoc --chunk 1'
 
 # Elasticsearch 6.2 and earlier
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -46,6 +46,7 @@
 :apm-attacher-ref:     https://www.elastic.co/guide/en/apm/attacher/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 :esf-ref:              https://www.elastic.co/guide/en/esf/{esf_version}
+:kinesis-firehose-ref: https://www.elastic.co/guide/en/kinesis/{branch}
 ///////
 Elastic-level pages
 ///////


### PR DESCRIPTION
https://github.com/elastic/observability-docs/pull/2802 adds new docs for ingesting data for Amazon Kinesis. This PR gets them building.

https://github.com/elastic/observability-docs/pull/2802 must be merged before this PR will build.

Note: Because we're building these docs out of the observability-docs repo, they will follow the stack versioning strategy. If we want to have a different versioning strategy, we'll need to move these files to a repo with branches that match the versions we want to build.

Preview is here: https://docs_2671.docs-preview.app.elstc.co/guide/en/kinesis/current/aws-firehose.html 

I'll fix the actual book structure when I work on https://github.com/elastic/observability-docs/issues/2893 