### PR TITLE
Bump docs version to 8.9.2

### DIFF
--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.9.1
+:version:                8.9.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.9.1
-:logstash_version:       8.9.1
-:elasticsearch_version:  8.9.1
-:kibana_version:         8.9.1
-:apm_server_version:     8.9.1
+:bare_version:           8.9.2
+:logstash_version:       8.9.2
+:elasticsearch_version:  8.9.2
+:kibana_version:         8.9.2
+:apm_server_version:     8.9.2
 :branch:                 8.9
 :minor-version:          8.9
 :major-version:          8.x


### PR DESCRIPTION
**Do not merge until release day.**

This updates the stack docs shared version attributes to 8.9.2.

Rel: https://github.com/elastic/dev/issues/2338