### PR TITLE
Re organize docs pipelines

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,8 +22,12 @@ spec:
       repository: elastic/docs
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
+        docs-build-guild:
+          access_level: MANAGE_BUILD_AND_READ
         ci-docs-migration-taskforce:
           access_level: MANAGE_BUILD_AND_READ
+        docs:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
       env:
@@ -58,8 +62,12 @@ spec:
       provider_settings:
         trigger_mode: none
       teams:
+        docs-build-guild:
+          access_level: MANAGE_BUILD_AND_READ
         ci-docs-migration-taskforce:
           access_level: MANAGE_BUILD_AND_READ
+        docs:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -88,8 +96,12 @@ spec:
       repository: elastic/docs
       pipeline_file: ".buildkite/pr_main_mr_test.yml"
       teams:
+        docs-build-guild:
+          access_level: MANAGE_BUILD_AND_READ
         ci-docs-migration-taskforce:
           access_level: MANAGE_BUILD_AND_READ
+        docs:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -119,7 +131,11 @@ spec:
       provider_settings:
         trigger_mode: none
       teams:
+        docs-build-guild:
+          access_level: MANAGE_BUILD_AND_READ
         ci-docs-migration-taskforce:
           access_level: MANAGE_BUILD_AND_READ
+        docs:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,10 +4,10 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-docs
-  description: Buildkite Pipeline for docs
+  description: Build the docs
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/docs
+      url: https://buildkite.com/elastic/docs-build
 
 spec:
   type: buildkite-pipeline
@@ -17,7 +17,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: docs
+      name: docs / build
     spec:
       repository: elastic/docs
       pipeline_file: ".buildkite/pipeline.yml"
@@ -41,11 +41,11 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-preview-cleaner
+  name: buildkite-pipeline-docs-preview-cleaner
   description: Daily Preview Cleaner
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/preview-cleaner
+      url: https://buildkite.com/elastic/docs-preview-cleaner
 
 spec:
   type: buildkite-pipeline
@@ -55,7 +55,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: preview-cleaner
+      name: docs / preview-cleaner
     spec:
       repository: elastic/docs
       pipeline_file: ".buildkite/preview_cleaner_pipeline.yml"
@@ -76,11 +76,11 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pr-main-mr-test
+  name: buildkite-pipeline-docs-test
   description: PR and Merge-to-Main Test
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/pr-main-mr-test
+      url: https://buildkite.com/elastic/docs-test
 
 spec:
   type: buildkite-pipeline
@@ -90,7 +90,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: pr-main-mr-test
+      name: docs-test
     spec:
       branch_configuration: "main"
       repository: elastic/docs
@@ -110,11 +110,11 @@ spec:
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
-  name: buildkite-pipeline-build-air-gapped
+  name: buildkite-pipeline-docs-build-air-gapped
   description: Build air-gapped
   links:
     - title: Pipeline
-      url: https://buildkite.com/elastic/docs-air-gapped
+      url: https://buildkite.com/elastic/docs-build-air-gapped
 
 spec:
   type: buildkite-pipeline
@@ -124,7 +124,7 @@ spec:
     apiVersion: buildkite.elastic.dev/v1
     kind: Pipeline
     metadata:
-      name: docs-air-gapped
+      name: docs / build air-gapped
     spec:
       repository: elastic/docs
       pipeline_file: ".buildkite/air_gapped_pipeline.yml"


### PR DESCRIPTION
This PR renames so docs pipelines so that they're better organized in Buildkite (before they start getting used widely). Our original naive approach produced pipelines such as buildkite.com/elastic/preview-cleaner - which is not very descriptive or obvious.


This changeset also update some teams permissions to reflect the end-state.

cc @bmorelli25 for review on the teams permissions.

current looking state:

<img width="367" alt="image" src="https://github.com/elastic/docs/assets/124953/1678307b-7e56-4c9e-88cc-b154cc8fb3e8">



Note - this change will be fairly destructive from a terrazzo perspective and will require some manul tending from the CI team (I should also be able to help out with it).
