### PR TITLE
Add an attribute for ES|QL

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -249,6 +249,7 @@ Common words and phrases
 :functionbeat:    Functionbeat
 :journalbeat:     Journalbeat
 :es-sql:          {es} SQL
+:esql:            ES|QL
 :elastic-agent:   {agent}
 :k8s:             Kubernetes
 :log-driver-long: Elastic Logging Plugin for Docker


### PR DESCRIPTION
ESQL has been renamed ES|QL. This adds an attribute so we can use `{esql}` in the docs.
