### PR TITLE
ESS - Change current to ms-111

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.14
   stacklive: &stacklive [ 8.14, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-110
+  cloudSaasCurrent: &cloudSaasCurrent ms-111
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-111.

Do not merge until release day.