### PR TITLE
Change ECE current docs version

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2028,7 +2028,7 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-105
+            current:    ms-92
             live:
               - ms-105
               - ms-92


### PR DESCRIPTION
This PR updates the "current" branch for the Elastic Cloud Enterprise docs in the conf.yaml 

The PR currently fails due to:

````

INFO:build_docs:Bad cross-document links:
--
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-enterprise/3.7/ece-migrate-ccs.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-other-ece.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-enterprise/3.7/ece-remote-cluster-other-ece.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-ece-ess.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud-enterprise/3.7/ece-remote-cluster-same-ece.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-same-ece.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud/current/ec-enable-ccs.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-ece-ess.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud/current/ec-remote-cluster-ece.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-ece-ess.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud/latest/ec-enable-ccs.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-ece-ess.html
  | INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/cloud/latest/ec-remote-cluster-ece.html contains broken links to:
  | INFO:build_docs:   - en/cloud-enterprise/current/ece-remote-cluster-ece-ess.html
  | 🚨 Error: The command exited with status 255

````

I am testing whether we can fix that problem by making the `ece-ref` attribute version-aware in https://github.com/elastic/docs/pull/2997