### PR TITLE
Increase agent disk for docs builds

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -36,6 +36,7 @@ steps:
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
+      diskSizeGb: 150
       machineType: ${BUILD_MACHINE_TYPE}
     concurrency_group: build-docs-${BUILDKITE_BRANCH}
     concurrency: 1


### PR DESCRIPTION
Increase VM disk space for docs build process to 150GB, to prevent intermittent breaks where the build runs out of space.

Follows a similar fix from https://github.com/elastic/docs/pull/2946.
