### PR TITLE
Add shared attribute for Elastic Cloud API

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -202,7 +202,7 @@ Elastic Cloud
 :cloud-only: This feature is designed for indirect use by {ess-trial}[{ess}], {ece-ref}[{ece}], and {eck-ref}[{eck}]. Direct use is not supported.
 :ess-setting-change: {ess-icon} indicates a change to a supported {cloud}/ec-add-user-settings.html[user setting] for {ess}.
 :ess-skip-section: If you use {ess}, skip this section. {ess} handles these changes for you.
-
+:api-cloud:  https://www.elastic.co/docs/api/doc/cloud
 //////////
 Elasticsearch
 //////////


### PR DESCRIPTION
This PR adds a variable / shared attribute for https://www.elastic.co/docs/api/doc/cloud