### PR TITLE
Update Serverless full product name

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -179,7 +179,7 @@ Elastic Cloud
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
-:serverless-full:  Elastic Serverless
+:serverless-full:  Elastic Cloud Serverless
 :serverless-short: Serverless
 :serverless-feature-flag: no
 :serverless-docs: https://docs.elastic.co/serverless


### PR DESCRIPTION
Changing "Elastic Serverless" to "Elastic Cloud Serverless" per new naming guidelines.
