### PR TITLE
Bump primary ingest tools to top of ingest section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1443,82 +1443,6 @@ contents:
 
     -   title:     "Ingest: Add your data"
         sections:
-          - title:      Amazon Kinesis Data Firehose Ingest Guide
-            prefix:     en/kinesis
-            index:      docs/en/aws-firehose/index.asciidoc
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            chunk:      1
-            tags:       Cloud Native Ingest/Reference
-            subject:    cloud native ingest
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
-            live:       [ *stackcurrent ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Logging Plugin for Docker
-            prefix:     en/beats/loggingplugin
-            current:    *stackcurrent
-            index:      x-pack/dockerlogbeat/docs/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
-            chunk:      1
-            tags:       Elastic Logging Plugin/Reference
-            respect_edit_url_overrides: true
-            subject:    Elastic Logging Plugin
-            sources:
-              -
-                repo:   beats
-                path:   x-pack/dockerlogbeat/docs
-              -
-                repo:   beats
-                path:   libbeat/docs
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Serverless Forwarder Guide
-            prefix:     en/esf
-            index:      docs/en/index.asciidoc
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            chunk:      2
-            tags:       Cloud Native Ingest/Reference
-            subject:    cloud native ingest
-            sources:
-              -
-                repo:   esf
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
@@ -1624,6 +1548,82 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/versioned-plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Amazon Kinesis Data Firehose Ingest Guide
+            prefix:     en/kinesis
+            index:      docs/en/aws-firehose/index.asciidoc
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            chunk:      1
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Ingest Reference Architectures
+            prefix:     en/ingest
+            current:    *stackcurrent
+            index:      docs/en/ingest-arch/index.asciidoc
+            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
+            live:       [ *stackcurrent ]
+            chunk:      1
+            tags:       Ingest/Reference
+            subject:    Ingest
+            sources:
+              -
+                repo:   ingest-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Logging Plugin for Docker
+            prefix:     en/beats/loggingplugin
+            current:    *stackcurrent
+            index:      x-pack/dockerlogbeat/docs/index.asciidoc
+            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6 ]
+            chunk:      1
+            tags:       Elastic Logging Plugin/Reference
+            respect_edit_url_overrides: true
+            subject:    Elastic Logging Plugin
+            sources:
+              -
+                repo:   beats
+                path:   x-pack/dockerlogbeat/docs
+              -
+                repo:   beats
+                path:   libbeat/docs
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+          - title:      Elastic Serverless Forwarder Guide
+            prefix:     en/esf
+            index:      docs/en/index.asciidoc
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            chunk:      2
+            tags:       Cloud Native Ingest/Reference
+            subject:    cloud native ingest
+            sources:
+              -
+                repo:   esf
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1470,31 +1470,6 @@ contents:
                 repo:   apm-server
                 path:   docs
                 exclude_branches:   [ main, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0 ]
-          - title:      Integrations Developer Guide
-            prefix:     en/integrations-developer
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            index:      docs/en/integrations/index.asciidoc
-            chunk:      1
-            tags:       Integrations/Developer
-            subject:    Integrations
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-              -
-                repo:   package-spec
-                path:   versions
-              -
-                repo:   package-spec
-                path:   spec
           - title:      Logstash Reference
             prefix:     en/logstash
             current:    *stackcurrent
@@ -1627,6 +1602,31 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
+          - title:      Integrations Developer Guide
+            prefix:     en/integrations-developer
+            current:    main
+            branches:   [ {main: master} ]
+            live:       [ main ]
+            index:      docs/en/integrations/index.asciidoc
+            chunk:      1
+            tags:       Integrations/Developer
+            subject:    Integrations
+            sources:
+              -
+                repo:   observability-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/versions/stack/{version}.asciidoc
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
+              -
+                repo:   package-spec
+                path:   versions
+              -
+                repo:   package-spec
+                path:   spec
           - title:      Auditbeat Reference
             prefix:     en/beats/auditbeat
             index:      auditbeat/docs/index.asciidoc


### PR DESCRIPTION
As requested by our ingest PM, it'd be very nice to have the Fleet, Integrations, and Logstash docs appear at the top of the `Ingest: Add your data` section.

