### PR TITLE
Buildkite use pat

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -2,8 +2,8 @@ env:
   USE_HTTPS_CLONE: true
 
 steps:
-  - key: "cancel-existing-builds"
-    command: ".buildkite/scripts/cancel_running_pr.sh || true"
+  #- key: "cancel-existing-builds"
+  #  command: ".buildkite/scripts/cancel_running_pr.sh || true"
   - key: "build-pr-setup"
     label: "setup"
     command: ".buildkite/scripts/build_pr_commit_status.sh pending"

--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -1,3 +1,5 @@
+env:
+  USE_HTTPS_CLONE: true
 
 steps:
   - key: "cancel-existing-builds"

--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -2,8 +2,8 @@ env:
   USE_HTTPS_CLONE: true
 
 steps:
-  #- key: "cancel-existing-builds"
-  #  command: ".buildkite/scripts/cancel_running_pr.sh || true"
+  - key: "cancel-existing-builds"
+    command: ".buildkite/scripts/cancel_running_pr.sh || true"
   - key: "build-pr-setup"
     label: "setup"
     command: ".buildkite/scripts/build_pr_commit_status.sh pending"

--- a/.buildkite/preview_cleaner_pipeline.yml
+++ b/.buildkite/preview_cleaner_pipeline.yml
@@ -1,3 +1,6 @@
+env:
+  USE_HTTPS_CLONE: true
+
 steps:
   - label: ":white_check_mark: Preview cleaning"
     command: ".buildkite/scripts/clean_preview_branches.sh"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -66,6 +66,7 @@ else
   # When https://github.com/elastic/docs/issues/1823 is fixed, this
   # should be removed and the original behavior restored.
   rebuild_opt=" --rebuild --procs 16"
+  sleep 1800
 fi
 
 

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -66,7 +66,6 @@ else
   # When https://github.com/elastic/docs/issues/1823 is fixed, this
   # should be removed and the original behavior restored.
   rebuild_opt=" --rebuild --procs 16"
-  sleep 1800
 fi
 
 

--- a/.buildkite/scripts/build_pr_commit_status.sh
+++ b/.buildkite/scripts/build_pr_commit_status.sh
@@ -27,7 +27,7 @@ echo "Setting commit status: buildkite/${BUILDKITE_PIPELINE_SLUG} - ${status_sta
 curl -s -L \
   -X POST \
   -H "Accept: application/vnd.github+json" \
-  -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+  -H "Authorization: Bearer ${VAULT_GITHUB_TOKEN}" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   "${githubPublishStatus}" \
   -d "${data}"

--- a/.buildkite/scripts/clean_preview_branches.sh
+++ b/.buildkite/scripts/clean_preview_branches.sh
@@ -12,7 +12,7 @@ ssh-agent bash -c '
         -v ~/.ssh/known_hosts:/root/.ssh/known_hosts:cached,ro \
         -v $SSH_AUTH_SOCK:$SSH_AUTH_SOCK:cached,ro \
         -e SSH_AUTH_SOCK=$SSH_AUTH_SOCK \
-        -e GITHUB_TOKEN=$GITHUB_TOKEN \
+        -e GITHUB_TOKEN=$VAULT_GITHUB_TOKEN \
         -v /opt/git-mirrors:/opt/git-mirrors:cached,ro \
         -e CACHE_DIR=/opt/git-mirrors \
         $IMAGE node /docs_build/preview/clean.js $REPO'

--- a/preview/clean.js
+++ b/preview/clean.js
@@ -96,7 +96,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
   }
 
   const is_pr_closed = function (pr) {
-    console.log("Checking " + pr.repo + "-" + pr.number);
+    console.info(`Checking status of https://github.com/elastic/${pr.repo}/pull/${pr.number}`);
     return new Promise((resolve, reject) => {
       const body = {
         query: `
@@ -137,7 +137,6 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
             try {
               const parsed = JSON.parse(data);
               const repo = parsed.data.repository;
-              console.log(repo);
               if (repo && repo.pullRequest) {
                 closed = repo.pullRequest.closed;
               } else {

--- a/preview/clean.js
+++ b/preview/clean.js
@@ -137,7 +137,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
             try {
               const parsed = JSON.parse(data);
               const repo = parsed.data.repository;
-              if (repo && repo.pullRequest) {
+              if (repo) {
                 closed = repo.pullRequest.closed;
               } else {
                 console.warn(pr.branch,

--- a/preview/clean.js
+++ b/preview/clean.js
@@ -138,7 +138,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
               const parsed = JSON.parse(data);
               const repo = parsed.data.repository;
               console.log(repo);
-              if (repo) {
+              if (repo && repo.pullRequest) {
                 closed = repo.pullRequest.closed;
               } else {
                 console.warn(pr.branch,

--- a/preview/clean.js
+++ b/preview/clean.js
@@ -37,7 +37,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
         if (found) {
           acc.push({
             branch: found[1],
-            // Temporary hack during the Buildkite migration that breaks the <repo>_<PR> convention, 
+            // Temporary hack during the Buildkite migration that breaks the <repo>_<PR> convention,
             // and introduces the <repo>_BK_<PR> convention - see https://github.com/elastic/docs-projects/issues/134
             repo: found[2].includes('_bk') ? found[2].replace('_bk', '') : found[2],
             number: Number(found[3]),
@@ -96,6 +96,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
   }
 
   const is_pr_closed = function (pr) {
+    console.log("Checking " + pr.repo + "-" + pr.number);
     return new Promise((resolve, reject) => {
       const body = {
         query: `
@@ -136,6 +137,7 @@ function Cleaner(token, repo, cache_dir, tmp_dir) {
             try {
               const parsed = JSON.parse(data);
               const repo = parsed.data.repository;
+              console.log(repo);
               if (repo) {
                 closed = repo.pullRequest.closed;
               } else {


### PR DESCRIPTION
This PR re-enables the use of pat (personal access token) to perform various GitHub operations (preview-cleaner, setting commit status). This was rolled out a first time a week ago, then reverted due to un-expected issues (explained [here](https://github.com/elastic/ci/discussions/2542#discussioncomment-8294238) and fixed since then).

The testing done on this PR shows the problem to be addressed for both the docs-build-pr and preview-cleaner.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
