### PR TITLE
Revert "Bumps the docs version to 7.17.20 (#2978)"

### DIFF
--- a/shared/versions/stack/7.17.asciidoc
+++ b/shared/versions/stack/7.17.asciidoc
@@ -1,12 +1,12 @@
-:version:                7.17.20
+:version:                7.17.19
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           7.17.20
-:logstash_version:       7.17.20
-:elasticsearch_version:  7.17.20
-:kibana_version:         7.17.20
-:apm_server_version:     7.17.20
+:bare_version:           7.17.19
+:logstash_version:       7.17.19
+:elasticsearch_version:  7.17.19
+:kibana_version:         7.17.19
+:apm_server_version:     7.17.19
 :branch:                 7.17
 :minor-version:          7.17
 :major-version:          7.x


### PR DESCRIPTION
This reverts commit 9af2730fdbe41e403cff76af41c5bded525710eb.

