### PR TITLE
Change current to 3.6.0

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -764,8 +764,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-81
+            current:    ms-92
             branches:
+              - ms-92: 3.6
               - ms-81: 3.5
               - ms-78: 3.4
               - ms-75: 3.3

--- a/conf.yaml
+++ b/conf.yaml
@@ -806,6 +806,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-92: master
                   ms-81: master
                   ms-78: master
                   ms-75: master

--- a/conf.yaml
+++ b/conf.yaml
@@ -84,6 +84,7 @@ variables:
   cloudSaasCurrent: &cloudSaasCurrent ms-91
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-92: master
     ms-81: master
     ms-78: master
     ms-75: master


### PR DESCRIPTION
This changes "current" for the ECE docs to version 3.6.0.
Do not merge until release day (June 20th 2023)