### PR TITLE
Change Elastic Cloud placement on landing page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1943,6 +1943,22 @@ contents:
 
     -   title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
         sections:
+          - title:      Elastic Cloud, Hosted Elastic Stack
+            prefix:     en/cloud
+            tags:       Cloud/Reference
+            subject:    Elastic Cloud
+            current:    *cloudSaasCurrent
+            branches:   [ { *cloudSaasCurrent : latest} ]
+            index:      docs/saas/index.asciidoc
+            chunk:      1
+            private:    1
+            sources:
+              -
+                repo:   cloud
+                path:   docs/saas
+              -
+                repo:   cloud
+                path:   docs/shared
           - title:      Amazon Kinesis Data Firehose Ingest Guide
             prefix:     en/kinesis
             index:      docs/en/aws-firehose/index.asciidoc
@@ -2156,22 +2172,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Elasticsearch Service - Hosted Elastic Stack
-            prefix:     en/cloud
-            tags:       Cloud/Reference
-            subject:    Elastic Cloud
-            current:    *cloudSaasCurrent
-            branches:   [ { *cloudSaasCurrent : latest} ]
-            index:      docs/saas/index.asciidoc
-            chunk:      1
-            private:    1
-            sources:
-              -
-                repo:   cloud
-                path:   docs/saas
-              -
-                repo:   cloud
-                path:   docs/shared
           
     -   title:      Legacy Documentation
         sections:


### PR DESCRIPTION
This PR moves the Elastic Cloud book to the top of the appropriate section of the landing page. 