### PR TITLE
Update ECS versions for 8.11 feature freeze

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -262,8 +262,8 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             current:    8.10
-            branches:   [  {main: master}, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 1.12 ]
+            branches:   [  {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.10
+:ecs_version:            8.11
 :esf_version:            master
 
 //////////


### PR DESCRIPTION
Updating ECS versions for 8.11 feature freeze.

- Relates elastic/security-team#7620
