### PR TITLE
Bumps docs version to 7.17.12

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.11
+:version:                7.17.12
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.11
-:logstash_version:       7.17.11
-:elasticsearch_version:  7.17.11
-:kibana_version:         7.17.11
-:apm_server_version:     7.17.11
+:bare_version:           7.17.12
+:logstash_version:       7.17.12
+:elasticsearch_version:  7.17.12
+:kibana_version:         7.17.12
+:apm_server_version:     7.17.12
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
**Do not merge until release day.**

This updates the stack docs shared version attributes to 7.17.12.

Rel: https://github.com/elastic/dev/issues/2311