### PR TITLE
Freeze published Functionbeat docs at 8.10

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2027,55 +2027,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          - title:      Functionbeat Reference
-            prefix:     en/beats/functionbeat
-            current:    *stackcurrent
-            index:      x-pack/functionbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       [ 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            chunk:      1
-            tags:       Functionbeat/Reference
-            respect_edit_url_overrides: true
-            subject:    Functionbeat
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/functionbeat
-              -
-                repo:   beats
-                path:   x-pack/functionbeat/docs
-              -
-                repo:   beats
-                path:   CHANGELOG.asciidoc
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/processors/*/docs/*
-                exclude_branches:   *beatsProcessorExclude
-              -
-                repo:   beats
-                path:   x-pack/libbeat/processors/*/docs/*
-                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
-              -
-                repo:   beats
-                path:   libbeat/outputs/*/docs/*
-                exclude_branches:   *beatsOutputExclude
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   beats
-                path:   x-pack/libbeat/docs
-                exclude_branches:   *beatsXpackLibbeatExclude
-              -
-                repo:   beats
-                path:   filebeat/docs
-                exclude_branches: [ 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
           - title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
@@ -2386,6 +2337,54 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+          - title:      Functionbeat Reference
+            prefix:     en/beats/functionbeat
+            current:    *stackcurrent
+            index:      x-pack/functionbeat/docs/index.asciidoc
+            branches:   [ 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
+            chunk:      1
+            tags:       Functionbeat/Reference
+            respect_edit_url_overrides: true
+            subject:    Functionbeat Reference for 6.5-8.10
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/functionbeat
+              -
+                repo:   beats
+                path:   x-pack/functionbeat/docs
+              -
+                repo:   beats
+                path:   CHANGELOG.asciidoc
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/processors/*/docs/*
+                exclude_branches:   *beatsProcessorExclude
+              -
+                repo:   beats
+                path:   x-pack/libbeat/processors/*/docs/*
+                exclude_branches:   [ 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 1.3, 1.2, 1.1, 1.0.1 ]
+              -
+                repo:   beats
+                path:   libbeat/outputs/*/docs/*
+                exclude_branches:   *beatsOutputExclude
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   beats
+                path:   x-pack/libbeat/docs
+                exclude_branches:   *beatsXpackLibbeatExclude
+              -
+                repo:   beats
+                path:   filebeat/docs
+                exclude_branches: [ 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
           - title:      Journalbeat Reference for 6.5-7.15
             prefix:     en/beats/journalbeat
             current:    7.15

--- a/conf.yaml
+++ b/conf.yaml
@@ -2032,7 +2032,7 @@ contents:
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
-            live:       *stacklive
+            live:       [ 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             chunk:      1
             tags:       Functionbeat/Reference
             respect_edit_url_overrides: true

--- a/conf.yaml
+++ b/conf.yaml
@@ -2339,7 +2339,7 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Functionbeat Reference
             prefix:     en/beats/functionbeat
-            current:    *stackcurrent
+            current:    8.10
             index:      x-pack/functionbeat/docs/index.asciidoc
             branches:   [ 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
             chunk:      1


### PR DESCRIPTION
Functionbeat docs have been deprecated. This should:
 - Freeze the build at v8.10
 - Move the Functionbeat docs to the "Legacy Documentation" section.

I've removed the `live:` setting from conf.yaml for the Functionbeat docs, but please let me know if that's not the correct thing to do.

Rel: https://github.com/elastic/ingest-docs/issues/608

