### PR TITLE
Bk use pat for commit statuses

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  USE_HTTPS_CLONE: true
+
 steps:
   - key: "cancel-existing-builds"
     command: ".buildkite/scripts/cancel_running_pr.sh || true"

--- a/.buildkite/preview_cleaner_pipeline.yml
+++ b/.buildkite/preview_cleaner_pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  USE_HTTPS_CLONE: true
+
 steps:
   - label: ":white_check_mark: Preview cleaning"
     command: ".buildkite/scripts/clean_preview_branches.sh"

--- a/.buildkite/scripts/build_pr_commit_status.sh
+++ b/.buildkite/scripts/build_pr_commit_status.sh
@@ -27,7 +27,7 @@ echo "Setting commit status: buildkite/${BUILDKITE_PIPELINE_SLUG} - ${status_sta
 curl -s -L \
   -X POST \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer ${VAULT_GITHUB_TOKEN}" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   "${githubPublishStatus}" \
   -d "${data}"

--- a/.buildkite/scripts/clean_preview_branches.sh
+++ b/.buildkite/scripts/clean_preview_branches.sh
@@ -2,10 +2,6 @@
 
 set -eo pipefail
 
-set +x
-export GITHUB_TOKEN=$(vault read -field=value secret/ci/elastic-docs/docs_preview_cleaner)
-set -x
-
 export REPO=git@github.com:elastic/built-docs.git
 export IMAGE=docker.elastic.co/docs/build:latest
 
@@ -17,7 +13,7 @@ ssh-agent bash -c '
         -v ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached,ro \
         -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK:cached,ro \
         -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
-        -e GITHUB_TOKEN=$GITHUB_TOKEN \
+        -e GITHUB_TOKEN=$VAULT_GITHUB_TOKEN \
         -v /opt/git-mirrors:/opt/git-mirrors:cached,ro \
         -e CACHE_DIR=/opt/git-mirrors \
         $IMAGE node /docs_build/preview/clean.js $REPO'


### PR DESCRIPTION
Switch to using the short lived personal access tokens rolled out by the CI team - see https://github.com/elastic/docs-projects/issues/142

