### PR TITLE
ESS - Change current to ms-101

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.11
   stacklive: &stacklive [ 8.11, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-99
+  cloudSaasCurrent: &cloudSaasCurrent ms-100
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main

--- a/conf.yaml
+++ b/conf.yaml
@@ -79,7 +79,7 @@ variables:
   stackcurrent: &stackcurrent 8.11
   stacklive: &stacklive [ 8.11, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-100
+  cloudSaasCurrent: &cloudSaasCurrent ms-101
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-101.

Do not merge until release day.