### PR TITLE
Add 'Elastic Serverless' shared attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -175,6 +175,7 @@ Elastic Cloud
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
+:serverless:  Elastic Serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -175,7 +175,8 @@ Elastic Cloud
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
-:serverless:  Elastic Serverless
+:serverless-full:  Elastic Serverless
+:serverless-short: Serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -177,6 +177,7 @@ Elastic Cloud
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Serverless
 :serverless-short: Serverless
+:serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup?baymax=docs-body&elektra=docs
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service?baymax=docs-body&elektra=docs


### PR DESCRIPTION
I expect we'll want this attribute for mentioning any restrictions or other references about Serverless from within the classic docs.