### PR TITLE
Add `--build_live_only` flag to only build live branches

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -1007,6 +1007,7 @@ sub command_line_opts {
         'reposcache=s',
         'skiplinkcheck',
         'warnlinkcheck',
+        'build_live_only',
         'sub_dir=s@',
         'user=s',
         # Options only compatible with --preview
@@ -1070,6 +1071,7 @@ sub usage {
                             Defaults to `<script_dir>/.repos`.
           --skiplinkcheck   Omit the step that checks for broken links
           --warnlinkcheck   Checks for broken links but does not fail if they exist
+          --build_live_only Only build `live` branches
           --sub_dir         Use a directory as a branch of some repo
                             (eg --sub_dir elasticsearch:master:~/Code/elasticsearch)
           --target_repo     Repository to which to commit docs
@@ -1115,6 +1117,7 @@ sub check_opts {
         die('--reposcache only compatible with --all') if $Opts->{reposcache};
         die('--skiplinkcheck only compatible with --all') if $Opts->{skiplinkcheck};
         die('--warnlinkcheck only compatible with --all') if $Opts->{warnlinkcheck};
+        die('--build_live_only only compatible with --all') if $Opts->{build_live_only};
         die('--sub_dir only compatible with --all') if $Opts->{sub_dir};
     }
     if ( !$Opts->{preview} ) {

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -787,6 +787,29 @@ RSpec.describe 'building all books' do
     end
   end
 
+  context 'when run with --build_live_only' do
+    convert_before do |src, dest|
+      repo = src.repo_with_index 'repo', 'some text'
+      repo.switch_to_new_branch 'foo'
+      repo.switch_to_new_branch 'bar'
+
+      book = src.book 'Test'
+      book.source repo, 'index.asciidoc'
+      book.branches = ['master', 'foo', 'bar']
+      book.live_branches = ['foo']
+      dest.prepare_convert_all(src.conf)
+          .build_live_only
+          .convert
+    end
+    it 'builds the live branch' do
+      expect(outputs[0]).to include('Test: Building foo...')
+    end
+    it 'does not build non-live branches' do
+      expect(outputs[0]).not_to include('Test: Building master...')
+      expect(outputs[0]).not_to include('Test: Building bar...')
+    end
+  end
+
   context 'when run with --announce_preview' do
     target_branch = 'foo_1'
     preview_location = "http://#{target_branch}.docs-preview.app.elstc.co/guide"

--- a/integtest/spec/helper/dest.rb
+++ b/integtest/spec/helper/dest.rb
@@ -245,6 +245,11 @@ class Dest
       self
     end
 
+    def build_live_only
+      @cmd += ['--build_live_only']
+      self
+    end
+
     def uses_preview
       false
     end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -166,6 +166,7 @@ sub new {
         index         => $index,
         branches      => \@branches,
         live_branches => $args{live} || \@branches,
+        live_branches_only => $args{live} || [],
         branch_titles => \%branch_titles,
         current       => $current,
         tags          => $tags,
@@ -202,7 +203,11 @@ sub build {
     my $latest = !$self->{suppress_migration_warnings};
     my $update_version_toc = 0;
     my $rebuilding_current_branch = 0;
+    my $build_live_only = $Opts->{build_live_only} || 0;
     for my $branch ( @{ $self->branches } ) {
+        if ($build_live_only && !$self->is_live_branch($branch)) {
+            next;
+        }
         my $building = $self->_build_book( $branch, $pm, $rebuild, $latest );
         $update_version_toc ||= $building;
         $latest = 0;
@@ -467,6 +472,14 @@ sub _page_header_text {
         . $self->lang
         . " and phrase: $phrase";
 
+}
+
+#===================================
+sub is_live_branch {
+#===================================
+    my ($self, $branch) = @_;
+    my $live_branches_only = $self->{live_branches_only};
+    return grep { $_ eq $branch } @$live_branches_only;
 }
 
 #===================================


### PR DESCRIPTION
**Problem:**
Stack releases often require a time-consuming full docs rebuild. Long build times can cause release delays, especially when multiple builds are needed due to various issues. Rebuilding unmaintained books significantly contributes to these long build times.

**Solution:**
Add an option to only rebuild actively maintained (`live`)  branches during a full docs rebuild.

**Build time benchmarks:**
Only rebuilding live branches: 23 min. [[link](https://elasticsearch-ci.elastic.co/job/elastic+docs+pull-request+build/1739/timings/)]
Full rebuild: 1 hr. [[link](https://elasticsearch-ci.elastic.co/job/elastic+docs+pull-request+build/1738/timings/)]

Log of a build using the `--build_live_only` flag [[link](https://elasticsearch-ci.elastic.co/job/elastic+docs+pull-request+build/1739/console)]

**Infra updates:**
To have this work in CI, we'll need to make updates to our Jenkins jobs: https://github.com/elastic/infra/pull/39906