### PR TITLE
Remove Elastic Platform Security

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2487,25 +2487,6 @@ contents:
 
     -   title:      Docs in Development
         sections:
-          - title:      Elastic Platform Security
-            prefix:     en/elastic-platform-security
-            current:    main
-            index:      platform-security/index.asciidoc
-            branches:   [ main ]
-            noindex:    1
-            chunk:      1
-            tags:       Elastic Platform/Security
-            subject:    Elastic Platform
-            sources:
-              -
-                repo:   tech-content
-                path:   platform-security
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Logstash and Kubernetes
             prefix:     en/logstash-kubernetes
             current:    main


### PR DESCRIPTION
Removes the [Elastic Platform Security](https://www.elastic.co/guide/en/elastic-platform-security/current/index.html) docs.

The Platform Docs team doesn't plan to update or publish these docs in the near future.

Relates to https://github.com/elastic/tech-content/issues/184