### PR TITLE
Ensure that _all_ legacy books contain `noindex: 1`

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2189,12 +2189,12 @@ contents:
     -   title:      Legacy Documentation
         sections:
           - title:      Elastic Stack and Google Cloud's Anthos
+            noindex:    1
             prefix:     en/elastic-stack-gke
             current:    main
             index:      docs/en/gke-on-prem/index.asciidoc
             branches:   [ {main: master} ]
             private:    1
-            noindex:    1
             chunk:      1
             tags:       Elastic Stack/Google
             subject:    Elastic Stack
@@ -2210,12 +2210,12 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Elasticsearch - The Definitive Guide
+            noindex:    1
             prefix:     en/elasticsearch/guide
             current:    2.x
             branches:   [ master, 2.x, 1.x ]
             index:      book.asciidoc
             chunk:      1
-            noindex:    1
             private:    1
             tags:       Legacy/Elasticsearch/Definitive Guide
             subject:    Elasticsearch
@@ -2230,6 +2230,7 @@ contents:
                 exclude_branches:   [ master, 2.x]
 
           - title:      Elasticsearch Resiliency Status
+            noindex:    1
             prefix:     en/elasticsearch/resiliency
             toc:        1
             branches:   [{main: master}]
@@ -2255,13 +2256,13 @@ contents:
                 exclude_branches:   [ 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
           - title:      Elasticsearch.js for 5.6-7.6
+            noindex:    1
             prefix:     en/elasticsearch/client/elasticsearch-js
             current:    16.x
             branches:   [ 16.x ]
             index:      docs/index.asciidoc
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Clients/Elasticsearch-js
             subject:    Clients
             sources:
@@ -2270,6 +2271,7 @@ contents:
                 path:   docs
 
           - title:      Functionbeat Reference
+            noindex:    1
             prefix:     en/beats/functionbeat
             current:    *stackcurrent
             index:      x-pack/functionbeat/docs/index.asciidoc
@@ -2320,13 +2322,13 @@ contents:
                 exclude_branches: [ 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2 ]
 
           - title:      Getting Started
+            noindex:    1
             prefix:     en/elastic-stack-get-started
             current:    8.2
             index:      docs/en/getting-started/index.asciidoc
             branches:   [ 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             live:       [ 8.2, 7.17 ]
             chunk:      1
-            noindex:    1
             tags:       Elastic Stack/Getting started
             subject:    Elastic Stack
             sources:
@@ -2345,11 +2347,11 @@ contents:
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
 
           - title:      Graph Reference for 2.x
+            noindex:    1
             prefix:     en/graph
             repo:       x-pack
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Graph/Reference
             subject:    Graph
             current:    2.4
@@ -2364,12 +2366,12 @@ contents:
                 path:   shared/legacy-attrs.asciidoc
 
           - title:      Groovy API
+            noindex:    1
             prefix:     en/elasticsearch/client/groovy-api
             current:    2.4
             branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
             index:      docs/groovy-api/index.asciidoc
             private:    1
-            noindex:    1
             tags:       Legacy/Clients/Groovy
             subject:    Clients
             sources:
@@ -2382,6 +2384,7 @@ contents:
                 exclude_branches:   [ 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
 
           - title:      Infrastructure Monitoring Guide for 6.5-7.4
+            noindex:    1
             prefix:     en/infrastructure/guide
             current:    7.4
             branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5 ]
@@ -2402,6 +2405,7 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Journalbeat Reference for 6.5-7.15
+            noindex:    1
             prefix:     en/beats/journalbeat
             current:    7.15
             index:      journalbeat/docs/index.asciidoc
@@ -2443,6 +2447,7 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Legacy APM Overview
+            noindex:    1
             prefix:     get-started
             index:      docs/guide/index.asciidoc
             current:    7.15
@@ -2459,6 +2464,7 @@ contents:
                 path:   docs
 
           - title:      Legacy APM Server Reference
+            noindex:    1
             prefix:     server
             index:      docs/index.asciidoc
             current:    7.15
@@ -2479,6 +2485,7 @@ contents:
                 path:   CHANGELOG.asciidoc
 
           - title:      Logs Monitoring Guide for 7.5-7.9
+            noindex:    1
             prefix:     en/logs/guide
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
@@ -2499,10 +2506,10 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Marvel Reference for 2.x and 1.x
+            noindex:    1
             prefix:     en/marvel
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Marvel/Reference
             subject:    Marvel
             current:    2.4
@@ -2518,6 +2525,7 @@ contents:
                 exclude_branches: [marvel-1.3]
 
           - title:      Metrics Monitoring Guide for 7.5-7.9
+            noindex:    1
             prefix:     en/metrics/guide
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5 ]
@@ -2538,10 +2546,10 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Reporting Reference for 2.x
+            noindex:    1
             prefix:     en/reporting
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Reporting/Reference
             subject:    Reporting
             current:    2.4
@@ -2553,11 +2561,11 @@ contents:
                 path:   docs/public/reporting
 
           - title:      Sense Editor for 4.x
+            noindex:    1
             prefix:     en/sense
             current:    master
             branches:   [ master ]
             index:      docs/index.asciidoc
-            noindex:    1
             private:    1
             tags:       Legacy/Elasticsearch/Sense-Editor
             subject:    Sense
@@ -2567,10 +2575,10 @@ contents:
                 path:   docs
 
           - title:      Shield Reference for 2.x and 1.x
+            noindex:    1
             prefix:     en/shield
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Shield/Reference
             subject:    Shield
             current:    2.4
@@ -2586,6 +2594,7 @@ contents:
                 exclude_branches: [shield-1.2, shield-1.1 , shield-1.0]
 
           - title:      SIEM Guide
+            noindex:    1
             prefix:     en/siem/guide
             current:    7.8
             branches:   [ 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
@@ -2606,6 +2615,7 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Site Search Reference
+            noindex:    1
             prefix:     en/swiftype/sitesearch
             index:      docs/sitesearch/index.asciidoc
             private:    1
@@ -2620,12 +2630,12 @@ contents:
                 path:   docs
 
           - title:      Topbeat Reference
+            noindex:    1
             prefix:     en/beats/topbeat
             index:      topbeat/docs/index.asciidoc
             current:    1.3
             branches:   [ 1.3, 1.2, 1.1, 1.0.1 ]
             chunk:      1
-            noindex:    1
             tags:       Legacy/Topbeat/Reference
             respect_edit_url_overrides: true
             subject:    Topbeat
@@ -2641,6 +2651,7 @@ contents:
                 path:   libbeat/docs
 
           - title:      Uptime Monitoring Guide for 7.2-7.9
+            noindex:    1
             prefix:     en/uptime
             current:    7.9
             branches:   [ 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2 ]
@@ -2661,12 +2672,12 @@ contents:
                 path:   shared/attributes.asciidoc
 
           - title:      Stack Overview
+            noindex:    1
             prefix:     en/elastic-stack-overview
             current:    7.4
             index:      docs/en/stack/index.asciidoc
             branches:   [ 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3 ]
             chunk:      1
-            noindex:    1
             tags:       Legacy/Elastic Stack/Overview
             subject:    Elastic Stack
             sources:
@@ -2684,10 +2695,10 @@ contents:
                 path:   shared/settings.asciidoc
 
           - title:      Watcher Reference for 2.x and 1.x
+            noindex:    1
             prefix:     en/watcher
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/Watcher/Reference
             subject:    Watcher
             current:    2.4
@@ -2702,10 +2713,10 @@ contents:
                 path:   shared/legacy-attrs.asciidoc
 
           - title:      X-Pack Reference for 6.0-6.2 and 5.x
+            noindex:    1
             prefix:     en/x-pack
             chunk:      1
             private:    1
-            noindex:    1
             tags:       Legacy/XPack/Reference
             current:    6.2
             subject:    X-Pack
@@ -2735,12 +2746,12 @@ contents:
             lang:       zh_cn
             sections:
               - title:      《Elasticsearch 权威指南》中文版
+                noindex:    1
                 prefix:     elasticsearch/guide
                 index:      book.asciidoc
                 current:    cn
                 branches:   [ {cn: 2.x} ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       zh_cn
                 tags:       Elasticsearch/Definitive Guide
@@ -2751,11 +2762,11 @@ contents:
                     repo: guide-cn
                     path: /
               - title:      PHP API
+                noindex:    1
                 prefix:     elasticsearch/php
                 index:      index.asciidoc
                 current:    cn
                 branches:   [ {cn: 6.0} ]
-                noindex:    1
                 lang:       zh_cn
                 tags:       Elasticsearch/PHP
                 subject:    Elasticsearch
@@ -2764,13 +2775,13 @@ contents:
                     repo: elasticsearch-php-cn
                     path: /
               - title:      Kibana 用户手册
+                noindex:    1
                 prefix:     kibana
                 index:      docs/index.asciidoc
                 current:    cn
                 branches:   [ {cn: 6.0} ]
                 lang:       zh_cn
                 chunk:      1
-                noindex:    1
                 private:    1
                 tags:       Kibana/Reference
                 subject:    Kibana
@@ -2783,12 +2794,12 @@ contents:
             lang:       ja
             sections:
               - title:      Elasticsearchリファレンス
+                noindex:    1
                 prefix:     elasticsearch/reference
                 index:      docs/jp/reference/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Elasticsearch/Reference
@@ -2801,12 +2812,12 @@ contents:
                     repo: elasticsearch
                     path: /docs
               - title:      Logstashリファレンス
+                noindex:    1
                 prefix:     logstash
                 index:      docs/jp/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Logstash/Reference
@@ -2816,12 +2827,12 @@ contents:
                     repo: logstash
                     path: /docs/jp
               - title:      Kibanaユーザーガイド
+                noindex:    1
                 prefix:     kibana
                 index:      docs/jp/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       Kibana/Reference
@@ -2831,12 +2842,12 @@ contents:
                     repo: kibana
                     path: /docs/jp
               - title:      X-Packリファレンス
+                noindex:    1
                 prefix:     x-pack
                 index:      docs/jp/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ja
                 tags:       X-Pack/Reference
@@ -2858,12 +2869,12 @@ contents:
             lang:       ko
             sections:
               - title:      Elasticsearch 참조
+                noindex:    1
                 prefix:     elasticsearch/reference
                 index:      docs/kr/reference/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Elasticsearch/Reference
@@ -2876,12 +2887,12 @@ contents:
                     repo: elasticsearch
                     path: /docs
               - title:      Logstash 참조
+                noindex:    1
                 prefix:     logstash
                 index:      docs/kr/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Logstash/Reference
@@ -2891,12 +2902,12 @@ contents:
                     repo: logstash
                     path: /docs/kr
               - title:      Kibana 사용자 가이드
+                noindex:    1
                 prefix:     kibana
                 index:      docs/kr/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4, 5.3 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       Kibana/Reference
@@ -2906,12 +2917,12 @@ contents:
                     repo: kibana
                     path: /docs/kr
               - title:      X-Pack 참조
+                noindex:    1
                 prefix:     x-pack
                 index:      docs/kr/gs-index.asciidoc
                 current:    5.4
                 branches:   [ 5.4 ]
                 chunk:      1
-                noindex:    1
                 private:    1
                 lang:       ko
                 tags:       X-Pack/Reference


### PR DESCRIPTION
Makes sure that all versions of all legacy books are not being indexed. (Not sure if we should be indexing Functionbeat and SIEM docs as they still have live versions...)

cc @lcawl @KOTungseth @katymcdougall 