### PR TITLE
[DOCS] Add `live` branches to ECE docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -803,13 +803,13 @@ contents:
             subject:    ECE
             current:    ms-92
             live:
-              - ms-92: 3.6
-              - ms-81: 3.5
-              - ms-78: 3.4
-              - ms-75: 3.3
-              - ms-72: 3.2
-              - ms-70: 3.1
-              - ms-69: 3.0
+              - ms-92
+              - ms-81
+              - ms-78
+              - ms-75
+              - ms-72
+              - ms-70
+              - ms-69
             branches:
               - ms-92: 3.6
               - ms-81: 3.5

--- a/conf.yaml
+++ b/conf.yaml
@@ -802,6 +802,14 @@ contents:
             tags:       CloudEnterprise/Reference
             subject:    ECE
             current:    ms-92
+            live:
+              - ms-92: 3.6
+              - ms-81: 3.5
+              - ms-78: 3.4
+              - ms-75: 3.3
+              - ms-72: 3.2
+              - ms-70: 3.1
+              - ms-69: 3.0
             branches:
               - ms-92: 3.6
               - ms-81: 3.5


### PR DESCRIPTION
Adds a `live` branch property to the ECE docs. This ensures that branches for 2.x docs are no longer indexed.