### PR TITLE
Update for a coming apm-agent-nodejs 4.x stream

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1341,9 +1341,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Node.js Agent
                     prefix:     nodejs
-                    current:    3.x
-                    branches:   [ {main: master}, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ 3.x ]
+                    current:    4.x
+                    branches:   [ {main: master}, 4.x, 3.x ]
+                    live:       [ 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM

--- a/conf.yaml
+++ b/conf.yaml
@@ -1342,7 +1342,7 @@ contents:
                   - title:      APM Node.js Agent
                     prefix:     nodejs
                     current:    4.x
-                    branches:   [ {main: master}, 4.x, 3.x ]
+                    branches:   [ {main: master}, 4.x, 3.x, 2.x, 1.x ]
                     live:       [ 4.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference

--- a/conf.yaml
+++ b/conf.yaml
@@ -1362,6 +1362,7 @@ contents:
                         exclude_branches:   [ 2.x, 1.x, 0.x ]
                         map_branches:
                           3.x: *stackcurrent
+                          4.x: *stackcurrent
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x

--- a/shared/versions/stack/6.6.asciidoc
+++ b/shared/versions/stack/6.6.asciidoc
@@ -20,7 +20,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        3.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.7.asciidoc
+++ b/shared/versions/stack/6.7.asciidoc
@@ -20,7 +20,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/6.8.asciidoc
+++ b/shared/versions/stack/6.8.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        4.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.0.asciidoc
+++ b/shared/versions/stack/7.0.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.1.asciidoc
+++ b/shared/versions/stack/7.1.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.10.asciidoc
+++ b/shared/versions/stack/7.10.asciidoc
@@ -30,7 +30,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x

--- a/shared/versions/stack/7.11.asciidoc
+++ b/shared/versions/stack/7.11.asciidoc
@@ -35,7 +35,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x

--- a/shared/versions/stack/7.12.asciidoc
+++ b/shared/versions/stack/7.12.asciidoc
@@ -35,7 +35,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.13.asciidoc
+++ b/shared/versions/stack/7.13.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        main
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.14.asciidoc
+++ b/shared/versions/stack/7.14.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.15.asciidoc
+++ b/shared/versions/stack/7.15.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.16.asciidoc
+++ b/shared/versions/stack/7.16.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/7.2.asciidoc
+++ b/shared/versions/stack/7.2.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.3.asciidoc
+++ b/shared/versions/stack/7.3.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.4.asciidoc
+++ b/shared/versions/stack/7.4.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.5.asciidoc
+++ b/shared/versions/stack/7.5.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       2.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.6.asciidoc
+++ b/shared/versions/stack/7.6.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.7.asciidoc
+++ b/shared/versions/stack/7.7.asciidoc
@@ -25,7 +25,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.8.asciidoc
+++ b/shared/versions/stack/7.8.asciidoc
@@ -26,7 +26,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x
 :apm-dotnet-branch:     1.x

--- a/shared/versions/stack/7.9.asciidoc
+++ b/shared/versions/stack/7.9.asciidoc
@@ -26,7 +26,7 @@ APM Agent versions
 :apm-go-branch:         1.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        master
 :apm-py-branch:         5.x
 :apm-ruby-branch:       3.x

--- a/shared/versions/stack/7.x.asciidoc
+++ b/shared/versions/stack/7.x.asciidoc
@@ -36,7 +36,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.0.asciidoc
+++ b/shared/versions/stack/8.0.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         5.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.1.asciidoc
+++ b/shared/versions/stack/8.1.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -43,7 +43,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.2.asciidoc
+++ b/shared/versions/stack/8.2.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.3.asciidoc
+++ b/shared/versions/stack/8.3.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.4.asciidoc
+++ b/shared/versions/stack/8.4.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.5.asciidoc
+++ b/shared/versions/stack/8.5.asciidoc
@@ -38,7 +38,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.6.asciidoc
+++ b/shared/versions/stack/8.6.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.7.asciidoc
+++ b/shared/versions/stack/8.7.asciidoc
@@ -37,7 +37,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.8.asciidoc
+++ b/shared/versions/stack/8.8.asciidoc
@@ -18,7 +18,7 @@ bare_version never includes -alpha or -beta
 :kinesis_version:        master
 
 //////////
-Keep the :esf_version: attribute value as master. 
+Keep the :esf_version: attribute value as master.
 //////////
 
 //////////
@@ -43,7 +43,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -17,7 +17,7 @@ bare_version never includes -alpha or -beta
 :esf_version:            master
 
 //////////
-Keep the :esf_version: attribute value as master. 
+Keep the :esf_version: attribute value as master.
 //////////
 
 //////////
@@ -43,7 +43,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -17,7 +17,7 @@ bare_version never includes -alpha or -beta
 :esf_version:            master
 
 //////////
-Keep the :esf_version: attribute value as master. 
+Keep the :esf_version: attribute value as master.
 //////////
 
 //////////
@@ -43,7 +43,7 @@ APM Agent versions
 :apm-ios-branch:        0.x
 :apm-java-branch:       1.x
 :apm-rum-branch:        5.x
-:apm-node-branch:       3.x
+:apm-node-branch:       4.x
 :apm-php-branch:        1.x
 :apm-py-branch:         6.x
 :apm-ruby-branch:       4.x


### PR DESCRIPTION
This also *drops* hosting the ancient 0.x version of the apm-agent-nodejs docs.
