### PR TITLE
Test only: Bump Cloud docs to latest master branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.12
   stacklive: &stacklive [ 8.12, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-106
+  cloudSaasCurrent: &cloudSaasCurrent master
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main

--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.12
   stacklive: &stacklive [ 8.12, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-103
+  cloudSaasCurrent: &cloudSaasCurrent ms-106
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-92: main


### PR DESCRIPTION
Please ignore me, I'm just a humble test PR.

While I move and remove some directories in the elastic/cloud repo, I hope to pre-emptively catch any breakages that could occur when Cloud docs are bumped to the milestone where those changes are happening. Right now that's `ms-106`.
