### PR TITLE
Bumps docs version to 7.17.11

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.10
+:version:                7.17.11
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.10
-:logstash_version:       7.17.10
-:elasticsearch_version:  7.17.10
-:kibana_version:         7.17.10
-:apm_server_version:     7.17.10
+:bare_version:           7.17.11
+:logstash_version:       7.17.11
+:elasticsearch_version:  7.17.11
+:kibana_version:         7.17.11
+:apm_server_version:     7.17.11
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
**Do not merge until release day.**

This updates the stack docs shared version attributes to 7.17.11.

[Docs release issue](https://github.com/elastic/dev/issues/2304)