### PR TITLE
[wip] Add Elastic Distributions for OpenTelemetry docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -32,6 +32,7 @@ repos:
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
+    elastic-otel-dotnet:  https://github.com/elastic/elastic-otel-dotnet.git
     elastic-otel-java:    https://github.com/elastic/elastic-otel-java.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
@@ -710,6 +711,18 @@ contents:
                     sources:
                       -
                         repo:   elastic-otel-java
+                        path:   docs
+                  - title:      Elastic Distribution for OpenTelemetry .NET
+                    prefix:     dotnet
+                    current:    main
+                    branches:   [ {main: master} ]
+                    live:       [ main ]
+                    index:      docs/index.asciidoc
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   elastic-otel-dotnet
                         path:   docs
           - title:      ECS logging
             base_dir:   en/ecs-logging

--- a/conf.yaml
+++ b/conf.yaml
@@ -34,6 +34,7 @@ repos:
     eland:                https://github.com/elastic/eland.git
     elastic-otel-dotnet:  https://github.com/elastic/elastic-otel-dotnet.git
     elastic-otel-java:    https://github.com/elastic/elastic-otel-java.git
+    elastic-otel-node:    https://github.com/elastic/elastic-otel-node.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -697,7 +698,7 @@ contents:
                   -
                     repo:   apm-k8s-attacher
                     path:   docs
-              - title:      OpenTelemetry Distro Documentation
+              - title:      Elastic Distributions for OpenTelemetry
                 base_dir:   open-telemetry
                 sections:
                   - title:      Elastic Distribution for OpenTelemetry Java
@@ -724,6 +725,18 @@ contents:
                       -
                         repo:   elastic-otel-dotnet
                         path:   docs
+                  - title:      Elastic Distribution for OpenTelemetry Node.js
+                    prefix:     nodejs
+                    current:    main
+                    branches:   [ {main: master} ]
+                    live:       [ main ]
+                    index:      docs/index.asciidoc
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   elastic-otel-node
+                        path:   packages/opentelemetry-node/docs
           - title:      ECS logging
             base_dir:   en/ecs-logging
             sections:

--- a/conf.yaml
+++ b/conf.yaml
@@ -32,6 +32,7 @@ repos:
     ecs-logging-python:   https://github.com/elastic/ecs-logging-python.git
     ecs-logging-ruby:     https://github.com/elastic/ecs-logging-ruby.git
     eland:                https://github.com/elastic/eland.git
+    elastic-otel-java:    https://github.com/elastic/elastic-otel-java.git
     elasticsearch-hadoop: https://github.com/elastic/elasticsearch-hadoop.git
     elasticsearch-java:   https://github.com/elastic/elasticsearch-java.git
     elasticsearch-js:     https://github.com/elastic/elasticsearch-js.git
@@ -695,6 +696,21 @@ contents:
                   -
                     repo:   apm-k8s-attacher
                     path:   docs
+              - title:      OpenTelemetry Distro Documentation
+                base_dir:   open-telemetry
+                sections:
+                  - title:      Elastic Distribution for OpenTelemetry Java
+                    prefix:     java
+                    current:    main
+                    branches:   [ {main: master} ]
+                    live:       [ main ]
+                    index:      docs/index.asciidoc
+                    subject:    APM
+                    chunk:      1
+                    sources:
+                      -
+                        repo:   elastic-otel-java
+                        path:   docs
           - title:      ECS logging
             base_dir:   en/ecs-logging
             sections:

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -204,6 +204,9 @@ alias docbldaws='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-aws-lambda/docs/i
 
 alias docbldamw='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-k8s-attacher/docs/index.asciidoc --chunk 1'
 
+# Otel Distro
+alias docbldoteljava='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-java/docs/index.asciidoc --chunk 1'
+
 # APM Legacy
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'
 

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -205,9 +205,11 @@ alias docbldaws='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-aws-lambda/docs/i
 alias docbldamw='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-k8s-attacher/docs/index.asciidoc --chunk 1'
 
 # Otel Distros
+alias docbldoteldotnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-dotnet/docs/index.asciidoc --chunk 1'
+
 alias docbldoteljava='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-java/docs/index.asciidoc --chunk 1'
 
-alias docbldoteldotnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-dotnet/docs/index.asciidoc --chunk 1'
+alias docbldotelnode='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-node/packages/opentelemetry-node/docs/index.asciidoc --chunk 1'
 
 # APM Legacy
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -204,8 +204,10 @@ alias docbldaws='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-aws-lambda/docs/i
 
 alias docbldamw='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-k8s-attacher/docs/index.asciidoc --chunk 1'
 
-# Otel Distro
+# Otel Distros
 alias docbldoteljava='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-java/docs/index.asciidoc --chunk 1'
+
+alias docbldoteldotnet='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elastic-otel-dotnet/docs/index.asciidoc --chunk 1'
 
 # APM Legacy
 alias docbldamg='$GIT_HOME/docs/build_docs --doc $GIT_HOME/apm-server/docs/guide/index.asciidoc --chunk 1'


### PR DESCRIPTION
Adds docs for Elastic Distributions for OpenTelemetry. Distro docs will be at `elastic.co/guide/en/apm/open-telemetry/{language}`.

## Add new books to the config

- [ ] **Java**
  - [x] Add to this repo https://github.com/elastic/docs/pull/3033/commits/27f46ca87529ee4a3cb436c5dc57ae396fba1a3d
  - [ ] Merge docs in content repo https://github.com/elastic/elastic-otel-java/pull/328
- [ ] **.NET**
  - [x] Add to this repo https://github.com/elastic/docs/pull/3033/commits/da93c02f7b83c736a877c8de25dbdc7ba37060e9
  - [ ] Merge docs in content repo https://github.com/elastic/elastic-otel-dotnet/pull/127
- [ ] **Node.js**
  - [x] Add to this repo https://github.com/elastic/docs/pull/3033/commits/b41b176a8848b253f9a9cb8c633aa456812c8e68
  - [ ] Merge docs in content repo https://github.com/elastic/elastic-otel-node/pull/287

_Other languages will be added in follow up PR(s)._

## Update navigation

- [ ] Update APM landing page ([`extra/apm_docs_landing.html`](https://github.com/elastic/docs/blob/master/extra/apm_docs_landing.html))
- [ ] Add links to APM breadcrumb dropdown ([`resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb`](https://github.com/elastic/docs/blob/master/resources/asciidoctor/lib/chunker/obs_breadcrumbs.rb))

## Add shared attributes

TBD

cc @bmorelli25 