### PR TITLE
Fix Azure Marketplace link

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -336,7 +336,7 @@
         <a href="https://aws.amazon.com/marketplace/pp/prodview-voru33wi6xs7k">AWS Marketplace</a>
       </li>
       <li>
-        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp">Azure Marketplace</a>
+        <a href="https://azuremarketplace.microsoft.com/en-us/marketplace/apps/elastic.ec-azure-pp?tab=Overview">Azure Marketplace</a>
       </li>
       <li>
         <a href="https://console.cloud.google.com/marketplace/product/endpoints/elasticsearch-service.gcpmarketplace.elastic.co">GCP Marketplace</a>


### PR DESCRIPTION
Adds a query parameter to the Azure Marketplace link on the [Docs landing page](https://www.elastic.co/guide/index.html).

Currently, a third-party script is appending `&euid=foo` to this URL. Without a query param, the link breaks.

Closes https://github.com/elastic/docs/issues/2730