### PR TITLE
Revert "Move ingest reference architectures up in the ingest section"

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1465,22 +1465,6 @@ contents:
 
     -   title:     "Ingest: Add your data"
         sections:
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
-            live:       [ *stackcurrent ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent


### PR DESCRIPTION
Reverts elastic/docs#2947