### PR TITLE
ECK: Promote 2.9 version to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -883,7 +883,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.8
+            current:    2.9
             branches:   [ {main: master}, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -884,7 +884,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.8
-            branches:   [ {main: master}, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Do not merge before release of Elastic stack 8.9/ECK 2.9