### PR TITLE
ESS - Change current to ms-97

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.9
   stacklive: &stacklive [ 8.9, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-95
+  cloudSaasCurrent: &cloudSaasCurrent ms-97
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: master


### PR DESCRIPTION
This PR changes "current" for the Cloud ESS docs to ms-97.
Do not merge until release day.