### PR TITLE
Bump the docs version to 8.12.2

### DIFF
--- a/shared/versions/stack/8.12.asciidoc
+++ b/shared/versions/stack/8.12.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.12.1
+:version:                8.12.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.12.1
-:logstash_version:       8.12.1
-:elasticsearch_version:  8.12.1
-:kibana_version:         8.12.1
-:apm_server_version:     8.12.1
+:bare_version:           8.12.2
+:logstash_version:       8.12.2
+:elasticsearch_version:  8.12.2
+:kibana_version:         8.12.2
+:apm_server_version:     8.12.2
 :branch:                 8.12
 :minor-version:          8.12
 :major-version:          8.x


### PR DESCRIPTION
Contributes to https://github.com/elastic/dev/issues/2507 by incrementing the docs version to 8.12.2.

> [!IMPORTANT]
> Don't merge this PR until release day.