### PR TITLE
Buildkite PR job - batch2

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -12,7 +12,7 @@
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
-      "always_trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -40,7 +40,7 @@
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
-      "always_trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -73,7 +73,7 @@
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
-      "always_trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [
         "skip docs-build"
       ],


### PR DESCRIPTION
This PR adds a few more repositories to the Buildkite job rollout - see [comm email](https://groups.google.com/a/elastic.co/g/docs/c/2ppj8Bmd6SA/m/Xe5mkgXFAQAJ) about it.

Note to reviewers (ideally doc point persons): 

# 1. Validate the build avoidance logic (if applicable)

The Buildkite PR bot has some build avoidance logic in place. Some repositories are configured to have the docs PR job for [any changes in the repo](https://github.com/elastic/docs/blob/master/.buildkite/pull-requests.org-wide.json#L20). Other are configured for [changes in the "docs" folder only.](https://github.com/elastic/docs/blob/master/.buildkite/pull-requests.org-wide.json#L49). I tried to follow the [docs script build avoidance logic](https://github.com/elastic/docs/blob/c2f883f1247bf561fdd18102b5af3e1124dfadc2/conf.yaml) to determine how the repo should be configured, but you need to validate that this is actually the case.

## Repos configured to trigger PR on `every` changes

* stack-docs - cc @lcawl 
* logstash-docs @karenzone  

## Repos configured to trigger PR on changes in the `docs` folder only

* curator: @jrodewig  @untergeek 
* ecctl: @gigerdo 
* eland: @pquentin 
* logstash @karenzone  

# 2. Setup or update your GH action

As mentioned in the comm email, you can setup a GitHub action that posts a comment with various links to validate the doc
![image](https://github.com/elastic/docs/assets/124953/4fc493b2-e98b-43d5-a088-b797d26d84ea)

[Here](https://github.com/elastic/elasticsearch-py/blob/main/.github/workflows/docs-preview.yml)'s an example setup you can copy in your repo.


# 3. Assess if you anticipate potential conflicts with other Buildkite pipelines in your repository

The docs PR job leverages the Buildkite PR bot. Before merging this PR, I will setup a webhook in your repository (following the instructions [here](https://docs.elastic.dev/ci/configuring-pull-requests-for-buildkite)). The config used for the PR job lives in the docs repo in the [./buildkite/pull-requests.org-wide.json](https://github.com/elastic/docs/blob/master/.buildkite/pull-requests.org-wide.json) file. There should not be any conflicts with your current jobs, but I like to be overly explicit with it. 

# 4. What to expect once this is setup?

The Buildkite PR jobs are non-blocking at this time - but we need your help validating that they produce the same results than in Jenkins - see [comm](https://groups.google.com/a/elastic.co/g/docs/c/2ppj8Bmd6SA/m/Xe5mkgXFAQAJ).

The below options are supported to trigger the docs builds:

```
run docs-build
run docs-build rebuild
run docs-build warnlinkcheck
run docs-build skiplinkcheck (takes precedence over the warnlinkcheck option)
buildkite test this
buildkite test this rebuild
buildkite test this warnlinkcheck
buildkite test this skiplinkcheck (takes precedence over the warnlinkcheck option)
```

CC - @robbavey  @dliappis  on the new Buildkite jobs for logstash