### PR TITLE
Releases 8.9 branch for .NET Client docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -545,9 +545,9 @@ contents:
                     path:   .doc/
               - title:      .NET Clients
                 prefix:     net-api
-                current:    8.1
+                current:    8.9
                 branches:   [ {main: master}, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
-                live:       [ main, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                live:       [ main, 8.9, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
                 subject:    Clients


### PR DESCRIPTION
## Overview

As the 8.9 version of the .NET Client has been released, this PR bumps the docs version number appropriately.