### PR TITLE
[apm docs consolidation] Update landing pages and APM breadcrumb dropdown

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -441,6 +441,7 @@ contents:
                 path:   shared/attributes.asciidoc
           - title:      Application Performance Monitoring (APM)
             base_dir:   en/apm
+            toc_extra:  extra/apm_docs_landing.html
             sections:
               - title:      APM Guide
                 prefix:     guide

--- a/extra/apm_docs_landing.html
+++ b/extra/apm_docs_landing.html
@@ -7,7 +7,7 @@
 <div class="w-100 mb-5">
   <h2>APM user guide</h2>
   <p>
-    Learn how to use APM in the <a href="/guide/en/observability/current/apm.html">Observability guide</a>.
+    Learn how to use APM in the <a href="/guide/en/observability/master/apm.html">Observability guide</a>.
   </p>
 </div>
 <div class="w-100 mb-5">

--- a/extra/apm_docs_landing.html
+++ b/extra/apm_docs_landing.html
@@ -1,0 +1,34 @@
+<style>
+#content > .ulist .itemizedlist {
+  visibility: hidden;
+}
+</style>
+
+<div class="w-100 mb-5">
+  <h2>APM user guide</h2>
+  <p>
+    Learn how to use APM in the <a href="/guide/en/observability/current/apm.html">Observability guide</a>.
+  </p>
+</div>
+<div class="w-100 mb-5">
+  <h2>APM agents</h2>
+  <ul>
+    <li><a href="/guide/en/apm/agent/android/current/intro.html">Android Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/go/current/introduction.html">Go Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/swift/current/intro.html">iOS Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/java/current/intro.html">Java Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/dotnet/current/intro.html">.NET Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/nodejs/current/intro.html">Node.js Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/php/current/intro.html">PHP Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/python/current/getting-started.html">Python Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/ruby/current/introduction.html">Ruby Agent Reference</a></li>
+    <li><a href="/guide/en/apm/agent/rum-js/current/intro.html">Real User Monitoring JavaScript Agent Reference</a></li>
+  </ul>
+</div>
+<div class="w-100 mb-5">
+  <h2>APM extensions</h2>
+  <ul>
+    <li><a href="/guide/en/apm/lambda/current/aws-lambda-arch.html">Monitoring AWS Lambda Functions</a></li>
+    <li><a href="/guide/en/apm/attacher/current/apm-attacher.html">Attacher</a></li>
+  </ul>
+</div>

--- a/extra/client_docs_landing.html
+++ b/extra/client_docs_landing.html
@@ -60,7 +60,7 @@
         <h2>Welcome to the Clients documentation</h2>
       </p>
       <p>
-        You can find the documentation of all the offical Elasticsearch clients here!
+        You can find the documentation of all the official Elasticsearch clients here!
       </p>
     </div>
     <div class="col-md-6 col-12">

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -16,7 +16,7 @@ module Chunker
           <ul>
           <li class="dropdown-category">APM</li>
           <ul>
-          <li><a href="/guide/en/observability/current/apm.html">Observability › APM</a></li>
+          <li><a href="/guide/en/observability/master/apm.html">Observability › APM</a></li>
           </ul>
           <li class="dropdown-category">APM agents</li>
           <ul>

--- a/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb
@@ -16,7 +16,7 @@ module Chunker
           <ul>
           <li class="dropdown-category">APM</li>
           <ul>
-          <li><a href="/guide/en/apm/guide/current/apm-overview.html">User Guide</a></li>
+          <li><a href="/guide/en/observability/current/apm.html">Observability › APM</a></li>
           </ul>
           <li class="dropdown-category">APM agents</li>
           <ul>


### PR DESCRIPTION
Related to https://github.com/elastic/obs-docs-projects/issues/216

Update how users navigate to APM content in the Observability guide from other pages in `elastic.co/guide/*`:

- [ ] Update the APM dropdown for moving between books
- [ ] Update [APM landing page](https://www.elastic.co/guide/en/apm/index.html)
- [ ] Update [landing page](https://www.elastic.co/guide/index.html)

⚠️  Before merging:

- [ ] Update Observability > APM links to use `current` instead of `master`

cc @bmorelli25 
