### PR TITLE
ESS - Change current to MS-105

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.12
   stacklive: &stacklive [ 8.12, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-103
+  cloudSaasCurrent: &cloudSaasCurrent ms-105
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-105.
Do not merge until release day.

Rel: [MS-105 Release Notes PR](https://github.com/elastic/cloud/pull/124568)
