### PR TITLE
Enable running tests for PR's and forks

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -97,6 +97,26 @@
       "repositories": [
         "elastic/docs"
       ]
+    },
+    {
+      "enabled": true,
+      "pipeline_slug": "docs-test",
+      "allow_org_users": true,
+      "allowed_repo_permissions": [
+        "admin",
+        "write"
+      ],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
+      "build_on_commit": true,
+      "build_on_comment": true,
+      "trigger_comment_regex": "run docs-test",
+      "always_trigger_comment_regex": "run docs-test",
+      "skip_ci_labels": [],
+      "skip_ci_on_only_changed": [],
+      "always_require_ci_on_changed": [],
+      "repositories": [
+        "elastic/docs"
+      ]
     }
   ]
 }

--- a/.buildkite/test_pipeline.yml
+++ b/.buildkite/test_pipeline.yml
@@ -1,10 +1,9 @@
 steps:
   - label: "Execute tests"
     command: ".buildkite/scripts/test.sh"
-    if: build.branch == "master" || build.env("BUILDKITE_PULL_REQUEST") != "false"
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
 notify:
   - email: "docs-status@elastic.co"
-    if: build.state == "failed"
+    if: build.state == "failed" && build.branch == "master"


### PR DESCRIPTION
By default Buildkite can build PRs or branches from the repo but not from forks outside of the org, for security purposes. This PR configure the PR bot so that PR from forks can also run the tests.
PRs from contributors without `admin` or `write` access to the repo will require an explicit `run docs-test` comment to kick-off the tests.


<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
