### PR TITLE
Bump docs version to 8.10.2

### DIFF
--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.10.1
+:version:                8.10.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.10.1
-:logstash_version:       8.10.1
-:elasticsearch_version:  8.10.1
-:kibana_version:         8.10.1
-:apm_server_version:     8.10.1
+:bare_version:           8.10.2
+:logstash_version:       8.10.2
+:elasticsearch_version:  8.10.2
+:kibana_version:         8.10.2
+:apm_server_version:     8.10.2
 :branch:                 8.10
 :minor-version:          8.10
 :major-version:          8.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY.

This updates the stack docs shared version attributes to 8.10.2.