### PR TITLE
Move ingest reference architectures up in the ingest section

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1465,6 +1465,22 @@ contents:
 
     -   title:     "Ingest: Add your data"
         sections:
+          - title:      Elastic Ingest Reference Architectures
+            prefix:     en/ingest
+            current:    *stackcurrent
+            index:      docs/en/ingest-arch/index.asciidoc
+            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
+            live:       [ *stackcurrent ]
+            chunk:      1
+            tags:       Ingest/Reference
+            subject:    Ingest
+            sources:
+              -
+                repo:   ingest-docs
+                path:   docs/en
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
@@ -1564,22 +1580,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
-            live:       [ *stackcurrent ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc


### PR DESCRIPTION
Received a request from @karenzone to move the reference architecture docs up in the ingest section because the content is fundamental to choosing which ingest method to use. I think this is OK since the section is not alphabetized anyhow.