### PR TITLE
Change current for ECE docs to 3.7.1

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,7 +83,7 @@ variables:
   cloudSaasCurrent: &cloudSaasCurrent ms-106
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
-#    ms-105: main
+    ms-105: main
     ms-92: main
     ms-81: main
     ms-78: main
@@ -2028,9 +2028,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-92
+            current:    ms-105
             live:
-#              - ms-105
+              - ms-105
               - ms-92
               - ms-81
               - ms-78
@@ -2039,7 +2039,7 @@ contents:
               - ms-70
               - ms-69
             branches:
-#              - ms-105: 3.7
+              - ms-105: 3.7
               - ms-92: 3.6
               - ms-81: 3.5
               - ms-78: 3.4
@@ -2082,7 +2082,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
-#                  ms-105: master
+                  ms-105: master
                   ms-92: master
                   ms-81: master
                   ms-78: master

--- a/shared/versions/ece/current.asciidoc
+++ b/shared/versions/ece/current.asciidoc
@@ -1,1 +1,1 @@
-include::ms-92.asciidoc[]
+include::ms-105.asciidoc[]

--- a/shared/versions/ece/master.asciidoc
+++ b/shared/versions/ece/master.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.7.0
+:ece-version:  3.7.1
 :ece-version-short:  3.7
 :ece-version-link: 3.7

--- a/shared/versions/ece/ms-105.asciidoc
+++ b/shared/versions/ece/ms-105.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.7.0
+:ece-version:  3.7.1
 :ece-version-short:  3.7
 :ece-version-link: 3.7


### PR DESCRIPTION
This changes "current" for the ECE docs to version 3.7.1.
Do not merge until release day (May 9th 2024)