### PR TITLE
Expand styles for ESQL

### DIFF
--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -10,6 +10,7 @@ import * as utils from "./utils.js";
 import PR from "../lib/prettify/prettify";
 import "./prettify/lang-asciidoc";
 import "./prettify/lang-console";
+import "../lib/prettify/lang-esql";
 import "../lib/prettify/lang-sql";
 import "../lib/prettify/lang-yaml";
 

--- a/resources/web/lib/prettify/lang-esql.js
+++ b/resources/web/lib/prettify/lang-esql.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import PR from "./prettify";
+
+PR['registerLangHandler'](
+    PR['createSimpleLexer'](
+        [
+         [PR['PR_PLAIN'],       /^[\t\n\r \xA0]+/, null, '\t\n\r \xA0'],
+         [PR['PR_STRING'],      /^(?:"(?:[^\"\\]|\\.)*")/, null, '"']
+        ],
+        [
+         [PR['PR_COMMENT'], /^(?:\/\/[^\r\n]*|\/\*[\s\S]*?(?:\*\/|$))/],
+         [PR['PR_KEYWORD'], /^(?:AND|OR|BY|DISSECT|DROP|EVAL|FROM|GROK|LIKE|LIMIT|MV_EXPAND|NOT|PROJECT|RENAME|RLIKE|ROW|SHOW|SORT|STATS|WHERE)(?=[^\w-]|$)/i, null],
+         [PR['PR_LITERAL'], /^[+-]?(?:\.\d+|\d+(?:\.\d*)?)/i],
+         [PR['PR_PLAIN'], /^[a-z_][\w-]*/i],
+        ]),
+    ['esql']);

--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -27,8 +27,10 @@
     }
     &.merge {
       margin-bottom: 0px;
+      width: calc(100% - 10px);
       &.styled {
-        box-shadow: 5px 0px 5px rgba(0, 0, 0, 0.15);
+        box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.15);
+        z-index: 1;
       }
     }
   }

--- a/resources/web/style/code.pcss
+++ b/resources/web/style/code.pcss
@@ -25,6 +25,12 @@
     pre {
       margin: 0;
     }
+    &.merge {
+      margin-bottom: 0px;
+      &.styled {
+        box-shadow: 5px 0px 5px rgba(0, 0, 0, 0.15);
+      }
+    }
   }
 
   /* Code blocks with and without prettyprint. */

--- a/resources/web/style/table.pcss
+++ b/resources/web/style/table.pcss
@@ -57,7 +57,9 @@
     }
   }
 
-  .styled {
+  table.styled {
+    position: relative;
+    z-index: 2;
     margin-bottom:2em;
     border: none;
     width: calc(100% - 10px);


### PR DESCRIPTION
This implements the `esql` language in prettify so it'll look nice and it adds another couple of styles that let us merge the results like I'm trying to do here:
https://github.com/elastic/elasticsearch-internal/pull/1259
