### PR TITLE
Update concurrency rules and limit build queue to one

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -24,6 +24,10 @@ steps:
           - label: "Fail the build"
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
+  - wait
+  - label: "Check for queue"
+    if: build.source == "schedule"
+    command: ".buildkite/scripts/check_queue.sh"
     concurrency: 1
     concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - wait

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -1,6 +1,4 @@
 steps:
-    concurrency_group: docs-build-${BUILDKITE_BRANCH}
-    concurrency: 1
   - input: "Build parameters"
     if: build.source == "ui"
     fields:
@@ -26,10 +24,13 @@ steps:
           - label: "Fail the build"
             value: ""
         hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
+    concurrency: 1
+    concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - wait
   - label: "Full rebuild or incremental build?"
     if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
+    concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - label: ":white_check_mark: Build docs"
     command: |
       export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
@@ -39,6 +40,7 @@ steps:
       provider: "gcp"
       image: family/docs-ubuntu-2204
       machineType: ${BUILD_MACHINE_TYPE}
+    concurrency_group: docs-build-${BUILDKITE_BRANCH}
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -1,36 +1,36 @@
 steps:
-  - input: "Build parameters"
-    if: build.source == "ui"
-    fields:
-      - select: "Rebuild?"
-        key: "REBUILD"
-        default: ""
-        required: false
-        options:
-          - label: "no"
-            value: ""
-          - label: "yes"
-            value: "rebuild"
-        hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
-      - select: "How should broken links be handled?"
-        key: "BROKEN_LINKS"
-        default: ""
-        required: false
-        options:
-          - label: "Continue without warning"
-            value: "skiplinkcheck"
-          - label: "Continue, but log a warning"
-            value: "warnlinkcheck"
-          - label: "Fail the build"
-            value: ""
-        hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
-  - wait
+  # - input: "Build parameters"
+  #   if: build.source == "ui"
+  #   fields:
+  #     - select: "Rebuild?"
+  #       key: "REBUILD"
+  #       default: ""
+  #       required: false
+  #       options:
+  #         - label: "no"
+  #           value: ""
+  #         - label: "yes"
+  #           value: "rebuild"
+  #       hint: "Should all books be rebuilt, regardless of what has changed? Build once with this set to true after every release."
+  #     - select: "How should broken links be handled?"
+  #       key: "BROKEN_LINKS"
+  #       default: ""
+  #       required: false
+  #       options:
+  #         - label: "Continue without warning"
+  #           value: "skiplinkcheck"
+  #         - label: "Continue, but log a warning"
+  #           value: "warnlinkcheck"
+  #         - label: "Fail the build"
+  #           value: ""
+  #       hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
+  # - wait
   - label: "Check for queue"
-    if: build.source == "schedule"
+    # if: build.source == "schedule"
     command: ".buildkite/scripts/check_queue.sh"
   - wait
   - label: "Full rebuild or incremental build?"
-    if: build.source == "schedule"
+    # if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
     concurrency: 1
     concurrency_group: docs-build-${BUILDKITE_BRANCH}

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -28,12 +28,11 @@ steps:
   - label: "Check for queue"
     if: build.source == "schedule"
     command: ".buildkite/scripts/check_queue.sh"
-    concurrency: 1
-    concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - wait
   - label: "Full rebuild or incremental build?"
     if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
+    concurrency: 1
     concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - label: ":white_check_mark: Build docs"
     command: |

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -25,16 +25,28 @@ steps:
   #           value: ""
   #       hint: "Should we ignore checking broken links? Should we allow to run the build without failing if there's a broken link? Ignoring broken links is dangerous not just because bad links will leak into the public site but because subsequent builds and pull requests that do not fix the links fail."
   # - wait
+    # This step is purposefully outside of the concurrency gate
   - label: "Check for queue"
+    key: check-queue
     # if: build.source == "schedule"
     command: ".buildkite/scripts/check_queue.sh"
+  - label: "Start of concurrency gate"
+    key: start-gate
+    depends_on: check-queue
+    command: echo "Start of concurrency gate"
+    concurrency_group: gate/docs-build-${BUILDKITE_BRANCH}
+    concurrency: 1
   - wait
   - label: "Full rebuild or incremental build?"
+    key: build-type
+    depends_on: start-gate
     # if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
     concurrency: 1
     concurrency_group: docs-build-${BUILDKITE_BRANCH}
   - label: ":white_check_mark: Build docs"
+    key: build-docs
+    depends_on: build-type
     command: |
       export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
       export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
@@ -44,6 +56,11 @@ steps:
       image: family/docs-ubuntu-2204
       machineType: ${BUILD_MACHINE_TYPE}
     concurrency_group: docs-build-${BUILDKITE_BRANCH}
+  - label: "End of concurrency gate"
+    key: end-gate
+    depends_on: build-docs
+    command: echo "End of concurrency gate"
+    concurrency_group: gate/docs-build-${BUILDKITE_BRANCH}
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -1,4 +1,6 @@
 steps:
+    concurrency_group: docs-build-${BUILDKITE_BRANCH}
+    concurrency: 1
   - input: "Build parameters"
     if: build.source == "ui"
     fields:
@@ -37,8 +39,6 @@ steps:
       provider: "gcp"
       image: family/docs-ubuntu-2204
       machineType: ${BUILD_MACHINE_TYPE}
-    concurrency_group: build-docs-${BUILDKITE_BRANCH}
-    concurrency: 1
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -30,23 +30,17 @@ steps:
     key: check-queue
     # if: build.source == "schedule"
     command: ".buildkite/scripts/check_queue.sh"
+  - wait
   - label: "Start of concurrency gate"
-    key: start-gate
-    depends_on: check-queue
     command: echo "Start of concurrency gate"
     concurrency_group: gate/docs-build-${BUILDKITE_BRANCH}
     concurrency: 1
   - wait
   - label: "Full rebuild or incremental build?"
-    key: build-type
-    depends_on: start-gate
     # if: build.source == "schedule"
     command: ".buildkite/scripts/compare_commits.sh"
-    concurrency: 1
-    concurrency_group: docs-build-${BUILDKITE_BRANCH}
+  - wait
   - label: ":white_check_mark: Build docs"
-    key: build-docs
-    depends_on: build-type
     command: |
       export REBUILD="$(buildkite-agent meta-data get REBUILD --default '' --log-level fatal)"
       export BROKEN_LINKS="$(buildkite-agent meta-data get BROKEN_LINKS --default '' --log-level fatal)"
@@ -55,12 +49,11 @@ steps:
       provider: "gcp"
       image: family/docs-ubuntu-2204
       machineType: ${BUILD_MACHINE_TYPE}
-    concurrency_group: docs-build-${BUILDKITE_BRANCH}
+  - wait
   - label: "End of concurrency gate"
-    key: end-gate
-    depends_on: build-docs
     command: echo "End of concurrency gate"
     concurrency_group: gate/docs-build-${BUILDKITE_BRANCH}
+    concurrency: 1
 notify:
   - email: "docs-status@elastic.co"
     if: build.state == "failed"

--- a/.buildkite/scripts/check_queue.sh
+++ b/.buildkite/scripts/check_queue.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-last_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds?branch=${BUILDKITE_BRANCH}"
+build_data_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds?branch=${BUILDKITE_BRANCH}"
 cancel_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_JOB_ID}/cancel"
 
 # Don't look at this build (it's running now!)
 # Don't look at the last build (it's okay if it's still running!)
 # Look three builds back instead (if this build is still running,
 # it means there's already one in the queue and we can safely cancel this one)
-THIRD_TO_LAST_BUILD_STATE=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $last_successful_build_url | jq -r '.[2].status')
+THIRD_TO_LAST_BUILD_STATE=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $build_data_url | jq -r '.[2].status')
+
+echo $(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $build_data_url)
 
 echo "Determining if there are multiple builds waiting."
 if [[ "$THIRD_TO_LAST_BUILD_STATE" == "running" ]]; then

--- a/.buildkite/scripts/check_queue.sh
+++ b/.buildkite/scripts/check_queue.sh
@@ -7,9 +7,7 @@ cancel_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/$
 # Don't look at the last build (it's okay if it's still running!)
 # Look three builds back instead (if this build is still running,
 # it means there's already one in the queue and we can safely cancel this one)
-THIRD_TO_LAST_BUILD_STATE=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $build_data_url | jq -r '.[2].status')
-
-echo $(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $build_data_url)
+THIRD_TO_LAST_BUILD_STATE=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $build_data_url | jq -r '.[2].state')
 
 echo "Determining if there are multiple builds waiting."
 if [[ "$THIRD_TO_LAST_BUILD_STATE" == "running" ]]; then

--- a/.buildkite/scripts/check_queue.sh
+++ b/.buildkite/scripts/check_queue.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+last_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds?branch=${BUILDKITE_BRANCH}"
+cancel_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_JOB_ID}/cancel"
+
+LAST_BUILD_STATE=$(curl -s -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $last_successful_build_url | jq -r '.[1].status')
+
+echo "Determining if the last build is currently blocked."
+if [[ "$LAST_BUILD_STATE" == "blocked" ]]; then
+  echo "The pipeline is congested. Canceling this build."
+  curl -sX PUT -H "Authorization: Bearer ${BUILDKITE_API_TOKEN}" $cancel_build_url
+else
+  echo "The pipeline is ready for a new build."
+fi

--- a/.buildkite/scripts/check_queue.sh
+++ b/.buildkite/scripts/check_queue.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 build_data_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds?branch=${BUILDKITE_BRANCH}"
-cancel_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_JOB_ID}/cancel"
+cancel_build_url="https://api.buildkite.com/v2/organizations/elastic/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}/cancel"
 
 # Don't look at this build (it's running now!)
 # Don't look at the last build (it's okay if it's still running!)


### PR DESCRIPTION
### Summary

This PR builds on https://github.com/elastic/docs/pull/2931.

#### Goal 1: Set concurrency at the pipeline level, not the step level.

Pipeline-level concurrency isn't a feature of BK: https://forum.buildkite.community/t/pipeline-concurrency-limit/240. Instead, you have to set concurrency limits on each step in a build within a pipeline. In this implementation, I use a [concurrency gate](https://buildkite.com/blog/concurrency-gates) as it seems to be the cleanest implementation.

In the following screenshot you can see how the concurrency gate prevents new builds from starting the "Build the docs" step and instead holds them at the "Start concurrency gate" step:

<img width="1168" alt="Screenshot 2024-02-09 at 2 19 21 PM" src="https://github.com/elastic/docs/assets/5618806/28032224-1a69-430a-84f0-34a577cdfdd1">

#### Goal 2: Set a queue limit of one running build and one queued build.

The downside of concurrency limits paired with scheduled builds is that the queue for builds will grow if/when we have a `rebuild`. This happens because our `rebuild` build time is way longer (70 mins) than our scheduled build time (30 mins). 

To fix this problem, this PR adds a new first BK build step: check not this build and not the previous build, but the third build back to determine if it is still in a `running` state. If it is, it means we already have a BK build in the queue. We can then safely cancel the current build to prevent the queue from growing. See [this diagram](https://buildkite.com/docs/pipelines/defining-steps#build-states) for more on build states.

Because the `"Full rebuild or incremental build?"` step is concurrency gated, we will only determine the type of build after the previous build has been unblocked. This prevents this step from breaking the functionality added in https://github.com/elastic/docs/pull/2931.

### Testing

Testing this PR is fun and easy. Go here and create a new build: https://buildkite.com/elastic/docs-build/builds?branch=move-concurrency. Wait until an agent is assigned. Once an agent is assigned, create another new build. Repeat this process until you have three builds running.

#### Build 1
The first build should do the following in the **Check for queue** step:
```
2024-02-09 13:14:08 PST | Determining if there are multiple builds waiting.
2024-02-09 13:14:08 PST | The pipeline is ready for a new build.
```
The first build will then run the **✅ Build Docs** step.

#### Build 2
The second build should do the following in the **Check for queue** step:
```
2024-02-09 13:16:08 PST | Determining if there are multiple builds waiting.
2024-02-09 13:16:08 PST | The pipeline is ready for a new build.
```
The second build should say "Waiting on currency group" in the **Start of concurrency** step:
<img width="1180" alt="Screenshot 2024-02-09 at 1 50 00 PM" src="https://github.com/elastic/docs/assets/5618806/d05013c9-40a6-488b-b348-beb60d76e717">

#### Build 3
The third build should do the following in the **Check for queue** step:
```
2024-02-09 22:17:07 UTC | Determining if there are multiple builds waiting.
2024-02-09 22:17:07 UTC | The pipeline is congested. Canceling this build.
```
The third build will then cancel itself. Example: https://buildkite.com/elastic/docs-build/builds/3638

<img width="1209" alt="Screenshot 2024-02-09 at 2 17 35 PM" src="https://github.com/elastic/docs/assets/5618806/86ea285d-3145-47f3-8057-86d530e56e5a">

#### Build 2

Eventually, Build 1 will complete. This will open the concurrency gate and allow Build 2 to enter the **✅ Build Docs** step.