### PR TITLE
Updates title of welcome to elastic

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -70,7 +70,7 @@ repos:
     x-pack-kibana:        https://github.com/elastic/x-pack-kibana.git
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
 
-contents_title:     Welcome to Elastic Docs
+contents_title:     Starting with the Elasticsearch Platform and its Solutions
 
 # Each item should take the form:
 #   <key>: &<variable> <value>
@@ -124,15 +124,15 @@ toc_extra: extra/docs_landing.html
 contents:
     -   title: Elastic Documentation
         sections:
-          - title:      "Welcome to Elastic"
-            prefix:     en/welcome-to-elastic
+          - title:      "Starting with the Elasticsearch Platform and its Solutions"
+            prefix:     en/starting-with-the-elasticsearch-platform-and-its-solutions
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
             branches:   [ {main: master}, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 7.17 ]
             live:       [ 8.8 ]
             chunk:      1
-            tags:       Elastic/Welcome
-            subject:    Welcome to Elastic
+            tags:       Elastic/Starting with the Elasticsearch Platform and its Solutions
+            subject:    Starting with the Elasticsearch Platform and its Solutions
             sources:
               -
                 repo:   tech-content


### PR DESCRIPTION
Replaces `Welcome to Elastic` with new `Starting with the Elasticsearch Platform and its Solutions` terminology introduced in https://github.com/elastic/tech-content/pull/232.
