### PR TITLE
Remove x-pack docs dir from ES book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -357,7 +357,8 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/docs
                 private: true
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                # only exists from 6.2 to 8.8
+                exclude_branches:   [ main, 8.10, 8.9, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/qa/sql

--- a/conf.yaml
+++ b/conf.yaml
@@ -357,8 +357,8 @@ contents:
                 repo:   elasticsearch
                 path:   x-pack/docs
                 private: true
-                # only exists from 6.2 to 8.8
-                exclude_branches:   [ main, 8.10, 8.9, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
+                # only exists from 6.2 to 8.9
+                exclude_branches:   [ main, 8.10, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
               -
                 repo:   elasticsearch
                 path:   x-pack/qa/sql


### PR DESCRIPTION
**Problem:** With https://github.com/elastic/elasticsearch/pull/99209, the elasticsearch repo's `x-pack/docs` directory no longer contains docs for the Elasticsearch Guide in 8.10+. However, the docs build config still lists the `x-pack/docs` directory as a dependency.

**Solution:** Update the docs build config to remove the `x-pack/docs` dependency for the Elasticsearch Guide in 8.10+.

Depends on https://github.com/elastic/elasticsearch/pull/99209
Rel: https://github.com/elastic/platform-docs-team/issues/208