### PR TITLE
ESS - change current to ms-99

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.10
   stacklive: &stacklive [ 8.10, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-98
+  cloudSaasCurrent: &cloudSaasCurrent ms-99
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-99.
Do not merge until release day.