### PR TITLE
Enable edit links on `master`/`main` branches

### DIFF
--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -519,6 +519,7 @@ sub private {
 #===================================
     my ( $self, $branch ) = @_;
     return 1 if $self->{private};
+    return 0 if $branch =~ /^(master|main)$/;
     return 0 if grep( /^$branch$/, @{ $self->{live_branches} } );
     return 1;
 }


### PR DESCRIPTION
Re-enables `Edit` links for the `master`/`main` branches of docs.

When https://github.com/elastic/docs/pull/2690 disabled indexing for these branches, it also removed the `Edit` links as an unintended side effect.

Closes https://github.com/elastic/platform-docs-team/issues/119 (sorry — internal link)