### PR TITLE
Build doc every 30 minutes

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -24,6 +24,11 @@ spec:
       branch_configuration: master
       provider_settings:
         build_pull_requests: false
+      schedules:
+        periodic_docs_build:
+          branch: "master"
+          message: "Build the docs every 30 minutes"
+          cronline: "*/30 * * * *"
       teams:
         docs-build-guild:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
I just realized that the cronjob was not setup - we're still pushing to the `staging` branch, but we won't be able to compare the elastic/built-docs master and staging branch if they don't build at the same frequency.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
