### PR TITLE
Add o11y docs to Buildkite for validation

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -21,6 +21,7 @@
       "repositories": [
         "elastic/docs",
         "elastic/tech-content"
+        "elastic/observability-docs"
       ]
     },
     {
@@ -46,7 +47,6 @@
         "docs\\.*"
       ],
       "repositories": [
-        "elastic/observability-docs",
         "elastic/x-pack"
       ]
     }

--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -46,6 +46,7 @@
         "docs\\.*"
       ],
       "repositories": [
+        "elastic/observability-docs",
         "elastic/x-pack"
       ]
     }


### PR DESCRIPTION
This is the config to enable the PRs in elastic/observability-docs to build in Buildkite - I also setup a webhook following these [instructions](https://docs.elastic.dev/ci/configuring-pull-requests-for-buildkite#1-create-a-github-webhook)

Note - only changes in ./docs will trigger Buildkite builds - let me know if this is too restrictive.