### PR TITLE
Add shared attribute for AWS Bedrock connector

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -323,6 +323,7 @@ Do not use `endpoint-cloud-sec` in versions 8.5.0 and newer
 :webhook:                 Webhook
 :webhook-cm:              {webhook} - Case Management
 :opsgenie:                Opsgenie
+:bedrock:                 AWS Bedrock
 :monitoring:              X-Pack monitoring
 :monitor-features:        monitoring features
 :stack-monitor-features:  {stack} {monitor-features}


### PR DESCRIPTION
Relates to https://github.com/elastic/security-docs/issues/4031, which indicates this name might soon change.

The attribute will be used in pages like https://www.elastic.co/guide/en/kibana/master/bedrock-action-type.html