### PR TITLE
Cancel existing builds on running PRs

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -1,4 +1,6 @@
 steps:
+  - key: "cancel-existing-builds"
+    command: ".buildkite/scripts/cancel_running_pr.sh || true"
   - key: "build-pr-setup"
     label: "setup"
     command: ".buildkite/scripts/build_pr_commit_status.sh pending"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -28,7 +28,7 @@ export BUILD_PR_MACHINE_TYPE="n2-standard-4"
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
     export GITHUB_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/docs_preview_cleaner)
-
+    export BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/buildkite_token)
     if [[ ${GITHUB_PR_BASE_REPO:="unset"} == "docs" ]]; then
         # Docs PR require a full rebuild - so let's boost the builds so they don't take 2 hours
         export BUILD_PR_MACHINE_TYPE="n2-highcpu-32"

--- a/.buildkite/scripts/cancel_running_pr.sh
+++ b/.buildkite/scripts/cancel_running_pr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+set +x
+
+# This script should only be invoked by the Buildkite PR bot
+if [ -z ${GITHUB_PR_NUMBER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ];then
+  echo "One of the following env. variable GITHUB_PR_NUMBER, GITHUB_PR_BASE_REPO is missing - exiting."
+  exit 1
+fi
+
+running_builds_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds"
+running_builds_url+="?branch=${BUILDKITE_PIPELINE_DEFAULT_BRANCH}&state[]=scheduled&state[]=running"
+jq_filter="map(select(any(.meta_data; .repo_pr == \"${GITHUB_PR_BASE_REPO}_${GITHUB_PR_NUMBER}\"))) | .[] .number"
+
+for bn in $(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $running_builds_url | jq -c "${jq_filter}"); do
+  if [ "$bn" != "${BUILDKITE_BUILD_NUMBER}" ];then
+    echo "Cancelling build ${bn} targetting the same PR"
+    cancel_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${bn}/cancel"
+    curl --silent -X PUT -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" "${cancel_url}" > /dev/null
+  fi
+done
+
+

--- a/.buildkite/scripts/cancel_running_pr.sh
+++ b/.buildkite/scripts/cancel_running_pr.sh
@@ -9,7 +9,7 @@ if [ -z ${GITHUB_PR_NUMBER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ];then
 fi
 
 running_builds_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds"
-running_builds_url+="?branch=${BUILDKITE_PIPELINE_DEFAULT_BRANCH}&state[]=scheduled&state[]=running"
+running_builds_url+="?branch=${BUILDKITE_BRANCH}&state[]=scheduled&state[]=running"
 jq_filter="map(select(any(.meta_data; .repo_pr == \"${GITHUB_PR_BASE_REPO}_${GITHUB_PR_NUMBER}\"))) | .[] .number"
 
 for bn in $(curl -sH "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $running_builds_url | jq -c "${jq_filter}"); do


### PR DESCRIPTION
As noted in https://github.com/elastic/docs/pull/2835, the docs-pr job always trigger the master branch of the Buildkite job.  A PR in repo1 and another PR in repo 2 will both call the head code of the master branch of the elastic/docs and the job itself is configured to fetch the PR content. As a result, I had to disable cancelling intermediate builds since that would mean only one build at a time can run. The downside is that 2 commits in a row on the same PR will trigger a build twice for the same PR.

To tackle this, we introduce this PR that filters the existing running builds (by inspecting the build metadata to check if it came from a specific PR) and cancel the running builds.

Note:  while the [Buildkite API doc](https://buildkite.com/docs/apis/rest-api/builds) states that we can filter builds by meta_data, it does not work :( as a result, we have to run some jq shenanigans.