### PR TITLE
Fix aspect ratio of video on docs landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -64,7 +64,7 @@
    </div>
    <div class="col-md-6 col-12">
      <div class="embed-responsive embed-responsive-16by9">
-       <iframe class="embed-responsive-item vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp;" scrolling="no" frameborder="0" allowfullscreen=""></iframe>
+       <iframe class="embed-responsive-item vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3" scrolling="no" frameborder="0" allowfullscreen=""></iframe>
      </div>
    </div>
 

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -63,7 +63,7 @@
    </p>
    </div>
    <div class="col-md-6 col-12">
-    <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp; width="640" height="360" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
+    <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3" width="448" height="252" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
    </div>
   </div>
 

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -67,7 +67,7 @@
        <iframe class="embed-responsive-item vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3" scrolling="no" frameborder="0" allowfullscreen=""></iframe>
      </div>
    </div>
-
+  </div>
   <h2>Learn about the Elastic Stack</h2>
   <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
 

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -63,9 +63,10 @@
    </p>
    </div>
    <div class="col-md-6 col-12">
-    <iframe class="vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3" width="448" height="252" scrolling="no" frameborder="0" allowfullscreen="" /></iframe>
+     <div class="embed-responsive embed-responsive-16by9">
+       <iframe class="embed-responsive-item vidyard_iframe" src="https://play.vidyard.com/qAS1W24928bBrc2sv5f5Ti?v=4.3&amp;" scrolling="no" frameborder="0" allowfullscreen=""></iframe>
+     </div>
    </div>
-  </div>
 
   <h2>Learn about the Elastic Stack</h2>
   <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>


### PR DESCRIPTION
The dimensions set for the embedded video on our [docs landing page](https://www.elastic.co/guide/index.html) are incorrectly coded (invalid HTML) and do not optimize usage of space on the page.

This PR fixes the existing HTML.

I may try a few different settings to see what works best.