### PR TITLE
Add section about attribute scope to readme

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -713,6 +713,25 @@ Here is a link to the {ref}/search.html[search page]
 ----------------------------------
 ==================================
 
+[[attribute-scope]]
+== Attribute scope
+
+Attributes are in-scope for the entire book unless you explicitly clear them by
+setting `:!attributename:`. For example:
+
+.Clearing an attribute
+==================================
+
+[source,asciidoc]
+----------------------------------
+:myattribute: some value
+All the things on the page.
+:!myattribute:
+----------------------------------
+==================================
+
+To create page-scoped attributes, clear the attribute at the end of the page.
+
 [[linking]]
 == Linking
 


### PR DESCRIPTION
We're seeing some unexpected behavior when attributes are used to set metadata. Resetting the attribute when it's no longer needed should be a best practice (just as it is when variables are used in code).