### PR TITLE
Promote ECK 2.12 branch to current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2157,7 +2157,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.11
+            current:    2.12
             branches:   [ {main: master}, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This sets the ECK 2.12 branch as the current version.

It should only be merged after #2948 and ECK 2.12 is released (planned March 26th).