### PR TITLE
Remove Amazon Firehose guide

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1564,25 +1564,6 @@ contents:
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc
-          - title:      Amazon Kinesis Data Firehose Ingest Guide
-            prefix:     en/kinesis
-            index:      docs/en/aws-firehose/index.asciidoc
-            current:    main
-            branches:   [ {main: master} ]
-            live:       [ main ]
-            chunk:      1
-            tags:       Cloud Native Ingest/Reference
-            subject:    cloud native ingest
-            sources:
-              -
-                repo:   observability-docs
-                path:   docs/en
-              -
-                repo:   docs
-                path:   shared/versions/stack/{version}.asciidoc
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Elastic Logging Plugin for Docker
             prefix:     en/beats/loggingplugin
             current:    *stackcurrent


### PR DESCRIPTION
This PR removes the entire Amazon Kinesis Data Firehose Ingest Guide https://www.elastic.co/guide/en/kinesis/current/index.html because:

- most of this content is out-of-date
- the updated pages will live in the AWS Monitoring section (Observability docset)

