### PR TITLE
Add feedback widget to docs sidebar

### DIFF
--- a/resources/web/docs_js/components/feedback_modal.jsx
+++ b/resources/web/docs_js/components/feedback_modal.jsx
@@ -1,0 +1,233 @@
+import { h, Component } from '../../../../../../node_modules/preact';
+
+const FEEDBACK_URL = 'https://docs.elastic.co/api/feedback'
+const MAX_COMMENT_LENGTH = 1000;
+
+export default class FeedbackModal extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      comment: '',
+      modalClosed: false,
+      isLoading: false,
+      hasError: false,
+    };
+    this.onEscape = this.onEscape.bind(this);
+    this.resetState = this.resetState.bind(this);
+    this.submitFeedback = this.submitFeedback.bind(this);
+  }
+
+  onEscape(event) {
+    if (event.key === 'Escape') {
+      this.resetState();
+    }
+  }
+
+  resetState() {
+    this.setState({ modalClosed: true });
+    document.querySelectorAll('.isPressed').forEach((el) => {
+      el.classList.remove('isPressed');
+    });
+  }
+
+  submitFeedback() {
+    this.setState({ isLoading: true });
+    fetch(FEEDBACK_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        comment: this.state.comment,
+        feedback: this.props.isLiked ? 'liked' : 'disliked',
+      }),
+    })
+      .then((response) => response.json())
+      .then(() => {
+        this.setState({ modalClosed: true })
+        document.getElementById('feedbackSuccess').classList.remove('hidden')
+        document.querySelectorAll('.feedbackButton').forEach((el) => {
+          el.disabled = true
+        })
+      })
+      .catch((error) => {
+        this.setState({ isLoading: false, hasError: true });
+        console.error('Error:', error);
+      });
+
+  }
+
+  componentDidMount() {
+    document.addEventListener('keydown', this.onEscape, false);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('keydown', this.onEscape, false);
+  }
+
+  render(props, state) {
+    const { isLiked } = props;
+    const { modalClosed, isLoading, hasError, comment } = state;
+    const maxCommentLengthReached = comment.length > MAX_COMMENT_LENGTH;
+    const sendDisabled = isLoading || maxCommentLengthReached;
+
+    if (modalClosed) {
+      return null;
+    }
+
+    return (
+      <div
+        data-relative-to-header="above"
+        id="feedbackModal"
+      >
+        <div
+          data-focus-guard="true"
+          tabindex="0"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        ></div>
+        <div data-focus-lock-disabled="false">
+          <div className="feedbackModalContent" tabindex="0">
+            <button
+              className="closeIcon"
+              type="button"
+              aria-label="Closes this modal window"
+              onClick={this.resetState}
+              disabled={isLoading}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                role="img"
+                data-icon-type="cross"
+                data-is-loaded="true"
+                aria-hidden="true"
+              >
+                <path d="M7.293 8 3.146 3.854a.5.5 0 1 1 .708-.708L8 7.293l4.146-4.147a.5.5 0 0 1 .708.708L8.707 8l4.147 4.146a.5.5 0 0 1-.708.708L8 8.707l-4.146 4.147a.5.5 0 0 1-.708-.708L7.293 8Z"></path>
+              </svg>
+            </button>
+            <div className="feedbackModalHeader">
+              <h2>Send us your feedback</h2>
+            </div>
+            <div className="feedbackModalBody">
+              <div className="feedbackModalBodyOverflow">
+                <div>
+                  Thank you for helping us improve Elastic documentation.
+                </div>
+                <div className="spacer"></div>
+                <div className="feedbackForm">
+                  <div className="feedbackFormRow">
+                    <div className="feedbackFormRow__labelWrapper">
+                      <label
+                        className="feedbackFormLabel"
+                        id="feedbackLabel"
+                        for="feedbackComment"
+                      >
+                        Additional comment (optional)
+                      </label>
+                    </div>
+                    <div className="feedbackFormRow__fieldWrapper">
+                      <div className="feedbackFormControlLayout">
+                        <div className="feedbackFormControlLayout__childrenWrapper">
+                          <textarea
+                            className="feedbackTextArea"
+                            rows="6"
+                            id="feedbackComment"
+                            disabled={isLoading}
+                            onKeyUp={(e) =>
+                              this.setState({ comment: e.target.value })
+                            }
+                          ></textarea>
+                          {maxCommentLengthReached && (
+                            <div className="feedbackFormError">
+                              Max comment length of {MAX_COMMENT_LENGTH}{' '}
+                              characters reached.
+                              <br />
+                              <br />
+                              Character count: {comment.length}
+                            </div>
+                          )}
+                          {hasError && (
+                            <div className="feedbackFormError">
+                              There was a problem submitting your feedback.
+                              <br />
+                              <br />
+                              Please try again.
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              className={`feedbackModalFooter ${isLoading ? 'loading' : ''}`}
+            >
+              <button
+                className="feedbackButton cancelButton"
+                type="button"
+                onClick={this.resetState}
+                disabled={isLoading}
+              >
+                <span className="feedbackButtonContent">
+                  <span>Cancel</span>
+                </span>
+              </button>
+              <button
+                type="button"
+                disabled={sendDisabled}
+                className={`feedbackButton sendButton ${
+                  isLiked ? 'like' : 'dislike'
+                }`}
+                onClick={this.submitFeedback}
+              >
+                <span className="loadingContent">
+                  <span
+                    class="loadingSpinner"
+                    role="progressbar"
+                    aria-label="Loading"
+                    style="border-color: rgb(0, 119, 204) currentcolor currentcolor;"
+                  ></span>
+                  <span>Sending...</span>
+                </span>
+                <span className="feedbackButtonContent">
+                  <span>Send</span>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="sendIcon like"
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57l.03-.32c0-.41-.17-.79-.44-1.06L14.17 1L7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z"></path>
+                  </svg>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="sendIcon dislike"
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57l-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12l-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z"></path>
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+        <div
+          data-focus-guard="true"
+          tabindex="0"
+          style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+        ></div>
+      </div>
+    );
+  }
+}

--- a/resources/web/docs_js/components/feedback_modal.jsx
+++ b/resources/web/docs_js/components/feedback_modal.jsx
@@ -40,6 +40,7 @@ export default class FeedbackModal extends Component {
       body: JSON.stringify({
         comment: this.state.comment,
         feedback: this.props.isLiked ? 'liked' : 'disliked',
+        url: window.location.href,
       }),
     })
       .then((response) => response.json())

--- a/resources/web/docs_js/components/feedback_widget.jsx
+++ b/resources/web/docs_js/components/feedback_widget.jsx
@@ -1,0 +1,94 @@
+import { h, Component } from '../../../../../../node_modules/preact';
+
+export default class FeedbackWidget extends Component {
+  render() {
+    return (
+      <div>
+        <div id="feedbackWidget">
+          Was this helpful?
+          <span className="docHorizontalSpacer"></span>
+          <fieldset className="buttonGroup">
+            <legend className="screenReaderOnly">Feedback</legend>
+            <div className="buttonGroup">
+              <button
+                aria-pressed="false"
+                id="feedbackLiked"
+                type="button"
+                className="feedbackButton feedbackLiked"
+                title="Like"
+              >
+                <span className="feedbackButtonContent">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="feedbackIcon unpressed"
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <path d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57l.03-.32c0-.41-.17-.79-.44-1.06L14.17 1L7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2zM9 9l4.34-4.34L12 10h9v2l-3 7H9V9zM1 9h4v12H1z"></path>
+                  </svg>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="feedbackIcon pressed"
+                    role="img"
+                    data-is-loaded="true"
+                    aria-hidden="true"
+                  >
+                    <path d="M1 21h4V9H1v12zm22-11c0-1.1-.9-2-2-2h-6.31l.95-4.57l.03-.32c0-.41-.17-.79-.44-1.06L14.17 1L7.59 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2z"></path>
+                  </svg>
+                  <span className="screenReaderOnly" data-text="Like">
+                    Like
+                  </span>
+                </span>
+              </button>
+              <button
+                aria-pressed="false"
+                id="feedbackDisliked"
+                type="button"
+                className="feedbackButton feedbackDisliked"
+                title="Dislike"
+              >
+                <span className="feedbackButtonContent">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="feedbackIcon unpressed"
+                    role="img"
+                    aria-hidden="true"
+                  >
+                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57l-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm0 12l-4.34 4.34L12 14H3v-2l3-7h9v10zm4-12h4v12h-4z"></path>
+                  </svg>
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    className="feedbackIcon pressed"
+                    role="img"
+                    data-is-loaded="true"
+                    aria-hidden="true"
+                  >
+                    <path d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57l-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2zm4 0v12h4V3h-4z"></path>
+                  </svg>
+                  <span className="screenReaderOnly" data-text="Dislike">
+                    Dislike
+                  </span>
+                </span>
+              </button>
+            </div>
+          </fieldset>
+        </div>
+        <div id="feedbackSuccess" className="hidden">
+          Thank you for your feedback.
+        </div>
+      </div>
+    );
+  }
+}

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -1,5 +1,6 @@
 import AlternativeSwitcher from "./components/alternative_switcher";
 import ConsoleWidget from "./components/console_widget";
+import FeedbackModal from './components/feedback_modal';
 import FeedbackWidget from './components/feedback_widget';
 import Modal from "./components/modal";
 import mount from "./components/mount";
@@ -92,6 +93,11 @@ export function init_console_widgets() {
 
 export function init_feedback_widget() {
   mount($('#feedbackWidgetContainer'), FeedbackWidget);
+  $('.feedbackButton').click(function () {
+    const isLiked = $(this).hasClass('feedbackLiked');
+    $(this).addClass('isPressed');
+    mount($('#feedbackModalContainer'), FeedbackModal, { isLiked: isLiked });
+  });
 }
 
 export function init_sense_widgets() {
@@ -337,8 +343,8 @@ $(function() {
       }
     })
     // Bold the item in the popover that represents
-    // the current book 
-    const currentBookTitle = dropDownAnchor.text() 
+    // the current book
+    const currentBookTitle = dropDownAnchor.text()
     const items = dropDownContent.find("li")
     items.each(function(i) {
       if (items[i].innerText === currentBookTitle) {

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -1,5 +1,6 @@
 import AlternativeSwitcher from "./components/alternative_switcher";
 import ConsoleWidget from "./components/console_widget";
+import FeedbackWidget from './components/feedback_widget';
 import Modal from "./components/modal";
 import mount from "./components/mount";
 import {switchTabs} from "./components/tabbed_widget";
@@ -87,6 +88,10 @@ export function init_console_widgets() {
                                       snippet,
                                       langs});
   });
+}
+
+export function init_feedback_widget() {
+  mount($('#feedbackWidgetContainer'), FeedbackWidget);
 }
 
 export function init_sense_widgets() {
@@ -365,6 +370,7 @@ $(function() {
   init_sense_widgets();
   init_console_widgets();
   init_kibana_widgets();
+  init_feedback_widget();
   $("div.ess_widget").each(function() {
     const div         = $(this),
           snippet     = div.attr('data-snippet'),

--- a/resources/web/style/feedback.pcss
+++ b/resources/web/style/feedback.pcss
@@ -1,0 +1,121 @@
+#feedbackWidget {
+  font-size: 14px;
+  display: flex;
+  line-height: 16px;
+  margin: 0 12px;
+  padding-top: 20px;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 200px;
+  border-top: 1px solid rgb(211, 218, 230);
+
+  .docHorizontalSpacer {
+    display: inline-block;
+    width: 12px;
+  }
+
+  .screenReaderOnly {
+    position: absolute;
+    inset-block-start: auto;
+    inset-inline-start: -10000px;
+    inline-size: 1px;
+    block-size: 1px;
+    clip: rect(0px, 0px, 0px, 0px);
+    clip-path: inset(50%);
+    overflow: hidden;
+    margin: -1px;
+  }
+
+  .buttonGroup {
+    max-inline-size: 100%;
+    display: flex;
+    border-radius: 4px;
+  }
+
+  .feedbackButton {
+    -webkit-font-smoothing: antialiased;
+    box-sizing: border-box;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font-family: 'Inter',BlinkMacSystemFont,Helvetica,Arial,sans-serif;
+    display: inline-block;
+    appearance: none;
+    cursor: pointer;
+    white-space: nowrap;
+    max-inline-size: 100%;
+    vertical-align: middle;
+    font-weight: 500;
+    padding-block: 0px;
+    block-size: 32px;
+    font-size: 14px;
+    line-height: 20px;
+    min-inline-size: 0px;
+    flex-shrink: 1;
+    -webkit-box-flex: 0;
+    flex-grow: 0;
+    padding-inline: 8px;
+    border-radius: 0px;
+    color: rgb(52, 55, 65);
+    background-color: rgb(233, 237, 243);
+    transition: background-color 250ms ease-in-out 0s, color 250ms ease-in-out 0s;
+    border-start-start-radius: 4px;
+    border-start-end-radius: 0px;
+    border-end-end-radius: 0px;
+    border-end-start-radius: 4px;
+
+    &:last-child {
+      border-start-start-radius: 0px;
+      border-start-end-radius: 4px;
+      border-end-end-radius: 4px;
+      border-end-start-radius: 0px;
+      box-shadow: rgba(0, 0, 0, 0.1) -1px 0px 0px 0px;
+    }
+
+    .feedbackButtonContent {
+      block-size: 100%;
+      inline-size: 100%;
+      display: flex;
+      -webkit-box-pack: center;
+      justify-content: center;
+      -webkit-box-align: center;
+      align-items: center;
+      vertical-align: middle;
+      gap: 8px;
+    }
+
+    .feedbackIcon {
+      -webkit-flex-shrink: 0;
+      -ms-flex-negative: 0;
+      flex-shrink: 0;
+      display: inline-block;
+      vertical-align: middle;
+      fill: currentColor;
+      -webkit-transform: translate(0, 0);
+      -moz-transform: translate(0, 0);
+      -ms-transform: translate(0, 0);
+      transform: translate(0, 0);
+      inline-size: 16px;
+      block-size: 16px;
+      color: inherit;
+
+      &.pressed {
+        display: none;
+      }
+    }
+
+    &.isPressed {
+      color: rgb(255, 255, 255);
+      background-color: rgb(105, 112, 125);
+      outline-color: rgb(0, 0, 0);
+      .feedbackIcon.unpressed {
+        display: none;
+      }
+      .feedbackIcon.pressed {
+        display: inline-block;
+      }
+    }
+  }
+
+}

--- a/resources/web/style/feedback.pcss
+++ b/resources/web/style/feedback.pcss
@@ -119,3 +119,384 @@
   }
 
 }
+
+@keyframes animation-modal {
+  0% {
+    opacity: 0;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+@keyframes animation-loading {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(359deg);
+  }
+}
+
+#feedbackModal {
+  position: fixed;
+  inset-block: 0px;
+  inset-inline: 0px;
+  display: flex;
+  -webkit-box-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  justify-content: center;
+  padding-block-end: 10vh;
+  animation: 150ms ease-in 0s 1 normal none running animation-modal;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 6000;
+
+  .feedbackModalContent {
+    font-family: Inter, Arial, sans-serif;
+    font-size: 14px;
+    line-height: 22.75px;
+    -webkit-font-smoothing: antialiased;
+    --removed-body-scroll-bar-size: 16px;
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+    border: none;
+    vertical-align: baseline;
+    box-shadow: rgba(0, 0, 0, 0.13) 0px 2.7px 9px, rgba(0, 0, 0, 0.09) 0px 9.4px 24px, rgba(0, 0, 0, 0.08) 0px 21.8px 43px;
+    display: flex;
+    flex-direction: column;
+    max-block-size: 75vh;
+    position: relative;
+    background-color: rgb(255, 255, 255);
+    border-radius: 6px;
+    z-index: 8000;
+    min-inline-size: 475px;
+    max-inline-size: 768px;
+    animation: 350ms cubic-bezier(0.34, 1.61, 0.7, 1) 0s 1 normal none running animation-5jmqj1;
+
+    .closeIcon {
+      transition: transform 250ms ease-in-out 0s, background-color 250ms ease-in-out 0s;
+      appearance: none;
+      cursor: pointer;
+      white-space: nowrap;
+      max-inline-size: 100%;
+      vertical-align: middle;
+      display: inline-flex;
+      -webkit-box-align: center;
+      align-items: center;
+      justify-content: space-around;
+      inline-size: 24px;
+      block-size: 24px;
+      border-radius: 4px;
+      color: rgb(52, 55, 65);
+      position: absolute;
+      inset-inline-end: 4px;
+      inset-block-start: 4px;
+      z-index: 3;
+      border-width: 0px;
+      background-color: transparent;
+      right: 2px;
+
+      > svg {
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        display: inline-block;
+        vertical-align: middle;
+        fill: currentColor;
+        -webkit-transform: translate(0, 0);
+        -moz-transform: translate(0, 0);
+        -ms-transform: translate(0, 0);
+        transform: translate(0, 0);
+        inline-size: 16px;
+        block-size: 16px;
+        color: inherit;
+      }
+    }
+
+    .feedbackModalHeader {
+      display: flex;
+      -webkit-box-pack: justify;
+      justify-content: space-between;
+      -webkit-box-align: center;
+      align-items: center;
+      -webkit-box-flex: 0;
+      flex-grow: 0;
+      flex-shrink: 0;
+      padding: 24px;
+      padding-inline: 24px 40px;
+
+      h2 {
+        font-size: 24px;
+        line-height: 28px;
+        margin: 0px;
+        padding: 0px;
+        color: rgb(52, 55, 65);
+      }
+    }
+
+    .feedbackModalBody {
+      -webkit-box-flex: 1;
+      flex-grow: 1;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      font-size: 16px;
+      line-height: 24px;
+      color: rgb(52, 55, 65);
+
+      .feedbackModalBodyOverflow {
+        block-size: 100%;
+        overflow: hidden auto;
+        padding-inline: 24px;
+        padding-block: 8px;
+      }
+
+      .spacer {
+        -webkit-flex-shrink: 0;
+        -ms-flex-negative: 0;
+        flex-shrink: 0;
+        block-size: 24px;
+      }
+    }
+
+    .feedbackModalFooter {
+      display: flex;
+      -webkit-box-pack: end;
+      justify-content: flex-end;
+      padding: 24px;
+      padding-inline: 24px;
+      -webkit-box-flex: 0;
+      flex-grow: 0;
+      flex-shrink: 0;
+      gap: 16px;
+
+      &.loading {
+        .feedbackButton {
+          color: rgb(162, 171, 186);
+          &.sendButton {
+            background-color: rgba(0, 119, 204, 0.1);
+          }
+
+          .feedbackButtonContent {
+            display: none;
+          }
+        }
+
+        .loadingContent {
+          display: inline-block;
+        }
+      }
+
+      .feedbackButton {
+        display: inline-block;
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        -ms-appearance: none;
+        appearance: none;
+        cursor: pointer;
+        white-space: nowrap;
+        max-inline-size: 100%;
+        vertical-align: middle;
+        font-weight: 500;
+        block-size: 40px;
+        font-size: 14px;
+        line-height: 1.4286rem;
+        border-radius: 6px;
+        border-width: 0;
+        color: rgb(0, 97, 166);
+        background-color: rgb(204, 228, 245);
+
+        &:hover {
+          text-decoration: underline;
+        }
+
+        .feedbackButtonContent {
+          block-size: 100%;
+          inline-size: 100%;
+          display: -webkit-box;
+          display: -webkit-flex;
+          display: -ms-flexbox;
+          display: flex;
+          -webkit-box-pack: center;
+          -ms-flex-pack: center;
+          -webkit-justify-content: center;
+          justify-content: center;
+          -webkit-align-items: center;
+          -webkit-box-align: center;
+          -ms-flex-align: center;
+          align-items: center;
+          vertical-align: middle;
+          gap: 8px;
+        }
+      }
+
+      .cancelButton {
+        transition-timing-function: ease-in;
+        transition-duration: 150ms;
+        display: inline-block;
+        padding-inline: 8px;
+        block-size: 40px;
+        line-height: 40px;
+        border-radius: 6px;
+        background-color: transparent;
+        color: #0061a6;
+      }
+
+      .sendButton {
+        padding: 0px;
+        padding-inline: 12px;
+        line-height: 20px;
+        min-inline-size: 112px;
+        transition: transform 250ms ease-in-out 0s, background-color 250ms ease-in-out 0s;
+
+        &:hover {
+          transform: translateY(-1px);
+        }
+
+        .sendIcon {
+          -webkit-flex-shrink: 0;
+          -ms-flex-negative: 0;
+          flex-shrink: 0;
+          display: inline-block;
+          vertical-align: middle;
+          fill: currentColor;
+          -webkit-transform: translate(0, 0);
+          -moz-transform: translate(0, 0);
+          -ms-transform: translate(0, 0);
+          transform: translate(0, 0);
+          inline-size: 16px;
+          block-size: 16px;
+          color: inherit;
+
+          &.dislike {
+            display: none;
+          }
+        }
+
+        &.dislike {
+          .sendIcon.like {
+            display: none;
+          }
+          .sendIcon.dislike {
+            display: inline-block;
+          }
+        }
+
+        &.like {
+          .sendIcon.like {
+            display: inline-block;
+          }
+        }
+
+      }
+
+      .loadingContent {
+        display: none;
+      }
+
+      .loadingSpinner {
+        animation: 0.6s linear 0s infinite normal none running animation-loading;
+        flex-shrink: 0;
+        display: inline-block;
+        border-radius: 50%;
+        border: 1.5px solid rgb(211, 218, 230);
+        border-block-color: rgb(1, 81, 137) rgb(211, 218, 230);
+        border-inline-color: rgb(211, 218, 230);
+        inline-size: 16px;
+        block-size: 16px;
+        position: relative;
+        left: -5px;
+        top: 2px;
+      }
+    }
+
+
+  }
+
+  .feedbackFormRow {
+    display: -webkit-flex;
+    display: flex;
+    -webkit-flex-direction: column;
+    flex-direction: column;
+    max-width: 400px;
+
+    .feedbackFormRow__labelWrapper {
+      display: -webkit-flex;
+      display: flex;
+      -webkit-flex-wrap: wrap;
+      flex-wrap: wrap;
+      -webkit-justify-content: space-between;
+      justify-content: space-between;
+      margin-bottom: 4px;
+
+      .feedbackFormLabel {
+        cursor: pointer;
+        overflow-wrap: break-word!important;
+        word-break: break-word;
+        color: #1a1c21;
+        font-weight: 600;
+        display: inline-block;
+        transition: all .15s cubic-bezier(.694,.0482,.335,1);
+        font-size: 12px;
+        line-height: 16px;
+        margin-bottom: 0;
+      }
+    }
+
+    .feedbackFormControlLayout {
+      height: auto;
+      max-width: 400px;
+      width: 100%;
+
+      .feedbackFormControlLayout__childrenWrapper {
+        position: relative;
+      }
+
+      .feedbackTextArea {
+        resize: vertical;
+        height: auto;
+        max-width: 400px;
+        width: 100%;
+        /* height: 40px; */
+        background-color: #fbfcfd;
+        background-repeat: no-repeat;
+        background-size: 0 100%;
+        box-shadow: 0 0 transparent, inset 0 0 0 1px rgba(17,42,134,.1);
+        transition: box-shadow .15s ease-in,background-image .15s ease-in,background-size .15s ease-in,background-color .15s ease-in;
+        font-family: Inter UI,-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+        font-weight: 400;
+        letter-spacing: normal;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+        -webkit-font-kerning: normal;
+        font-kerning: normal;
+        font-size: 14px;
+        color: #343741;
+        border: none;
+        border-radius: 6px;
+        padding: 12px;
+        line-height: 1.5;
+      }
+    }
+
+    .feedbackFormError {
+      padding: 16px;
+      background-color: #f8e9e9;
+      font-size: 14px;
+    }
+  }
+}
+
+#feedbackSuccess {
+  margin: 12px;
+  font-size: 14px;
+  padding: 16px;
+  background-color: #e6f1fa;
+
+  &.hidden {
+    display: none;
+  }
+}

--- a/resources/web/styles.pcss
+++ b/resources/web/styles.pcss
@@ -14,6 +14,7 @@
 @import './style/console_widget.pcss';
 @import './style/docbook.pcss';
 @import './style/example.pcss';
+@import './style/feedback.pcss';
 @import './style/heading.pcss';
 @import './style/img.pcss';
 @import './style/layout.pcss';

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -132,15 +132,18 @@
         </div>
 
 
-<div id='elastic-footer'></div>
-<script src='https://www.elastic.co/elastic-footer.js'></script>
-<!-- Footer Section end-->
+        <div id='elastic-footer'></div>
+        <script src='https://www.elastic.co/elastic-footer.js'></script>
+        <!-- Footer Section end-->
 
       </section>
     </div>
 
-<script src="/guide/static/jquery.js"></script>
-<script type="text/javascript" src="/guide/static/docs.js"></script>
-<!-- DOCS FINAL -->
+    <!-- Feedback modal -->
+    <div id="feedbackModalContainer"></div>
+
+    <script src="/guide/static/jquery.js"></script>
+    <script type="text/javascript" src="/guide/static/docs.js"></script>
+    <!-- DOCS FINAL -->
   </body>
 </html>

--- a/resources/web/template.html
+++ b/resources/web/template.html
@@ -118,6 +118,9 @@
                             </div>
                           </div>
                         </div>
+
+                        <!-- Feedback widget -->
+                        <div id="feedbackWidgetContainer"></div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
Closes https://github.com/elastic/docsmobile/issues/697

This PR adds a feedback widget to the end of the right sidebar. This mimics the feedback experience that exists on https://docs.elastic.co.

Here is a video of the experience:

https://github.com/elastic/docs/assets/1869731/d0bf6260-45f1-4375-9f38-894a166c62bc

Notes: 

- Because of the need for shared state but different locations in the markup (modal needs to be outside of the content and the widget in the sidebar), I opted to maintain all state in the modal component and use JavaScript to alter class names in the widget. The codebase contains redux, but I thought it overkill to wire up a solution that shares state as the need in the widget is minimal.