### PR TITLE
Add eck 2.13 to build list

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2146,7 +2146,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.12
-            branches:   [ {main: master}, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Add ECK 2.13 to the build list, the release of ECK 2.13.0 is planned for May 21 2024. Should be merged only on May 21