### PR TITLE
Remove ECE 3.7

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,7 +83,7 @@ variables:
   cloudSaasCurrent: &cloudSaasCurrent ms-106
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
-    ms-105: main
+#    ms-105: main
     ms-92: main
     ms-81: main
     ms-78: main
@@ -2028,9 +2028,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-105
+            current:    ms-92
             live:
-              - ms-105
+#              - ms-105
               - ms-92
               - ms-81
               - ms-78
@@ -2039,7 +2039,7 @@ contents:
               - ms-70
               - ms-69
             branches:
-              - ms-105: 3.7
+#              - ms-105: 3.7
               - ms-92: 3.6
               - ms-81: 3.5
               - ms-78: 3.4
@@ -2082,7 +2082,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
-                  ms-105: master
+#                  ms-105: master
                   ms-92: master
                   ms-81: master
                   ms-78: master

--- a/shared/versions/ece/current.asciidoc
+++ b/shared/versions/ece/current.asciidoc
@@ -1,1 +1,1 @@
-include::ms-105.asciidoc[]
+include::ms-92.asciidoc[]


### PR DESCRIPTION
This PR removes ECE 3.7 from the build as per ongoing incident around ECE https://elastic.slack.com/archives/C071N20PEF7

This PR can be reverted once ECE 3.7.1 version gets released, in the coming days 