### PR TITLE
Adds 8.13 branch to Ingest Ref book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1469,7 +1469,7 @@ contents:
             prefix:     en/ingest
             current:    *stackcurrent
             index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.12, 8.11, 8.10, 8.9 ]
+            branches:   [ {main: master}, 8.13, 8.12, 8.11, 8.10, 8.9 ]
             live:       [ *stackcurrent ]
             chunk:      1
             tags:       Ingest/Reference


### PR DESCRIPTION
## Overview

This PR makes it possible to generate a `8.13` branch to the Ingest Ref book.