### PR TITLE
Add required limbxml build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN rm -rf /var/log/nginx && rm -rf /run/nginx
 ##### Everything below this run tests
 FROM base AS py_test
 # There's not a published wheel for yamale, so we need setuptools and wheel
-RUN install_packages python3 python3-pip python3-setuptools python3-wheel
+RUN install_packages python3 python3-pip python3-setuptools python3-wheel python3-dev libxml2-dev libxslt-dev zlib1g-dev
 RUN pip3 install \
   beautifulsoup4==4.8.1 \
   lxml==4.4.2 \


### PR DESCRIPTION
Running `make check` locally fails for me with the following error:

```
INFO:docker build:#13 3.087   building 'lxml.etree' extension
INFO:docker build:#13 3.087   creating build/temp.linux-aarch64-3.7
INFO:docker build:#13 3.087   creating build/temp.linux-aarch64-3.7/src
INFO:docker build:#13 3.087   creating build/temp.linux-aarch64-3.7/src/lxml
INFO:docker build:#13 3.087   aarch64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DCYTHON_CLINE_IN_TRACEBACK=0 -I/usr/include/libxml2 -Isrc -Isrc/lxml/includes -I/usr/include/python3.7m -c src/lxml/etree.c -o build/temp.linux-aarch64-3.7/src/lxml/etree.o -w
INFO:docker build:#13 3.087   src/lxml/etree.c:97:10: fatal error: Python.h: No such file or directory
INFO:docker build:#13 3.087    #include "Python.h"
INFO:docker build:#13 3.087             ^~~~~~~~~~
INFO:docker build:#13 3.087   compilation terminated.
INFO:docker build:#13 3.087   Compile failed: command 'aarch64-linux-gnu-gcc' failed with exit status 1
INFO:docker build:#13 3.087   creating tmp
INFO:docker build:#13 3.087   cc -I/usr/include/libxml2 -I/usr/include/libxml2 -c /tmp/xmlXPathInit3l8l922a.c -o tmp/xmlXPathInit3l8l922a.o
INFO:docker build:#13 3.087   /tmp/xmlXPathInit3l8l922a.c:2:1: warning: return type defaults to ‘int’ [-Wimplicit-int]
INFO:docker build:#13 3.087    main (int argc, char **argv) {
INFO:docker build:#13 3.087    ^~~~
INFO:docker build:#13 3.087   cc tmp/xmlXPathInit3l8l922a.o -lxml2 -o a.out
INFO:docker build:#13 3.087   error: command 'aarch64-linux-gnu-gcc' failed with exit status 1
```

This seems to be caused by missing dependencies (see for example https://stackoverflow.com/questions/5178416/libxml-install-error-using-pip). This PR adds those missing dependencies.
