### PR TITLE
Bumps docs version to 8.11.1

### DIFF
--- a/shared/versions/stack/8.11.asciidoc
+++ b/shared/versions/stack/8.11.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.11.0
+:version:                8.11.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.11.0
-:logstash_version:       8.11.0
-:elasticsearch_version:  8.11.0
-:kibana_version:         8.11.0
-:apm_server_version:     8.11.0
+:bare_version:           8.11.1
+:logstash_version:       8.11.1
+:elasticsearch_version:  8.11.1
+:kibana_version:         8.11.1
+:apm_server_version:     8.11.1
 :branch:                 8.11
 :minor-version:          8.11
 :major-version:          8.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY.

This updates the stack docs shared version attributes to 8.11.1.
