### PR TITLE
Update Cloud UTM parameters

### DIFF
--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -100,19 +100,19 @@
                             <p class="aside-heading">Most Popular</p>
                             <div class="pb-2">
                               <p class="media-type">Video</p>
-                              <a href="https://www.elastic.co/webinars/getting-started-elasticsearch?baymax=default&elektra=docs&storm=top-video">
+                              <a href="https://www.elastic.co/webinars/getting-started-elasticsearch?page=docs&placement=top-video">
                                 <p class="mb-0">Get Started with Elasticsearch</p>
                               </a>
                             </div>
                             <div class="pb-2">
                               <p class="media-type">Video</p>
-                              <a href="https://www.elastic.co/webinars/getting-started-kibana?baymax=default&elektra=docs&storm=top-video">
+                              <a href="https://www.elastic.co/webinars/getting-started-kibana?page=docs&placement=top-video">
                                 <p class="mb-0">Intro to Kibana</p>
                               </a>
                             </div>
                             <div class="pb-2">
                               <p class="media-type">Video</p>
-                              <a href="https://www.elastic.co/webinars/introduction-elk-stack?baymax=default&elektra=docs&storm=top-video">
+                              <a href="https://www.elastic.co/webinars/introduction-elk-stack?page=docs&placement=top-video">
                                 <p class="mb-0">ELK for Logs & Metrics</p>
                               </a>
                             </div>

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -138,12 +138,13 @@ Elastic Cloud
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
 :cloud:       https://www.elastic.co/guide/en/cloud/current
-:ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
-:ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs
-:ess-console: https://cloud.elastic.co?baymax=docs-body&elektra=docs
+:ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup{ess-utm-params}
+:ess-product: https://www.elastic.co/cloud/elasticsearch-service{ess-utm-params}
+:ess-console: https://cloud.elastic.co{ess-utm-params}
 :ess-console-name: {ess} Console
-:ess-deployments: https://cloud.elastic.co/deployments?baymax=docs-body&elektra=docs
-:ess-baymax:  ?baymax=docs-body&elektra=docs
+:ess-deployments: https://cloud.elastic.co/deployments{ess-utm-params}
+:ess-baymax:  {ess-utm-params}
+:ess-utm-params: ?page=docs&placement=docs-body
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current
 :eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current
 :ess-leadin: You can run Elasticsearch on your own hardware or use our hosted Elasticsearch Service that is available on AWS, GCP, and Azure. {ess-trial}[Try the Elasticsearch Service for free].

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -138,13 +138,13 @@ Elastic Cloud
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
 :cloud:       https://www.elastic.co/guide/en/cloud/current
+:ess-utm-params: ?page=docs&placement=docs-body
+:ess-baymax:  {ess-utm-params}
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup{ess-utm-params}
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service{ess-utm-params}
 :ess-console: https://cloud.elastic.co{ess-utm-params}
 :ess-console-name: {ess} Console
 :ess-deployments: https://cloud.elastic.co/deployments{ess-utm-params}
-:ess-baymax:  {ess-utm-params}
-:ess-utm-params: ?page=docs&placement=docs-body
 :ece-ref:     https://www.elastic.co/guide/en/cloud-enterprise/current
 :eck-ref:     https://www.elastic.co/guide/en/cloud-on-k8s/current
 :ess-leadin: You can run Elasticsearch on your own hardware or use our hosted Elasticsearch Service that is available on AWS, GCP, and Azure. {ess-trial}[Try the Elasticsearch Service for free].

--- a/shared/cloud/cloud-login.asciidoc
+++ b/shared/cloud/cloud-login.asciidoc
@@ -1,5 +1,5 @@
 // tag::ess[]
-. Log in to the link:https://cloud.elastic.co/?baymax=docs-body&elektra=docs[Elasticsearch Service Console].
+. Log in to the link:https://cloud.elastic.co/{ess-utm-params}[Elasticsearch Service Console].
 . Select your deployment on the home page in the {ess} card or go to the deployments page.
 +
 Narrow your deployments by name, ID, or choose from several other filters. To customize your view, use a combination of filters, or change the format from a grid to a list.


### PR DESCRIPTION
**IMPORTANT: DO NOT MERGE UNTIL AUG 31, 2023**

Updates the UTM parameters used to track Cloud trial signups from the docs.

Per Marketing, the old parameter keys (`baymax`, `elektra`) are outdated: https://elastic.slack.com/archives/C01AA2TLEUX/p1691580994671689 (Sorry — internal link only)

