### PR TITLE
Update Observability link

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -234,7 +234,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/observability/current/observability-get-started.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>


### PR DESCRIPTION
### Summary

Over the past year, we've received numerous complaints from users and employees that the link to Observability getting started content is confusing and not where users ultimately want to end up. I'm changing this link to point to our getting started content in the Observability Guide.