### PR TITLE
Update the aliases file for removed APM guide

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -58,7 +58,7 @@ docbldlsvpr() {
 }
 
 # Installation and Upgrade Guide 7.10 and later
-alias docbldstk='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/observability-docs/docs/en/observability --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --resource=$GIT_HOME/security-docs/docs/ --chunk 1'
+alias docbldstk='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/observability-docs/docs/en/observability --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --resource=$GIT_HOME/security-docs/docs/ --chunk 1'
 
 # Installation and Upgrade Guide 7.0 to 7.9
 alias docbldstkold2='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/apm-server/docs/guide --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --chunk 1'


### PR DESCRIPTION
When I attempt to build the Installation and Upgrade Guide using `docbldstk` it returns:

 `Can't find --resource /Users/kilfoyle/repos/apm-server/docs/guide`

It's just a guess, but maybe this path was removed as part of https://github.com/elastic/apm-server/pull/12341

Anyway, removing the `--resource=$GIT_HOME/apm-server/docs/guide` part of the alias for `docbldstk` has the Install and Upgrade Guide building nicely again. 🎉 