### PR TITLE
Remove z-index for edit button to prepare for incoming nav refactor

### DIFF
--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -62,7 +62,6 @@
     position: absolute;
     font-size: 14px;
     top: 0;
-    z-index: 1000;
     padding-top: 26px;
     line-height: 1;
     opacity: 0.3;


### PR DESCRIPTION
We have a new navigation refactor coming in. Despite setting the z-index for the dropdowns in the new navigation to larger than 1000 (as seen in this PR), the browsers still didn't respect the enforcement. This is also a better long term way as the z-index isn't necessary on this element. In addition, the main bug here is that `opacity: 0.3` created a new stacking order that broke any z-index declarations.