### PR TITLE
Bump docs version to 8.10.1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,8 +76,8 @@ contents_title:     Starting with the Elasticsearch Platform and its Solutions
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.9
-  stacklive: &stacklive [ 8.9, 7.17 ]
+  stackcurrent: &stackcurrent 8.10
+  stacklive: &stacklive [ 8.10, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-95
 
@@ -261,7 +261,7 @@ contents:
                 path:   shared/versions/stack/{version}.asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            current:    8.9
+            current:    8.10
             branches:   [  {main: master}, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 1.12 ]
             index:      docs/index.asciidoc

--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -23,12 +23,12 @@ Keep the :esf_version: attribute value as master.
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:         released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.10.0
+:version:                8.10.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.10.0
-:logstash_version:       8.10.0
-:elasticsearch_version:  8.10.0
-:kibana_version:         8.10.0
-:apm_server_version:     8.10.0
+:bare_version:           8.10.1
+:logstash_version:       8.10.1
+:elasticsearch_version:  8.10.1
+:kibana_version:         8.10.1
+:apm_server_version:     8.10.1
 :branch:                 8.10
 :minor-version:          8.10
 :major-version:          8.x

--- a/shared/versions/stack/8.9.asciidoc
+++ b/shared/versions/stack/8.9.asciidoc
@@ -28,7 +28,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.9.asciidoc[]
+include::8.10.asciidoc[]


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

[docs release issue ](https://github.com/elastic/dev/issues/2355)