### PR TITLE
Change destination for Search solution to Elasticsearch

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -223,13 +223,13 @@
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
   <div class="row my-4">
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/index.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
             Search
           </h4>
-          <p>Build an application on top of Elasticsearch with Elastic Enterprise Search.</p>
+          <p>Build custom applications with your data using Elasticsearch.</p>
         </div>
       </a>
     </div>


### PR DESCRIPTION
For the "Search" solution, direct readers to the Elasticsearch docs rather than the Enterprise Search docs.

For the link text, use the same text we use in the Elastic Cloud console to describe Elasticsearch projects.