### PR TITLE
Update ECS docs to version 8.9

### DIFF
--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            master
+:ecs_version:            8.9
 :esf_version:            master
 
 //////////


### PR DESCRIPTION
The ECS version in the 8.9 docs was accidentally left at `master` rather than `8.9`. 