### PR TITLE
Add attribute for "Elastic Artifact Registry"

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -228,6 +228,7 @@ Ingest terms
 :package-manager: Elastic Package Manager
 :integrations: Integrations
 :package-registry: Elastic Package Registry
+:artifact-registry: Elastic Artifact Registry
 
 //////////
 Common words and phrases


### PR DESCRIPTION
We have an attribute for the Elastic Package Registry. For consistency, we should also have one for the Elastic Artifact Registry.
