### PR TITLE
Update link checker to remove period (.) at end of URLs

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -380,8 +380,8 @@ sub check_kibana_links {
                 # We don't want to check any links to www.elastic.co that aren't
                 # part of the docs.
                 $path =~ s/.$//g;
-                # We need to strip the final period off of examples like this: 
-                # refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.
+                # We need to strip the final period off of URLs like this one: 
+                #      'refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.'
                 return "" if $path =~ m/\$\{(?:baseUrl|ELASTIC_WEBSITE_URL|ELASTIC_GITHUB)\}.*/;
                 # Otherwise, return the link to check
                 return ( split /#/, $path );

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -379,9 +379,9 @@ sub check_kibana_links {
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;
                 # We don't want to check any links to www.elastic.co that aren't
                 # part of the docs.
-                $path =~ s/.$//g;
                 # We need to strip the final period off of URLs like this one: 
                 #      'refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.'
+                $path =~ s/.$//g;
                 return "" if $path =~ m/\$\{(?:baseUrl|ELASTIC_WEBSITE_URL|ELASTIC_GITHUB)\}.*/;
                 # Otherwise, return the link to check
                 return ( split /#/, $path );

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -379,7 +379,7 @@ sub check_kibana_links {
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;
                 # We don't want to check any links to www.elastic.co that aren't
                 # part of the docs.
-                $path =~ s/.$/ ./g;
+                $path =~ s/.$//g;
                 # We need to strip the final period off of examples like this: 
                 # refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.
                 return "" if $path =~ m/\$\{(?:baseUrl|ELASTIC_WEBSITE_URL|ELASTIC_GITHUB)\}.*/;

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -379,6 +379,9 @@ sub check_kibana_links {
                 $path =~ s!\$\{(?:baseUrl|ELASTIC_WEBSITE_URL)\}guide/!!;
                 # We don't want to check any links to www.elastic.co that aren't
                 # part of the docs.
+                $path =~ s/.$/ ./g;
+                # We need to strip the final period off of examples like this: 
+                # refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.
                 return "" if $path =~ m/\$\{(?:baseUrl|ELASTIC_WEBSITE_URL|ELASTIC_GITHUB)\}.*/;
                 # Otherwise, return the link to check
                 return ( split /#/, $path );


### PR DESCRIPTION
I think this should work, but I'm not really sure how to test it, so any suggestions would be much appreciated.

Our problem is that links like the following (for example from [this PR](https://github.com/elastic/security-docs/pull/4847/files)):

```
- To configure Fleet Server refer to the https://www.elastic.co/guide/en/fleet/current/fleet-server.html.
```

Are generating errors like these, due to the period (.) at the end of the string:

```
2024-02-21 11:40:23 EST | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/security/8.11/access-of-stored-browser-credentials.html contains broken links to:
-- | --
  | 2024-02-21 11:40:23 EST | INFO:build_docs:   - en/fleet/current/agent-policy.html.
  | 2024-02-21 11:40:23 EST | INFO:build_docs:   - en/fleet/current/fleet-server.html.
```

See this [log](https://buildkite.com/elastic/docs-build-pr/builds/31801#018dcc7a-af86-4d6e-8c92-83d5848c59bc) for example.