### PR TITLE
Bump the docs version to 7.17.19

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.18
+:version:                7.17.19
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.18
-:logstash_version:       7.17.18
-:elasticsearch_version:  7.17.18
-:kibana_version:         7.17.18
-:apm_server_version:     7.17.18
+:bare_version:           7.17.19
+:logstash_version:       7.17.19
+:elasticsearch_version:  7.17.19
+:kibana_version:         7.17.19
+:apm_server_version:     7.17.19
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
Contributes to https://github.com/elastic/dev/issues/2525 by incrementing the docs version to 7.17.19.

> [!IMPORTANT]
> Don't merge this PR until release day.
