### PR TITLE
Stop indexing `master`/`main` in all stack-versioned books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -78,8 +78,8 @@ contents_title:     Welcome to Elastic Docs
 variables:
   stackcurrent: &stackcurrent 8.8
   stacklive: &stacklive [ master, 8.8, 8.7, 8.6, 7.17 ]
-
   stacklivemain: &stacklivemain [ main, 8.8, 8.7, 8.6, 7.17 ]
+  stackliveNoMain: &stackliveNoMain [ 8.8, 8.7, 8.6, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-91
 
@@ -1143,7 +1143,7 @@ contents:
             prefix:     en/observability
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
-            live:       *stacklivemain
+            live:       *stackliveNoMain
             index:      docs/en/observability/index.asciidoc
             chunk:      2
             tags:       Observability/Guide
@@ -1181,7 +1181,7 @@ contents:
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stackliveNoMain
                 chunk:      2
                 tags:       APM Guide
                 subject:    APM
@@ -1228,7 +1228,7 @@ contents:
                     prefix:     go
                     current:    2.x
                     branches:   [ {main: master}, 2.x, 1.x, 0.5 ]
-                    live:       [ main, 2.x, 1.x ]
+                    live:       [ 2.x, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
                     subject:    APM
@@ -1245,7 +1245,7 @@ contents:
                     prefix: swift
                     current: 0.x
                     branches: [ main, 0.x ]
-                    live: [ main, 0.x ]
+                    live: [ 0.x ]
                     index: docs/index.asciidoc
                     tags: APM iOS Agent/Reference
                     subject: APM
@@ -1261,7 +1261,7 @@ contents:
                     prefix:     java
                     current:    1.x
                     branches:   [ {main: master}, 1.x, 0.7, 0.6 ]
-                    live:       [ main, 1.x ]
+                    live:       [ 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
                     subject:    APM
@@ -1284,7 +1284,7 @@ contents:
                     prefix:     dotnet
                     current:    1.x
                     branches:   [ {main: master}, 1.x, 1.8 ]
-                    live:       [ main, 1.x ]
+                    live:       [ 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM
@@ -1300,7 +1300,7 @@ contents:
                     prefix:     nodejs
                     current:    3.x
                     branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ main, 3.x ]
+                    live:       [ 3.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM
@@ -1323,7 +1323,7 @@ contents:
                     prefix:     php
                     current:    1.x
                     branches:   [ {main: master}, 1.x ]
-                    live:       [ main, 1.x ]
+                    live:       [ 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
                     subject:    APM
@@ -1339,7 +1339,7 @@ contents:
                     prefix:     python
                     current:    6.x
                     branches:   [ {main: master}, 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ main, 6.x, 5.x ]
+                    live:       [ 6.x, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM
@@ -1362,7 +1362,7 @@ contents:
                     prefix:     ruby
                     current:    4.x
                     branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ main, 4.x ]
+                    live:       [ 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
                     subject:    APM
@@ -1379,7 +1379,7 @@ contents:
                     prefix:     rum-js
                     current:    5.x
                     branches:   [ {main: master}, 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ main, 5.x, 4.x]
+                    live:       [ 5.x, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
                     subject:    APM
@@ -1530,7 +1530,7 @@ contents:
                 prefix:     java
                 current:    1.x
                 branches:   [ {main: master}, 1.x, 0.x ]
-                live:       [ main, 1.x ]
+                live:       [ 1.x ]
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       ECS-logging/java/Guide

--- a/conf.yaml
+++ b/conf.yaml
@@ -77,9 +77,9 @@ contents_title:     Welcome to Elastic Docs
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 8.8
-  stacklive: &stacklive [ master, 8.8, 8.7, 8.6, 7.17 ]
-  stacklivemain: &stacklivemain [ main, 8.8, 8.7, 8.6, 7.17 ]
-  stackliveNoMain: &stackliveNoMain [ 8.8, 8.7, 8.6, 7.17 ]
+  stacklive: &stacklive [ master, 8.8, 7.17 ]
+  stacklivemain: &stacklivemain [ main, 8.8, 7.17 ]
+  stackliveNoMain: &stackliveNoMain [ 8.8, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-91
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -77,9 +77,7 @@ contents_title:     Welcome to Elastic Docs
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
   stackcurrent: &stackcurrent 8.8
-  stacklive: &stacklive [ master, 8.8, 7.17 ]
-  stacklivemain: &stacklivemain [ main, 8.8, 7.17 ]
-  stackliveNoMain: &stackliveNoMain [ 8.8, 7.17 ]
+  stacklive: &stacklive [ 8.8, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-91
 
@@ -149,7 +147,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/install-upgrade/index.asciidoc
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Installation and Upgrade
             subject:    Elastic Stack
@@ -223,7 +221,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/stack/ml/index.asciidoc
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Elastic Stack/Machine Learning
             subject:    Machine Learning
@@ -276,7 +274,7 @@ contents:
             prefix:     en/elasticsearch/reference
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/reference/index.x.asciidoc
             chunk:      1
             tags:       Elasticsearch/Reference
@@ -404,7 +402,7 @@ contents:
             prefix:     en/elasticsearch/painless
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/painless/index.asciidoc
             chunk:      1
             tags:       Elasticsearch/Painless
@@ -430,7 +428,7 @@ contents:
             current:    *stackcurrent
             index:      docs/plugins/index.asciidoc
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      2
             tags:       Elasticsearch/Plugins
             subject:    Elasticsearch
@@ -470,7 +468,7 @@ contents:
                 prefix:     java-api-client
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Java
@@ -492,7 +490,7 @@ contents:
                 prefix:     javascript-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/JavaScript
@@ -505,7 +503,7 @@ contents:
                 prefix:     ruby-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/Ruby
@@ -518,7 +516,7 @@ contents:
                 prefix:     go-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      .doc/index.asciidoc
                 chunk:      1
                 tags:       Clients/Go
@@ -547,7 +545,7 @@ contents:
                 prefix:     php-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
                 tags:       Clients/PHP
@@ -576,7 +574,7 @@ contents:
                 prefix:     python-api
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 chunk:     1
                 tags:       Clients/Python
@@ -702,7 +700,7 @@ contents:
             prefix:     en/elasticsearch/hadoop
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/src/reference/asciidoc/index.adoc
             tags:       Elasticsearch/Apache Hadoop
             subject:    Elasticsearch
@@ -912,7 +910,7 @@ contents:
             prefix:     en/kibana
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 4.6, 4.5, 4.4, 4.3, 4.2, 4.1, 4.0, 3.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Kibana/Reference
@@ -965,7 +963,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Enterprise Search/Guide
             subject:    Enterprise Search
@@ -982,7 +980,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Workplace Search/Guide
             subject:    Workplace Search
@@ -999,7 +997,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       App Search/Guide
             subject:    App Search
@@ -1032,7 +1030,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      client-docs/app-search-javascript/index.asciidoc
                 tags:       App Search Clients/JavaScript
                 subject:    App Search Clients
@@ -1049,7 +1047,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      client-docs/app-search-node/index.asciidoc
                 tags:       App Search Clients/Node.js
                 subject:    App Search Clients
@@ -1079,7 +1077,7 @@ contents:
                 prefix:     php
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
                 subject:    Enterprise Search Clients
@@ -1094,7 +1092,7 @@ contents:
                 prefix:     python
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
                 subject:    Enterprise Search Clients
@@ -1109,7 +1107,7 @@ contents:
                 prefix:     ruby
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
                 subject:    Enterprise Search Clients
@@ -1126,7 +1124,7 @@ contents:
                 single:     1
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stacklivemain
+                live:       *stacklive
                 index:      client-docs/workplace-search-node/index.asciidoc
                 tags:       Workplace Search Clients/Node.js
                 subject:    Workplace Search Clients
@@ -1668,7 +1666,7 @@ contents:
             prefix:     en/security
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/index.asciidoc
             chunk:      1
             tags:       Security/Guide
@@ -1717,7 +1715,7 @@ contents:
             prefix:     en/logstash
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/index.x.asciidoc
             chunk:      1
             tags:       Logstash/Reference
@@ -1776,7 +1774,7 @@ contents:
             prefix:     en/fleet
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklivemain
+            live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2
             tags:       Fleet/Guide/Elastic Agent
@@ -1874,7 +1872,7 @@ contents:
             index:      libbeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Libbeat/Reference
             subject:    libbeat
@@ -1899,7 +1897,7 @@ contents:
             index:      auditbeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Auditbeat/Reference
             respect_edit_url_overrides: true
@@ -1952,7 +1950,7 @@ contents:
             index:      filebeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Filebeat/Reference
             respect_edit_url_overrides: true
@@ -2007,7 +2005,7 @@ contents:
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Functionbeat/Reference
             respect_edit_url_overrides: true
@@ -2056,7 +2054,7 @@ contents:
             current:    *stackcurrent
             index:      heartbeat/docs/index.asciidoc
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Heartbeat/Reference
             respect_edit_url_overrides: true
@@ -2103,7 +2101,7 @@ contents:
             index:      metricbeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Metricbeat/Reference
             respect_edit_url_overrides: true
@@ -2160,7 +2158,7 @@ contents:
             index:      packetbeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Packetbeat/Reference
             respect_edit_url_overrides: true
@@ -2203,7 +2201,7 @@ contents:
             index:      winlogbeat/docs/index.asciidoc
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Winlogbeat/Reference
             respect_edit_url_overrides: true
@@ -2246,7 +2244,7 @@ contents:
             index:      docs/devguide/index.asciidoc
             current:    main
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-            live:       *stacklivemain
+            live:       *stacklive
             chunk:      1
             tags:       Devguide/Reference
             subject:    Beats

--- a/conf.yaml
+++ b/conf.yaml
@@ -1141,7 +1141,7 @@ contents:
             prefix:     en/observability
             current:    *stackcurrent
             branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
-            live:       *stackliveNoMain
+            live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      2
             tags:       Observability/Guide
@@ -1179,7 +1179,7 @@ contents:
                 index:      docs/integrations-index.asciidoc
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
-                live:       *stackliveNoMain
+                live:       *stacklive
                 chunk:      2
                 tags:       APM Guide
                 subject:    APM


### PR DESCRIPTION
Creates a new `stackliveNoMain` in `conf.yml` that includes an array of recent versions _without_ `main` or `master`, and applies that variable to Observability books where possible. (It's not possible where `main`/`master` is the value for the `current` property.) 
