### PR TITLE
Formally publish ESRE book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -247,7 +247,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.9, 8.8 ]
-            live:       *stacklive
+            live:       [ main, 8.9, 8.8 ]
             chunk:      1
             tags:       ESRE/Guide
             subject:    ESRE

--- a/conf.yaml
+++ b/conf.yaml
@@ -248,7 +248,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.9, 8.8 ]
-            live:       [ main, 8.9, 8.8 ]
+            live:       [ 8.9, 8.8 ]
             chunk:      1
             tags:       ESRE/Guide
             subject:    ESRE

--- a/conf.yaml
+++ b/conf.yaml
@@ -241,6 +241,23 @@ contents:
               -
                 repo:   docs
                 path:   shared/settings.asciidoc
+          - title:      Elasticsearch Relevance Engine (ESRE)
+            prefix:     en/esre
+            index:      esre-docs/index.asciidoc
+            private:    1
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.9, 8.8 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       ESRE/Guide
+            subject:    ESRE
+            sources:
+              -
+                repo:   enterprise-search-pubs
+                path:   esre-docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    8.8
@@ -2325,23 +2342,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Elasticsearch Relevance Engine (ESRE)
-            prefix:     en/esre
-            index:      esre-docs/index.asciidoc
-            private:    1
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.9, 8.8 ]
-            live:       []
-            chunk:      1
-            tags:       ESRE/Guide
-            subject:    ESRE
-            sources:
-              -
-                repo:   enterprise-search-pubs
-                path:   esre-docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
 
     -   title:      Legacy Documentation
         sections:


### PR DESCRIPTION
The MVP content has all been merged in the source repository.

- Move book from "Docs in Development" to "Elastic Stack"
- Add "live" versions to enable search engine indexing