### PR TITLE
Remove 'serverless-feature-flag'

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -181,7 +181,6 @@ Elastic Cloud
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Cloud serverless
 :serverless-short: serverless
-:serverless-feature-flag: no
 :serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-utm-params: ?page=docs&placement=docs-body


### PR DESCRIPTION
I think I was the only one using this feature flag, so in the end it seems cleaner just to remove it rather than enabling it.


