### PR TITLE
Add ECS_VERSION to doc link checker

### DIFF
--- a/build_docs.pl
+++ b/build_docs.pl
@@ -357,6 +357,7 @@ sub check_kibana_links {
             while ( $contents =~ m!`(\$\{(?:baseUrl|ELASTIC.+|KIBANA_DOCS|PLUGIN_DOCS|FLEET_DOCS|APM_DOCS|STACK_DOCS|SECURITY_SOLUTION_DOCS|STACK_GETTING_STARTED|APP_SEARCH_DOCS|ENTERPRISE_SEARCH_DOCS|WORKPLACE_SEARCH_DOCS)\}[^`]+)`!g ) {
                 my $path = $1;
                 $path =~ s/\$\{(?:DOC_LINK_VERSION|urlVersion)\}/$version/;
+                $path =~ s/\$\{(?:ECS_VERSION)\}/current/;
                 # In older versions, the variable `${ELASTIC_DOCS}` referred to
                 # the Elasticsearch Guide. In newer branches, the
                 # variable is called `${ELASTICSEARCH_DOCS}`


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/182192

This PR fixes the documentation link tests so that they're aware of the `ECS_VERSION` that is being added in the Kibana doc link service.  It addresses the following errors that otherwise appear in the doc build output:

````

INFO:build_docs:Bad cross-document links:
--
  | INFO:build_docs:  Kibana [master]: packages/kbn-doc-links/src/get_doc_links.ts contains broken links to:
  | INFO:build_docs:   - en/ecs/${ECS_VERSION}/ecs-converting.html
  | INFO:build_docs:   - en/ecs/${ECS_VERSION}/index.html


````