### PR TITLE
Update `/welcome-to-elastic` links

### DIFF
--- a/extra/client_docs_landing.html
+++ b/extra/client_docs_landing.html
@@ -105,7 +105,7 @@
       </li>
       <li>
         <a href="rust-api/current/index.html">Rust Client</a>
-      </li> 
+      </li>
     </ul>
   </div>
 
@@ -155,7 +155,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -58,7 +58,7 @@
     </p>
     <p>
       <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">All Elastic docs</a>
-      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/new.html">Release docs</a>
+      <a class="inline-block mr-3" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/new.html">Release docs</a>
       <a class="inline-block mr-3" href="https://www.elastic.co/videos">Videos & Webinars</a>
    </p>
    </div>
@@ -245,7 +245,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-siem-security.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-siem-security.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
@@ -258,7 +258,7 @@
   </div>
   <div class="row my-4">
    <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-endpoint-security.html">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-endpoint-security.html">
       <div class="card h-100">
         <h4 class="mt-3">
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
@@ -269,7 +269,7 @@
     </a>
   </div>
   <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-kubernetes.html">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-kubernetes.html">
       <div class="card h-100">
         <h4 class="mt-3">
           <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
@@ -280,7 +280,7 @@
     </a>
   </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-general-purpose.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-general-purpose.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltcb0e79820c355263/636c1905cbd6b84ecb4851b2/stack-logo-color-32px.png');"></span>
@@ -356,7 +356,7 @@
     </div>
     <ul class="ul-col-md-2 ul-col-1">
       <li>
-        <a href="en/welcome-to-elastic/current/get-support-help.html">How to get support</a>
+        <a href="en/starting-with-the-elasticsearch-platform-and-its-solutions/current/get-support-help.html">How to get support</a>
       </li>
       <li>
         <a href="https://discuss.elastic.co/">Forums</a>
@@ -365,10 +365,10 @@
         <a href="https://www.elastic.co/training/">Training</a>
       </li>
       <li>
-        <a href="en/welcome-to-elastic/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a>
+        <a href="en/starting-with-the-elasticsearch-platform-and-its-solutions/current/troubleshooting-and-faqs.html">Troubleshooting and FAQs</a>
       </li>
       <li>
-        <a href="en/welcome-to-elastic/current/introducing-elastic-documentation.html">Introducing Elastic documentation</a>
+        <a href="en/starting-with-the-elasticsearch-platform-and-its-solutions/current/introducing-elastic-documentation.html">Introducing Elastic documentation</a>
       </li>
       <li>
         <a href="https://www.elastic.co/events/?tab=1&solution=null&event=Meetup&region=null&language=English&industry=null">Meetups and virtual events</a>

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -50,9 +50,9 @@
 ///////
 Elastic-level pages
 ///////
-:estc-welcome-current: https://www.elastic.co/guide/en/welcome-to-elastic/current
-:estc-welcome:         https://www.elastic.co/guide/en/welcome-to-elastic/{branch}
-:estc-welcome-all:     https://www.elastic.co/guide/en/welcome-to-elastic
+:estc-welcome-current: https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current
+:estc-welcome:         https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/{branch}
+:estc-welcome-all:     https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions
 :hadoop-ref:           https://www.elastic.co/guide/en/elasticsearch/hadoop/{branch}
 :stack-ref:            https://www.elastic.co/guide/en/elastic-stack/{branch}
 :stack-ref-67:         https://www.elastic.co/guide/en/elastic-stack/6.7


### PR DESCRIPTION
**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix and name for the "Welcome to Elastic Docs" docs. Several links and attributes still point to the old URLs.

**Solution:** Change any `/welcome-to-elastic` to `/starting-with-the-elasticsearch-platform-and-its-solutions` in any links and attributes.

**Note:** https://github.com/elastic/website-development/issues/11616 will add related redirects.