### PR TITLE
Move some book-scoped attributes from /observability-docs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -180,6 +180,7 @@ Kibana app and UI names
 
 :apm-app:            APM app
 :uptime-app:         Uptime app
+:synthetics-app:     Synthetics app
 :logs-app:           Logs app
 :metrics-app:        Metrics app
 :infrastructure-app: Infrastructure app
@@ -428,6 +429,11 @@ Do not use `endpoint-cloud-sec` in versions 8.5.0 and newer
 :apm-rum-agent:              Elastic APM Real User Monitoring (RUM) JavaScript agent
 :apm-rum-agents:             Elastic APM RUM JavaScript agents
 :apm-lambda-ext:             Elastic APM AWS Lambda extension
+
+:project-monitors:           project monitors
+:project-monitors-cap:       Project monitors
+:private-location:           Private Location
+:private-locations:          Private Locations
 
 :pwd:             YOUR_PASSWORD
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -135,35 +135,35 @@ The if directives below are required for versions 6.3-7.4 of the legacy APM Get 
 Without these if directives, the links below fail and break the build.
 //////////
 
-ifdef::apm-py-branch[Only set this attr if apm-py-branch is set]
+ifdef::apm-py-branch[]
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
 endif::[]
 
-ifdef::apm-node-branch[Only set this attr if apm-node-branch is set]
+ifdef::apm-node-branch[]
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
 endif::[]
 
-ifdef::apm-rum-branch[Only set this attr if apm-rum-branch is set]
+ifdef::apm-rum-branch[]
 :apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
 endif::[]
 
-ifdef::apm-ruby-branch[Only set this attr if apm-ruby-branch is set]
+ifdef::apm-ruby-branch[]
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
 endif::[]
 
-ifdef::apm-java-branch[Only set this attr if apm-java-branch is set]
+ifdef::apm-java-branch[]
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
 endif::[]
 
-ifdef::apm-go-branch[Only set this attr if apm-go-branch is set]
+ifdef::apm-go-branch[]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
 endif::[]
 
-ifdef::apm-ios-branch[Only set this attr if apm-ios-branch is set]
+ifdef::apm-ios-branch[]
 :apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
 endif::[]
 
-ifdef::apm-dotnet-branch[Only set this attr if apm-dot-branch is set]
+ifdef::apm-dotnet-branch[]
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 endif::[]
 

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -128,6 +128,14 @@ Elastic-level pages
 :integrations-devguide: https://www.elastic.co/guide/en/integrations-developer/current
 :time-units:           {ref}/api-conventions.html#time-units
 :byte-units:           {ref}/api-conventions.html#byte-units
+:apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+:apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+:apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+:apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+:apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+:apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+:apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
+:apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 
 //////////
 Elastic Cloud

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -128,14 +128,44 @@ Elastic-level pages
 :integrations-devguide: https://www.elastic.co/guide/en/integrations-developer/current
 :time-units:           {ref}/api-conventions.html#time-units
 :byte-units:           {ref}/api-conventions.html#byte-units
+
+//////////
+APM agents
+The if directives below are required for versions 6.3-7.4 of the legacy APM Get started book.
+Without these if directives, the links below fail and break the build.
+//////////
+
+ifdef::apm-py-branch[Only set this attr if apm-py-branch is set]
 :apm-py-ref-v:         https://www.elastic.co/guide/en/apm/agent/python/{apm-py-branch}
+endif::[]
+
+ifdef::apm-node-branch[Only set this attr if apm-node-branch is set]
 :apm-node-ref-v:       https://www.elastic.co/guide/en/apm/agent/nodejs/{apm-node-branch}
+endif::[]
+
+ifdef::apm-rum-branch[Only set this attr if apm-rum-branch is set]
 :apm-rum-ref-v:        https://www.elastic.co/guide/en/apm/agent/rum-js/{apm-rum-branch}
+endif::[]
+
+ifdef::apm-ruby-branch[Only set this attr if apm-ruby-branch is set]
 :apm-ruby-ref-v:       https://www.elastic.co/guide/en/apm/agent/ruby/{apm-ruby-branch}
+endif::[]
+
+ifdef::apm-java-branch[Only set this attr if apm-java-branch is set]
 :apm-java-ref-v:       https://www.elastic.co/guide/en/apm/agent/java/{apm-java-branch}
+endif::[]
+
+ifdef::apm-go-branch[Only set this attr if apm-go-branch is set]
 :apm-go-ref-v:         https://www.elastic.co/guide/en/apm/agent/go/{apm-go-branch}
+endif::[]
+
+ifdef::apm-ios-branch[Only set this attr if apm-ios-branch is set]
 :apm-ios-ref-v:        https://www.elastic.co/guide/en/apm/agent/swift/{apm-ios-branch}
+endif::[]
+
+ifdef::apm-dotnet-branch[Only set this attr if apm-dot-branch is set]
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
+endif::[]
 
 //////////
 Elastic Cloud

--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -61,3 +61,8 @@ ECS Logging
 :ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master
+
+////
+Synthetics
+////
+:synthetics_version: v1.3.0

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -61,3 +61,8 @@ ECS Logging
 :ecs-logging-php:       master
 :ecs-logging-python:    master
 :ecs-logging-ruby:      master
+
+////
+Synthetics
+////
+:synthetics_version: v1.3.0


### PR DESCRIPTION
🧀  Pairs with https://github.com/elastic/observability-docs/pull/3138

Moves some book-scoped variables from /observability-docs here.