### PR TITLE
ESS - Change current to ms-108

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.13
   stacklive: &stacklive [ 8.13, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-107
+  cloudSaasCurrent: &cloudSaasCurrent ms-108
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to MS-108.
Do not merge until release day.
