### PR TITLE
Test job migration

### DIFF
--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -1,7 +1,6 @@
 steps:
   - label: "Execute tests"
-    command:
-      - ./.buildkite/scripts/test.sh
+    command: ".buildkite/scripts/test.sh"
 #    branches: "master"
 notify:
   - email: "docs-status@elastic.co"

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -2,6 +2,9 @@ steps:
   - label: "Execute tests"
     command: ".buildkite/scripts/test.sh"
 #    branches: "master"
+    agents:
+      provider: "gcp"
+      image: family/docs-ubuntu-2204
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -1,11 +1,8 @@
 steps:
   - label: "Execute tests"
-    command: |
-      bash .buildkite/scripts/test.sh
+    command:
+      - ./.buildkite/test.sh
 #    branches: "master"
-    agents:
-      provider: "gcp"
-      image: family/docs-ubuntu-2204
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "Execute tests"
     command:
-      - ./.buildkite/test.sh
+      - ./.buildkite/scripts/test.sh
 #    branches: "master"
 notify:
   - email: "docs-status@elastic.co"

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -2,7 +2,7 @@ steps:
   - label: "Execute tests"
     command: |
       bash .buildkite/scripts/test.sh
-    branches: "master"
+#    branches: "master"
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -1,3 +1,11 @@
 steps:
-  - label: "Test"
-    command: echo "Test"
+  - label: "Execute tests"
+    command: |
+      bash .buildkite/scripts/test.sh
+    branches: "master"
+    agents:
+      provider: "gcp"
+      image: family/docs-ubuntu-2204
+notify:
+  - email: "docs-status@elastic.co"
+    if: build.state == "failed"

--- a/.buildkite/pr_main_mr_test.yml
+++ b/.buildkite/pr_main_mr_test.yml
@@ -1,7 +1,7 @@
 steps:
   - label: "Execute tests"
     command: ".buildkite/scripts/test.sh"
-#    branches: "master"
+    branches: "master"
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204

--- a/.buildkite/scripts/test.sh
+++ b/.buildkite/scripts/test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 cd $(git rev-parse --show-toplevel)
 
-echo "Building images for test execution"
+echo "Building images for docs test"
 for IMAGE in build py_test node_test ruby_test integ_test diff_tool; do
   echo Building $IMAGE
   ./build_docs --docker-build $IMAGE

--- a/.buildkite/scripts/test.sh
+++ b/.buildkite/scripts/test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd $(git rev-parse --show-toplevel)
+
+echo "Building images for test execution"
+for IMAGE in build py_test node_test ruby_test integ_test diff_tool; do
+  echo Building $IMAGE
+  ./build_docs --docker-build $IMAGE
+done
+
+make

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -84,7 +84,7 @@ spec:
     metadata:
       name: pr-main-mr-test
     spec:
-      branch_configuration: "main"
+#      branch_configuration: "main"
       repository: elastic/docs
       pipeline_file: ".buildkite/pr_main_mr_test.yml"
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -84,7 +84,7 @@ spec:
     metadata:
       name: pr-main-mr-test
     spec:
-#      branch_configuration: "main"
+      branch_configuration: "main"
       repository: elastic/docs
       pipeline_file: ".buildkite/pr_main_mr_test.yml"
       teams:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -92,6 +92,12 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      env:
+        ELASTIC_SLACK_NOTIFICATIONS_ENABLED: 'true'
+        SLACK_NOTIFICATIONS_CHANNEL: '#docs-builds'
+        SLACK_NOTIFICATIONS_ALL_BRANCHES: 'false'
+        SLACK_NOTIFICATIONS_ON_SUCCESS: 'false'
+
 
 # Declare build air-gapped
 ---


### PR DESCRIPTION
As described in Issue [130](https://github.com/elastic/docs-projects/issues/130) - created test.sh that combines logic from Jenkins related ./ci/test.sh and ./ci/packer_cache.sh scripts. New BK pipeline is created and triggered only while changing main branch.
Tests were successfully executed from manual build trigger (https://buildkite.com/elastic/pr-main-mr-test/builds/4#018b1e1d-789b-4626-af2f-e57204927f9f)