### PR TITLE
Ci build avoidance

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -2,11 +2,11 @@ env:
   USE_HTTPS_CLONE: true
 
 steps:
-  - key: "cancel-existing-builds"
-    command: ".buildkite/scripts/cancel_running_pr.sh || true"
+  #- key: "cancel-existing-builds"
+  #  command: ".buildkite/scripts/cancel_running_pr.sh || true"
   - key: "build-pr-setup"
     label: "setup"
-    command: ".buildkite/scripts/build_pr_commit_status.sh pending"
+    command: "echo .buildkite/scripts/build_pr_commit_status.sh pending"
   - key: "build-pr"
     label: ":hammer: Build docs PR"
     command: ".buildkite/scripts/build_pr.sh"
@@ -21,17 +21,17 @@ steps:
     label: "teardown"
     command: |
       if [ $(buildkite-agent step get "outcome" --step "build-pr") == "passed" ]; then
-        .buildkite/scripts/build_pr_commit_status.sh success
+        echo .buildkite/scripts/build_pr_commit_status.sh success
       else
-        .buildkite/scripts/build_pr_commit_status.sh failure
+        echo .buildkite/scripts/build_pr_commit_status.sh failure
       fi
     depends_on:
       - step: "build-pr"
-  - wait
-  - key: "branch-comparison"
-    label: "Compare branches"
-    command: |
-      .buildkite/scripts/compare_bk_jenkins_branches.sh ${GITHUB_PR_BASE_REPO}_bk_${GITHUB_PR_NUMBER} ${GITHUB_PR_BASE_REPO}_${GITHUB_PR_NUMBER}
-    agents:
-      provider: "gcp"
-      image: family/docs-ubuntu-2204
+        #- wait
+        #- key: "branch-comparison"
+        #  label: "Compare branches"
+        #  command: |
+        #    .buildkite/scripts/compare_bk_jenkins_branches.sh ${GITHUB_PR_BASE_REPO}_bk_${GITHUB_PR_NUMBER} ${GITHUB_PR_BASE_REPO}_${GITHUB_PR_NUMBER}
+        #  agents:
+        #    provider: "gcp"
+        #    image: family/docs-ubuntu-2204

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -59,8 +59,10 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
   case "${GITHUB_PR_BASE_REPO}" in
     cloud|cloud-on-k8s|curator|ecctl|ecs|ecs-dotnet|ecs-logging|ecs-logging-go-logrus|ecs-logging-go-zap|ecs-logging-go-zerolog|ecs-logging-java|ecs-logging-nodejs|ecs-logging-php|ecs-logging-python|ecs-logging-ruby|eland|elastic-serverless-forwarder|elasticsearch-hadoop|elasticsearch-js|elasticsearch-php|elasticsearch-py|elasticsearch-rs|elasticsearch-ruby|enterprise-search-php|enterprise-search-python|enterprise-search-ruby|ingest-docs|logstash|security-docs|x-pack)
 
-      has_changes=0
-      git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs || has_changes=$?
+      set +e
+      git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs
+      has_changes=$?
+      set -e
       if [ $has_changes -eq 0 ]; then
         echo "${GITHUB_PR_BASE_REPO} has been configured to skip changes that do not touch the ./docs folder - this seems to be the case for this PR, so we're skipping the build"
         exit 0

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -56,7 +56,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
 
   # For some repos, if the change did not touch the ./docs folder, we can skip the build altogher - check this here
   # add a case statement
-  case "${GITHUB_PR_BASE_REPO}" IN
+  case "${GITHUB_PR_BASE_REPO}" in
     cloud|cloud-on-k8s|curator|ecctl|ecs|ecs-dotnet|ecs-logging|ecs-logging-go-logrus|ecs-logging-go-zap|ecs-logging-go-zerolog|ecs-logging-java|ecs-logging-nodejs|ecs-logging-php|ecs-logging-python|ecs-logging-ruby|eland|elastic-serverless-forwarder|elasticsearch-hadoop|elasticsearch-js|elasticsearch-php|elasticsearch-py|elasticsearch-rs|elasticsearch-ruby|enterprise-search-php|enterprise-search-python|enterprise-search-ruby|ingest-docs|logstash|security-docs|x-pack)
 
       has_changes=0

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -60,6 +60,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     cloud|cloud-on-k8s|curator|ecctl|ecs|ecs-dotnet|ecs-logging|ecs-logging-go-logrus|ecs-logging-go-zap|ecs-logging-go-zerolog|ecs-logging-java|ecs-logging-nodejs|ecs-logging-php|ecs-logging-python|ecs-logging-ruby|eland|elastic-serverless-forwarder|elasticsearch-hadoop|elasticsearch-js|elasticsearch-php|elasticsearch-py|elasticsearch-rs|elasticsearch-ruby|enterprise-search-php|enterprise-search-python|enterprise-search-ruby|ingest-docs|logstash|security-docs|x-pack)
 
       has_changes=0
+      set -x
       git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs || has_changes=$?
       if [ $has_changes -eq 0 ]; then
         echo "${GITHUB_PR_BASE_REPO} has been configured to skip changes that do not touch the ./docs folder - this seems to be the case for this PR, so we're skipping the build"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -euo pipefail
-set +x
+set -x
 
 # This script should only be invoked by the Buildkite PR bot
 if [ -z ${GITHUB_PR_TARGET_BRANCH+set} ] || [ -z ${GITHUB_PR_NUMBER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ];then
@@ -60,7 +60,6 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     cloud|cloud-on-k8s|curator|ecctl|ecs|ecs-dotnet|ecs-logging|ecs-logging-go-logrus|ecs-logging-go-zap|ecs-logging-go-zerolog|ecs-logging-java|ecs-logging-nodejs|ecs-logging-php|ecs-logging-python|ecs-logging-ruby|eland|elastic-serverless-forwarder|elasticsearch-hadoop|elasticsearch-js|elasticsearch-php|elasticsearch-py|elasticsearch-rs|elasticsearch-ruby|enterprise-search-php|enterprise-search-python|enterprise-search-ruby|ingest-docs|logstash|security-docs|x-pack)
 
       has_changes=0
-      set -x
       git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs || has_changes=$?
       if [ $has_changes -eq 0 ]; then
         echo "${GITHUB_PR_BASE_REPO} has been configured to skip changes that do not touch the ./docs folder - this seems to be the case for this PR, so we're skipping the build"

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -73,7 +73,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
 
 
   popd
-
+  exit 0
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"
   build_args+=" --sub_dir $GITHUB_PR_BASE_REPO:$GITHUB_PR_TARGET_BRANCH:./product-repo"


### PR DESCRIPTION
This is an attempt at adding some exit-early logic for product repo builds that require a build only on changes to `./docs`. I did not have time to invest in it and as a result it's very rough, hacky and not working at this time (hence still in draft), but  opened for contributions.

### What needs fixing: 

The logic to detect if the PR touches the `./docs` repo [here](https://github.com/elastic/docs/pull/2926/files#diff-5ea8cc5083302320861aeb6d2dc6d73f688d94c1ed975a3c4bd1ad351cd23a74R62-R65).


### Testing flow

Request a new [docs-build-pr](https://buildkite.com/elastic/docs-build-pr) build, with the below parameters:
branch: [ci-build-avoidance](https://buildkite.com/elastic/docs-build-pr/builds?branch=ci-build-avoidance) and the below parameters depending on the scenario you want to test:

* A change should be detected and be built:
```
GITHUB_PR_BASE_REPO=cloud-on-k8s
GITHUB_PR_TARGET_BRANCH=main
GITHUB_PR_NUMBER=7536
```

* The build should carry on since no build avoidance is setup for the repo
```
GITHUB_PR_BASE_REPO=apm-server
GITHUB_PR_TARGET_BRANCH=main 
GITHUB_PR_NUMBER=12605 
```

* No change should be detected and early exit should happen:
```
GITHUB_PR_BASE_REPO=cloud-on-k8s
GITHUB_PR_TARGET_BRANCH=main
GITHUB_PR_NUMBER=7537
```