### PR TITLE
Update doc comment README.md

### DIFF
--- a/.github/actions/docs-preview/README.md
+++ b/.github/actions/docs-preview/README.md
@@ -26,7 +26,7 @@ jobs:
   doc-preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/docs/.github/actions/docs-preview@current
+      - uses: elastic/docs/.github/actions/docs-preview@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           repo: ${{ github.event.repository.name }}


### PR DESCRIPTION
### Summary

@nkammah, I believe this actually needs to be `@master`.  When using `@current`, Kibana checks fail:

<img width="809" alt="Screenshot 2024-01-26 at 7 43 10 AM" src="https://github.com/elastic/docs/assets/5618806/b97fe601-bb16-4193-841f-02e9a883362d">

Repos like stack-docs and docs use `@master`. For example: https://github.com/elastic/docs/blob/master/.github/workflows/doc-preview.yml#L17