### PR TITLE
Bump current version to 8.13

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -77,8 +77,8 @@ contents_title:     Elastic documentation
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.12
-  stacklive: &stacklive [ 8.12, 7.17 ]
+  stackcurrent: &stackcurrent 8.13
+  stacklive: &stacklive [ 8.13, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-103
 

--- a/conf.yaml
+++ b/conf.yaml
@@ -551,7 +551,7 @@ contents:
                         path:   docs
                         exclude_branches:   [ 0.7, 0.6 ]
                         map_branches:
-                          1.x: *stackcurrent
+                          1.x:  main
                   - title:      APM .NET Agent
                     prefix:     dotnet
                     current:    1.x
@@ -590,8 +590,8 @@ contents:
                         path:   docs
                         exclude_branches:   [ 2.x, 1.x, 0.x ]
                         map_branches:
-                          3.x: *stackcurrent
-                          4.x: *stackcurrent
+                          3.x:  main
+                          4.x:  main
                   - title:      APM PHP Agent
                     prefix:     php
                     current:    1.x
@@ -630,7 +630,7 @@ contents:
                         path:   docs
                         exclude_branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x ]
                         map_branches:
-                          6.x: *stackcurrent
+                          6.x:  main
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    4.x

--- a/shared/versions/stack/8.12.asciidoc
+++ b/shared/versions/stack/8.12.asciidoc
@@ -28,7 +28,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.13.asciidoc
+++ b/shared/versions/stack/8.13.asciidoc
@@ -23,12 +23,12 @@ Keep the :esf_version: attribute value as master.
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.12.asciidoc[]
+include::8.13.asciidoc[]


### PR DESCRIPTION
Contributes to https://github.com/elastic/dev/issues/2505 by bumping the current version of documentation to 8.13.

> [!IMPORTANT]
> Do not merge until release day.