### PR TITLE
Update Serverless attribute to 'serverless'

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -179,8 +179,8 @@ Elastic Cloud
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
-:serverless-full:  Elastic Cloud Serverless
-:serverless-short: Serverless
+:serverless-full:  Elastic Cloud serverless
+:serverless-short: serverless
 :serverless-feature-flag: no
 :serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current


### PR DESCRIPTION
Based on request from PMM we are changing the serverless product names to:

Full: `Elastic Cloud serverless`
Short: `serverless`

