### PR TITLE
Remove apm-server dependency from Fleet docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -420,7 +420,7 @@ contents:
               -
                 repo:   apm-server
                 path:   docs
-                exclude_branches:   [ 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
+                exclude_branches:   [ 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
               -
                 repo:   beats
                 path:   libbeat/docs
@@ -1482,10 +1482,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-              -
-                repo:   apm-server
-                path:   docs
-                exclude_branches:   [ 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    main

--- a/conf.yaml
+++ b/conf.yaml
@@ -1482,6 +1482,11 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+              -
+                # Required only for versions 7.12-7.15
+                repo:   apm-server
+                path:   docs
+                exclude_branches:   [ main, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
           - title:      Integrations Developer Guide
             prefix:     en/integrations-developer
             current:    main


### PR DESCRIPTION
For https://github.com/elastic/obs-docs-projects/issues/216.