### PR TITLE
Update `live` value for several Stack books

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -129,7 +129,7 @@ contents:
             current:    *stackcurrent
             index:      welcome-to-elastic/index.asciidoc
             branches:   [ {main: master}, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 7.17 ]
-            live:       [ 8.8 ]
+            live:       [ 8.10 ]
             chunk:      1
             tags:       Elastic/Starting with the Elasticsearch Platform and its Solutions
             subject:    Starting with the Elasticsearch Platform and its Solutions
@@ -248,7 +248,7 @@ contents:
             private:    1
             current:    *stackcurrent
             branches:   [ {main: master}, 8.10, 8.9, 8.8 ]
-            live:       [ 8.10, 8.9, 8.8 ]
+            live:       [ 8.10 ]
             chunk:      1
             tags:       ESRE/Guide
             subject:    ESRE
@@ -277,7 +277,7 @@ contents:
             current:    *stackcurrent
             index:      docs/en/ingest-arch/index.asciidoc
             branches:   [ {main: master}, 8.10, 8.9 ]
-            live:       [ 8.10, 8.9 ]
+            live:       [ 8.10 ]
             chunk:      1
             tags:       Ingest/Reference
             subject:    Ingest
@@ -1098,7 +1098,7 @@ contents:
                 prefix:     enterprise-search-node
                 current:    *stackcurrent
                 branches:   [ {main: master}, 8.10, 8.9, 8.8, 8.7, 8.6 ]
-                live:       [ main, 8.6 ]
+                live:       [ 8.10 ]
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
                 subject:    Enterprise Search Clients


### PR DESCRIPTION
**Problem:**

A book's `live` variable determines what versions display outside of "other versions" in the version drop down. The following books have outdated `live` values:

- [Starting with the Elasticsearch Platform and its Solutions](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/index.html)
- [Elasticsearch Relevance Engine (ESRE)](https://www.elastic.co/guide/en/esre/current/index.html)
- [Elasticsearch Ingest Architectures](https://www.elastic.co/guide/en/ingest/current/index.html)
- [Enterprise Search Node.js client](https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/current/index.html)

This means old versions appear in the dropdown. Example screenshot:
<img width="1114" alt="Screenshot 2023-09-27 at 2 53 04 PM" src="https://github.com/elastic/docs/assets/40268737/1d874e3e-2bb4-4ac1-957f-7abe7a27e372">


**Solution:**

Updates the `live` values for the above books.