### PR TITLE
Update banner for master doc versions

### DIFF
--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -639,9 +639,8 @@ RSpec.describe 'building all books' do
       it 'includes the prelim docs header' do
         expect(body).to include <<~HTML
           <div class="page_header">
-          This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
-          
-          This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
+          <p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
+          <p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
           </div>
         HTML
       end

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -639,9 +639,9 @@ RSpec.describe 'building all books' do
       it 'includes the prelim docs header' do
         expect(body).to include <<~HTML
           <div class="page_header">
-          You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
-          Not what you want? See the
-          <a href="../current/index.html">current release documentation</a>.
+          This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
+          
+          This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
           </div>
         HTML
       end

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe 'building all books' do
       it 'includes the prelim docs header' do
         expect(body).to include <<~HTML
           <div class="page_header">
-          You are looking at preliminary documentation for a future release.
+          You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
           Not what you want? See the
           <a href="../current/index.html">current release documentation</a>.
           </div>

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -974,7 +974,7 @@ RSpec.describe 'building all books' do
     shared_examples 'future version' do
       it 'contains a "future" header' do
         expect(body).to include('<div class="page_header">')
-        expect(body).to include('You are looking at preliminary documentation')
+        expect(body).to include('This documentation contains work-in-progress')
       end
     end
     shared_examples 'past version' do

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -639,7 +639,7 @@ RSpec.describe 'building all books' do
       it 'includes the prelim docs header' do
         expect(body).to include <<~HTML
           <div class="page_header">
-          This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
+          This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. Check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a> for more details.
           </div>
         HTML
       end

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -639,8 +639,7 @@ RSpec.describe 'building all books' do
       it 'includes the prelim docs header' do
         expect(body).to include <<~HTML
           <div class="page_header">
-          <p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
-          <p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
+          This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
           </div>
         HTML
       end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -25,9 +25,9 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
-Not what you want? See the
-<a href="../current/index.html">current release documentation</a>.
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
+          
+This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
 HEADER
     },
     zh_cn => {
@@ -52,9 +52,9 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
-Not what you want? See the
-<a href="../current/index.html">current release documentation</a>.
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
+          
+This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
 HEADER
     },
     ko => {
@@ -68,9 +68,9 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
-Not what you want? See the
-<a href="../current/index.html">current release documentation</a>.
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
+          
+This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
 HEADER
         }
 

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -25,7 +25,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at preliminary documentation for a future release.
+You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
 Not what you want? See the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
@@ -52,7 +52,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at preliminary documentation for a future release.
+You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
 Not what you want? See the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
@@ -68,7 +68,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-You are looking at preliminary documentation for a future release.
+You are looking at documentation that might contain both current Elastic Cloud serverless and future Elastic Stack and Cloud details.
 Not what you want? See the
 <a href="../current/index.html">current release documentation</a>.
 HEADER

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -25,8 +25,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
-<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. Check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a> for more details.
 HEADER
     },
     zh_cn => {
@@ -51,8 +50,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
-<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. Check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a> for more details.
 HEADER
     },
     ko => {
@@ -66,8 +64,7 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
-<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
+This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs. It also contains some Elastic Cloud serverless information. Check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a> for more details.
 HEADER
         }
 

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -25,9 +25,8 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
-          
-This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
+<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
+<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
 HEADER
     },
     zh_cn => {
@@ -52,9 +51,8 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
-          
-This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
+<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
+<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
 HEADER
     },
     ko => {
@@ -68,9 +66,8 @@ will be released for this version. For the latest information, see the
 <a href="../current/index.html">current release documentation</a>.
 HEADER
         new => <<"HEADER"
-This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.
-          
-This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.
+<p>This documentation contains work-in-progress information for future Elastic Stack and Cloud releases. Use the version selector to view supported release docs.</p>
+<p>This documentation also contains the latest Elastic Cloud serverless information. For our serverless-specific documentation, check out our <a href="https://www.elastic.co/docs/current/serverless">serverless docs</a>.</p>
 HEADER
         }
 


### PR DESCRIPTION
This PR updates the banner that appears in "master" versions of the documentation, since it's currently unclear about the state of the serverless details in that branch.

## Before

![image](https://github.com/user-attachments/assets/228e119c-569d-40f7-8bae-43d8203990f3)


## After

![image](https://github.com/user-attachments/assets/18d9355a-ee72-4a70-901f-251b1510531b)

