### PR TITLE
Clarify data view shared attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -241,17 +241,13 @@ Kibana app and UI names
 :ems-init:           EMS
 :hosted-ems:         Elastic Maps Server
 :ipm-app:            Index Pattern Management
-:Data-Sources:       Data Views
-:Data-source:        Data view
+
 :data-source:        data view
-:Data-sources:       Data views
 :data-sources:       data views
 :data-source-caps:   Data View
 :data-sources-caps:  Data Views
 :data-source-cap:    Data view
 :data-sources-cap:   Data views
-:A-data-source:      A data view
-:a-data-source:      a data view
 
 
 //////////
@@ -538,3 +534,12 @@ Legacy definitions
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
+// Use data-sources-caps instead of Data-Sources
+:Data-Sources:         Data Views
+// Use data-source-cap instead of Data-source
+:Data-source:          Data view
+// Use data-sources-cap instead of Data-sources
+:Data-sources:         Data views
+// Do not use A-data-source or a-data-source
+:A-data-source:      A data view
+:a-data-source:      a data view


### PR DESCRIPTION
This PR clarifies the shared attributes for data views, since we want to have less duplication and potential confusion as we port them forward to the new docs system.

I have verified that the attributes that I have moved to the "legacy"/"do not use" sections are not used in the main branch of the kibana repo, with the exception of those cleaned up in https://github.com/elastic/kibana/pull/167943