### PR TITLE
Move edit button out of heading elements

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
@@ -14,7 +14,7 @@ module DocbookCompat
         xpack_tag(node),
         '</', tag_name, '>',
         node.attr('edit_me_link', ''),
-        '</div>',
+        '</div>'
       ].compact.join
     end
   end

--- a/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_floating_title.rb
@@ -7,12 +7,14 @@ module DocbookCompat
     def convert_floating_title(node)
       tag_name = %(h#{node.level + 1})
       [
+        '<div class="position-relative">',
         '<', tag_name, node.role ? %( class="#{node.role}") : nil, '>',
         node.id ? %(<a id="#{node.id}"></a>) : nil,
         node.title,
-        node.attr('edit_me_link', ''),
         xpack_tag(node),
-        '</', tag_name, '>'
+        '</', tag_name, '>',
+        node.attr('edit_me_link', ''),
+        '</div>',
       ].compact.join
     end
   end

--- a/resources/asciidoctor/lib/docbook_compat/extension.rb
+++ b/resources/asciidoctor/lib/docbook_compat/extension.rb
@@ -56,7 +56,7 @@ module DocbookCompat
       <<~HTML
         <div class="#{wrapper_class_for node}#{node.role ? " #{node.role}" : ''}">
         <div class="titlepage"><div><div>
-        <h#{hlevel node} class="title"><a id="#{node.id}"></a>#{node.captioned_title}#{node.attr 'edit_me_link', ''}#{xpack_tag node}</h#{hlevel node}>
+        <div class="position-relative"><h#{hlevel node} class="title"><a id="#{node.id}"></a>#{node.captioned_title}#{xpack_tag node}</h#{hlevel node}>#{node.attr 'edit_me_link', ''}</div>
         </div></div></div>
         #{node.content}
         </div>

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -566,7 +566,7 @@ RSpec.describe DocbookCompat do
           level = hlevel < 2 ? 2 : hlevel
           expect(converted).to include(<<~HTML)
             <div class="titlepage"><div><div>
-            <h#{level} class="title"><a id="#{id}"></a>#{title}#{xpack_tag}</h#{level}>
+            <div class="position-relative"><h#{level} class="title"><a id="#{id}"></a>#{title}#{xpack_tag}</h#{level}></div>
             </div></div></div>
           HTML
         end
@@ -976,7 +976,7 @@ RSpec.describe DocbookCompat do
       end
       it 'has the xpack tag' do
         expect(converted).to include <<~HTML
-          <span class="xpack">Foo</span><a class="xpack_tag" href="/subscriptions"></a></h4>
+          <span class="xpack">Foo</span><a class="xpack_tag" href="/subscriptions"></a></h4></div>
         HTML
       end
     end

--- a/resources/asciidoctor/spec/edit_me_spec.rb
+++ b/resources/asciidoctor/spec/edit_me_spec.rb
@@ -75,11 +75,11 @@ RSpec.describe EditMe do
         shared_examples 'has standard edit links' do
           it "adds a link to #{type} 1" do
             link = spec_dir_link "#{type}1.adoc"
-            expect(converted).to include("#{type.capitalize} 1#{link}</")
+            expect(converted).to include(link)
           end
           it "adds a link to #{type} 2" do
             link = spec_dir_link "#{type}2.adoc"
-            expect(converted).to include("#{type.capitalize} 2#{link}</")
+            expect(converted).to include(link)
           end
         end
         context "that doesn't override edit_url" do
@@ -112,15 +112,15 @@ RSpec.describe EditMe do
               }
             end
             it 'adds a link to the enclosing chapter' do
-              expect(converted).to include(">Chapter#{stdin_link}</")
+              expect(converted).to include(stdin_link)
             end
             it "adds a link to #{type} 1" do
               link = edit_link 'foo'
-              expect(converted).to include("#{type.capitalize} 1#{link}</")
+              expect(converted).to include(link)
             end
             it "adds a link to #{type} 2" do
               link = edit_link 'bar'
-              expect(converted).to include("#{type.capitalize} 2#{link}</")
+              expect(converted).to include(link)
             end
             context 'when overriding to an empty string' do
               let(:input) do
@@ -166,7 +166,7 @@ RSpec.describe EditMe do
       it 'uses the longest match' do
         link = edit_link 'www.example.com/section2'
         expect(converted).to include <<~HTML
-          <h2 class="title"><a id="_section_2"></a>Section 2#{link}</h2>
+          <h2 class="title"><a id="_section_2"></a>Section 2</h2>#{link}</div>
         HTML
       end
     end
@@ -188,7 +188,7 @@ RSpec.describe EditMe do
       end
       it "doesn't have an edit me link" do
         expect(converted).to include <<~HTML
-          <h2 class="title"><a id="_section_2"></a>Section 2</h2>
+          <h2 class="title"><a id="_section_2"></a>Section 2</h2></div>
         HTML
       end
     end
@@ -225,11 +225,11 @@ RSpec.describe EditMe do
         shared_examples 'has standard edit links' do
           it "adds a link to #{type} 1" do
             link = spec_dir_link "#{type}1.adoc"
-            expect(converted).to include("#{type.capitalize} 1#{link}</")
+            expect(converted).to include(link)
           end
           it "adds a link to #{type} 2" do
             link = spec_dir_link "#{type}2.adoc"
-            expect(converted).to include("#{type.capitalize} 2#{link}</")
+            expect(converted).to include(link)
           end
         end
         context "that doesn't override edit_url" do
@@ -263,15 +263,15 @@ RSpec.describe EditMe do
               }
             end
             it 'adds a link to the enclosing chapter' do
-              expect(converted).to include(">Chapter#{stdin_link}</")
+              expect(converted).to include(stdin_link)
             end
             it "adds a link to #{type} 1" do
               link = edit_link 'foo'
-              expect(converted).to include("#{type.capitalize} 1#{link}</")
+              expect(converted).to include(link)
             end
             it "adds a link to #{type} 2" do
               link = edit_link 'bar'
-              expect(converted).to include("#{type.capitalize} 2#{link}</")
+              expect(converted).to include(link)
             end
             context 'when overriding to an empty string' do
               let(:input) do
@@ -320,7 +320,7 @@ RSpec.describe EditMe do
       it 'uses the longest match' do
         link = edit_link 'www.example.com/section2'
         expect(converted).to include <<~HTML
-          <h2 class="title"><a id="_section_2"></a>Section 2#{link}</h2>
+          <h2 class="title"><a id="_section_2"></a>Section 2</h2>#{link}</div>
         HTML
       end
     end
@@ -345,7 +345,7 @@ RSpec.describe EditMe do
       end
       it "doesn't have an edit me link" do
         expect(converted).to include <<~HTML
-          <h2 class="title"><a id="_section_2"></a>Section 2</h2>
+          <h2 class="title"><a id="_section_2"></a>Section 2</h2></div>
         HTML
       end
     end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -195,7 +195,7 @@ RSpec.describe ElasticCompatPreprocessor do
     end
     it 'uses the attributes for the header' do
       expect(converted).to include <<~HTML
-        <h2 class="title"><a id="foo-bar"></a>Header</h2>
+        <h2 class="title"><a id="foo-bar"></a>Header</h2></div>
       HTML
     end
     it 'uses the attributes outside of the header' do
@@ -299,7 +299,7 @@ RSpec.describe ElasticCompatPreprocessor do
         expect(converted).to eq <<~HTML
           <div class="chapter">
           <div class="titlepage"><div><div>
-          <h2 class="title"><a id="_example"></a>Example</h2>
+          <div class="position-relative"><h2 class="title"><a id="_example"></a>Example</h2></div>
           </div></div></div>
 
           </div>
@@ -340,7 +340,7 @@ RSpec.describe ElasticCompatPreprocessor do
         expect(converted).to eq <<~HTML
           <div class="chapter">
           <div class="titlepage"><div><div>
-          <h2 class="title"><a id="_example"></a>Example</h2>
+          <div class="position-relative"><h2 class="title"><a id="_example"></a>Example</h2></div>
           </div></div></div>
 
           </div>
@@ -470,7 +470,7 @@ RSpec.describe ElasticCompatPreprocessor do
     end
     it 'has the right offset' do
       expect(converted).to include <<~HTML
-        <h2 class="title"><a id="_target"></a>Target</h2>
+        <h2 class="title"><a id="_target"></a>Target</h2></div>
       HTML
     end
   end


### PR DESCRIPTION
Closes https://github.com/elastic/docs/issues/1966

This PR moves the edit button out of the heading elements in the body of the content (edit buttons were already added outside page titles in #3015). This is important because when the edit button is inside the heading element, technically the full text of the heading includes `edit` appended to the end of the intended heading text. This is getting picked up by Google, but may also cause unexpected results elsewhere including for users using screenreaders.

<img width="602" alt="Screenshot 2024-08-27 at 9 44 20 AM" src="https://github.com/user-attachments/assets/61aa4420-cb57-4bdd-83b1-7c4c64b106b9">

Note: I opted for updating the HTML and using Bootstrap CSS classes to avoid having to bump the name (`-v1` to `-v2`) of the CSS file. If the user gets the updated HTML with a cached version of the CSS and JavaScript files, the edit button should still be positioned correctly and work as expected.