### PR TITLE
Revert "Always use h1 for first heading on a page (#3009)"

### DIFF
--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -138,10 +138,6 @@
     display: none;
   }
 
-  #left_col {
-    display: none;
-  }
-
   #guide .subnavigation {
     top: 00px;
     border-bottom: 1px solid var(--color-gray);

--- a/resources/asciidoctor/lib/chunker/breadcrumbs.rb
+++ b/resources/asciidoctor/lib/chunker/breadcrumbs.rb
@@ -22,7 +22,7 @@ module Chunker
 
       update_breadcrumbs_cases(result, chev, doc)
 
-      result.join("\n")
+      Asciidoctor::Block.new doc, :pass, source: result.join("\n")
     end
 
     def update_breadcrumbs_cases(result, chev, doc)

--- a/resources/asciidoctor/lib/chunker/extension.rb
+++ b/resources/asciidoctor/lib/chunker/extension.rb
@@ -57,15 +57,6 @@ module Chunker
       return yield unless section.level <= @chunk_level
 
       html = form_section_into_page doc, section, yield
-      # Replace the breadcrumbs placeholder with
-      # the generated breadcrumbs
-      if html =~ %r{<div id="breadcrumbs-go-here"></div>}
-        html.gsub!(
-          %r{<div id="breadcrumbs-go-here"></div>},
-          generate_breadcrumbs(doc, section).to_s
-        )
-        # raise("Couldn't add breadcrumbs in #{html}")
-      end
       write doc, "#{section.id}.html", html
       ''
     end
@@ -102,11 +93,12 @@ module Chunker
       # We don't use asciidoctor's "parent" documents here because they don't
       # seem to buy us much and they are an "internal" detail.
       subdoc = Asciidoctor::Document.new [], subdoc_opts(doc, section)
-      add_subdoc_sections doc, subdoc, html
+      add_subdoc_sections doc, subdoc, section, html
       subdoc.convert
     end
 
-    def add_subdoc_sections(doc, subdoc, html)
+    def add_subdoc_sections(doc, subdoc, section, html)
+      subdoc << generate_breadcrumbs(doc, section)
       nav = Nav.new subdoc
       subdoc << nav.header
       subdoc << Asciidoctor::Block.new(subdoc, :pass, source: html)
@@ -129,10 +121,7 @@ module Chunker
     def subdoc_attrs(doc, section)
       attrs = doc.attributes.dup
       maintitle = doc.doctitle partition: true
-      # Rendered h1 heading
-      attrs['doctitle'] = subdoc_doctitle section
-      # Value of `title` in the `head`
-      attrs['title'] = subdoc_title section, maintitle
+      attrs['doctitle'] = subdoc_title section, maintitle
       # Asciidoctor defaults these attribute to empty string if they aren't
       # specified and setting them to `nil` clears them. Since we want to
       # preserve the configuration from the parent into the child, we clear
@@ -141,20 +130,13 @@ module Chunker
       attrs['stylesheet'] = nil unless attrs['stylesheet']
       attrs['icons'] = nil unless attrs['icons']
       attrs['subdoc'] = true # Mark the subdoc so we don't try and chunk it
+      attrs['noheader'] = true
       attrs['title-separator'] = ''
       attrs['canonical-url'] = section.attributes['canonical-url']
       attrs.merge! find_related(section)
       attrs
     end
 
-    # For the `h1` heading that appears on the rendered page,
-    # use just the page title
-    def subdoc_doctitle(section)
-      strip_tags section.captioned_title.to_s
-    end
-
-    # For the `title` in the `head`, use the page title followed
-    # by the site title ("Elastic")
     def subdoc_title(section, maintitle)
       strip_tags "#{section.captioned_title} | #{maintitle.main}"
     end

--- a/resources/asciidoctor/lib/docbook_compat/convert_document.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_document.rb
@@ -25,7 +25,7 @@ module DocbookCompat
     def munge_html(doc, html, wants_toc)
       title = doc.doctitle partition: true
       munge_html_tag html
-      munge_head doc.attr('title-extra'), html
+      munge_head doc.attr('title-extra'), title, html
       munge_body doc, html
       munge_title doc, title, html
       add_toc doc, html if wants_toc
@@ -36,26 +36,15 @@ module DocbookCompat
         raise("Coudn't fix html in #{html}")
     end
 
-    def munge_head(title_extra, html)
-      if html !~ %r{^<title>([\S\s]+)<\/title>$}m
-        raise("Couldn't munge <title> in #{html}")
-      end
-
-      html.gsub!(%r{^<title>([\S\s]+)<\/title>$}m) do
-        add_content_meta Regexp.last_match[1], title_extra
-      end
+    def munge_head(title_extra, title, html)
+      html.gsub!(
+        %r{<title>.+?</title>}m, <<~HTML
+          <title>#{strip_tags title.main}#{title_extra} | Elastic</title>
+          <meta class=\"elastic\" name=\"content\" \
+          content=\"#{strip_tags title.main}#{title_extra}\">
+        HTML
+      ) || raise("Couldn't munge <title> in #{html}")
       munge_meta html
-    end
-
-    def add_content_meta(match, title_extra)
-      # If multiple lines, get just the first line
-      clean_title = match.gsub!(/\n[\S\s]+/, '') || match
-      clean_title = strip_tags clean_title
-      <<~HTML
-        <title>#{clean_title}#{title_extra} | Elastic</title>
-        <meta class=\"elastic\" name=\"content\" \
-        content=\"#{clean_title}#{title_extra}\">
-      HTML
     end
 
     META_VIEWPORT = <<~HTML
@@ -72,14 +61,12 @@ module DocbookCompat
     end
 
     def munge_title(doc, title, html)
+      return if doc.attr 'noheader'
+
       # Important: we're not replacing the whole header - it still will have a
       # closing </div>.
-      #
-      # We also add a placeholder for the breadcrumbs that will be replaced
-      # in resources/asciidoctor/lib/chunker/extension.rb
       header_start = <<~HTML
         <div class="titlepage">
-        <div id="breadcrumbs-go-here"></div>
         #{docbook_style_title doc, title}
       HTML
       html.gsub!(%r{<div id="header">\n<h1>.+?</h1>\n}m, header_start) ||
@@ -97,6 +84,7 @@ module DocbookCompat
       HTML
       result + <<~HTML.strip
         </div>
+        <hr>
         <!--EXTRA-->
       HTML
     end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -77,20 +77,19 @@ module DocbookCompat
     end
 
     def hlevel(section)
-      # If the heading level is less than 2, use 2,
-      # otherwise use the given heading level.
-      #
-      # This ensures:
-      # - There are no `h0`s, which are not valid HTML elements.
-      # - There are no `h1`s in the page's main content since
-      #   we only want one `h1` per page, and one is generated
-      #   automatically and added to the page header (outside
-      #   div#content).
-      if section.level < 2
-        2
-      else
-        section.level
-      end
+      # Walk up the ancestry until the ancestor's parent is the document. The
+      # ancestor that we end up with is the "biggest" section containing this
+      # section. Except don't walk *all* the way. Because docbook doesn't.
+      # See that `unless` below? If we were walking it should be `until` but
+      # docbook *doesn't* walk. It just does this. Why? Ghosts maybe. I dunno.
+      # But we're trying to emulate docbook. So here we are.
+      ancestor = section
+      ancestor = ancestor.parent unless ancestor.parent.context == :document
+      # If *that* section is level 0 then we have to bump the hlevel of our
+      # section by one. The argument for this goes: we have to bump the level 0
+      # section's hlevel by one anyway because there *isn't* an h0 tag. So we
+      # have to bump all of its children.
+      section.level + (ancestor.level.zero? ? 1 : 0)
     end
 
     SECTION_WRAPPER_CLASSES = %w[part chapter].freeze

--- a/resources/asciidoctor/spec/chunker_spec.rb
+++ b/resources/asciidoctor/spec/chunker_spec.rb
@@ -197,6 +197,14 @@ RSpec.describe Chunker do
               <p>Words words.<sup class="footnote">[<a id="_footnoteref_1" class="footnote" href="#_footnotedef_1" title="View footnote.">1</a>]</sup></p>
             HTML
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              </div>
+            HTML
+          end
           it 'contains a link to the second section' do
             expect(contents).to include(
               '<a href="s2.html">Section <code>2</code></a>'
@@ -228,6 +236,14 @@ RSpec.describe Chunker do
           it 'contains the contents' do
             expect(contents).to include '<p>Words again.</p>'
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              </div>
+            HTML
+          end
           it 'contains a link to an element in the first section' do
             expect(contents).to include(
               '<a href="s1.html#linkme">override text</a>'
@@ -244,36 +260,6 @@ RSpec.describe Chunker do
               </div>
               </div>
             HTML
-          end
-        end
-        context 'breadcrumbs' do
-          before(:each) do
-            # We need docbook compat to verify breadcrumbs
-            # We unregister_all first because the order that we
-            # register the plugins matters.
-            Asciidoctor::Extensions.unregister_all
-            Asciidoctor::Extensions.register DocbookCompat
-            Asciidoctor::Extensions.register Chunker
-          end
-          file_context 'the first section', 's1.html' do
-            it 'contains the breadcrumbs' do
-              expect(contents).to include <<~HTML
-                <div class="breadcrumbs">
-                <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                </div>
-              HTML
-            end
-          end
-          file_context 'the second section', 's2.html' do
-            it 'contains the breadcrumbs' do
-              expect(contents).to include <<~HTML
-                <div class="breadcrumbs">
-                <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                </div>
-              HTML
-            end
           end
         end
       end
@@ -416,25 +402,13 @@ RSpec.describe Chunker do
           include_examples 'standard page', 'index', nil
           let(:prev_title) { 'Title [fooo]' }
           include_examples 'subpage'
-        end
-        context 'breadcrumbs' do
-          before(:each) do
-            # We need docbook compat to verify breadcrumbs
-            # We unregister_all first because the order that we
-            # register the plugins matters.
-            Asciidoctor::Extensions.unregister_all
-            Asciidoctor::Extensions.register DocbookCompat
-            Asciidoctor::Extensions.register Chunker
-          end
-          file_context 'the section', 's1.html' do
-            it 'contains the breadcrumbs' do
-              expect(contents).to include <<~HTML
-                <div class="breadcrumbs">
-                <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title [fooo]</a></span>
-                </div>
-              HTML
-            end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title [fooo]</a></span>
+              </div>
+            HTML
           end
         end
       end
@@ -534,7 +508,7 @@ RSpec.describe Chunker do
           end
           it 'contains the heading' do
             expect(contents).to include(
-              '<h1 class="title"><a id="id-1"></a>Section: With subtitle</h1>'
+              '<h1 class="title"><a id="s"></a>Section: With subtitle</h1>'
             )
           end
           it 'contains the contents' do
@@ -654,6 +628,14 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s1">S1</h2>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              </div>
+            HTML
+          end
           it 'contains a link to the level 3 section' do
             expect(contents).to include('<a href="s2_1.html#s2_1_1">S2_1_1</a>')
           end
@@ -664,12 +646,29 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s1_1">S1_1</h3>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s1.html">S1</a></span>
+              </div>
+            HTML
+          end
         end
         file_context 'the second level 1 section', 's2.html' do
           include_examples 'standard page', 's1_1', 's2_1'
           include_examples 'subpage'
           it 'contains the heading' do
             expect(contents).to include('<h2 id="s2">S2</h2>')
+          end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              </div>
+            HTML
           end
         end
         file_context 'the second level 2 section', 's2_1.html' do
@@ -681,6 +680,15 @@ RSpec.describe Chunker do
           it 'contains the level 3 section' do
             expect(contents).to include('<h4 id="s2_1_1">S2_1_1</h4>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s2.html">S2</a></span>
+              </div>
+            HTML
+          end
         end
         file_context 'the last level 2 section', 's2_2.html' do
           include_examples 'standard page', 's2_1', nil
@@ -688,68 +696,14 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h3 id="s2_2">S2_2</h3>')
           end
-        end
-        context 'breadcrumbs' do
-          before(:each) do
-            # We need docbook compat to verify breadcrumbs
-            # We unregister_all first because the order that we
-            # register the plugins matters.
-            Asciidoctor::Extensions.unregister_all
-            Asciidoctor::Extensions.register DocbookCompat
-            Asciidoctor::Extensions.register Chunker
-          end
-          file_context 'the first level 1 section', 's1.html' do
-            it 'contains the breadcrumbs' do
-              expect(contents).to include <<~HTML
-                <div class="breadcrumbs">
-                <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                </div>
-              HTML
-            end
-            file_context 'the first level 2 section', 's1_1.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s1.html">S1</a></span>
-                  </div>
-                HTML
-              end
-            end
-            file_context 'the second level 1 section', 's2.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  </div>
-                HTML
-              end
-            end
-            file_context 'the second level 2 section', 's2_1.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s2.html">S2</a></span>
-                  </div>
-                HTML
-              end
-            end
-            file_context 'the last level 2 section', 's2_2.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s2.html">S2</a></span>
-                  </div>
-                HTML
-              end
-            end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="s2.html">S2</a></span>
+              </div>
+            HTML
           end
         end
       end
@@ -808,6 +762,14 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h2 id="app">Appendix A: Foo</h2>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              </div>
+            HTML
+          end
         end
         file_context 'the first page in the appendix', 'app_1.html' do
           include_examples 'standard page', 'app', 'app_2'
@@ -817,6 +779,15 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h3 id="app_1">Foo 1</h3>')
           end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="app.html">Foo</a></span>
+              </div>
+            HTML
+          end
         end
         file_context 'the first page in the appendix', 'app_2.html' do
           include_examples 'standard page', 'app_1', nil
@@ -825,47 +796,14 @@ RSpec.describe Chunker do
           it 'contains the heading' do
             expect(contents).to include('<h3 id="app_2">Foo 2</h3>')
           end
-        end
-        context 'breadcrumbs' do
-          before(:each) do
-            # We need docbook compat to verify breadcrumbs
-            # We unregister_all first because the order that we
-            # register the plugins matters.
-            Asciidoctor::Extensions.unregister_all
-            Asciidoctor::Extensions.register DocbookCompat
-            Asciidoctor::Extensions.register Chunker
-          end
-          file_context 'the appendix', 'app.html' do
-            it 'contains the breadcrumbs' do
-              expect(contents).to include <<~HTML
-                <div class="breadcrumbs">
-                <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                </div>
-              HTML
-            end
-            file_context 'the first page in the appendix', 'app_1.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="app.html">Foo</a></span>
-                  </div>
-                HTML
-              end
-            end
-            file_context 'the first page in the appendix', 'app_2.html' do
-              it 'contains the breadcrumbs' do
-                expect(contents).to include <<~HTML
-                  <div class="breadcrumbs">
-                  <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
-                  <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="app.html">Foo</a></span>
-                  </div>
-                HTML
-              end
-            end
+          it 'contains the breadcrumbs' do
+            expect(contents).to include <<~HTML
+              <div class="breadcrumbs">
+              <span class="breadcrumb-link"><a href="/guide/">Elastic Docs</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="index.html">Title</a></span>
+              <span class="chevron-right">›</span><span class="breadcrumb-link"><a href="app.html">Foo</a></span>
+              </div>
+            HTML
           end
         end
       end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -111,9 +111,11 @@ RSpec.describe DocbookCompat do
       it "is wrapped in docbook's funny titlepage" do
         expect(converted).to include(<<~HTML)
           <div class="titlepage">
-          <div id="breadcrumbs-go-here"></div>
           <div>
           <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
+          </div>
+          <hr>
+          <!--EXTRA-->
           </div>
         HTML
       end
@@ -131,9 +133,11 @@ RSpec.describe DocbookCompat do
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div id="breadcrumbs-go-here"></div>
             <div>
             <div><h1 class="title"><a id="title-id"></a>Title</h1></div>
+            </div>
+            <hr>
+            <!--EXTRA-->
             </div>
           HTML
         end
@@ -165,10 +169,10 @@ RSpec.describe DocbookCompat do
         it "is wrapped in docbook's funny titlepage" do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div id="breadcrumbs-go-here"></div>
             <div>
             <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
             </div>
+            <hr>
             <!--EXTRA-->
           HTML
         end
@@ -176,6 +180,7 @@ RSpec.describe DocbookCompat do
       context 'the table of contents' do
         it 'is outside the titlepage' do
           expect(converted).to include(<<~HTML)
+            <hr>
             <!--EXTRA-->
             </div>
             <div id="content">
@@ -288,7 +293,7 @@ RSpec.describe DocbookCompat do
               expect(converted).not_to include '<titleabbrev>'
             end
             it 'includes the unabbreviated title' do
-              expect(converted).to include 'Section 1</h2>'
+              expect(converted).to include 'Section 1</h1>'
             end
             it 'includes a link to the abbreviated section' do
               expect(converted).to include <<~HTML.strip
@@ -359,15 +364,23 @@ RSpec.describe DocbookCompat do
           Words.
         ASCIIDOC
       end
+      context 'the title' do
+        it "doesn't include the subtitle" do
+          expect(converted).to include(<<~HTML)
+            <title>Title | Elastic</title>
+            <meta class="elastic" name="content" content="Title">
+          HTML
+        end
+      end
       context 'the header' do
         it 'includes the title and subtitle' do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div id="breadcrumbs-go-here"></div>
             <div>
             <div><h1 class="title"><a id="id-1"></a>Title</h1></div>
             <div><h2 class="subtitle">Subtitle</h2></div>
             </div>
+            <hr>
             <!--EXTRA-->
             </div>
           HTML
@@ -394,10 +407,10 @@ RSpec.describe DocbookCompat do
         it 'includes the title and subtitle' do
           expect(converted).to include(<<~HTML)
             <div class="titlepage">
-            <div id="breadcrumbs-go-here"></div>
             <div>
             <div><h1 class="title"><a id="id-1"></a><code class="literal">foo</code></h1></div>
             </div>
+            <hr>
             <!--EXTRA-->
             </div>
           HTML
@@ -487,6 +500,64 @@ RSpec.describe DocbookCompat do
         {
           # Shrink the output slightly so it is easier to read
           'stylesheet!' => false,
+          # Disable the head
+          'noheader' => true,
+        }
+      end
+      let(:input) do
+        <<~ASCIIDOC
+          = Title
+
+          Words.
+        ASCIIDOC
+      end
+      context 'the header' do
+        it "doesn't contain the title h1" do
+          expect(converted).not_to include('Title</h1>')
+        end
+      end
+      context 'the body' do
+        it "doesn't have attributes" do
+          expect(converted).to include('<body>')
+        end
+        it "doesn't include the 'book' wrapper" do
+          expect(converted).not_to include(<<~HTML)
+            <div class="book" lang="en">
+          HTML
+        end
+      end
+
+      context 'when there is a page-header' do
+        let(:convert_attributes) do
+          {
+            # Shrink the output slightly so it is easier to read
+            'stylesheet!' => false,
+            'noheader' => true,
+            'page-header' => '<div class="foo" />',
+          }
+        end
+        let(:input) do
+          <<~ASCIIDOC
+            = Title
+
+            Words.
+          ASCIIDOC
+        end
+        context 'the header' do
+          it 'contains the page-header right after the body tag' do
+            expect(converted).not_to include <<~HTML
+              <body>
+              <div class="foo" />
+            HTML
+          end
+        end
+      end
+    end
+    context 'when the head is disabled' do
+      let(:convert_attributes) do
+        {
+          # Shrink the output slightly so it is easier to read
+          'stylesheet!' => false,
           # Set some metadata that will be included in the header
           'dc.type' => 'FooType',
           'dc.subject' => 'BarSubject',
@@ -563,10 +634,9 @@ RSpec.describe DocbookCompat do
           end
         end
         it "is wrapped in docbook's funny titlepage" do
-          level = hlevel < 2 ? 2 : hlevel
           expect(converted).to include(<<~HTML)
             <div class="titlepage"><div><div>
-            <h#{level} class="title"><a id="#{id}"></a>#{title}#{xpack_tag}</h#{level}>
+            <h#{hlevel} class="title"><a id="#{id}"></a>#{title}#{xpack_tag}</h#{hlevel}>
             </div></div></div>
           HTML
         end
@@ -731,7 +801,7 @@ RSpec.describe DocbookCompat do
         include_examples 'section basics', 'appendix', 1, '_foo',
                          'Appendix A: Foo'
         it "doesn't bump the h tags of sections within it" do
-          expect(converted).to include 'Bar</h2>'
+          expect(converted).to include 'Bar</h1>'
         end
       end
     end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ElasticCompatPreprocessor do
     end
     it 'uses the attributes for the header' do
       expect(converted).to include <<~HTML
-        <h2 class="title"><a id="foo-bar"></a>Header</h2>
+        <h1 class="title"><a id="foo-bar"></a>Header</h1>
       HTML
     end
     it 'uses the attributes outside of the header' do
@@ -299,7 +299,7 @@ RSpec.describe ElasticCompatPreprocessor do
         expect(converted).to eq <<~HTML
           <div class="chapter">
           <div class="titlepage"><div><div>
-          <h2 class="title"><a id="_example"></a>Example</h2>
+          <h1 class="title"><a id="_example"></a>Example</h1>
           </div></div></div>
 
           </div>
@@ -340,7 +340,7 @@ RSpec.describe ElasticCompatPreprocessor do
         expect(converted).to eq <<~HTML
           <div class="chapter">
           <div class="titlepage"><div><div>
-          <h2 class="title"><a id="_example"></a>Example</h2>
+          <h1 class="title"><a id="_example"></a>Example</h1>
           </div></div></div>
 
           </div>
@@ -470,7 +470,7 @@ RSpec.describe ElasticCompatPreprocessor do
     end
     it 'has the right offset' do
       expect(converted).to include <<~HTML
-        <h2 class="title"><a id="_target"></a>Target</h2>
+        <h1 class="title"><a id="_target"></a>Target</h1>
       HTML
     end
   end

--- a/resources/web/docs_js/__tests__/docs.test.js
+++ b/resources/web/docs_js/__tests__/docs.test.js
@@ -115,7 +115,7 @@ function describeInitHeaders(name, guideBody, onThisPageAssertions) {
   describe(name, () => {
     beforeEach(() => {
       document.body.innerHTML = dedent `
-        <div id="content">
+        <div id="guide">
           ${guideBody}
         </div>
         <div id="right_col">
@@ -142,28 +142,28 @@ describe('On This Page', () => {
   `;
   const oneSubsection = dedent `
     ${onlyTitle}
-    <h2>
+    <h3>
       <a id="nrt"></a>
       Near Realtime (NRT)
-    </h2>
+    </h3>
   `;
   const twoSubsections = dedent `
     ${oneSubsection}
-    <h2>
+    <h3>
       <a id="cluster"></a>
       Cluster
-    </h2>
+    </h3>
   `;
   const fourSubsections = dedent `
     ${twoSubsections}
-    <h3>
+    <h4>
       <a id="observability"></a>
       Observability
-    </h3>
-    <h2>
+    </h4>
+    <h3>
       <a id="apm"></a>
       APM
-    </h2>
+    </h3>
   `;
 
   describeInitHeaders('for page with just a title', onlyTitle, () => {

--- a/resources/web/style/admonishment.pcss
+++ b/resources/web/style/admonishment.pcss
@@ -85,13 +85,8 @@
 
   .admon_content {
     margin-left: 80px;
-    /* On page load, the heading level may be changed,
-    but we always what to style it the same way  */
-    h2, h3, h4, h5, h6 {
+    h3 {
       margin: 3px 0;
-      font-size: 22px;
-      font-weight: 600;
-      a { font-weight: 600; }
     }
     p:last-of-type {
       margin-bottom: 0em;

--- a/resources/web/style/console_widget.pcss
+++ b/resources/web/style/console_widget.pcss
@@ -65,9 +65,7 @@
 .try_console_selector {
   text-align: center;
 
-  /* On page load, the heading level may be changed,
-    but we always what to style it the same way  */
-  h2, h3, h4, h5, h6 {
+  h4 {
     font-size: 30px;
   }
 

--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -19,6 +19,11 @@
       background-image: inline("img/link.png");
     }
   }
+  h1 {
+    font-size: 36px;
+    margin: 10px 0 10px;
+    a { font-weight: 300; }
+  }
   h2 {
     font-size: 29px;
     margin: 20px 0;
@@ -77,20 +82,5 @@
     .title {
       margin: 10px 0 16px;
     }
-    /* Styles the page header, which is always an h1
-    wrapped in a div with the titlepage class, and always
-    has the title class. */
-    h1.title {
-      margin: 24px 0;
-      font-size: 36px;
-      padding: 0;
-      a { font-weight: 300; }
-    }
-  }
-
-  /* Hide the first heading within the main content
-    of the page since it is the same as the title */
-  div#content > div > .titlepage {
-    display: none;
   }
 }


### PR DESCRIPTION
This reverts commit d16085bebe5c46534a1242a0f1fd85c984643f4e.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
