### PR TITLE
Pass the --update-head-ok to fetch for PRs out of main

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -24,6 +24,7 @@ steps:
       fi
     depends_on:
       - step: "build-pr"
+        allow_failure: true
   - wait
   - key: "branch-comparison"
     label: "Compare branches"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -53,6 +53,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
   cd ./product-repo &&
       git fetch --update-head-ok origin pull/$GITHUB_PR_NUMBER/head:$GITHUB_PR_BRANCH &&
       git switch $GITHUB_PR_BRANCH &&
+      git show &&
       cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -53,7 +53,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
   cd ./product-repo &&
       git fetch --update-head-ok origin pull/$GITHUB_PR_NUMBER/head:$GITHUB_PR_BRANCH &&
       git switch $GITHUB_PR_BRANCH &&
-      git show &&
+      git rev-parse HEAD &&
       cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -51,7 +51,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     git@github.com:elastic/$GITHUB_PR_BASE_REPO.git ./product-repo
 
   cd ./product-repo &&
-      git fetch origin pull/$GITHUB_PR_NUMBER/head:$GITHUB_PR_BRANCH &&
+      git fetch --update-head-ok origin pull/$GITHUB_PR_NUMBER/head:$GITHUB_PR_BRANCH &&
       git switch $GITHUB_PR_BRANCH &&
       cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330

--- a/.buildkite/scripts/build_pr_commit_status.sh
+++ b/.buildkite/scripts/build_pr_commit_status.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 
 # This hook should only be invoked for builds triggered by the Buildkite PR bot
 if [ -z ${GITHUB_PR_BASE_OWNER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ] || [ -z ${GITHUB_PR_TRIGGERED_SHA+set} ];then
+  echo "Build not triggered via Buildkite PR bot - skipping setting status check"
   exit 0
 fi
 


### PR DESCRIPTION
It seems like docs PR coming from a local main branch fail to checkout on Buildkite with the error:
`fatal: Refusing to fetch into current branch refs/heads/main of non-bare repository`

This PR attempts solves the issue by using the `--update-head-ok` flag - see explanation in this [stack overflow](https://stackoverflow.com/questions/2236743/git-refusing-to-fetch-into-current-branch).

Note - this also addresses the issue where status checks were not reported when the build was failing

This was tested using one of the [problematic PR](https://github.com/elastic/apm-agent-android/pull/265):
* reproducing the failure
* with the fix (additional flag) (but then aborting the build)



<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
