### PR TITLE
Add mention of logs to the Observability getting started card

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -240,7 +240,7 @@
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
             Observability
           </h4>
-          <p>Monitor hosts with Elastic Observability.</p>
+          <p>Monitor hosts by collecting logs and metrics with Elastic Observability.</p>
         </div>
       </a>
     </div>


### PR DESCRIPTION
### Summary
This PR closes [Issue 93](https://github.com/elastic/obs-docs-projects/issues/93). The "Monitor hosts with Elastic Observability" was updated to mention logs to increase visibility into the fact that Observability is the home of logging.
