### PR TITLE
Set build type for scheduled builds based on doc repo changes

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,9 +33,9 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      output=$(curl GET https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed -H "Accept: application/json")
+      curl GET https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed
 
-      echo "$output"
+
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
       #   echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -25,6 +25,19 @@ steps:
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   - wait
+  - label: "Full rebuild or incremental rebuild?"
+    if: build.source == "schedule"
+    command: |
+      LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
+      CURRENT_COMMIT=$(git rev-parse HEAD)
+      if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then
+        echo "The docs repo has changed since the last build."
+        export REBUILD="rebuild"
+      else
+        echo "The docs repo has not changed since the last build."
+        export REBUILD=""
+      fi
+  - wait
   - label: ":white_check_mark: Build docs"
     command: |
       export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -25,17 +25,17 @@ steps:
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   - wait
-  - label: "Full rebuild or incremental rebuild?"
+  - label: "Full rebuild or incremental build?"
     if: build.source == "schedule"
     command: |
       LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
       CURRENT_COMMIT=$(git rev-parse HEAD)
       if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then
         echo "The docs repo has changed since the last build."
-        export REBUILD="rebuild"
+        buildkite-agent meta-data set "REBUILD" "rebuild"
       else
         echo "The docs repo has not changed since the last build."
-        export REBUILD=""
+        buildkite-agent meta-data set "REBUILD" ""
       fi
   - wait
   - label: ":white_check_mark: Build docs"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -32,17 +32,18 @@ steps:
     command: |
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
-      GET_PREVIOUS_BUILDS=$(curl https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)
-      echo "$GET_PREVIOUS_BUILDS"
 
-      echo "Last build commit: $(buildkite-agent meta get last_build_commit)"
-      if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
-        echo "The docs repo has changed since the last build."
-        buildkite-agent meta-data set "REBUILD" "rebuild"
-      else
-        echo "The docs repo has not changed since the last build."
-        buildkite-agent meta-data set "REBUILD" ""
-      fi
+      output=$(curl GET https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed -H "Accept: application/json")
+
+      echo "$output"
+
+      # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
+      #   echo "The docs repo has changed since the last build."
+      #   buildkite-agent meta-data set "REBUILD" "rebuild"
+      # else
+      #   echo "The docs repo has not changed since the last build."
+      #   buildkite-agent meta-data set "REBUILD" ""
+      # fi
   - wait
   - label: ":white_check_mark: Build docs"
     command: |

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,9 +33,9 @@ steps:
       LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 
       echo "Build commit: ${BUILDKITE_COMMIT}"
-      echo "Last successful commit: ${LAST_SUCCESSFUL_COMMIT}"
+      echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
 
-      if [[ "${BUILDKITE_COMMIT}" != "${LAST_SUCCESSFUL_COMMIT}" ]]; then
+      if [[ "${BUILDKITE_COMMIT}" != "$LAST_SUCCESSFUL_COMMIT" ]]; then
         echo "The docs repo has changed since the last build."
         buildkite-agent meta-data set "REBUILD" "rebuild"
       else

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -1,32 +1,34 @@
 steps:
-  - input: "Build parameters"
-    if: build.source == "ui"
-    fields:
-      - select: "Rebuild?"
-        key: "REBUILD"
-        default: ""
-        required: false
-        options:
-          - label: "no"
-            value: ""
-          - label: "yes"
-            value: "rebuild"
-        hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
-      - select: "How should broken links be handled?"
-        key: "BROKEN_LINKS"
-        default: ""
-        required: false
-        options:
-          - label: "Continue without warning"
-            value: "skiplinkcheck"
-          - label: "Continue, but log a warning"
-            value: "warnlinkcheck"
-          - label: "Fail the build"
-            value: ""
-        hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
-  - wait
+  # - input: "Build parameters"
+  #   if: build.source == "ui"
+  #   fields:
+  #     - select: "Rebuild?"
+  #       key: "REBUILD"
+  #       default: ""
+  #       required: false
+  #       options:
+  #         - label: "no"
+  #           value: ""
+  #         - label: "yes"
+  #           value: "rebuild"
+  #       hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
+  #     - select: "How should broken links be handled?"
+  #       key: "BROKEN_LINKS"
+  #       default: ""
+  #       required: false
+  #       options:
+  #         - label: "Continue without warning"
+  #           value: "skiplinkcheck"
+  #         - label: "Continue, but log a warning"
+  #           value: "warnlinkcheck"
+  #         - label: "Fail the build"
+  #           value: ""
+  #       hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
+  # - wait
   - label: "Full rebuild or incremental build?"
-    if: build.source == "schedule"
+    # this has to be changed for testing purposes
+    # if: build.source == "schedule"
+    if: build.source == "ui"
     command: |
       LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
       CURRENT_COMMIT=$(git rev-parse HEAD)
@@ -40,8 +42,9 @@ steps:
   - wait
   - label: ":white_check_mark: Build docs"
     command: |
-      export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
-      export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
+      echo REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
+      # export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
+      # export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
       bash .buildkite/scripts/build.sh
     agents:
       provider: "gcp"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -29,25 +29,7 @@ steps:
     # this has to be changed for testing purposes
     # if: build.source == "schedule"
     if: build.source == "ui"
-    command: |
-      curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed >> output.json
-
-      echo "$(LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0]'))"
-
-      # LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0].commit')
-
-      # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
-
-      echo "Build commit: ${BUILDKITE_COMMIT}"
-      echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
-
-      if [[ "${BUILDKITE_COMMIT}" != "$LAST_SUCCESSFUL_COMMIT" ]]; then
-        echo "The docs repo has changed since the last build."
-        buildkite-agent meta-data set "REBUILD" "rebuild"
-      else
-        echo "The docs repo has not changed since the last build."
-        buildkite-agent meta-data set "REBUILD" ""
-      fi
+    command: bash .buildkite/scripts/compare-commits.sh
   - wait
   - label: ":white_check_mark: Build docs"
     command: |

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -35,7 +35,7 @@ steps:
 
       LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0] | {commit: .commit}' )
 
-      if [[ "${BUILDKITE_COMMIT}" != "$LAST_SUCCESSFUL_COMMIT" ]]; then
+      if [[ "${BUILDKITE_COMMIT}" != "${LAST_SUCCESSFUL_COMMIT}" ]]; then
         echo "The docs repo has changed since the last build."
         buildkite-agent meta-data set "REBUILD" "rebuild"
       else

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -28,7 +28,7 @@ steps:
   - label: "Full rebuild or incremental build?"
     # this has to be changed for testing purposes
     #if: build.source == "schedule"
-    command: ".buildkite/scripts/compare-commits.sh"
+    command: ".buildkite/scripts/compare_commits.sh"
   - label: ":white_check_mark: Build docs"
     command: |
       echo REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,15 +33,15 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)
+      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0] | {commit: .commit}' )
 
-      # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
-      #   echo "The docs repo has changed since the last build."
-      #   buildkite-agent meta-data set "REBUILD" "rebuild"
-      # else
-      #   echo "The docs repo has not changed since the last build."
-      #   buildkite-agent meta-data set "REBUILD" ""
-      # fi
+      if [[ "${BUILDKITE_COMMIT}" != "$LAST_SUCCESSFUL_COMMIT" ]]; then
+        echo "The docs repo has changed since the last build."
+        buildkite-agent meta-data set "REBUILD" "rebuild"
+      else
+        echo "The docs repo has not changed since the last build."
+        buildkite-agent meta-data set "REBUILD" ""
+      fi
   - wait
   - label: ":white_check_mark: Build docs"
     command: |

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -32,7 +32,7 @@ steps:
     command: |
       curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed >> output.json
 
-      LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '[.0].commit')
+      LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0].commit')
 
       # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,7 +33,7 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      echo "$(curl -H \"Authorization: Bearer ${BUILDKITE_API_TOKEN}\" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
+      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
       #   echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,10 +30,14 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
-      echo \"Build commit is: ${BUILDKITE_COMMIT}\"
+      # this works
+      echo "Build commit is: ${BUILDKITE_COMMIT}"
+
       LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
       CURRENT_COMMIT=$(git rev-parse HEAD)
-      if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then
+
+      echo "Last build commit: $(buildkite-agent meta get last_build_commit)"
+      if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
         echo "The docs repo has changed since the last build."
         buildkite-agent meta-data set "REBUILD" "rebuild"
       else

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,7 +30,11 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
-      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
+      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
+
+      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0]')
+
+      # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 
       echo "Build commit: ${BUILDKITE_COMMIT}"
       echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,7 +33,7 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0]' )
+      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit' )
 
       echo "${LAST_SUCCESSFUL_COMMIT}"
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,10 +33,7 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      OUTPUT=$(curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed")
-      sleep 15
-      echo $OUTPUT
-
+      echo "$(curl https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
       #   echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -32,7 +32,9 @@ steps:
     command: |
       curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed >> output.json
 
-      LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0].commit')
+      echo $(LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0]'))
+
+      # LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0].commit')
 
       # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -27,10 +27,8 @@ steps:
   # - wait
   - label: "Full rebuild or incremental build?"
     # this has to be changed for testing purposes
-    # if: build.source == "schedule"
-    if: build.source == "ui"
-    command: bash .buildkite/scripts/compare-commits.sh
-  - wait
+    #if: build.source == "schedule"
+    command: ".buildkite/scripts/compare-commits.sh"
   - label: ":white_check_mark: Build docs"
     command: |
       echo REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -38,7 +38,7 @@ steps:
       provider: "gcp"
       image: family/docs-ubuntu-2204
       machineType: ${BUILD_MACHINE_TYPE}
-    concurrency_group: build-docs
+    concurrency_group: build-docs-${BUILDKITE_BRANCH}
     concurrency: 1
 notify:
   - email: "docs-status@elastic.co"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -1,33 +1,32 @@
 steps:
-  # - input: "Build parameters"
-  #   if: build.source == "ui"
-  #   fields:
-  #     - select: "Rebuild?"
-  #       key: "REBUILD"
-  #       default: ""
-  #       required: false
-  #       options:
-  #         - label: "no"
-  #           value: ""
-  #         - label: "yes"
-  #           value: "rebuild"
-  #       hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
-  #     - select: "How should broken links be handled?"
-  #       key: "BROKEN_LINKS"
-  #       default: ""
-  #       required: false
-  #       options:
-  #         - label: "Continue without warning"
-  #           value: "skiplinkcheck"
-  #         - label: "Continue, but log a warning"
-  #           value: "warnlinkcheck"
-  #         - label: "Fail the build"
-  #           value: ""
-  #       hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
-  # - wait
+  - input: "Build parameters"
+    if: build.source == "ui"
+    fields:
+      - select: "Rebuild?"
+        key: "REBUILD"
+        default: ""
+        required: false
+        options:
+          - label: "no"
+            value: ""
+          - label: "yes"
+            value: "rebuild"
+        hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
+      - select: "How should broken links be handled?"
+        key: "BROKEN_LINKS"
+        default: ""
+        required: false
+        options:
+          - label: "Continue without warning"
+            value: "skiplinkcheck"
+          - label: "Continue, but log a warning"
+            value: "warnlinkcheck"
+          - label: "Fail the build"
+            value: ""
+        hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
+  - wait
   - label: "Full rebuild or incremental build?"
-    # this has to be commented out for testing purposes
-    #if: build.source == "schedule"
+    if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
   - label: ":white_check_mark: Build docs"
     command: |

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -32,9 +32,8 @@ steps:
     command: |
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
-
-      LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
-      CURRENT_COMMIT=$(git rev-parse HEAD)
+      GET_PREVIOUS_BUILDS=$(curl https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)
+      echo "$GET_PREVIOUS_BUILDS"
 
       echo "Last build commit: $(buildkite-agent meta get last_build_commit)"
       if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,7 +33,7 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      echo "$(curl https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
+      echo "$(curl -H 'Authorization: Bearer ${BUILDKITE_API_TOKEN}' https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
       #   echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -32,7 +32,7 @@ steps:
     command: |
       curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed >> output.json
 
-      echo $(LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0]'))
+      echo "$(LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0]'))"
 
       # LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0].commit')
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,8 +33,9 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      curl GET https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed
-
+      OUTPUT=$(curl "https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed")
+      sleep 15
+      echo $OUTPUT
 
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,7 +30,9 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
-      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq ".[0].commit")
+      curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed >> output.json
+
+      LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '[.0].commit')
 
       # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,7 +33,7 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      echo "$(curl -H 'Authorization: Bearer ${BUILDKITE_API_TOKEN}' https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
+      echo "$(curl -H \"Authorization: Bearer ${BUILDKITE_API_TOKEN}\" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed)"
 
       # if [[ "${BUILDKITE_COMMIT}" != "$LAST_BUILD_COMMIT" ]]; then
       #   echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -33,7 +33,9 @@ steps:
       # this works
       echo "Build commit is: ${BUILDKITE_COMMIT}"
 
-      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0] | {commit: .commit}' )
+      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0]' )
+
+      echo "${LAST_SUCCESSFUL_COMMIT}"
 
       if [[ "${BUILDKITE_COMMIT}" != "${LAST_SUCCESSFUL_COMMIT}" ]]; then
         echo "The docs repo has changed since the last build."

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,9 +30,7 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
-      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
-
-      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0]')
+      echo $(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq ".[0].commit")
 
       # LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -26,14 +26,13 @@ steps:
   #       hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   # - wait
   - label: "Full rebuild or incremental build?"
-    # this has to be changed for testing purposes
+    # this has to be commented out for testing purposes
     #if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
   - label: ":white_check_mark: Build docs"
     command: |
-      echo REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
-      # export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
-      # export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
+      export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
+      export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
       bash .buildkite/scripts/build.sh
     agents:
       provider: "gcp"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,6 +30,7 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
+      echo \"Build commit is: ${BUILDKITE_COMMIT}\"
       LAST_BUILD_COMMIT=$(buildkite-agent meta get last_build_commit)
       CURRENT_COMMIT=$(git rev-parse HEAD)
       if [[ "$CURRENT_COMMIT" != "$LAST_BUILD_COMMIT" ]]; then

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,12 +30,10 @@ steps:
     # if: build.source == "schedule"
     if: build.source == "ui"
     command: |
-      # this works
-      echo "Build commit is: ${BUILDKITE_COMMIT}"
+      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
 
-      LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit' )
-
-      echo "${LAST_SUCCESSFUL_COMMIT}"
+      echo "Build commit: ${BUILDKITE_COMMIT}"
+      echo "Last successful commit: ${LAST_SUCCESSFUL_COMMIT}"
 
       if [[ "${BUILDKITE_COMMIT}" != "${LAST_SUCCESSFUL_COMMIT}" ]]; then
         echo "The docs repo has changed since the last build."

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -34,6 +34,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
     fi
 elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build" ]];then
     export BUILD_MACHINE_TYPE="n2-highcpu-32"
+    export BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/buildkite_token)
 elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-air-gapped" ]] && [[ "$BUILDKITE_STEP_KEY" == "publish-air-gapped-doc" ]]; then
     export DOCKER_USERNAME=$(retry 5 vault kv get -field=username secret/ci/elastic-docs/docker.elastic.co)
     export DOCKER_PASSWORD=$(retry 5 vault kv get -field=password secret/ci/elastic-docs/docker.elastic.co)

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 set +x
-
+echo "rebuild value: $REBUILD"
+exit 0
 # Configure the git author and committer information
 export GIT_AUTHOR_NAME='Buildkite CI'
 export GIT_AUTHOR_EMAIL='docs-status+buildkite@elastic.co'

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 set +x
-echo "rebuild value: $REBUILD"
-exit 0
+
 # Configure the git author and committer information
 export GIT_AUTHOR_NAME='Buildkite CI'
 export GIT_AUTHOR_EMAIL='docs-status+buildkite@elastic.co'

--- a/.buildkite/scripts/compare_commits.sh
+++ b/.buildkite/scripts/compare_commits.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed > output.json
+
+# LAST_SUCCESSFUL_COMMIT=$(cat output.json | jq '.[0]')
+
+LAST_SUCCESSFUL_COMMIT=$(curl -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed | jq '.[0].commit')
+
+echo "Build commit: ${BUILDKITE_COMMIT}"
+echo "Last successful commit: $LAST_SUCCESSFUL_COMMIT"
+
+if [[ "${BUILDKITE_COMMIT}" != "$LAST_SUCCESSFUL_COMMIT" ]]; then
+  echo "The docs repo has changed since the last build."
+  echo buildkite-agent meta-data set "REBUILD" "rebuild"
+else
+  echo "The docs repo has not changed since the last build."
+  echo buildkite-agent meta-data set "REBUILD" ""
+fi

--- a/.buildkite/scripts/compare_commits.sh
+++ b/.buildkite/scripts/compare_commits.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-last_successful_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/docs-build/builds?branch=master&state=passed"
+last_successful_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds?branch=${BUILDKITE_BRANCH}&state=passed"
 LAST_SUCCESSFUL_COMMIT=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $last_successful_build_url | jq -r '.[0].commit')
 
 echo "Comparing the current docs build commit ${BUILDKITE_COMMIT} to the last successful build commit ${LAST_SUCCESSFUL_COMMIT}"

--- a/.buildkite/scripts/compare_commits.sh
+++ b/.buildkite/scripts/compare_commits.sh
@@ -6,7 +6,7 @@ LAST_SUCCESSFUL_COMMIT=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN
 echo "Comparing the current docs build commit ${BUILDKITE_COMMIT} to the last successful build commit ${LAST_SUCCESSFUL_COMMIT}"
 if [[ "$BUILDKITE_COMMIT" == "$LAST_SUCCESSFUL_COMMIT" ]]; then
   echo "The docs repo has not changed since the last build."
-  buildkite-agent meta-data set "REBUILD" ""
+  buildkite-agent meta-data set "REBUILD" "false"
 else
   echo "The docs repo has changed since the last build."
   buildkite-agent meta-data set "REBUILD" "rebuild"


### PR DESCRIPTION
### Summary

In https://github.com/elastic/docs/pull/2929, we reverted to incremental builds run every 30 minutes. This works great, until a PR is merged to the elastic/docs repository. Almost every PR merged in this repo requires a `rebuild` in order for the changes to take effect on `elastic.co/guide/*`.

This PR updates our scheduled builds to first check to see if the build commit of `elastic/docs` has changed since the previous successful, scheduled run. If the commit **has** changed, we run a full docs rebuild to ensure the elastic/docs changes are propagated to all corners of elastic.co/guide. If the commit **hasn't** changed, there's no need for a full rebuild, and we instead run an incremental build—the faster and cheaper option.

### Testing

Testing this PR is fun and easy!

- You can run the bash script locally.
- You can kick off a BK build here: https://buildkite.com/elastic/docs-build/builds?branch=test-conditional-builds. Note, you must use the penultimate commit: [`c3e8250`](https://github.com/elastic/docs/pull/2931/commits/c3e82508a410a230ce278562ba07ae209d657266). Here's the successful run: https://buildkite.com/elastic/docs-build/builds/3589#018d8ce5-6265-4b9d-a8ff-49e0b8c4612a.