### PR TITLE
Update ECS current branch to 8.13

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -973,7 +973,7 @@ contents:
           - title:      Elastic Common Schema (ECS) Reference
             prefix:     en/ecs
             # Please do not update current to 8.12
-            current:    8.11
+            current:    8.13
             branches:   [  {main: master}, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             live:       [ main, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 1.12 ]
             index:      docs/index.asciidoc


### PR DESCRIPTION
The [ECS Reference](https://www.elastic.co/guide/en/ecs/current/index.html) is showing version 8.11 as the current branch. This updates current to version 8.13.