### PR TITLE
Updates action.yml to add note about checking images

### DIFF
--- a/.github/actions/docs-preview/action.yml
+++ b/.github/actions/docs-preview/action.yml
@@ -28,7 +28,7 @@ runs:
           const { REPO, PR, PREVIEW_PATH } = process.env
 
           const comment = `A documentation preview will be available soon.
-          Help us out by validating the Buildkite preview and reporting issues [here](https://github.com/elastic/docs/issues/new?labels=buildkite-migration,bug).
+          Help us out by validating the Buildkite preview and reporting issues [here](https://github.com/elastic/docs/issues/new?labels=buildkite-migration,bug). Please also be sure to double check all images to ensure they are correct in the preview. 
 
             - 🔨 Buildkite [builds](https://buildkite.com/elastic/docs-build-pr/builds?meta_data[repo_pr]=${REPO}_${PR})
             - 📚 HTML diff: [Buildkite](https://${REPO}_bk_${PR}.docs-preview.app.elstc.co/diff)  - [Jenkins](https://${REPO}_${PR}.docs-preview.app.elstc.co/diff)

--- a/.github/actions/docs-preview/action.yml
+++ b/.github/actions/docs-preview/action.yml
@@ -28,7 +28,7 @@ runs:
           const { REPO, PR, PREVIEW_PATH } = process.env
 
           const comment = `A documentation preview will be available soon.
-          Help us out by validating the Buildkite preview and reporting issues [here](https://github.com/elastic/docs/issues/new?labels=buildkite-migration,bug). Please also be sure to double check all images to ensure they are correct in the preview. 
+          Help us out by validating the Buildkite preview and reporting issues [here](https://github.com/elastic/docs/issues/new?labels=buildkite-migration,bug). Please also be sure to **double check all images to ensure they are correct** in the preview. 
 
             - 🔨 Buildkite [builds](https://buildkite.com/elastic/docs-build-pr/builds?meta_data[repo_pr]=${REPO}_${PR})
             - 📚 HTML diff: [Buildkite](https://${REPO}_bk_${PR}.docs-preview.app.elstc.co/diff)  - [Jenkins](https://${REPO}_${PR}.docs-preview.app.elstc.co/diff)


### PR DESCRIPTION
Adds a reminder to double-check images in the Buildkite preview.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
