### PR TITLE
Add stack-ref-80 attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -58,6 +58,7 @@ Elastic-level pages
 :stack-ref-67:         https://www.elastic.co/guide/en/elastic-stack/6.7
 :stack-ref-68:         https://www.elastic.co/guide/en/elastic-stack/6.8
 :stack-ref-70:         https://www.elastic.co/guide/en/elastic-stack/7.0
+:stack-ref-80:         https://www.elastic.co/guide/en/elastic-stack/8.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :stack-gs-current:     https://www.elastic.co/guide/en/elastic-stack-get-started/current


### PR DESCRIPTION
Adds an attribute for Elastic Stack docs v8.0.