### PR TITLE
Remove kibana dependencies

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1192,10 +1192,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-              -
-                repo:   kibana
-                path:   docs
-                exclude_branches: [ 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
             sections:
@@ -1707,10 +1703,6 @@ contents:
               -
                 repo:   stack-docs
                 path:   docs/en
-              -
-                repo:   kibana
-                path:   docs
-                exclude_branches: [ 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
           - title:      SIEM Guide
             prefix:     en/siem/guide
             current:    7.8

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -85,7 +85,7 @@ alias docbldsoold=docbldso
 alias docbldaz='$GIT_HOME/docs/build_docs --doc $GIT_HOME/azure-marketplace/docs/index.asciidoc --chunk 1'
 
 # Solutions
-alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/security-docs/docs/index.asciidoc --resource $GIT_HOME/stack-docs/docs --resource=$GIT_HOME/kibana/docs --chunk 1'
+alias docbldsec='$GIT_HOME/docs/build_docs --doc $GIT_HOME/security-docs/docs/index.asciidoc --resource $GIT_HOME/stack-docs/docs --chunk 1'
 
 alias docbldepd='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/endpoint/index.asciidoc --chunk 1'
 
@@ -110,10 +110,10 @@ alias docbldeesr='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-ru
 alias docbldewsn='$GIT_HOME/docs/build_docs --doc $GIT_HOME/enterprise-search-pubs/client-docs/workplace-search-node/index.asciidoc --single'
 
 # Observability Guide 8.8 and later
-alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/ingest-docs/docs'
+alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/ingest-docs/docs'
 
 # Observability Guide 8.7 and earlier
-alias docbldob='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/ingest-docs/docs'
+alias docbldobold='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/observability/index.asciidoc --chunk 2 --resource $GIT_HOME/beats/libbeat/docs --resource $GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/kibana/docs --resource=$GIT_HOME/ingest-docs/docs'
 
 # Observability Legacy
 alias docbldmet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/observability-docs/docs/en/metrics/index.asciidoc --chunk 1'


### PR DESCRIPTION
This PR reverts the changes from https://github.com/elastic/docs/pull/2592 and https://github.com/elastic/docs/pull/2589 since we're aiming for less content reuse where possible.

It also renames one of the Observability doc build aliases, since I think the duplication must have been unintentional.