### PR TITLE
Move old translations to legacy section of the docs landing page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2291,196 +2291,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
 
-    - title:     Docs in Your Native Tongue
-      sections:
-        - title:      简体中文
-          base_dir:   cn
-          lang:       zh_cn
-          sections:
-            - title:      《Elasticsearch 权威指南》中文版
-              prefix:     elasticsearch/guide
-              index:      book.asciidoc
-              current:    cn
-              branches:   [ {cn: 2.x} ]
-              chunk:      1
-              private:    1
-              lang:       zh_cn
-              tags:       Elasticsearch/Definitive Guide
-              subject:    Elasticsearch
-              suppress_migration_warnings: true
-              sources:
-                -
-                  repo: guide-cn
-                  path: /
-            - title:      PHP API
-              prefix:     elasticsearch/php
-              index:      index.asciidoc
-              current:    cn
-              branches:   [ {cn: 6.0} ]
-              lang:       zh_cn
-              tags:       Elasticsearch/PHP
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch-php-cn
-                  path: /
-            - title:      Kibana 用户手册
-              prefix:     kibana
-              index:      docs/index.asciidoc
-              current:    cn
-              branches:   [ {cn: 6.0} ]
-              lang:       zh_cn
-              chunk:      1
-              private:    1
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana-cn
-                  path: /docs
-        - title:      日本語
-          base_dir:   jp
-          lang:       ja
-          sections:
-            - title:      Elasticsearchリファレンス
-              prefix:     elasticsearch/reference
-              index:      docs/jp/reference/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Elasticsearch/Reference
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch
-                  path: /docs/jp/reference
-                -
-                  repo: elasticsearch
-                  path: /docs
-            - title:      Logstashリファレンス
-              prefix:     logstash
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Logstash/Reference
-              subject:    Logstash
-              sources:
-                -
-                  repo: logstash
-                  path: /docs/jp
-            - title:      Kibanaユーザーガイド
-              prefix:     kibana
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana
-                  path: /docs/jp
-            - title:      X-Packリファレンス
-              prefix:     x-pack
-              index:      docs/jp/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4 ]
-              chunk:      1
-              private:    1
-              lang:       ja
-              tags:       X-Pack/Reference
-              subject:    X-Pack
-              sources:
-                -
-                  repo: x-pack
-                  path: /docs/jp
-                -
-                  repo:   x-pack-kibana
-                  path:   docs/jp
-                  prefix: kibana-extra/x-pack-kibana
-                -
-                  repo: x-pack-elasticsearch
-                  path: /docs/jp
-                  prefix: elasticsearch-extra/x-pack-elasticsearch
-        - title:      한국어
-          base_dir:   kr
-          lang:       ko
-          sections:
-            - title:      Elasticsearch 참조
-              prefix:     elasticsearch/reference
-              index:      docs/kr/reference/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Elasticsearch/Reference
-              subject:    Elasticsearch
-              sources:
-                -
-                  repo: elasticsearch
-                  path: /docs/kr/reference
-                -
-                  repo: elasticsearch
-                  path: /docs
-            - title:      Logstash 참조
-              prefix:     logstash
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Logstash/Reference
-              subject:    Logstash
-              sources:
-                -
-                  repo: logstash
-                  path: /docs/kr
-            - title:      Kibana 사용자 가이드
-              prefix:     kibana
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4, 5.3 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       Kibana/Reference
-              subject:    Kibana
-              sources:
-                -
-                  repo: kibana
-                  path: /docs/kr
-            - title:      X-Pack 참조
-              prefix:     x-pack
-              index:      docs/kr/gs-index.asciidoc
-              current:    5.4
-              branches:   [ 5.4 ]
-              chunk:      1
-              private:    1
-              lang:       ko
-              tags:       X-Pack/Reference
-              subject:    X-Pack
-              sources:
-                -
-                  repo: x-pack
-                  path: /docs/kr
-                -
-                  repo: x-pack-kibana
-                  path: /docs/kr
-                  prefix: kibana-extra/x-pack-kibana
-                -
-                  repo: x-pack-elasticsearch
-                  path: /docs/kr
-                  prefix: elasticsearch-extra/x-pack-elasticsearch
-
     -   title:      Docs in Development
         sections:
           - title:      Logstash and Kubernetes
@@ -2914,6 +2724,194 @@ contents:
               -
                 repo:   elasticsearch-js-legacy
                 path:   docs
+
+          - title:      简体中文
+            base_dir:   cn
+            lang:       zh_cn
+            sections:
+              - title:      《Elasticsearch 权威指南》中文版
+                prefix:     elasticsearch/guide
+                index:      book.asciidoc
+                current:    cn
+                branches:   [ {cn: 2.x} ]
+                chunk:      1
+                private:    1
+                lang:       zh_cn
+                tags:       Elasticsearch/Definitive Guide
+                subject:    Elasticsearch
+                suppress_migration_warnings: true
+                sources:
+                  -
+                    repo: guide-cn
+                    path: /
+              - title:      PHP API
+                prefix:     elasticsearch/php
+                index:      index.asciidoc
+                current:    cn
+                branches:   [ {cn: 6.0} ]
+                lang:       zh_cn
+                tags:       Elasticsearch/PHP
+                subject:    Elasticsearch
+                sources:
+                  -
+                    repo: elasticsearch-php-cn
+                    path: /
+              - title:      Kibana 用户手册
+                prefix:     kibana
+                index:      docs/index.asciidoc
+                current:    cn
+                branches:   [ {cn: 6.0} ]
+                lang:       zh_cn
+                chunk:      1
+                private:    1
+                tags:       Kibana/Reference
+                subject:    Kibana
+                sources:
+                  -
+                    repo: kibana-cn
+                    path: /docs
+          - title:      日本語
+            base_dir:   jp
+            lang:       ja
+            sections:
+              - title:      Elasticsearchリファレンス
+                prefix:     elasticsearch/reference
+                index:      docs/jp/reference/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ja
+                tags:       Elasticsearch/Reference
+                subject:    Elasticsearch
+                sources:
+                  -
+                    repo: elasticsearch
+                    path: /docs/jp/reference
+                  -
+                    repo: elasticsearch
+                    path: /docs
+              - title:      Logstashリファレンス
+                prefix:     logstash
+                index:      docs/jp/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ja
+                tags:       Logstash/Reference
+                subject:    Logstash
+                sources:
+                  -
+                    repo: logstash
+                    path: /docs/jp
+              - title:      Kibanaユーザーガイド
+                prefix:     kibana
+                index:      docs/jp/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ja
+                tags:       Kibana/Reference
+                subject:    Kibana
+                sources:
+                  -
+                    repo: kibana
+                    path: /docs/jp
+              - title:      X-Packリファレンス
+                prefix:     x-pack
+                index:      docs/jp/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4 ]
+                chunk:      1
+                private:    1
+                lang:       ja
+                tags:       X-Pack/Reference
+                subject:    X-Pack
+                sources:
+                  -
+                    repo: x-pack
+                    path: /docs/jp
+                  -
+                    repo:   x-pack-kibana
+                    path:   docs/jp
+                    prefix: kibana-extra/x-pack-kibana
+                  -
+                    repo: x-pack-elasticsearch
+                    path: /docs/jp
+                    prefix: elasticsearch-extra/x-pack-elasticsearch
+          - title:      한국어
+            base_dir:   kr
+            lang:       ko
+            sections:
+              - title:      Elasticsearch 참조
+                prefix:     elasticsearch/reference
+                index:      docs/kr/reference/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ko
+                tags:       Elasticsearch/Reference
+                subject:    Elasticsearch
+                sources:
+                  -
+                    repo: elasticsearch
+                    path: /docs/kr/reference
+                  -
+                    repo: elasticsearch
+                    path: /docs
+              - title:      Logstash 참조
+                prefix:     logstash
+                index:      docs/kr/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ko
+                tags:       Logstash/Reference
+                subject:    Logstash
+                sources:
+                  -
+                    repo: logstash
+                    path: /docs/kr
+              - title:      Kibana 사용자 가이드
+                prefix:     kibana
+                index:      docs/kr/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4, 5.3 ]
+                chunk:      1
+                private:    1
+                lang:       ko
+                tags:       Kibana/Reference
+                subject:    Kibana
+                sources:
+                  -
+                    repo: kibana
+                    path: /docs/kr
+              - title:      X-Pack 참조
+                prefix:     x-pack
+                index:      docs/kr/gs-index.asciidoc
+                current:    5.4
+                branches:   [ 5.4 ]
+                chunk:      1
+                private:    1
+                lang:       ko
+                tags:       X-Pack/Reference
+                subject:    X-Pack
+                sources:
+                  -
+                    repo: x-pack
+                    path: /docs/kr
+                  -
+                    repo: x-pack-kibana
+                    path: /docs/kr
+                    prefix: kibana-extra/x-pack-kibana
+                  -
+                    repo: x-pack-elasticsearch
+                    path: /docs/kr
+                    prefix: elasticsearch-extra/x-pack-elasticsearch
 
 redirects:
     -

--- a/conf.yaml
+++ b/conf.yaml
@@ -2735,6 +2735,7 @@ contents:
                 current:    cn
                 branches:   [ {cn: 2.x} ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       zh_cn
                 tags:       Elasticsearch/Definitive Guide
@@ -2749,6 +2750,7 @@ contents:
                 index:      index.asciidoc
                 current:    cn
                 branches:   [ {cn: 6.0} ]
+                noindex:    1
                 lang:       zh_cn
                 tags:       Elasticsearch/PHP
                 subject:    Elasticsearch
@@ -2763,6 +2765,7 @@ contents:
                 branches:   [ {cn: 6.0} ]
                 lang:       zh_cn
                 chunk:      1
+                noindex:    1
                 private:    1
                 tags:       Kibana/Reference
                 subject:    Kibana
@@ -2780,6 +2783,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Elasticsearch/Reference
@@ -2797,6 +2801,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Logstash/Reference
@@ -2811,6 +2816,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Kibana/Reference
@@ -2824,7 +2830,8 @@ contents:
                 index:      docs/jp/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4 ]
-                chunk:      1
+                chunk:      1 
+                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       X-Pack/Reference
@@ -2851,6 +2858,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Elasticsearch/Reference
@@ -2868,6 +2876,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Logstash/Reference
@@ -2882,6 +2891,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Kibana/Reference
@@ -2896,6 +2906,7 @@ contents:
                 current:    5.4
                 branches:   [ 5.4 ]
                 chunk:      1
+                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       X-Pack/Reference


### PR DESCRIPTION
If we must keep these translations of very old docs (5.x and 6.0), I propose that we move them to the legacy section. Otherwise I think we are raising expectations pretty high and will only disappoint users.

This PR moves the translated content to the Legacy section. Someone should explore whether we can just remove them completely. I did spot check a couple of the books in google analytics and there was no traffic, but someone should look more closely.

@KOTungseth Thoughts?

(Marking as draft for now until I can see the output)