### PR TITLE
Update tech preview copy

### DIFF
--- a/integtest/spec/single_book_spec.rb
+++ b/integtest/spec/single_book_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe 'building a single book' do
       it 'includes the experimental text' do
         expect(body).to include(
           'This functionality is in technical preview and may be changed or '\
-          'removed in a future release. Elastic will apply best effort to fix '\
+          'removed in a future release. Elastic will work to fix '\
           'any issues, but features in technical preview are not subject to '\
           'the support SLA of official GA features.'
         )

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -25,7 +25,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   PREVIEW_DEFAULT_TEXT = <<~TEXT.strip
-    This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+    This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
 
   def activate(registry)

--- a/resources/asciidoctor/spec/care_admonition_spec.rb
+++ b/resources/asciidoctor/spec/care_admonition_spec.rb
@@ -247,7 +247,7 @@ RSpec.describe CareAdmonition do
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       TEXT
     end
     include_examples 'care admonition'
@@ -257,7 +257,7 @@ RSpec.describe CareAdmonition do
     let(:admon_class) { 'warning' }
     let(:default_text) do
       <<~TEXT.strip
-        This functionality is in technical preview and may be changed or removed in a future release. Elastic will apply best effort to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+        This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
       TEXT
     end
     include_examples 'care admonition'


### PR DESCRIPTION
Adjusts the copy for the `preview` admonition.