### PR TITLE
Make tables stylable

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -53,7 +53,7 @@ module DocbookCompat
         %( border="#{border}" cellpadding="4px"),
         node.title ? %( summary="#{strip_tags node.title}") : nil,
         (width = node.attr 'width') ? %( width="#{width}") : nil,
-        node.role ? %( class=#{node.role}) : nil,
+        node.role ? %( class="#{node.role}") : nil,
         '>',
       ].compact.join
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_table.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_table.rb
@@ -53,6 +53,7 @@ module DocbookCompat
         %( border="#{border}" cellpadding="4px"),
         node.title ? %( summary="#{strip_tags node.title}") : nil,
         (width = node.attr 'width') ? %( width="#{width}") : nil,
+        node.role ? %( class=#{node.role}) : nil,
         '>',
       ].compact.join
     end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -2320,6 +2320,51 @@ RSpec.describe DocbookCompat do
         HTML
       end
     end
+    context 'with role shorthand' do
+      let(:input) do
+        <<~ASCIIDOC
+          [.role]
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'has the class' do
+        expect(converted).to include <<~HTML
+          <table border="1" cellpadding="4px" class="role">
+        HTML
+      end
+    end
+    context 'with roles shorthand' do
+      let(:input) do
+        <<~ASCIIDOC
+          [.role1.role2]
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'has the classes' do
+        expect(converted).to include <<~HTML
+          <table border="1" cellpadding="4px" class="role1 role2">
+        HTML
+      end
+    end
+    context 'with role attribute' do
+      let(:input) do
+        <<~ASCIIDOC
+          [role=role]
+          |===
+          |Col 1 | Col 2
+          |===
+        ASCIIDOC
+      end
+      it 'has the class' do
+        expect(converted).to include <<~HTML
+          <table border="1" cellpadding="4px" class="role">
+        HTML
+      end
+    end
     context 'with colspan' do
       let(:input) do
         <<~ASCIIDOC

--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -51,7 +51,7 @@
     }
   }
 
-  .fixed-width { 
+  .monospaced { 
     td p, th {
       font-family: Consolas, Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Lucida Console", monospace;
     }

--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -85,6 +85,9 @@
 
     tr:nth-child(even) td[rowspan] {
       background: none;
+    }
+
+    td[rowspan] {
       vertical-align: middle;
     }
   }

--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -82,5 +82,10 @@
     tr:nth-child(even) td {
       background: #F1F4F9;
     }
+
+    tr:nth-child(even) td[rowspan] {
+      background: none;
+      vertical-align: middle;
+    }
   }
 }

--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -50,4 +50,37 @@
       border: none;
     }
   }
+
+  .fixed-width { 
+    td p, th {
+      font-family: Consolas, Menlo, "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Lucida Console", monospace;
+    }
+  }
+
+  .styled {
+    margin-bottom:2em;
+    border: none;
+    width: calc(100% - 10px);
+    box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+    th, td, tr:last-child th, tr:last-child td {
+      border: none;
+      border-left: 1px solid #F1F4F9;
+      border-top: 1px solid #F1F4F9;
+    }
+    td p {
+      margin: 0;
+    }
+    th {
+      font-weight: 700;
+      padding: 0.4em;
+      background: #F1F4F9;
+    }
+    td {
+      vertical-align: top;
+      padding: 0.4em 0.4em;
+    }
+    tr:nth-child(even) td {
+      background: #F1F4F9;
+    }
+  }
 }


### PR DESCRIPTION
The current default styling of tables is not great. Even though Asciidoctor allows [assigning roles to a table](https://docs.asciidoctor.org/asciidoc/latest/tables/assign-a-role/), which are rendered as CSS `class` attributes in HTML, [our implementation of tables](https://github.com/elastic/docs/blob/master/resources/asciidoctor/lib/docbook_compat/convert_table.rb#L50) does not support that.

This PR enables that functionality, by passing any roles as `class` attributes of the rendered table. 

The PR also introduces two new CSS classes: `styled` and `fixed-width`, which can optionally be assigned as roles to a table, using for example `[.styled]`,  or even `[.styled.fixed-width]`, if you want to apply both.

It enables us to do something like this (note the `.styled`):

```
.Script {watcher-transform} settings
[.styled,options="header"]
|======
| Name      |Required | Default    | Description

| `inline`  | yes     | -          | When using an inline script, this field holds
                                     the script itself.

| `id`      | yes     | -          | When referring to a stored script, this
                                     field holds the id of the script.

| `lang`    | no      | `painless` | The script language

| `params`  | no      | -          | Additional parameters/variables that are
                                     accessible by the script
|======
```

This gets rendered as:

<img width="864" alt="image" src="https://github.com/elastic/docs/assets/9715543/da7a9d66-9c19-40bf-848b-6851bc611a08">

Which is an improvement over [the current styling](https://www.elastic.co/guide/en/elasticsearch/reference/master/transform-script.html#transform-script-settings). I'm sure we can make tables even more beautiful than this, but this is a step forward already ("Progress, perfection").

This change does not affect any existing tables. Those tables don't have any roles assigned to them, and they will be rendered as they have been before.
