### PR TITLE
Remove duplicate data view attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -538,6 +538,4 @@ Legacy definitions
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
-// Do not use A-data-source or a-data-source
-:A-data-source:      A data view
-:a-data-source:      a data view
+:a-data-source:        a data view

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -249,7 +249,9 @@ Kibana app and UI names
 :data-sources-caps:  Data Views
 :data-source-cap:    Data view
 :data-sources-cap:   Data views
-
+// Use data-source-cap instead of Data-source
+// Use data-sources-cap instead of Data-sources
+// Use data-sources-caps instead of Data-Sources
 
 //////////
 Enterprise Search
@@ -536,12 +538,6 @@ Legacy definitions
 :apm-overview-ref-70:  https://www.elastic.co/guide/en/apm/get-started/7.0
 :apm-overview-ref-m:   https://www.elastic.co/guide/en/apm/get-started/master
 :infra-guide:          https://www.elastic.co/guide/en/infrastructure/guide/{branch}
-// Use data-sources-caps instead of Data-Sources
-:Data-Sources:         Data Views
-// Use data-source-cap instead of Data-source
-:Data-source:          Data view
-// Use data-sources-cap instead of Data-sources
-:Data-sources:         Data views
 // Do not use A-data-source or a-data-source
 :A-data-source:      A data view
 :a-data-source:      a data view


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2778, https://github.com/elastic/kibana/pull/178759

Per https://docs.asciidoctor.org/asciidoc/latest/attributes/names-and-values/ "Although uppercase characters are permitted in an attribute name, the name is converted to lowercase before being stored. For example, URL-REPO and URL-Repo are treated as url-repo when a document is loaded or converted. A best practice is to only use lowercase letters in the name and avoid starting the name with a number".  Therefore the "legacy" attributes like `Data-Sources` are considered to be the same as `data-sources` and since the former appears later in the attributes file, its value is used in pages such as:

https://www.elastic.co/guide/en/kibana/current/introduction.html

![image](https://github.com/elastic/docs/assets/26471269/21a02b02-6c94-4b8b-9f34-3001d5e427e3)

https://www.elastic.co/guide/en/kibana/current/dashboard.html

![image](https://github.com/elastic/docs/assets/26471269/9e5ec346-27d1-409c-93bf-18879dc03807)

This PR therefore removes the problematic case-sensitive attribute names.