### PR TITLE
Bumps docs version to 8.10.4

### DIFF
--- a/shared/versions/stack/8.10.asciidoc
+++ b/shared/versions/stack/8.10.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.10.3
+:version:                8.10.4
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.10.3
-:logstash_version:       8.10.3
-:elasticsearch_version:  8.10.3
-:kibana_version:         8.10.3
-:apm_server_version:     8.10.3
+:bare_version:           8.10.4
+:logstash_version:       8.10.4
+:elasticsearch_version:  8.10.4
+:kibana_version:         8.10.4
+:apm_server_version:     8.10.4
 :branch:                 8.10
 :minor-version:          8.10
 :major-version:          8.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY.

This updates the stack docs shared version attributes to 8.10.4.