### PR TITLE
Remove versioning for terraform docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2176,8 +2176,8 @@ contents:
             prefix:     en/tpec
             tags:       CloudTerraform/Reference
             subject:    TPEC
-            current:    0.2
-            branches:   [ master, 0.2, 0.1 ]
+            current:    master
+            branches:   [ master ]
             index:      docs-elastic/index.asciidoc
             single:     1
             chunk:      1


### PR DESCRIPTION
Our terraform doc versions are 8+ versions behind, and nothing changes between versions (the docs are just a stub that redirects)

This PR flattens the terraform docs so we just have one version, and no versioning confusion for end users.


---


When I preview this, I still see this index page that has links - not sure how this is generated/whether this can be previewed in this build

https://docs_bk_3007.docs-preview.app.elstc.co/guide/en/tpec/index.html

@elastic/docs-engineering is there any way I can preview this before it ships? 