### PR TITLE
Change current for ECE docs to 3.7.0

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,6 +83,7 @@ variables:
   cloudSaasCurrent: &cloudSaasCurrent ms-105
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-105: main
     ms-92: main
     ms-81: main
     ms-78: main
@@ -2046,8 +2047,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-92
+            current:    ms-105
             live:
+              - ms-105
               - ms-92
               - ms-81
               - ms-78
@@ -2056,6 +2058,7 @@ contents:
               - ms-70
               - ms-69
             branches:
+              - ms-105: 3.7
               - ms-92: 3.6
               - ms-81: 3.5
               - ms-78: 3.4
@@ -2095,6 +2098,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-105: master
                   ms-92: master
                   ms-81: master
                   ms-78: master


### PR DESCRIPTION
This changes "current" for the ECE docs to version 3.7.0.
Do not merge until release day (April 10th 2024)
