### PR TITLE
Add feature flag for Serverless

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -181,6 +181,7 @@ Elastic Cloud
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Serverless
 :serverless-short: Serverless
+:serverless-feature-flag: no
 :serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-utm-params: ?page=docs&placement=docs-body


### PR DESCRIPTION
This adds a Serverless feature flag so that we can add any content, admonitions, etc. to the classic docs and have it disabled until the Serverless documentation is live. I've CCed folks just for awareness in case you need to use this.

For example:

```
ifeval::["{serverless-feature-flag}"=="yes"]
IMPORTANT: On-premises {fleet-server} is not currently available for use with
link:{serverless-docs}[{serverless-full}] projects. In a {serverless-short}
environment we recommend using {fleet-server} hosted on {ess}.
endif::[]
```
![Screenshot 2023-09-21 at 4 39 36 PM](https://github.com/elastic/docs/assets/41695641/86373241-41c9-4810-9b93-fac11b585778)
