### PR TITLE
Set Buildkite PR job to use master and add batch1 of repos

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -3,7 +3,7 @@
     {
       "enabled": true,
       "pipeline_slug": "docs-build-pr",
-      "always_trigger_branch": "buildkite-webhook-rebuild-136",
+      "always_trigger_branch": "master",
       "allow_org_users": true,
       "allowed_repo_permissions": [
         "admin",
@@ -19,14 +19,17 @@
       "skip_ci_on_only_changed": [],
       "always_require_ci_on_changed": [],
       "repositories": [
+        "elastic/elasticsearch",
+        "elastic/kibana",
         "elastic/tech-content",
+        "elastic/beats",
         "elastic/observability-docs"
       ]
     },
     {
       "enabled": true,
       "pipeline_slug": "docs-build-pr",
-      "always_trigger_branch": "buildkite-webhook-rebuild-136",
+      "always_trigger_branch": "master",
       "allow_org_users": true,
       "allowed_repo_permissions": [
         "admin",
@@ -46,6 +49,10 @@
         "docs\\.*"
       ],
       "repositories": [
+        "elastic/security-docs",
+        "elastic/elasticsearch-py",
+        "elastic/cloud-on-k8s",
+        "elastic/ingest-docs",
         "elastic/x-pack"
       ]
     },

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -77,8 +77,6 @@ spec:
           access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
-      env:
-        ELASTIC_PR_COMMENTS_ENABLED: 'true'
 
 # Declare daily preview cleaner
 ---


### PR DESCRIPTION
This PR that goes hand in hand with [this one](https://github.com/elastic/docs/pull/2835) hooks up a few more products-docs repositories to Buildkite. On such repos, when a PR is opened or commented on (with `run docs-build`), the [docs-build-pr](https://buildkite.com/elastic/docs-build-pr) job will be triggered (alongside it's Jenkins counterpart), and push preview changes to the `elastic/built-docs` repo under the `<doc>_bk_<PR_NUMBER>` branch name.

Commit statuses for the Buildkite build will be set but they are not configured to be blocking. 
Additionally, the Buildkite job is configured to report back on the PR with a link to the preview and diff reports. [Here's](https://github.com/elastic/observability-docs/pull/3356#issuecomment-1819842064) an example of such comment.

The intent in the coming days is to gain confidence in the Jenkins VS Buildkite PR docs job.


cc @brianseeders @mark-vieira for the elasticsearch repo
cc @delanni for the kibana repo
cc @thbkrkr  for cloud-on-k8s
cc @kilfoyle for ingest-docs
cc @v1v / @jlind23 for beats 
cc @natasha-moore-elastic for security-docs
cc @pquentin for elasticsearch-py

