### PR TITLE
Add AWS attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -280,6 +280,7 @@ Ingest terms
 //////////
 Common words and phrases
 //////////
+:aws:             AWS
 :stack:           Elastic Stack
 :xpack:           X-Pack
 :es:              Elasticsearch


### PR DESCRIPTION
As book-scoped attributes are no longer supported, this PR proposes to add the AWS attribute that is used in the AWS Monitoring docs.