### PR TITLE
Build docs hourly - every 30 min is running into race conditions

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,8 +27,8 @@ spec:
       schedules:
         periodic_docs_build:
           branch: "master"
-          message: "Build the docs every 30 minutes"
-          cronline: "*/30 * * * *"
+          message: "Build the docs hourly"
+          cronline: "@hourly"
       teams:
         docs-build-guild:
           access_level: MANAGE_BUILD_AND_READ


### PR DESCRIPTION
<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
