### PR TITLE
Add attribute for Elasticsearch serverless

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -180,6 +180,7 @@ Elastic Cloud
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Cloud serverless
+:es-serverless: Elasticsearch Serverless
 :serverless-short: serverless
 :serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -180,7 +180,7 @@ Elastic Cloud
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Cloud serverless
-:es-serverless: Elasticsearch Serverless
+:es-serverless: Elasticsearch on serverless
 :serverless-short: serverless
 :serverless-docs: https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current


### PR DESCRIPTION
Add attribute for Elasticsearch on serverless for use in classic docs
