### PR TITLE
Adds API reference page to top nav on landing page

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -419,6 +419,7 @@
 <div id="subnavigation" class="subnavigation">
   <p>
     <a class="inline-block mr-3" href="https://www.elastic.co/guide/index.html#viewall">Browse all docs</a>
+    <a class="inline-block mr-3" href="en/starting-with-the-elasticsearch-platform-and-its-solutions/current/api-reference.html">API reference</a>
     <a class="inline-block mr-3" href="en/starting-with-the-elasticsearch-platform-and-its-solutions/current/new.html">Release docs</a>
   </p>
 </div>


### PR DESCRIPTION
Adds `API reference` to the top nav so users can easily access the single location for all Elastic API documentation. 