### PR TITLE
ESS - Change current to ms-112

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.15
   stacklive: &stacklive [ 8.15, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-111
+  cloudSaasCurrent: &cloudSaasCurrent ms-112
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Cloud ESS docs to ms-112.

Do not merge until release day.