### PR TITLE
Tiny updates for the docs homepage

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -921,6 +921,22 @@ contents:
                 path:   docs/en
     -   title:      Elastic Stack
         sections:
+          - title:      "Starting with the Elasticsearch Platform and its Solutions"
+            prefix:     en/starting-with-the-elasticsearch-platform-and-its-solutions
+            current:    *stackcurrent
+            index:      welcome-to-elastic/index.asciidoc
+            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 7.17 ]
+            live:       [ *stackcurrent ]
+            chunk:      1
+            tags:       Elastic/Starting with the Elasticsearch Platform and its Solutions
+            subject:    Starting with the Elasticsearch Platform and its Solutions
+            sources:
+              -
+                repo:   tech-content
+                path:   welcome-to-elastic
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
           - title:      Curator Index Management
             prefix:     en/elasticsearch/client/curator
             current:    8.0
@@ -1423,22 +1439,6 @@ contents:
                 repo:   docs
                 path:   shared/attributes.asciidoc
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-          - title:      "Starting with the Elasticsearch Platform and its Solutions"
-            prefix:     en/starting-with-the-elasticsearch-platform-and-its-solutions
-            current:    *stackcurrent
-            index:      welcome-to-elastic/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 7.17 ]
-            live:       [ *stackcurrent ]
-            chunk:      1
-            tags:       Elastic/Starting with the Elasticsearch Platform and its Solutions
-            subject:    Starting with the Elasticsearch Platform and its Solutions
-            sources:
-              -
-                repo:   tech-content
-                path:   welcome-to-elastic
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
 
     -   title:     "Ingest: Add your data"
         sections:

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -691,7 +691,7 @@
             <h3 class="mt-3">
               Self managed
             </h3>
-            <p>Download, install, and run Elastic products.</p>
+            <p>Install, configure, and run self-managed Elastic products.</p>
             <span class="button btn-tertiary">
               View Self managed docs
               <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -691,7 +691,7 @@
             <h3 class="mt-3">
               Self managed
             </h3>
-            <p>Install, configure, and run self-managed Elastic products on your own premises.</p>
+            <p>Install, configure, and run Elastic products on your own premises.</p>
             <span class="button btn-tertiary">
               View Self managed docs
               <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -691,7 +691,7 @@
             <h3 class="mt-3">
               Self managed
             </h3>
-            <p>Install, configure, and run self-managed Elastic products.</p>
+            <p>Install, configure, and run self-managed Elastic products on your own premises.</p>
             <span class="button btn-tertiary">
               View Self managed docs
               <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">


### PR DESCRIPTION
This makes two minor changes to the docs homepage based on discussion with Kaarina.

 - Moves "[Starting with the Elasticsearch Platform and its Solutions [8.11]](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/index.html) — [other versions](https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/index.html)" to the top of the list under the "Elastic Stack" heading.

 - Changes the text on the "Self managed" card to `Install, configure, and run Elastic products on your own premises.`
