### PR TITLE
Add esql test references

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -336,6 +336,10 @@ contents:
                 path:   x-pack/plugin/sql/qa
                 exclude_branches:   [ 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
+                repo:   elasticsearch
+                path:   x-pack/plugin/esql/qa/testFixtures/src/main/resources
+                exclude_branches:   [ 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+              -
                 alternatives: { source_lang: console, alternative_lang: php }
                 repo:   elasticsearch-php
                 path:   docs/examples


### PR DESCRIPTION
The ESQL docs reference some of ESQL's tests so we need to check those out when we build the ESQL docs.
