### PR TITLE
ESS - Change current to MS-92

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -81,7 +81,7 @@ variables:
 
   stacklivemain: &stacklivemain [ main, 8.8, 8.7, 8.6, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-91
+  cloudSaasCurrent: &cloudSaasCurrent ms-92
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-81: master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-92.
Do not merge until release day.