### PR TITLE
Add version attributes for 8.13.0

### DIFF
--- a/shared/versions/stack/8.13.asciidoc
+++ b/shared/versions/stack/8.13.asciidoc
@@ -1,0 +1,69 @@
+:version:                8.13.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           8.13.0
+:logstash_version:       8.13.0
+:elasticsearch_version:  8.13.0
+:kibana_version:         8.13.0
+:apm_server_version:     8.13.0
+:branch:                 master
+:minor-version:          8.13
+:major-version:          8.x
+:prev-major-version:     7.x
+:prev-major-last:        7.17
+:major-version-only:     8
+:ecs_version:            8.11
+:esf_version:            master
+
+//////////
+Keep the :esf_version: attribute value as master.
+//////////
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
+
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
+////
+APM Agent versions
+////
+:apm-android-branch:    0.x
+:apm-go-branch:         2.x
+:apm-ios-branch:        1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        5.x
+:apm-node-branch:       4.x
+:apm-php-branch:        1.x
+:apm-py-branch:         6.x
+:apm-ruby-branch:       4.x
+:apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging:           master
+:ecs-logging-go-logrus: master
+:ecs-logging-go-zap:    master
+:ecs-logging-go-zerolog: master
+:ecs-logging-java:      1.x
+:ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
+:ecs-logging-php:       master
+:ecs-logging-python:    master
+:ecs-logging-ruby:      master
+
+////
+Synthetics
+////
+:synthetics_version: v1.3.0

--- a/shared/versions/stack/8.13.asciidoc
+++ b/shared/versions/stack/8.13.asciidoc
@@ -7,7 +7,7 @@ bare_version never includes -alpha or -beta
 :elasticsearch_version:  8.13.0
 :kibana_version:         8.13.0
 :apm_server_version:     8.13.0
-:branch:                 master
+:branch:                 8.13
 :minor-version:          8.13
 :major-version:          8.x
 :prev-major-version:     7.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -1,14 +1,14 @@
-:version:                8.12.0
+:version:                8.14.0
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.12.0
-:logstash_version:       8.12.0
-:elasticsearch_version:  8.12.0
-:kibana_version:         8.12.0
-:apm_server_version:     8.12.0
+:bare_version:           8.14.0
+:logstash_version:       8.14.0
+:elasticsearch_version:  8.14.0
+:kibana_version:         8.14.0
+:apm_server_version:     8.14.0
 :branch:                 master
-:minor-version:          8.12
+:minor-version:          8.14
 :major-version:          8.x
 :prev-major-version:     7.x
 :prev-major-last:        7.17


### PR DESCRIPTION
Contributes to https://github.com/elastic/dev/issues/2505 by adding version attributes for 8.13.0.
