### PR TITLE
Add dependabot[bot] to the allowed_list

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -9,7 +9,7 @@
         "admin",
         "write"
       ],
-      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",


### PR DESCRIPTION
This will allow triggering docs build on PR's and get the Buildkite status check required for merging.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
