### PR TITLE
Change location of Kinesis index file

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1849,7 +1849,7 @@ contents:
 
           - title:      Amazon Kinesis Data Firehose Ingestion Guide
             prefix:     en/kinesis
-            index:      docs/en/observability/aws-firehose-index.asciidoc
+            index:      docs/en/observability/aws-firehouse/index.asciidoc
             current:    main
             branches:   [ {main: master} ]
             live:       [ main ]

--- a/conf.yaml
+++ b/conf.yaml
@@ -1847,7 +1847,7 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
-          - title:      Amazon Kinesis Data Firehose Ingestion Guide
+          - title:      Amazon Kinesis Data Firehose Ingest Guide
             prefix:     en/kinesis
             index:      docs/en/observability/aws-firehose/index.asciidoc
             current:    main

--- a/conf.yaml
+++ b/conf.yaml
@@ -1849,7 +1849,7 @@ contents:
 
           - title:      Amazon Kinesis Data Firehose Ingestion Guide
             prefix:     en/kinesis
-            index:      docs/en/observability/aws-firehouse/index.asciidoc
+            index:      docs/en/observability/aws-firehose/index.asciidoc
             current:    main
             branches:   [ {main: master} ]
             live:       [ main ]

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -18,7 +18,7 @@ alias docbldes=docbldesx
 alias docbldesf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-serverless-forwarder/docs/en/index.asciidoc --chunk 2'
 
 # Amazon Kinesis Firehose
-alias docbldakf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/aws-firehose-index.asciidoc --chunk 1'
+alias docbldakf='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/aws-firehose/index.asciidoc --chunk 1'
 
 # Elasticsearch 6.2 and earlier
 


### PR DESCRIPTION
This PR needs to be merged at the same time as https://github.com/elastic/docs/pull/2674.

To test this PR:

1. Checkout https://github.com/elastic/observability-docs/pull/2895
2. Checkout this PR.
3. Reload the doc_build_aliases.sh file (for example, `source ~/.bash_profile` or whatever works on your system).
4. Run `docbldakf --open` to preview the output in your browser.