### PR TITLE
Add help to code snippets widget

### DIFF
--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -76,10 +76,11 @@ export const ConsoleWidget = props => {
 
   // Simple function to display a modal/tooltip
   const showHelp = () => {
-    alert('1. Use the toggle in the lower left-hand corner to change client languages.\n' +
-          '2. - Select "Copy as curl" to copy the code in curl format.\n' +
-          '    - Select "View in Console" to load example in Kibana Console.\n' +
-          '3. Use the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.This ensures the code examples target your Elasticsearch instance.\n\n')
+    alert('1. To change the client language, use the dropdown.\n' +
+          '2. To copy the code in curl format, click "Copy as curl".\n' +
+          '3. To open the example in Kibana Console:
+                a. Click the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username, and Kibana Console  URL. This ensures the code examples target your Elasticsearch instance.
+                b. Click "View in Console".\n' +
 };
 
 

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -76,11 +76,11 @@ export const ConsoleWidget = props => {
 
   // Simple function to display a modal/tooltip
   const showHelp = () => {
-    alert('1. When code examples are available for different programming languages, use the toggle in the lower left-hand corner.\n\n' +
+    alert('1. Use the toggle in the lower left-hand corner to change programming language.\n\n' +
           '2. To copy a code snippet: \n\n' +
           '- Select "Copy as curl" to copy the code in curl format. \n' +
           '- Select "View in Console" to load the example into your Kibana Console.\n\n' +
-          '3. Use the gear icon in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.\n\nThis ensures the code examples target your Elasticsearch instance.\n\n')
+          '3. Use the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.\n\nThis ensures the code examples target your Elasticsearch instance.\n\n')
 };
 
 
@@ -103,7 +103,7 @@ export const ConsoleWidget = props => {
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
       
-<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none', marginRight : '10px'}}>
+<a className="help_info" onClick={showHelp}>
   <strong>ℹ️</strong>
 </a>
 

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -76,13 +76,14 @@ export const ConsoleWidget = props => {
 
   // Simple function to display a modal/tooltip
   const showHelp = () => {
-    alert('1. To change the client language, use the dropdown.\n' +
-          '2. To copy the code in curl format, click "Copy as curl".\n' +
-          '3. To open the example in Kibana Console:
-                a. Click the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username, and Kibana Console  URL. This ensures the code examples target your Elasticsearch instance.
-                b. Click "View in Console".\n' +
+    alert('1. To change the client language, use the dropdown.\n\n' +
+          '2. To copy the code in curl format:\n' +
+          '- Use the gear icon (⚙) to set Elasticsearch URL and username\n' +
+          '- Click "Copy as curl".\n\n' +
+          '3. To open the example in Kibana Console:\n'+
+                '- Use the gear icon (⚙) to set Kibana Console URL.\n' +
+                '- Click "View in Console".')
 };
-
 
   return <div className="u-space-between">
     <AlternativePicker langs={props.langs} />

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -76,11 +76,10 @@ export const ConsoleWidget = props => {
 
   // Simple function to display a modal/tooltip
   const showHelp = () => {
-    alert('1. Use the toggle in the lower left-hand corner to change programming language.\n\n' +
-          '2. To copy a code snippet: \n\n' +
-          '- Select "Copy as curl" to copy the code in curl format. \n' +
-          '- Select "View in Console" to load the example into your Kibana Console.\n\n' +
-          '3. Use the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.\n\nThis ensures the code examples target your Elasticsearch instance.\n\n')
+    alert('1. Use the toggle in the lower left-hand corner to change client languages.\n' +
+          '2. - Select "Copy as curl" to copy the code in curl format.\n' +
+          '    - Select "View in Console" to load example in Kibana Console.\n' +
+          '3. Use the gear icon (⚙) in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.This ensures the code examples target your Elasticsearch instance.\n\n')
 };
 
 
@@ -103,7 +102,7 @@ export const ConsoleWidget = props => {
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
       
-<a className="help_info" onClick={showHelp}>
+<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none', marginRight : '10px'}}>
   <strong>ℹ️</strong>
 </a>
 

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -73,6 +73,17 @@ export const ConsoleForm = connect((state, props) =>
 // ConsoleWidget isn't quite the right name for this any more....
 export const ConsoleWidget = props => {
   const modalAction = () => props.openModal(ConsoleForm, {setting: props.setting, url_label: props.url_label});
+
+  // Simple function to display a modal/tooltip
+  const showHelp = () => {
+    alert('1. When code examples are available for different programming languages, use the toggle in the lower left-hand corner.\n\n' +
+          '2. To copy a code snippet: \n\n' +
+          '- Select "Copy as curl" to copy the code in curl format. \n' +
+          '- Select "View in Console" to load the example into your Kibana Console.\n\n' +
+          '3. Use the gear icon in the lower right-hand corner to configure your Elasticsearch host URL, username and Kibana Console URL.\n\nThis ensures the code examples target your Elasticsearch instance.\n\n')
+};
+
+
   return <div className="u-space-between">
     <AlternativePicker langs={props.langs} />
     <div className="u-space-between">
@@ -91,6 +102,11 @@ export const ConsoleWidget = props => {
           title={props.langStrings(props.view_in_text)}
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
+      
+<a className="sense_widget copy_as_curl" onClick={showHelp} style={{ textDecoration: 'none' }}>
+  <strong>ℹ️</strong>
+</a>
+
       <a className="console_settings" onClick={modalAction} title={props.langStrings(props.configure_text)}>&nbsp;</a>
     </div>
   </div>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -102,8 +102,8 @@ export const ConsoleWidget = props => {
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
       
-<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none', marginRight : '10px'}}>
-  <strong>ℹ️</strong>
+<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none'}}>
+  ℹ️
 </a>
 
       <a className="console_settings" onClick={modalAction} title={props.langStrings(props.configure_text)}>&nbsp;</a>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -81,8 +81,8 @@ export const ConsoleWidget = props => {
           '- Use the gear icon (⚙) to set Elasticsearch URL and username\n' +
           '- Click "Copy as curl".\n\n' +
           '3. To open the example in Kibana Console:\n'+
-                '- Use the gear icon (⚙) to set Kibana Console URL.\n' +
-                '- Click "View in Console".')
+          '- Use the gear icon (⚙) to set Kibana Console URL.\n' +
+          '- Click "View in Console".')
 };
 
   return <div className="u-space-between">

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -103,7 +103,7 @@ export const ConsoleWidget = props => {
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
       
-<a className="sense_widget copy_as_curl" onClick={showHelp} style={{ textDecoration: 'none' }}>
+<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none' }}>
   <strong>ℹ️</strong>
 </a>
 

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -78,11 +78,11 @@ export const ConsoleWidget = props => {
   const showHelp = () => {
     alert('1. To change the client language, use the dropdown.\n\n' +
           '2. To copy the code in curl format:\n' +
-          '- Use the gear icon (⚙) to set Elasticsearch URL and username\n' +
-          '- Click "Copy as curl".\n\n' +
+          '  - Use gear icon (⚙) to set Elasticsearch URL + username.\n' +
+          '  - Click "Copy as curl".\n\n' +
           '3. To open the example in Kibana Console:\n'+
-          '- Use the gear icon (⚙) to set Kibana Console URL.\n' +
-          '- Click "View in Console".')
+          '  - Use gear icon (⚙) to set Kibana Console URL.\n' +
+          '  - Click "View in Console".')
 };
 
   return <div className="u-space-between">

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -103,7 +103,7 @@ export const ConsoleWidget = props => {
           href={`${props[props.setting + "_url"]}?load_from=${props.baseUrl}${props.snippet}`}>{props.langStrings(props.view_in_text)}</a>
       }
       
-<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none' }}>
+<a className="help_info" onClick={showHelp} style={{ textDecoration: 'none', marginRight : '10px'}}>
   <strong>ℹ️</strong>
 </a>
 

--- a/resources/web/style/console_widget.pcss
+++ b/resources/web/style/console_widget.pcss
@@ -6,7 +6,7 @@
     background: #343741;
     padding: 7px 15px 7px 0;
   }
-  .view_in_link, .copy_as_curl {
+  .view_in_link, .copy_as_curl, .help_info {
     color: #ffffff;
     cursor: pointer;
     font-weight: 500;


### PR DESCRIPTION
## 🎦 [Live preview](https://docs_bk_2867.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/getting-started.html)


Adds an ℹ️ button to our docs code example widget, just before the gear icon:

<img width="500" alt="Screenshot 2023-12-13 at 18 10 45" src="https://github.com/elastic/docs/assets/32779855/7a0f7377-fe86-4a64-a94c-efd1bef262f7">

When clicked it raises an plaintext alert box that explains how to use our code examples: 

<img width="578" alt="Screenshot 2023-12-18 at 15 05 49" src="https://github.com/elastic/docs/assets/32779855/dd56f220-85d1-49f0-ac20-57ca1c440b42">


## Problem

Lots of folks don't know how our code samples widget works. This attempts to provide help text, without switching context by linking to docs.

### Issues

This is a quick and dirty solution. We could use a more involved modal to enable rich text, but I was able to put this together in less than an hour.

### `TODO`

- [x] Fix tests
  - [ ] CI is green but I haven't added any tests for my changes