### PR TITLE
🚧 [WIP] Remove attributes with case-sensitive names

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -536,12 +536,3 @@ Legacy definitions
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
-// Use data-sources-caps instead of Data-Sources
-:Data-Sources:         Data Views
-// Use data-source-cap instead of Data-source
-:Data-source:          Data view
-// Use data-sources-cap instead of Data-sources
-:Data-sources:         Data views
-// Do not use A-data-source or a-data-source
-:A-data-source:      A data view
-:a-data-source:      a data view


### PR DESCRIPTION
🚧 WORK IN PROGRESS — More details to come soon. Please hold off on reviewing or commenting.

---
Contributes to https://github.com/elastic/security-docs/issues/4754 by removing attributes with case-sensitive names/keys. AsciiDoc [doesn't actually](https://docs.asciidoctor.org/asciidoc/latest/attributes/names-and-values/) support uppercase attribute names, and these legacy attributes are causing incorrect capitalization of the term "data view" throughout the docs.

### Previews
[add pages to test]

### Related
- https://github.com/elastic/docs.elastic.co/pull/205 — Removes equivalent variables from docs.elastic.co. Those variables aren't causing trouble because Docsmobile seems to support uppercase variable names, but they're still legacy variables that we shouldn't encourage anyone to use.