### PR TITLE
Fix product repo PR checkout

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -2,8 +2,8 @@ env:
   USE_HTTPS_CLONE: true
 
 steps:
-  - key: "cancel-existing-builds"
-    command: ".buildkite/scripts/cancel_running_pr.sh || true"
+  #- key: "cancel-existing-builds"
+  #  command: ".buildkite/scripts/cancel_running_pr.sh || true"
   - key: "build-pr-setup"
     label: "setup"
     command: ".buildkite/scripts/build_pr_commit_status.sh pending"

--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -1,5 +1,5 @@
 env:
-  USE_HTTPS_CLONE: true
+  USE_HTTPS_CLONE: false
 
 steps:
   #- key: "cancel-existing-builds"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -3,8 +3,8 @@ set -euo pipefail
 set +x
 
 # This script should only be invoked by the Buildkite PR bot
-if [ -z ${GITHUB_PR_BRANCH+set} ] || [ -z ${GITHUB_PR_TARGET_BRANCH+set} ] || [ -z ${GITHUB_PR_NUMBER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ];then
-  echo "One of the following env. variable GITHUB_PR_BRANCH, GITHUB_PR_TARGET_BRANCH, GITHUB_PR_NUMBER, GITHUB_PR_BASE_REPO is missing - exiting."
+if [ -z ${GITHUB_PR_TARGET_BRANCH+set} ] || [ -z ${GITHUB_PR_NUMBER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ];then
+  echo "One of the following env. variable GITHUB_PR_TARGET_BRANCH, GITHUB_PR_NUMBER, GITHUB_PR_BASE_REPO is missing - exiting."
   exit 1
 fi
 
@@ -51,8 +51,8 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     git@github.com:elastic/$GITHUB_PR_BASE_REPO.git ./product-repo
 
   cd ./product-repo &&
-      git fetch origin pull/$GITHUB_PR_NUMBER/head:$GITHUB_PR_BRANCH &&
-      git switch $GITHUB_PR_BRANCH &&
+      git fetch origin pull/$GITHUB_PR_NUMBER/head:pr_$GITHUB_PR_NUMBER &&
+      git switch pr_$GITHUB_PR_NUMBER &&
       cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"


### PR DESCRIPTION
In https://github.com/elastic/docs/pull/2904 we tried to fix the PR checkout mechanism to work even when the branch name of the original PR matched an existing branch name, such as `main`. This turned out to be creating some issues and was reverted in https://github.com/elastic/docs/commit/0854c6ecb30e0bb28158ecd60a53c4da1bd2de51.

In this PR, we checkout the PR into a local pr_<number> head, to avoid any sort of conflicts.