### PR TITLE
Update bedrock connector name

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -323,7 +323,7 @@ Do not use `endpoint-cloud-sec` in versions 8.5.0 and newer
 :webhook:                 Webhook
 :webhook-cm:              {webhook} - Case Management
 :opsgenie:                Opsgenie
-:bedrock:                 AWS Bedrock
+:bedrock:                 Amazon Bedrock
 :monitoring:              X-Pack monitoring
 :monitor-features:        monitoring features
 :stack-monitor-features:  {stack} {monitor-features}


### PR DESCRIPTION
This PR changes the name that is used for the AWS Bedrock connector per https://github.com/elastic/kibana/pull/168663#pullrequestreview-1680109995