### PR TITLE
ESS - Change current to MS-95

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.9
   stacklive: &stacklive [ 8.9, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-94
+  cloudSaasCurrent: &cloudSaasCurrent ms-95
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: master


### PR DESCRIPTION
This changes `current` to `ms-95`.
DO NOT merge until release day (Aug 15).
