### PR TITLE
Add version attribute for Kinesis firehose docs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -46,7 +46,7 @@
 :apm-attacher-ref:     https://www.elastic.co/guide/en/apm/attacher/current
 :docker-logging-ref:   https://www.elastic.co/guide/en/beats/loggingplugin/{branch}
 :esf-ref:              https://www.elastic.co/guide/en/esf/{esf_version}
-:kinesis-firehose-ref: https://www.elastic.co/guide/en/kinesis/{branch}
+:kinesis-firehose-ref: https://www.elastic.co/guide/en/kinesis/{kinesis_version}
 ///////
 Elastic-level pages
 ///////

--- a/shared/versions/stack/8.8.asciidoc
+++ b/shared/versions/stack/8.8.asciidoc
@@ -15,6 +15,7 @@ bare_version never includes -alpha or -beta
 :major-version-only:     8
 :ecs_version:            8.8
 :esf_version:            master
+:kinesis_version:        master
 
 //////////
 Keep the :esf_version: attribute value as master. 


### PR DESCRIPTION
Adds version attribute for Kinesis firehose docs because this feature "is not tied to stack release versions, but for under-the-hood reasons is tied to ESS release milestones. in the future though this we be silently decoupled from the ESS releases."