### PR TITLE
ESS - Change current to MS-94

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.8
   stacklive: &stacklive [ 8.8, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-92
+  cloudSaasCurrent: &cloudSaasCurrent ms-94
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-81: master


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-94.
Do not merge until release day.