### PR TITLE
Make Ingest Architecture docs generally available

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -272,6 +272,22 @@ contents:
               -
                 repo:   ecs
                 path:   docs/
+          - title:      Elastic Ingest Reference Architectures
+            prefix:     en/ingest
+            current:    *stackcurrent
+            index:      docs/en/ingest-arch/index.asciidoc
+            branches:   [ {main: master}, 8.9 ]
+            live:       *stacklive
+            chunk:      1
+            tags:       Ingest/Reference
+            subject:    Ingest
+            sources:
+              -
+                repo:   ingest-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Azure Marketplace and Resource Manager (ARM) template
             prefix:     en/elastic-stack-deploy
             current:    7.11
@@ -2331,22 +2347,6 @@ contents:
               -
                 repo:   logstash
                 path:   docsk8s
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    main
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master} ]
-            noindex:    1
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -277,7 +277,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/ingest-arch/index.asciidoc
             branches:   [ {main: master}, 8.9 ]
-            live:       *stacklive
+            live:       [ 8.9 ]
             chunk:      1
             tags:       Ingest/Reference
             subject:    Ingest


### PR DESCRIPTION
Related: https://github.com/elastic/ingest-dev/issues/2307

* Moves Ingest architecture docs from "Docs in Development" section to Stack section for find-ability
* Removes `noindex` tag to get content indexed and available from internet searches
* Sets up versioning starting with 8.9