### PR TITLE
Do a full rebuild of the docs every 30 minutes

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -4,17 +4,17 @@ steps:
     fields:
       - select: "Rebuild?"
         key: "REBUILD"
-        default: false
+        default: "rebuild"
         required: false
         options:
           - label: "no"
-            value: "false"
+            value: ""
           - label: "yes"
             value: "rebuild"
         hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
       - select: "How should broken links be handled?"
         key: "BROKEN_LINKS"
-        default: false
+        default: ""
         required: false
         options:
           - label: "Continue without warning"
@@ -27,7 +27,7 @@ steps:
   - wait
   - label: ":white_check_mark: Build docs"
     command: |
-      export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
+      export REBUILD="$(buildkite-agent meta-data get REBUILD --default 'rebuild' --log-level fatal)"
       export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
       bash .buildkite/scripts/build.sh
     agents:

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -8,9 +8,9 @@ steps:
         required: false
         options:
           - label: "no"
-            value: false
+            value: "false"
           - label: "yes"
-            value: true
+            value: "rebuild"
         hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
       - select: "How should broken links be handled?"
         key: "BROKEN_LINKS"


### PR DESCRIPTION
We are trying to understand build discrepancies between Jenkins and Buildkite and exploring if this may be the issue.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
