### PR TITLE
Add `docs/data` and `docs/spec` to APM guide sources

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -453,6 +453,12 @@ contents:
                     repo:   apm-server
                     path:   changelogs
                     exclude_branches:   [ 6.0 ]
+                 -
+                    repo:   apm-server
+                    path:   docs/data
+                 -
+                    repo:   apm-server
+                    path:   docs/spec
                   -
                     repo:   apm-server
                     path:   CHANGELOG.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -453,10 +453,10 @@ contents:
                     repo:   apm-server
                     path:   changelogs
                     exclude_branches:   [ 6.0 ]
-                 -
+                  -
                     repo:   apm-server
                     path:   docs/data
-                 -
+                  -
                     repo:   apm-server
                     path:   docs/spec
                   -


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/pull/3476

We need to be able to access the `docs/data` and `docs/spec` directories in /apm-server in order for https://github.com/elastic/observability-docs/pull/3476 to work. I defined each individually to make sure we're not relying on any other AsciiDoc files in `docs/` outside those two subdirectories.