### PR TITLE
Bumps current version to 8.9

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,8 +76,8 @@ contents_title:     Welcome to Elastic Docs
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.8
-  stacklive: &stacklive [ 8.8, 7.17 ]
+  stackcurrent: &stackcurrent 8.9
+  stacklive: &stacklive [ 8.9, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-92
 
@@ -261,7 +261,7 @@ contents:
                 path:   shared/versions/stack/{version}.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.8
+            current:    8.9
             branches:   [  {main: master}, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 1.12 ]
             index:      docs/index.asciidoc

--- a/shared/versions/stack/8.8.asciidoc
+++ b/shared/versions/stack/8.8.asciidoc
@@ -29,7 +29,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -23,12 +23,12 @@ Keep the :esf_version: attribute value as master.
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.8.asciidoc[]
+include::8.9.asciidoc[]


### PR DESCRIPTION
This PR changes the "current" version of the documentation to 8.9 and changes that set of docs from "unreleased" to "released".

**Do not merge until release day**