### PR TITLE
Only enable console alternatives that have a snippet

### DIFF
--- a/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
+++ b/resources/web/docs_js/__tests__/components/alternative_picker.test.jsx
@@ -53,6 +53,37 @@ describe(_AlternativePicker, () => {
     });
   });
 
+  describe("when console alternative snippets are missing", () => {
+    const picker = render(<_AlternativePicker
+      consoleAlternative="console"
+      alternatives={{
+        console: {
+          js: {},
+          csharp: {},
+        }
+      }}
+      langs={["js"]}/>);
+    const select = picker.childNodes[0];
+
+    test("disables the missing options", () => {
+      expect(picker).toStrictEqual(render(
+        <div class="AlternativePicker u-space-between">
+          <select class="AlternativePicker-select">
+            <option value="console">Console</option>
+            <option value="js">JavaScript</option>
+            <option value="csharp" disabled>C#</option>
+          </select>
+          <div class="AlternativePicker-warning" />
+          {null}
+        </div>
+      ));
+    });
+
+    test("selects the consoleAlternative from the props", () => {
+      expect(select.value).toBe("console");
+    });
+  });
+
   describe("when the console alternative isn't in the options", () => {
     const picker = render(<_AlternativePicker
       consoleAlternative="bort"

--- a/resources/web/docs_js/components/alternative_picker.jsx
+++ b/resources/web/docs_js/components/alternative_picker.jsx
@@ -17,8 +17,8 @@ const alternativePrettyName = rawName => {
   }
 };
 
-const AlternativeChoice = ({name: name}) => {
-  return <option value={name}>{alternativePrettyName(name)}</option>;
+const AlternativeChoice = ({name: name, disabled: disabled}) => {
+  return <option value={name} disabled={disabled}>{alternativePrettyName(name)}</option>;
 };
 
 export class _AlternativePicker extends Component {
@@ -49,7 +49,8 @@ export class _AlternativePicker extends Component {
     items.push(<AlternativeChoice name='console'/>);
     for (const name of Object.keys(consoleAlternatives)) {
       sawChoice |= name === consoleAlternative;
-      items.push(<AlternativeChoice name={name} />);
+      let disabled = this.props.langs ? !this.props.langs.includes(name) : false;
+      items.push(<AlternativeChoice name={name} disabled={disabled} />);
     }
 
     /* If value isn't in the list then *make* it and we'll render our standard

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -74,7 +74,7 @@ export const ConsoleForm = connect((state, props) =>
 export const ConsoleWidget = props => {
   const modalAction = () => props.openModal(ConsoleForm, {setting: props.setting, url_label: props.url_label});
   return <div className="u-space-between">
-    <AlternativePicker />
+    <AlternativePicker langs={props.langs} />
     <div className="u-space-between">
       <a className="sense_widget copy_as_curl"
         onClick={e => props.copyAsCurl({

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -75,7 +75,8 @@ export function init_console_widgets() {
   $('div.console_widget').each(function() {
     const div         = $(this),
           snippet     = div.attr('data-snippet'),
-          consoleText = div.prev().text() + '\n';
+          consoleText = div.prev().text() + '\n',
+          langs       = div.attr("class").split(" ").filter(c => c.startsWith("has-")).map(function(string) { return string.substring(4) });
 
     return mount(div, ConsoleWidget, {setting: "console",
                                       url_label: 'Enter the URL of the Console editor',
@@ -83,7 +84,8 @@ export function init_console_widgets() {
                                       configure_text: 'Configure Console URL',
                                       addPretty: true,
                                       consoleText,
-                                      snippet});
+                                      snippet,
+                                      langs});
   });
 }
 


### PR DESCRIPTION
In books that have configured alternative languages for `console` code examples, the alternative picker currently shows all the configured languages, regardless of whether a snippet actually exists for each of the languages:

<img width="131" alt="image" src="https://github.com/elastic/docs/assets/9715543/6253b9ca-a1d0-415e-8385-603c1aeee118">

This leads to a poor UX, as users can select a language, only to find out that a code snippet does not exist for that language.

This PR changes the alternative picker such that, per code snippet, only those languages for which snippets actually exist are enabled. Other languages are still shown greyed out, but cannot be selected:

<img width="126" alt="image" src="https://github.com/elastic/docs/assets/9715543/5418164c-7d49-4f5b-826d-ed55d3053148">

If a user has previously selected a language on another code snippet, but that language does not exist on the current example, the option will be disabled, but still preselected, so their preference is not reset:

<img width="159" alt="image" src="https://github.com/elastic/docs/assets/9715543/df08ab53-9554-479f-aaca-7edb693f70e0">

(If you want to give it a spin, take a look at the first two code snippets on [this page](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html))


Closes https://github.com/elastic/docs/issues/2380
Related: https://github.com/elastic/tech-content/issues/314