### PR TITLE
Add ECK 2.12

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2158,7 +2158,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.11
-            branches:   [ {main: master}, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This adds the ECK `2.12` branch to the branches list.

ECK `2.12.0` is planned for release on March 26th, so this has to be merged 1 day before, March 25th.

Relates to:
- https://github.com/elastic/k8s-dev/issues/488