### PR TITLE
Add APM PHP agent conditional

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -167,6 +167,10 @@ ifdef::apm-dotnet-branch[]
 :apm-dotnet-ref-v:     https://www.elastic.co/guide/en/apm/agent/dotnet/{apm-dotnet-branch}
 endif::[]
 
+ifdef::apm-php-branch[]
+:apm-php-ref-v:         https://www.elastic.co/guide/en/apm/agent/php/{apm-php-branch}
+endif::[]
+
 //////////
 Elastic Cloud
 //////////


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/2735

@bmorelli25 it looks like we missed the PHP agent in https://github.com/elastic/docs/pull/2735. I'm seeing unresolved attributes in the ["PHP" tab in the "Step 2: Install APM agents" section](https://www.elastic.co/guide/en/observability/current/ingest-traces.html#add-apm-integration-agents). I think might fix it? 

<img width="877" alt="Screenshot 2023-09-18 at 3 07 40 PM" src="https://github.com/elastic/docs/assets/10479155/e20b1819-ca10-44dc-b352-50facac7bcb2">



