### PR TITLE
preview: Use dumb-init as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,10 @@ RUN install_packages \
     # Used both to install dependencies and at run time
   bash less \
     # Just in case you have to shell into the image
-  locales
+  locales \
     # Deal with utf-8 characters properly
+  dumb-init
+    # Reap zombie git gc processes
 RUN echo 'en_US.UTF-8 UTF-8' > /etc/locale.gen && locale-gen
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/preview/Dockerfile
+++ b/preview/Dockerfile
@@ -25,4 +25,5 @@ COPY preview /docs_build/preview
 COPY template /docs_build/template
 COPY resources /docs_build/resources
 
+ENTRYPOINT ["dumb-init", "--"]
 CMD ["/docs_build/build_docs.pl", "--in_standard_docker", "--preview"]

--- a/preview/build.sh
+++ b/preview/build.sh
@@ -5,7 +5,7 @@
 set -eo pipefail
 
 export IMAGE=docker.elastic.co/docs/preview
-export VERSION=17
+export VERSION=18
 
 cd $(git rev-parse --show-toplevel)
 ./build_docs --docker-build build


### PR DESCRIPTION
`build_docs.pl` runs a number of git commands through its normal course of operation. After a certain point, these git commands will implicitly run `git gc` in the background. By design, the original git process forks off the gc child process and forgets about it. The child process will get reparented to PID 1, which is either `build_docs.pl` or a shell. Neither of those will handle `SIGCHLD` for processes they're not aware of, so the number of zombie processes grows indefinitely.

With a large number of zombie processes (80k processes observed in elastic-apps-web), metricbeat starts consuming all available CPU resources, severely degradating the performance of the cluster. This has a side effect of reducing the network performance to around ~50Mbps and increasing the I/O wait to ~30%.

dumb-init was picked because it's dumb and doesn't try to do anything fancy. There should be nothing that interferes with `build_docs.pl`'s operation. Signals are forwarded to dumb-init's child. dumb-init will also detach itself from the controlling TTY and attach its child process instead.

Ticket: https://elasticco.atlassian.net/browse/SRVCS-1367

(**2024-04-12 update**: This has been successfully tested in the elastic-apps-web cluster.)