### PR TITLE
Slack notification on main failure for docs build

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -26,6 +26,11 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#docs-builds'
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: 'false'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
 
 # Declare daily preview cleaner
 ---


### PR DESCRIPTION
Added Slack notification sending to #docs-builds channel using [Terrazzo](https://docs.elastic.dev/ci/notifications-in-buildkite#slack---alternative) for main branch failure cases.
Required for issue [134](https://github.com/elastic/docs-projects/issues/134)