### PR TITLE
Remove Logstash Kubernetes from published docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1572,22 +1572,6 @@ contents:
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches:   [ main, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
-          - title:      Logstash and Kubernetes
-            prefix:     en/logstash-kubernetes
-            current:    main
-            index:      docsk8s/index.asciidoc
-            branches:   [ {main: master} ]
-            noindex:    1
-            chunk:      1
-            tags:       Logstash/Kubernetes
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash
-                path:   docsk8s
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs


### PR DESCRIPTION
Fixes: https://github.com/elastic/logstash/issues/15863

Updates `conf.yaml` to remove Logstash on Kubernets from docs landing page.

[Logstash on ECK](https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-logstash.html) is the preferred path forward with Logstash on Kubernetes.

