### PR TITLE
Use bigger CI machine for docs repo

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -11,6 +11,7 @@ steps:
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
+      machineType: ${BUILD_PR_MACHINE_TYPE}
   - key: "teardown"
     label: "teardown"
     command: |

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -22,14 +22,15 @@ function retry {
     return 0
 }
 
+export BUILD_PR_MACHINE_TYPE="n2-standard-4"
+
 # Secrets must be redacted
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
     export GITHUB_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/docs_preview_cleaner)
+
     if [[ ${GITHUB_PR_BASE_REPO:="unset"} == "docs" ]]; then
-        # Docs PR require a full rebuilt - so let's boost the builds so they don't take 2 hours
+        # Docs PR require a full rebuild - so let's boost the builds so they don't take 2 hours
         export BUILD_PR_MACHINE_TYPE="n2-highcpu-32"
-    else
-        export BUILD_PR_MACHINE_TYPE="n2-standard-4"
     fi
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -26,4 +26,10 @@ function retry {
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
     export GITHUB_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/docs_preview_cleaner)
+    if [[ ${GITHUB_PR_BASE_REPO:="unset"} == "docs" ]]; then
+        # Docs PR require a full rebuilt - so let's boost the builds so they don't take 2 hours
+        export BUILD_PR_MACHINE_TYPE="n2-highcpu-32"
+    else
+        export BUILD_PR_MACHINE_TYPE="n2-standard-4"
+    fi
 fi

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -65,7 +65,7 @@ else
   # books for PRs to the docs repo, for now.
   # When https://github.com/elastic/docs/issues/1823 is fixed, this
   # should be removed and the original behavior restored.
-  rebuild_opt=" --rebuild"
+  rebuild_opt=" --rebuild --procs 16"
 fi
 
 


### PR DESCRIPTION
We always do a full rebuild on `elastic/docs` which takes up to 2 hours with the standard n1-standard-4 CI machine. This PR introduces an optimization only for builds on elastic/docs to use n2-standard-32 to drop the build time to about 1 hour. For any other builds, we'll use n2-standard-4 and tolerate the <20 min build time for docs given the price difference (10x cheaper).

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
