### PR TITLE
ECS current to 8.11

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -932,9 +932,10 @@ contents:
                 path:   docs/asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
+            # The omission of 8.12 is intentional, please do not add
             current:    8.11
-            branches:   [  {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 1.12 ]
+            branches:   [  {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.11, 8.10, 8.9, 8.8, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/conf.yaml
+++ b/conf.yaml
@@ -932,10 +932,10 @@ contents:
                 path:   docs/asciidoc
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
-            # The omission of 8.12 is intentional, please do not add
+            # Please do not update current to 8.12
             current:    8.11
-            branches:   [  {main: master}, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ main, 8.11, 8.10, 8.9, 8.8, 1.12 ]
+            branches:   [  {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ main, 8.12, 8.11, 8.10, 8.9, 8.8, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/8.12.asciidoc
+++ b/shared/versions/stack/8.12.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.12
+:ecs_version:            8.11
 :esf_version:            master
 
 //////////


### PR DESCRIPTION
The team will not be releasing an ECS 8.12 while we decide how to approach releases of ECS going forward

I also cleared out some of the older versions from the live options.

___
Relates https://github.com/elastic/security-team/issues/8182
