### PR TITLE
Move cloud native ingest docs to ingest section of docs landing page

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1443,6 +1443,25 @@ contents:
 
     -   title:     "Ingest: Add your data"
         sections:
+          - title:      Amazon Kinesis Data Firehose Ingest Guide
+            prefix:     en/kinesis
+            index:      docs/en/aws-firehose/index.asciidoc
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            chunk:      1
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Elastic Ingest Reference Architectures
             prefix:     en/ingest
             current:    *stackcurrent
@@ -1475,6 +1494,25 @@ contents:
               -
                 repo:   beats
                 path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Serverless Forwarder Guide
+            prefix:     en/esf
+            index:      docs/en/index.asciidoc
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            chunk:      2
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   esf
+                path:   docs/en
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -1960,7 +1998,7 @@ contents:
                 path:   shared/attributes.asciidoc
                 exclude_branches:   *beatsSharedExclude
 
-    -   title:      "Cloud: Provision, Manage and Monitor the Elastic Stack"
+    -   title:      "Cloud: Provision, Manage, and Monitor the Elastic Stack"
         sections:
           - title:      Elastic Cloud, Hosted Elastic Stack
             prefix:     en/cloud
@@ -1978,25 +2016,6 @@ contents:
               -
                 repo:   cloud
                 path:   docs/shared
-          - title:      Amazon Kinesis Data Firehose Ingest Guide
-            prefix:     en/kinesis
-            index:      docs/en/aws-firehose/index.asciidoc
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            chunk:      1
-            tags:       Cloud Native Ingest/Reference
-            subject:    cloud native ingest
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Elasticsearch Add-On for Heroku - Hosted Elasticsearch and Kibana for Heroku Users
             prefix:     en/cloud-heroku
             tags:       Cloud-Heroku/Reference
@@ -2172,25 +2191,6 @@ contents:
               -
                 repo:   terraform-provider-ec
                 path:   docs-elastic/
-          - title:      Elastic Serverless Forwarder Guide
-            prefix:     en/esf
-            index:      docs/en/index.asciidoc
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            chunk:      2
-            tags:       Cloud Native Ingest/Reference
-            subject:    cloud native ingest
-            sources:
-              -
-                repo:   esf
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
 
     -   title:      Legacy Documentation
         sections:


### PR DESCRIPTION
Moves "cloud native" methods of data ingestion to the ingest section under "Browse all docs".

One could argue that the [Amazon Kinesis Data Firehose Ingest Guide](https://www.elastic.co/guide/en/kinesis/current/index.html) does belong under cloud, but IMO it does not belong under the description "Provision, manage, and monitor the Elastic Stack".

The [Elastic Serverless Forwarder Guide](https://www.elastic.co/guide/en/esf/current/index.html) on the other hand is not cloud-specific and shouldn't be under that category.

I think it would be good to keep all the data ingestion topics under ingest. Thoughts?

The section seems to be mostly organized alphabetically, with Beats books being grouped together, so I added these guides in alphabetical order. I'm open to other suggestions.