### PR TITLE
Fix tabbed widgets

### DIFF
--- a/resources/web/docs_js/components/tabbed_widget.js
+++ b/resources/web/docs_js/components/tabbed_widget.js
@@ -1,5 +1,7 @@
 export const switchTabs = () => {
-  window.addEventListener("DOMContentLoaded", () => {
+  
+  document.addEventListener("readystatechange", () => {
+   if (document.readyState === "interactive") {
     const tabs = document.querySelectorAll('[role="tab"]');
     const tabList = document.querySelector('[role="tablist"]');
     // Add a click event handler to each tab
@@ -30,6 +32,7 @@ export const switchTabs = () => {
         tabs[tabFocus].focus();
       }
     });
+   }
   });
 }
 

--- a/resources/web/docs_js/components/tabbed_widget.js
+++ b/resources/web/docs_js/components/tabbed_widget.js
@@ -1,7 +1,5 @@
 export const switchTabs = () => {
-  
-  document.addEventListener("readystatechange", () => {
-   if (document.readyState === "interactive") {
+  document.addEventListener("DOMContentLoaded", () => {
     const tabs = document.querySelectorAll('[role="tab"]');
     const tabList = document.querySelector('[role="tablist"]');
     // Add a click event handler to each tab
@@ -32,7 +30,6 @@ export const switchTabs = () => {
         tabs[tabFocus].focus();
       }
     });
-   }
   });
 }
 


### PR DESCRIPTION
There was a report today that the tabbed widgets were not working. Hovering over an inactive tab results in style changes, but the click event listener is not being applied, so the active tab doesn't change and the panel contents don't change.

After poking around, I found that the [`DOMContentLoaded` event listener](https://github.com/elastic/docs/blob/master/resources/web/docs_js/components/tabbed_widget.js#LL2C20-L2C20) in the tabbed widget component isn't working. I don't know why, but using the `readystatechange` event listener and waiting for the document's `readyState` to be `interactive` does work locally at least. 🤷‍♀️ 

## For reviewers

Find a couple pages in your team's docs that use the tabbed widget and make sure switching between tabs works as expected. Preview link: https://docs_2677.docs-preview.app.elstc.co/guide