### PR TITLE
Update PR bot config to trigger for non docs repos

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -14,7 +14,30 @@
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "always_trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [
-        "skip-ci"
+        "skip docs-build"
+      ],
+      "skip_ci_on_only_changed": [],
+      "always_require_ci_on_changed": [],
+      "repositories": [
+        "elastic/docs",
+        "elastic/tech-content"
+      ]
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "docs-build",
+      "always_trigger_branch": "buildkite-webhook-rebuild-136",
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "always_trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "skip_ci_labels": [
+        "skip docs-build"
       ],
       "skip_ci_on_only_changed": [
         ".*"
@@ -23,8 +46,6 @@
         "docs\\.*"
       ],
       "repositories": [
-        "elastic/docs",
-        "elastic/tech-content",
         "elastic/x-pack"
       ]
     }


### PR DESCRIPTION
The current PR bot config was assuming that only changes in the docs folder should trigger docs builds - but that's not the case for some repositories, such as:
* `elastic/docs`
* `elastic/tech-content`

This PR fixes that.

Also reported [here](https://github.com/elastic/docs-projects/issues/139#issuecomment-1798840531)