### PR TITLE
Creates 8.10 version attributes file

### DIFF
--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -1,0 +1,68 @@
+:version:                8.10.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           8.10.0
+:logstash_version:       8.10.0
+:elasticsearch_version:  8.10.0
+:kibana_version:         8.10.0
+:apm_server_version:     8.10.0
+:branch:                 8.10.0
+:minor-version:          8.10
+:major-version:          8.x
+:prev-major-version:     7.x
+:prev-major-last:        7.17
+:major-version-only:     8
+:ecs_version:            8.10
+:esf_version:            master
+
+//////////
+Keep the :esf_version: attribute value as master.
+//////////
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
+
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
+////
+APM Agent versions
+////
+:apm-android-branch:    main
+:apm-go-branch:         2.x
+:apm-ios-branch:        0.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        5.x
+:apm-node-branch:       3.x
+:apm-php-branch:        1.x
+:apm-py-branch:         6.x
+:apm-ruby-branch:       4.x
+:apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging:           master
+:ecs-logging-go-logrus: master
+:ecs-logging-go-zap:    master
+:ecs-logging-java:      1.x
+:ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
+:ecs-logging-php:       master
+:ecs-logging-python:    master
+:ecs-logging-ruby:      master
+
+////
+Synthetics
+////
+:synthetics_version: v1.3.0


### PR DESCRIPTION
Creates a new version attributes file for the 8.10 release, per the instructions [here](https://docs.elastic.dev/docs/releases). Does not edit the master version attributes file because that was completed in another [PR](https://github.com/elastic/docs/pull/2736).

