### PR TITLE
Allow bots actions PR's to trigger docs builds

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -9,6 +9,7 @@
         "admin",
         "write"
       ],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
@@ -54,6 +55,7 @@
         "admin",
         "write"
       ],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
@@ -105,6 +107,7 @@
         "admin",
         "write"
       ],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",


### PR DESCRIPTION
As explained in [Slack](https://elastic.slack.com/archives/C05SZ9CGB19/p1704726015608749), PR opened by bots do not kick-off docs builds, which is the major source of discrepancies between Jenkins and Buildkite builds.

This PR fixes that.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
