### PR TITLE
Remove duplicates from conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1425,6 +1425,167 @@ contents:
 
     -   title:     "Ingest: Add your data"
         sections:
+          - title:      Elastic Ingest Reference Architectures
+            prefix:     en/ingest
+            current:    *stackcurrent
+            index:      docs/en/ingest-arch/index.asciidoc
+            branches:   [ {main: master}, 8.11, 8.10, 8.9 ]
+            live:       [ 8.11 ]
+            chunk:      1
+            tags:       Ingest/Reference
+            subject:    Ingest
+            sources:
+              -
+                repo:   ingest-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Logging Plugin for Docker
+            prefix:     en/beats/loggingplugin
+            current:    *stackcurrent
+            index:      x-pack/dockerlogbeat/docs/index.asciidoc
+            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            chunk:      1
+            tags:       Elastic Logging Plugin/Reference
+            respect_edit_url_overrides: true
+            subject:    Elastic Logging Plugin
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/dockerlogbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Fleet and Elastic Agent Guide
+            prefix:     en/fleet
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            live:       *stacklive
+            index:      docs/en/ingest-management/index.asciidoc
+            chunk:      2
+            tags:       Fleet/Guide/Elastic Agent
+            subject:    Fleet and Elastic Agent
+            sources:
+              -
+                repo:   ingest-docs
+                path:   docs/en
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   apm-server
+                path:   docs
+                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]   
+          - title:      Integrations Developer Guide
+            prefix:     en/integrations-developer
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            index:      docs/en/integrations/index.asciidoc
+            chunk:      1
+            tags:       Integrations/Developer
+            subject:    Integrations
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   package-spec
+                path:   versions
+              -
+                repo:   package-spec
+                path:   spec
+          - title:      Logstash Reference
+            prefix:     en/logstash
+            current:    *stackcurrent
+            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+            live:       *stacklive
+            index:      docs/index.x.asciidoc
+            chunk:      1
+            tags:       Logstash/Reference
+            subject:    Logstash
+            respect_edit_url_overrides: true
+            sources:
+              -
+                repo:   logstash
+                path:   docs/
+              -
+                repo:   x-pack-logstash
+                prefix: logstash-extra/x-pack-logstash
+                path:   docs/en
+                private: true
+                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   logstash-docs
+                path:   docs/
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/attributes62.asciidoc
+                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
+              -
+                repo:   docs
+                path:   shared/legacy-attrs.asciidoc
+                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+          - title:      Logstash and Kubernetes
+            prefix:     en/logstash-kubernetes
+            current:    main
+            index:      docsk8s/index.asciidoc
+            branches:   [ {main: master} ]
+            noindex:    1
+            chunk:      1
+            tags:       Logstash/Kubernetes
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash
+                path:   docsk8s
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Logstash Versioned Plugin Reference
+            prefix:     en/logstash-versioned-plugins
+            current:    versioned_plugin_docs
+            branches:   [ versioned_plugin_docs ]
+            index:      docs/versioned-plugins/index.asciidoc
+            private:    1
+            chunk:      1
+            noindex:    1
+            tags:       Logstash/Plugin Reference
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash-docs
+                path:   docs/versioned-plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc
@@ -1534,44 +1695,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.11, 8.10, 8.9 ]
-            live:       [ 8.11 ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Logging Plugin for Docker
-            prefix:     en/beats/loggingplugin
-            current:    *stackcurrent
-            index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            chunk:      1
-            tags:       Elastic Logging Plugin/Reference
-            respect_edit_url_overrides: true
-            subject:    Elastic Logging Plugin
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/dockerlogbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Filebeat Reference
             prefix:     en/beats/filebeat
             index:      filebeat/docs/index.asciidoc
@@ -1627,32 +1750,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          - title:      Fleet and Elastic Agent Guide
-            prefix:     en/fleet
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
-            live:       *stacklive
-            index:      docs/en/ingest-management/index.asciidoc
-            chunk:      2
-            tags:       Fleet/Guide/Elastic Agent
-            subject:    Fleet and Elastic Agent
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   apm-server
-                path:   docs
-                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]   
           - title:      Heartbeat Reference
             prefix:     en/beats/heartbeat
             current:    *stackcurrent
@@ -1700,103 +1797,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
-          - title:      Integrations Developer Guide
-            prefix:     en/integrations-developer
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            index:      docs/en/integrations/index.asciidoc
-            chunk:      1
-            tags:       Integrations/Developer
-            subject:    Integrations
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   package-spec
-                path:   versions
-              -
-                repo:   package-spec
-                path:   spec
-          - title:      Logstash Reference
-            prefix:     en/logstash
-            current:    *stackcurrent
-            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-            live:       *stacklive
-            index:      docs/index.x.asciidoc
-            chunk:      1
-            tags:       Logstash/Reference
-            subject:    Logstash
-            respect_edit_url_overrides: true
-            sources:
-              -
-                repo:   logstash
-                path:   docs/
-              -
-                repo:   x-pack-logstash
-                prefix: logstash-extra/x-pack-logstash
-                path:   docs/en
-                private: true
-                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   logstash-docs
-                path:   docs/
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-                exclude_branches:   [ 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-                exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/attributes62.asciidoc
-                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.5 ]
-              -
-                repo:   docs
-                path:   shared/legacy-attrs.asciidoc
-                exclude_branches:   [ main, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
-          - title:      Logstash and Kubernetes
-            prefix:     en/logstash-kubernetes
-            current:    main
-            index:      docsk8s/index.asciidoc
-            branches:   [ {main: master} ]
-            noindex:    1
-            chunk:      1
-            tags:       Logstash/Kubernetes
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash
-                path:   docsk8s
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Logstash Versioned Plugin Reference
-            prefix:     en/logstash-versioned-plugins
-            current:    versioned_plugin_docs
-            branches:   [ versioned_plugin_docs ]
-            index:      docs/versioned-plugins/index.asciidoc
-            private:    1
-            chunk:      1
-            noindex:    1
-            tags:       Logstash/Plugin Reference
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash-docs
-                path:   docs/versioned-plugins
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Metricbeat Reference
             prefix:     en/beats/metricbeat
             index:      metricbeat/docs/index.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -932,44 +932,6 @@ contents:
               -
                 repo:   ecs
                 path:   docs/
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.11, 8.10, 8.9 ]
-            live:       [ 8.11 ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Logging Plugin for Docker
-            prefix:     en/beats/loggingplugin
-            current:    *stackcurrent
-            index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            chunk:      1
-            tags:       Elastic Logging Plugin/Reference
-            respect_edit_url_overrides: true
-            subject:    Elastic Logging Plugin
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/dockerlogbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Elasticsearch Clients
             base_dir:   en/elasticsearch/client
             toc_extra: extra/client_docs_landing.html

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -408,6 +408,7 @@ sub _resolve_branch {
 
     $branch = $self->_last_commit(@_);
     die "--keep_hash can't build on top of --sub_dir" if $branch eq 'local';
+    # If the build fails, this message can indicate that there are duplicate entries in the conf.yaml
     return $branch;
 }
 


### PR DESCRIPTION
This PR updates the conf.yaml to remove two books that were appearing in multiple sections (and thus potentially causing build problems).  It also updates the conf.yaml such that the Beats books are all grouped together.