### PR TITLE
Bump `master` attributes to 8.12

### DIFF
--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.10.0
+:version:                8.11.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.10.0
-:logstash_version:       8.10.0
-:elasticsearch_version:  8.10.0
-:kibana_version:         8.10.0
-:apm_server_version:     8.10.0
+:bare_version:           8.11.0
+:logstash_version:       8.11.0
+:elasticsearch_version:  8.11.0
+:kibana_version:         8.11.0
+:apm_server_version:     8.11.0
 :branch:                 master
-:minor-version:          8.10
+:minor-version:          8.11
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.11.0
+:version:                8.12.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.11.0
-:logstash_version:       8.11.0
-:elasticsearch_version:  8.11.0
-:kibana_version:         8.11.0
-:apm_server_version:     8.11.0
+:bare_version:           8.12.0
+:logstash_version:       8.12.0
+:elasticsearch_version:  8.12.0
+:kibana_version:         8.12.0
+:apm_server_version:     8.12.0
 :branch:                 master
-:minor-version:          8.11
+:minor-version:          8.12
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17


### PR DESCRIPTION
Bumps the current Stack version to 8.12 in `master` and `main` branches.

Rel: https://github.com/elastic/docs/pull/2809