### PR TITLE
Add a link on the landing page to Introducing Elastic Docs

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -368,6 +368,9 @@
         <a href="en/welcome-to-elastic/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a>
       </li>
       <li>
+        <a href="en/welcome-to-elastic/current/introducing-elastic-documentation.html">Introducing Elastic documentation</a>
+      </li>
+      <li>
         <a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a>
       </li>
       <li>


### PR DESCRIPTION
This adds a link on the [docs landing page](https://www.elastic.co/guide/index.html) to a new "Introducing Elastic docs" page. I'm not sure if there's maybe a better spot for it? This is the best I could think of.

![Screenshot 2023-07-19 at 11 51 25 AM](https://github.com/elastic/docs/assets/41695641/8d5af279-7969-4bae-a181-5ee444a57ac3)

Rel: https://github.com/elastic/tech-content/pull/342
(and of course this PR needs to wait for the above to merge)