### PR TITLE
Add "Try Console" selector to the Console Widget

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1104,7 +1104,7 @@ Code blocks can be followed by a "Copy as curl" link which will convert the
 snippet into a sequence of calls to the ubiquitous
 https://curl.se/[curl] tool that work in the bash shell and copy it to
 the clipboard. Similarly, if the target of the snippet is Elasticsearch we also
-add a "View in Console" link will open the code snippet in Console.
+add a "Try in Console" link will open the code snippet in Console.
 
 You enable it by setting the "language" of the snippet to a supported
 language. The options are "console" for Elasticsearch, "kibana" for Kibana,
@@ -1113,7 +1113,7 @@ for Elastic Cloud Enterprise.
 
 For Elasticsearch do this:
 
-.Code block with "Copy as curl" and "View in Console" link for Elasticsearch
+.Code block with "Copy as curl" and "Try in Console" link for Elasticsearch
 ==================================
 [source,asciidoc]
 --

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -31,34 +31,79 @@ export class _ConsoleForm extends Component {
     const getValueFromState = field => state[`${props.setting}_${field}`]
     const getFieldName = field => `${props.setting}_${field}`
 
-    return <form>
-      <label for="url">{props.langStrings(props.url_label)}</label>
-      <input id="url" type="text" value={getValueFromState("url")} onInput={linkState(this, getFieldName("url"))} />
+    return (
+      <form>
+        <label for="url">{props.langStrings(props.url_label)}</label>
+        <input
+          id="url"
+          type="text"
+          value={getValueFromState('url')}
+          onInput={linkState(this, getFieldName('url'))}
+        />
 
-      <label for="curl_host">curl {props.langStrings('host')}</label>
-      <input id="curl_host" type="text" value={getValueFromState("curl_host")} onInput={linkState(this, getFieldName("curl_host"))} />
+        <label for="curl_host">curl {props.langStrings('host')}</label>
+        <input
+          id="curl_host"
+          type="text"
+          value={getValueFromState('curl_host')}
+          onInput={linkState(this, getFieldName('curl_host'))}
+        />
 
-      <label for="curl_username">curl {props.langStrings('username')}</label>
-      <input id="curl_username" type="text" value={getValueFromState("curl_user")} onInput={linkState(this, getFieldName("curl_user"))} />
+        <label for="curl_username">curl {props.langStrings('username')}</label>
+        <input
+          id="curl_username"
+          type="text"
+          value={getValueFromState('curl_user')}
+          onInput={linkState(this, getFieldName('curl_user'))}
+        />
 
-      {/* TODO
+        {/* TODO
       <label for="curl_pw" title={props.langStrings("curl_pw_title")}>curl {props.langStrings('password')}</label>
       <input id="curl_pw" title={props.langStrings("curl_pw_title")} type="text" value={getValueFromState("curl_password")} onInput={linkState(this, getFieldName("curl_password"))} />
        */}
-      <button id="save_url" type="button" onClick={e => props.saveSettings(this.state)}>
-        {props.langStrings("Save")}
-      </button>
+        <button
+          id="save_url"
+          type="button"
+          onClick={(e) => props.saveSettings(this.state)}
+        >
+          {props.langStrings('Save')}
+        </button>
 
-      <button id="reset" onClick={e => this.setState(omit(['langStrings', 'saveSettings', 'url_label', 'setting'], props))} type="button">Reset</button>
-      <p>
-        {props.langStrings('Or install')}
-        {props.setting === "sense_url"
-         ? <a href="https://www.elastic.co/guide/en/sense/current/installing.html">the Sense 2 {props.langStrings('editor')}</a>
-         : <a href="https://www.elastic.co/guide/en/kibana/master/setup.html">Kibana</a>
-        }
-         {props.langStrings('.')}
-      </p>
-    </form>
+        <button
+          id="reset"
+          onClick={(e) =>
+            this.setState(
+              omit(
+                ['langStrings', 'saveSettings', 'url_label', 'setting'],
+                props
+              )
+            )
+          }
+          type="button"
+        >
+          Reset
+        </button>
+        <p className="console_help_text">
+          {props.langStrings('For information on how to set up and run')}
+          {props.setting === 'sense_url' ? (
+            <span>
+              &nbsp;the Sense 2 {props.langStrings('editor')} check&nbsp;
+              <a href="https://www.elastic.co/guide/en/sense/current/installing.html">
+                Installing Sense
+              </a>
+            </span>
+          ) : (
+            <span>
+              &nbsp;Kibana, check&nbsp;
+              <a href="https://www.elastic.co/guide/en/kibana/master/setup.html">
+                Set up
+              </a>
+            </span>
+          )}
+          {props.langStrings('.')}
+        </p>
+      </form>
+    )
   }
 }
 

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -81,6 +81,7 @@ export class _TryConsoleSelector extends Component {
         <p>We were unable to detect a running console server.</p>
         <p>
           <a
+            id="try_console_selector_try_cloud_button"
             className="button btn-primary btn-small"
             href="https://cloud.elastic.co/registration"
             target="_blank"
@@ -90,6 +91,7 @@ export class _TryConsoleSelector extends Component {
         </p>
         <p>
           <a
+            id="try_console_selector_install_elasticsearch_button"
             href="https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html"
             target="_blank"
           >
@@ -97,7 +99,11 @@ export class _TryConsoleSelector extends Component {
           </a>
         </p>
         <p>
-          <a href="#" onClick={handleConfigureClick}>
+          <a
+            id="try_console_selector_configure_example_widget_button"
+            href="#"
+            onClick={handleConfigureClick}
+          >
             Configure the example widget
           </a>
         </p>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -131,7 +131,7 @@ export class _TryConsoleSelector extends Component {
             href="https://cloud.elastic.co/registration"
             target="_blank"
           >
-            Start a free Cloud trial
+            Start a free Elastic Cloud trial
           </a>
         </p>
         <p>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -86,7 +86,7 @@ export class _TryConsoleSelector extends Component {
             href="https://cloud.elastic.co/registration"
             target="_blank"
           >
-            Sign up for Elastic Cloud trial
+            Start a free Cloud trial
           </a>
         </p>
         <p>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -92,7 +92,7 @@ export class _TryConsoleSelector extends Component {
         <p>
           <a
             id="try_console_selector_install_elasticsearch_button"
-            href="https://www.elastic.co/guide/en/elasticsearch/reference/current/setup.html"
+            href="https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html"
             target="_blank"
           >
             Install Elasticsearch and Kibana locally

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -78,7 +78,7 @@ export class _TryConsoleSelector extends Component {
     return (
       <div className="try_console_selector">
         <h4>Try in Console</h4>
-        <p>We were unable to detect a running console server.</p>
+        <p>We were unable to detect a running Console server.</p>
         <p>
           <a
             id="try_console_selector_try_cloud_button"

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -104,7 +104,7 @@ export class _TryConsoleSelector extends Component {
             href="#"
             onClick={handleConfigureClick}
           >
-            Configure the example widget
+            Configure Console settings
           </a>
         </p>
       </div>

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -114,7 +114,7 @@ export function init_console_widgets() {
 
     return mount(div, ConsoleWidget, {setting: "console",
                                       url_label: 'Enter the URL of the Console editor',
-                                      view_in_text: 'View in Console',
+                                      view_in_text: 'Try in Console',
                                       configure_text: 'Configure Console URL',
                                       addPretty: true,
                                       consoleText,

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -292,7 +292,8 @@ $(function() {
   var lang = $('section#guide[lang]').attr('lang') || 'en';
 
   const default_kibana_url  = 'http://localhost:5601',
-        default_console_url = default_kibana_url + '/app/kibana#/dev_tools/console',
+        default_base_path   = '/zzz', // Since the original implementation, the base path was added and most users use it.
+        default_console_url = default_kibana_url + default_base_path + '/app/kibana#/dev_tools/console',
         default_sense_url   = default_kibana_url + '/app/sense/',
         default_ess_url     = 'http://localhost:5601', // localhost is wrong, but we'll enhance this later
         default_ece_url     = 'http://localhost:5601',

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -113,7 +113,7 @@ export function init_console_widgets() {
           langs       = div.attr("class").split(" ").filter(c => c.startsWith("has-")).map(function(string) { return string.substring(4) });
 
     return mount(div, ConsoleWidget, {setting: "console",
-                                      url_label: 'Enter the URL of the Console editor',
+                                      url_label: 'Console URL',
                                       view_in_text: 'Try in Console',
                                       configure_text: 'Configure Console URL',
                                       addPretty: true,
@@ -139,7 +139,7 @@ export function init_sense_widgets() {
           consoleText = div.prev().text() + '\n';
 
     return mount(div, ConsoleWidget, {setting: "sense",
-                                      url_label: 'Enter the URL of the Sense editor',
+                                      url_label: 'Sense URL',
                                       view_in_text: 'View in Sense',
                                       configure_text: 'Configure Sense URL',
                                       addPretty: true,

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -65,8 +65,8 @@ export const lang_spec = {
   "View in Sense": {
     "zh_cn": "在 Sense 中查看"
   },
-  "View in Console": {
-    "zh_cn": "在 Console 中查看"
+  "Try in Console": {
+    "zh_cn": "在 Console 中尝试"
   },
   "curl_pw_title": {
     "en": "The password is stored in memory and will be reset after a page reload",

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -29,11 +29,14 @@ export const lang_spec = {
   "Default Kibana URL": {
     "zh_cn": "默认 Kibana URL"
   },
-  "Enter the URL of the Console editor": {
-    "zh_cn": "输入 Console 编辑器的 URL"
+  "Console URL": {
+    "zh_cn": "Console URL"
   },
-  "Enter the URL of the Sense editor": {
-    "zh_cn": "输入 Sense 编辑器的 URL"
+  "Sense URL": {
+    "zh_cn": "Sense URL"
+  },
+  "For information on how to set up and run": {
+    "zh_cn": "有关如何设置和运行的信息"
   },
   "Enter the URL of Kibana": {
     "zh_cn": "输入 Kibana 的 URL"

--- a/resources/web/style/console_widget.pcss
+++ b/resources/web/style/console_widget.pcss
@@ -74,3 +74,7 @@
     cursor: pointer;
   }
 }
+
+p.console_help_text {
+  font-size: 15px;
+}

--- a/resources/web/style/console_widget.pcss
+++ b/resources/web/style/console_widget.pcss
@@ -61,3 +61,16 @@
     background-image: inline("img/check.svg");
   }
 }
+
+.try_console_selector {
+  text-align: center;
+
+  h4 {
+    font-size: 30px;
+  }
+
+  a.button {
+    margin: 10px auto;
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
Updates the "View Console" link to say "Try Console" and adds a selector to the Console Widget, when the server cannot be reached.

![image](https://github.com/elastic/docs/assets/1869731/68506357-1b18-4cb7-960f-29e323238609)

[Example](https://docs_bk_2974.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/getting-started.html#add-single-document)

Demo:

https://github.com/elastic/docs/assets/1869731/ac627840-9653-4683-8e33-e23ce8c2a226
