### PR TITLE
Conditionally run rebuild or incremental build

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -25,6 +25,19 @@ steps:
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   - wait
+  - label: "Full rebuild or incremental rebuild?"
+    if: build.source == "schedule"
+    command: |
+      LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
+      CURRENT_COMMIT=$(git rev-parse HEAD)
+      if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then
+        echo "The docs repo has changed since the last build."
+        export REBUILD="rebuild"
+      else
+        echo "The docs repo has not changed since the last build."
+        export REBUILD=""
+      fi
+  - wait
   - label: ":white_check_mark: Build docs"
     command: |
       export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -25,17 +25,17 @@ steps:
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   - wait
-  - label: "Full rebuild or incremental rebuild?"
+  - label: "Full rebuild or incremental build?"
     if: build.source == "schedule"
     command: |
       LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
       CURRENT_COMMIT=$(git rev-parse HEAD)
       if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then
         echo "The docs repo has changed since the last build."
-        export REBUILD="rebuild"
+        buildkite-agent meta-data set "REBUILD" "rebuild"
       else
         echo "The docs repo has not changed since the last build."
-        export REBUILD=""
+        buildkite-agent meta-data set "REBUILD" ""
       fi
   - wait
   - label: ":white_check_mark: Build docs"


### PR DESCRIPTION
### Summary

In https://github.com/elastic/docs/pull/2929, we reverted to incremental builds run every 30 minutes. This works great, until a PR is merged to the elastic/docs repository. Almost every PR merged in this repo requires a `rebuild` in order for the changes to take effect on `elastic.co/guide/*`.

This PR checks to see if the build commit of `elastic/docs` has changed since the previous scheduled run. If it has changed, we run a full docs rebuild. If it hasn't changed, there's no need for a full rebuild, and we instead run an incremental build. 

I have no idea if this works or how to even begin testing it.