### PR TITLE
increase agent disk for pr builds

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -16,6 +16,7 @@ steps:
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
+      diskSizeGb: 150
       machineType: ${BUILD_MACHINE_TYPE}
   - key: "teardown"
     label: "teardown"
@@ -27,3 +28,4 @@ steps:
       fi
     depends_on:
       - step: "build-pr"
+        allow_failure: true


### PR DESCRIPTION
Increase agent disk for PR builds from 100GB to 150GB, we were starting to run out of space.

Add `allow_failure` to `depends_on` stanza so the teardown step runs and updates the PR's status even if the previous step fails.
