### PR TITLE
Check observability doc links in Kibana

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -364,6 +364,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{ELASTICSEARCH_DOCS\}!en/elasticsearch/reference/$version/!;
                 $path =~ s!\$\{KIBANA_DOCS\}!en/kibana/$version/!;
                 $path =~ s!\$\{PLUGIN_DOCS\}!en/elasticsearch/plugins/$version/!;
+                $path =~ s!\$\{OBSERVABILITY_DOCS\}!en/observability/$version/!;
                 $path =~ s!\$\{FLEET_DOCS\}!en/fleet/$version/!;
                 $path =~ s!\$\{APM_DOCS\}!en/apm/!;
                 $path =~ s!\$\{STACK_DOCS\}!en/elastic-stack/$version/!;


### PR DESCRIPTION
As a follow-on to https://github.com/elastic/kibana/pull/174725, adds observability link checking (for in-product links) back into the doc build.
