### PR TITLE
Remove duplicate Ingest Ref Architectures entry from conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1583,22 +1583,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Elastic Ingest Reference Architectures
-            prefix:     en/ingest
-            current:    *stackcurrent
-            index:      docs/en/ingest-arch/index.asciidoc
-            branches:   [ {main: master}, 8.13, 8.12, 8.11, 8.10, 8.9 ]
-            live:       [ *stackcurrent ]
-            chunk:      1
-            tags:       Ingest/Reference
-            subject:    Ingest
-            sources:
-              -
-                repo:   ingest-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent


### PR DESCRIPTION
Fixes the following in the ingest-docs PRs:
```
2024-03-13 07:06:34 EDT | INFO:build_docs:--keep_hash can't build on top of --sub_dir at lib/ES/Repo.pm line 410.
-- | --
  | 2024-03-13 07:07:00 EDT | 🚨 Error: The command exited with status 255
  | 2024-03-13 07:07:00 EDT | user command error: exit status 255


```