### PR TITLE
Add serverless links to solution cards in landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -459,6 +459,15 @@
               </svg>
             </span>
           </a>
+          <a class="no-text-decoration" href="https://docs.elastic.co/serverless/elasticsearch/what-is-elasticsearch-serverless">
+            <span class="button btn-tertiary">
+              View serverless docs
+              <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">
+                <path d="M0 7H25" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+                <path d="M19 1L25 7L19 13" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+              </svg>
+            </span>
+          </a>
           </div>
       </div>
       <div class="col-md-4 col-12 mb-2">
@@ -488,6 +497,15 @@
               </svg>
             </span>
           </a>
+          <a class="no-text-decoration" href="https://docs.elastic.co/serverless/observability/what-is-observability-serverless">
+            <span class="button btn-tertiary">
+              View serverless docs
+              <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">
+                <path d="M0 7H25" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+                <path d="M19 1L25 7L19 13" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+              </svg>
+            </span>
+          </a>
         </div>
       </div>
       <div class="col-md-4 col-12 mb-2">
@@ -511,6 +529,15 @@
             <a class="no-text-decoration" href="en/security/current/es-overview.html">
             <span class="button btn-tertiary">
               View Security docs
+              <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">
+                <path d="M0 7H25" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+                <path d="M19 1L25 7L19 13" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
+              </svg>
+            </span>
+          </a>
+          <a class="no-text-decoration" href="https://docs.elastic.co/serverless/security/what-is-security-serverless">
+            <span class="button btn-tertiary">
+              View serverless docs
               <svg width="27" height="14" viewBox="0 0 27 14" fill="none" xmlns="http://www.w3.org/2000/svg" class="jsx-3012141155">
                 <path d="M0 7H25" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>
                 <path d="M19 1L25 7L19 13" stroke="#0077CC" stroke-width="2" class="jsx-3012141155"></path>


### PR DESCRIPTION
Adds a link to each solution card to direct serverless solution users to the correct docs.

You can [view the preview here](https://docs_bk_2918.docs-preview.app.elstc.co/guide/index.html).

I'd like some feedback on the link text. I used generic text even though the links are specific because text like "View the Observability serverless docs" was quite long. I'd rather use text that's specific, if possible.

Closes https://github.com/elastic/observability-docs/issues/3594