### PR TITLE
Promotes serverless link higher on page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -218,6 +218,12 @@
     </dl>
   </details>
 
+  <h2>Learn about serverless projects</h2>
+  <p>Create serverless projects for an autoscaled and fully-managed Elastic solution based on Elasticsearch, Observability, or Security.</p>
+    <p>
+      <a class="inline-block mr-3" href="https://docs.elastic.co/serverless">Serverless docs</a>
+   </p>
+
   <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.
     Get hands-on with a solution and quickly see data in action, or start from a blank page. </p>
@@ -301,9 +307,6 @@
     </div>
     <ul class="ul-col-md-2 ul-col-1">
       <li>
-        <a href="https://docs.elastic.co/serverless">Serverless projects</a>
-      </li>
-      <li>
         <a href="en/cloud/current/ec-cloud-ingest-data.html">Add your data</a>
       </li>
       <li>
@@ -314,6 +317,9 @@
       </li>
       <li>
         <a href="en/cloud/current/ec-monitoring.html">Keep your deployment healthy</a>
+      </li>
+      <li>
+        <a href="en/elasticsearch/reference/current/example-using-index-lifecycle-policy.html">Manage data retention</a>
       </li>
       <li>
         <a href="en/kibana/current/dashboard.html">Visualize data with dashboards</a>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -68,7 +68,7 @@
      </div>
    </div>
   </div>
-  <h2>Learn about the Elastic Stack</h2>
+  <h2>The Elastic Stack</h2>
   <p>What exactly is the "Elastic Stack"? It&#8217;s a fast and highly scalable set of components &mdash; Elasticsearch, Kibana, Beats, Logstash, and others &mdash; that together enable you to securely take data from any source, in any format, and then search, analyze, and visualize it.</p>
 
     <details>
@@ -218,11 +218,8 @@
     </dl>
   </details>
 
-  <h2>Learn about serverless projects</h2>
-  <p>Create serverless projects for an autoscaled and fully-managed Elastic solution based on Elasticsearch, Observability, or Security.</p>
-    <p>
-      <a class="inline-block mr-3" href="https://docs.elastic.co/serverless">Serverless docs</a>
-   </p>
+  <h2>Serverless projects</h2>
+  <p>Create serverless projects for an autoscaled and fully-managed Elastic solution based on Elasticsearch, Observability, or Security. To learn more, check out the <a class="inline-block mr-3" href="https://docs.elastic.co/serverless">Serverless docs</a>.</p>
 
   <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -219,7 +219,7 @@
   </details>
 
   <h2>Serverless projects</h2>
-  <p>Create serverless projects for an autoscaled and fully-managed Elastic solution based on Elasticsearch, Observability, or Security. To learn more, check out the <a class="inline-block mr-3" href="https://docs.elastic.co/serverless">Serverless docs</a>.</p>
+  <p>Create serverless projects for an autoscaled and fully-managed Elastic solution based on Elasticsearch, Observability, or Security. To learn more, check out the <a class="inline-block mr-3" href="https://docs.elastic.co/serverless">Serverless docs.</a></p>
 
   <h2>Get started</h2>
   <p>New to Elastic? Learn how you can make the most of your data with the Elastic Stack.


### PR DESCRIPTION
Moves serverless docs link under `Learn about the Elastic Stack`. 
