### PR TITLE
Add CODEOWNER file

### DIFF
--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,0 +1,1 @@
+* @elastic/docs-release-team @colleenmcginnis 

--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,1 +1,1 @@
-* @elastic/docs-release-team @colleenmcginnis 
+* @elastic/docs-release-team @colleenmcginnis @kilfoyle @leemthompo

--- a/.github/CODEOWNER
+++ b/.github/CODEOWNER
@@ -1,1 +1,1 @@
-* @elastic/docs-release-team @colleenmcginnis @kilfoyle @leemthompo
+* @elastic/docs-release-team @elastic/docs-engineering @colleenmcginnis @kilfoyle @leemthompo


### PR DESCRIPTION
We need to add a code owner to this repository. No one commented on my spreadsheet with suggestions, so here's what I propose:

* @elastic/docs-release-team: This team includes, @bmorelli25, @KOTungseth, @abdonpijpelink, @joepeeples, and @lcawl
* The writer who knows the most about how the classic doc system works: @colleenmcginnis
* The two highest contributors (based on number of commits in the past year) to this repo outside of the above folks: @kilfoyle and @leemthompo 

These eight folks provide wide geographic coverage and wide coverage across elastic documentation teams.

A review from one of the eight folks listed above will be required to merge a PR in this repository.

~Note: We'll also eventually add @elastic/docs-engineering as codeowners and admins to this repo.~ I've updated this PR to also add @elastic/docs-engineering as codeowners.
