### PR TITLE
Bumps docs version to 7.17.15

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.14
+:version:                7.17.15
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.14
-:logstash_version:       7.17.14
-:elasticsearch_version:  7.17.14
-:kibana_version:         7.17.14
-:apm_server_version:     7.17.14
+:bare_version:           7.17.15
+:logstash_version:       7.17.15
+:elasticsearch_version:  7.17.15
+:kibana_version:         7.17.15
+:apm_server_version:     7.17.15
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY.

This updates the stack docs shared version attributes to 7.17.15.