### PR TITLE
Remove x-pack directory dependency from docbldesx build alias

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -10,7 +10,7 @@
 #
 
 # Elasticsearch
-alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --resource=$GIT_HOME/elasticsearch/x-pack/docs/ --chunk 1'
+alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --chunk 1'
 
 alias docbldes=docbldesx
 


### PR DESCRIPTION
The Elasticsearch docs that used to live in the `x-pack` directory have moved (https://github.com/elastic/elasticsearch/pull/99209). We no longer need the dependency to that directory in the `docbldesx` build alias.