### PR TITLE
feat: skip build for APM Server if there are no code changes

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -55,15 +55,18 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
       git switch pr_$GITHUB_PR_NUMBER
 
   if [[ "${GITHUB_PR_BASE_REPO}" == 'apm-server' ]]; then
-    git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs ./changelogs CHANGELOG.asciidoc
-
-    empty=$?
-
-    if [ $empty -eq 0 ]; then
-      echo "${GITHUB_PR_TARGET_BRANCH} in ${GITHUB_PR_BASE_REPO} has no docs changes"
-      exit 0
-    fi
+    docs_diff=$(git diff --stat "$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs ./changelogs CHANGELOG.asciidoc)
+  else
+    docs_diff=$(git diff --stat "$GITHUB_PR_TARGET_BRANCH"...HEAD)
   fi
+
+  if [[ -z $docs_diff ]]; then
+    echo "${GITHUB_PR_TARGET_BRANCH} in ${GITHUB_PR_BASE_REPO} has no docs changes"
+    exit 0
+  fi
+
+  echo "diff:"
+  echo "$docs_diff"
 
   cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -52,8 +52,20 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
 
   cd ./product-repo &&
       git fetch origin pull/$GITHUB_PR_NUMBER/head:pr_$GITHUB_PR_NUMBER &&
-      git switch pr_$GITHUB_PR_NUMBER &&
-      cd ..
+      git switch pr_$GITHUB_PR_NUMBER
+
+  if [[ "${GITHUB_PR_BASE_REPO}" == 'apm-server' ]]; then
+    git diff --quiet HEAD $GITHUB_PR_TARGET_BRANCH -- ./docs ./changelogs CHANGELOG.asciidoc
+
+    empty=$?
+
+    if [ $empty -eq 0 ]; then
+      echo "${GITHUB_PR_TARGET_BRANCH} in ${GITHUB_PR_BASE_REPO} has no docs changes"
+      exit 0
+    fi
+  fi
+
+  cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"
   build_args+=" --sub_dir $GITHUB_PR_BASE_REPO:$GITHUB_PR_TARGET_BRANCH:./product-repo"


### PR DESCRIPTION
docs/build-pr is the slowest job in apm-server CI pipeline and it is impacting significantly developer velocity when merging PRs. Update the buildkite pipeline to exit early if there are no docs changes.
APM Server docs is actually in a separate repository (observability-docs) and the few remaining files are barely touched (except for the changelog)

