### PR TITLE
Update code example widget

### DIFF
--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -33,7 +33,7 @@ export class _ConsoleForm extends Component {
 
     return (
       <form>
-         <p><strong>Want to use the Kibana Console?</strong></p>
+         <p><strong>Dev Tools Console settings</strong></p>
         <label for="url">{props.langStrings(props.url_label)}</label>
         <input
           id="url"
@@ -42,7 +42,7 @@ export class _ConsoleForm extends Component {
           onInput={linkState(this, getFieldName('url'))}
         />
         <p></p>
-        <p><strong>Want to use curl? (basic auth)</strong></p>
+        <p><strong>curl settings (basic auth)</strong></p>
         <label for="curl_host">Elasticsearch {props.langStrings('host')}</label>
         <input
           id="curl_host"
@@ -124,34 +124,33 @@ export class _TryConsoleSelector extends Component {
 
     return (
       <div className="try_console_selector">
-        <h4>Set your Kibana Console URL</h4>
-        <p><strong>Console</strong> is Elastic's native API client in the Kibana UI. Go to <strong>Dev Tools > Console</strong>, copy the URL, and
+        <h4>Try code examples in Elastic</h4>
+        <p>To run code examples in your Dev Tools Console, add your Console URL to  {' '}
        <a
             id="try_console_selector_configure_example_widget_button"
             href="#"
             onClick={handleConfigureClick}
           >
-          {' '} add the setting.
+         the settings.
           </a>
           </p>
-        <p><em>Don't have an Elastic deployment yet?</em></p>  
-        <div style={{ display: 'flex', justifyContent: 'space-between'}}>
+        <p><em>New to Elastic?</em></p>  
+        <div className="try_console_new_to_elastic_buttons">
+
           <a
             id="try_console_selector_try_cloud_button"
             className="button btn-primary btn-small"
             href="https://cloud.elastic.co/registration"
             target="_blank"
           >
-            Start free Elastic Cloud trial
+            Start free Cloud trial
           </a>
         <p> 
           <a
-            id="try_console_selector_install_elasticsearch_button"
-            className="button btn-secondary btn-small"
             href="https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html"
             target="_blank"
           >
-             Install Elastic stack locally
+             Install locally
           </a>
         </p>
         </div>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -96,7 +96,7 @@ export class _ConsoleForm extends Component {
             </span>
           ) : (
             <span>
-              &nbsp;Kibana, check&nbsp;
+              &nbsp;Kibana, refer to&nbsp;
               <a href="https://www.elastic.co/guide/en/kibana/master/setup.html">
                 Set up
               </a>

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -41,7 +41,9 @@ export class _ConsoleForm extends Component {
           value={getValueFromState('url')}
           onInput={linkState(this, getFieldName('url'))}
         />
-        <p></p>
+        <p>Learn more about the Dev Tools&nbsp;
+        <a href="https://www.elastic.co/guide/en/kibana/current/console-kibana.html">Console</a>.
+        </p>
         <p><strong>curl settings (basic auth)</strong></p>
         <label for="curl_host">Elasticsearch {props.langStrings('host')}</label>
         <input
@@ -125,14 +127,15 @@ export class _TryConsoleSelector extends Component {
     return (
       <div className="try_console_selector">
         <h4>Try code examples in Elastic</h4>
-        <p>To run code examples in your Dev Tools Console, add your Console URL to  {' '}
+        <p>To run code examples in your Dev Tools Console, add your Console URL to&nbsp;
        <a
             id="try_console_selector_configure_example_widget_button"
             href="#"
             onClick={handleConfigureClick}
           >
-         the settings.
+        the settings
           </a>
+          .
           </p>
         <p><em>New to Elastic?</em></p>  
         <div className="try_console_new_to_elastic_buttons">

--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -33,6 +33,7 @@ export class _ConsoleForm extends Component {
 
     return (
       <form>
+         <p><strong>Want to use the Kibana Console?</strong></p>
         <label for="url">{props.langStrings(props.url_label)}</label>
         <input
           id="url"
@@ -40,8 +41,9 @@ export class _ConsoleForm extends Component {
           value={getValueFromState('url')}
           onInput={linkState(this, getFieldName('url'))}
         />
-
-        <label for="curl_host">curl {props.langStrings('host')}</label>
+        <p></p>
+        <p><strong>Want to use curl? (basic auth)</strong></p>
+        <label for="curl_host">Elasticsearch {props.langStrings('host')}</label>
         <input
           id="curl_host"
           type="text"
@@ -49,7 +51,7 @@ export class _ConsoleForm extends Component {
           onInput={linkState(this, getFieldName('curl_host'))}
         />
 
-        <label for="curl_username">curl {props.langStrings('username')}</label>
+        <label for="curl_username">Elasticsearch {props.langStrings('username')}</label>
         <input
           id="curl_username"
           type="text"
@@ -122,36 +124,37 @@ export class _TryConsoleSelector extends Component {
 
     return (
       <div className="try_console_selector">
-        <h4>Try in Console</h4>
-        <p>We were unable to detect a running Console server.</p>
-        <p>
+        <h4>Set your Kibana Console URL</h4>
+        <p><strong>Console</strong> is Elastic's native API client in the Kibana UI. Go to <strong>Dev Tools > Console</strong>, copy the URL, and
+       <a
+            id="try_console_selector_configure_example_widget_button"
+            href="#"
+            onClick={handleConfigureClick}
+          >
+          {' '} add the setting.
+          </a>
+          </p>
+        <p><em>Don't have an Elastic deployment yet?</em></p>  
+        <div style={{ display: 'flex', justifyContent: 'space-between'}}>
           <a
             id="try_console_selector_try_cloud_button"
             className="button btn-primary btn-small"
             href="https://cloud.elastic.co/registration"
             target="_blank"
           >
-            Start a free Elastic Cloud trial
+            Start free Elastic Cloud trial
           </a>
-        </p>
-        <p>
+        <p> 
           <a
             id="try_console_selector_install_elasticsearch_button"
+            className="button btn-secondary btn-small"
             href="https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html"
             target="_blank"
           >
-            Install Elasticsearch and Kibana locally
+             Install Elastic stack locally
           </a>
         </p>
-        <p>
-          <a
-            id="try_console_selector_configure_example_widget_button"
-            href="#"
-            onClick={handleConfigureClick}
-          >
-            Configure Console settings
-          </a>
-        </p>
+        </div>
       </div>
     )
   }

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -114,7 +114,7 @@ export function init_console_widgets() {
 
     return mount(div, ConsoleWidget, {setting: "console",
                                       url_label: 'Console URL',
-                                      view_in_text: 'Try in Elastic Console',
+                                      view_in_text: 'Try in Elastic',
                                       configure_text: 'Configure Console URL',
                                       addPretty: true,
                                       consoleText,

--- a/resources/web/docs_js/index.js
+++ b/resources/web/docs_js/index.js
@@ -114,7 +114,7 @@ export function init_console_widgets() {
 
     return mount(div, ConsoleWidget, {setting: "console",
                                       url_label: 'Console URL',
-                                      view_in_text: 'Try in Console',
+                                      view_in_text: 'Try in Elastic Console',
                                       configure_text: 'Configure Console URL',
                                       addPretty: true,
                                       consoleText,

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -68,8 +68,8 @@ export const lang_spec = {
   "View in Sense": {
     "zh_cn": "在 Sense 中查看"
   },
-  "Try in Elastic Console": {
-    "zh_cn": "在 Elastic Console 中尝试"
+  "Try in Elastic": {
+    "zh_cn": "在 Elastic 中尝试"
   },
   "curl_pw_title": {
     "en": "The password is stored in memory and will be reset after a page reload",

--- a/resources/web/docs_js/localization.js
+++ b/resources/web/docs_js/localization.js
@@ -68,8 +68,8 @@ export const lang_spec = {
   "View in Sense": {
     "zh_cn": "在 Sense 中查看"
   },
-  "Try in Console": {
-    "zh_cn": "在 Console 中尝试"
+  "Try in Elastic Console": {
+    "zh_cn": "在 Elastic Console 中尝试"
   },
   "curl_pw_title": {
     "en": "The password is stored in memory and will be reset after a page reload",


### PR DESCRIPTION
## Summary

- Updates UI copy from https://github.com/elastic/docs/pull/2974
- Tries to help orient users who don't know what Kibana or Console is yet
  - The CTA is "Set your Kibana Console URL" 
  - Makes "Try in Console" button more explicit: "Try in Elastic Console"
  - Focuses on helping users set up their Console URL first and foremost
  - Clearly separates this from new users who don't yet have deployment, making cloud and local installations sibling buttons with emphasis on Cloud

In configuration itself:

- Clearly separates the Console and curl setup, as these are two different flows
- Fixes bugs like "curl username" and "curl password" by `s/curl/elasticsearch`


## Before / After

### Widget "Try" button

**Before**
![image](https://github.com/elastic/docs/assets/1869731/bb0d0b32-8cd6-4319-b60b-cfff1517fade)
**After**

<img width="846" alt="Screenshot 2024-04-16 at 11 53 14" src="https://github.com/elastic/docs/assets/32779855/7ee66f5c-c7c5-4f51-9bf3-7fff037e6b33">


### Modal
**Before**
![image](https://github.com/elastic/docs/assets/1869731/78dd13a6-fc36-41ac-9e8a-84bae0f19b0d)
**After**

<img width="562" alt="Screenshot 2024-04-16 at 11 53 01" src="https://github.com/elastic/docs/assets/32779855/95b1fcc3-fb1e-4638-a658-f55b1e3fbbf7">


### Configuration settings
**Before**
![image](https://github.com/elastic/docs/assets/1869731/81b06434-42fb-4215-9a48-e2e35a876603)
**After**

<img width="593" alt="Screenshot 2024-04-16 at 12 30 49" src="https://github.com/elastic/docs/assets/32779855/7acecf6f-2882-4490-afde-c5a55565d494">

## Test it

Here's a [page](https://docs_bk_2979.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/getting-started.html)


## ℹ️ 

Tests will probably fail, and code edits are probably very hacky, I'll do my best to fix whatever I can without putting work on other folks' laps (@scottybollinger 😉 🙏 )