### PR TITLE
Stop indexing legacy APM documentation

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1424,6 +1424,7 @@ contents:
                   - title:      Legacy APM Overview
                     prefix:     get-started
                     index:      docs/guide/index.asciidoc
+                    current:    7.15
                     branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                     chunk:      1
                     tags:       APM Server/Reference
@@ -1438,6 +1439,7 @@ contents:
                   - title:      Legacy APM Server Reference
                     prefix:     server
                     index:      docs/index.asciidoc
+                    current:    7.15
                     branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
                     chunk:      1
                     tags:       APM Server/Reference

--- a/conf.yaml
+++ b/conf.yaml
@@ -1424,9 +1424,7 @@ contents:
                   - title:      Legacy APM Overview
                     prefix:     get-started
                     index:      docs/guide/index.asciidoc
-                    current:    7.15
                     branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                    live:       [ 7.15, 6.8 ]
                     chunk:      1
                     tags:       APM Server/Reference
                     subject:    APM
@@ -1440,9 +1438,7 @@ contents:
                   - title:      Legacy APM Server Reference
                     prefix:     server
                     index:      docs/index.asciidoc
-                    current:    7.15
                     branches:   [ 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0 ]
-                    live:       [ 7.15, 6.8 ]
                     chunk:      1
                     tags:       APM Server/Reference
                     subject:    APM


### PR DESCRIPTION
### Summary

Legacy APM documentation still shows up in google search results. This PR stops indexing some very old versions 😨 .

For https://github.com/elastic/observability-docs/issues/2986.