### PR TITLE
Handle more heading levels

### DIFF
--- a/resources/web/docs_js/index-v1.js
+++ b/resources/web/docs_js/index-v1.js
@@ -71,16 +71,18 @@ export function init_headers(sticky_content, lang_strings) {
       this.href = '#' + this.id;
 
       // Extract on-this-page headers, without embedded links
-      var title_container = $(this).parent('h1,h2,h3,h4').clone();
+      var title_container = $(this).parent('h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11,h12').clone();
       if (title_container.length > 0) {
         // Assume initial heading is an H1, but adjust if it's not
-        let hLevel = 0;
+        let hLevel;
         if ($(this).parent().is("h2")){
           hLevel = 0;
         } else if ($(this).parent().is("h3")){
           hLevel = 1;
         } else if ($(this).parent().is("h4")){
           hLevel = 2;
+        } else if ($(this).parent().is("h5,h6,h7,h8,h9,h10,h11,h12")) {
+          hLevel = null
         }
 
         // Build list items for all headings except the page title
@@ -88,8 +90,10 @@ export function init_headers(sticky_content, lang_strings) {
           title_container.find('a,.added,.coming,.deprecated,.experimental')
             .remove();
           var text = title_container.html();
-          const li = '<li id="otp-text-' + i + '" class="heading-level-' + hLevel + '"><a href="#' + this.id + '">' + text + '</a></li>';
-          ul.append(li);
+          if (hLevel !== null) {
+            const li = '<li id="otp-text-' + i + '" class="heading-level-' + hLevel + '"><a href="#' + this.id + '">' + text + '</a></li>';
+            ul.append(li);
+          }
         }
       }
     });
@@ -342,7 +346,7 @@ $(function() {
   AlternativeSwitcher(store());
 
   // Get all headings inside the main body of the doc
-  const allHeadings = $('div#content').find('h1,h2,h3,h4,h5,h6,h7')
+  const allHeadings = $('div#content').find('h1,h2,h3,h4,h5,h6,h7,h8,h9,h10,h11,h12')
   let allLevels = []
   // Create a list of all heading levels used on the page
   allHeadings.each(function(index) {

--- a/resources/web/style/heading.pcss
+++ b/resources/web/style/heading.pcss
@@ -50,8 +50,11 @@
     margin: 16px 0 5px;
   }
 
-  /** I _think_ h7 is not technically valid HTML tag, but in the event that the nesting is deep enough we can at least bold the text */
-  h7 {
+  /**
+    Headings beyond h6 are not technically valid HTML tags,
+    but in the event that the nesting is deep enough we can at least bold the text.
+  **/
+  h7, h8, h9, h10, h11, h12 {
     font-weight: 600;
   }
 


### PR DESCRIPTION
In support of https://github.com/elastic/observability-docs/pull/4230

In https://github.com/elastic/observability-docs/pull/4230 I noticed that page subheadings in deeply-nested pages weren't working as expected. The highest heading level I found was h10, but in this PR I added logic for up to h12. Here's [an example](https://observability-docs_bk_4230.docs-preview.app.elstc.co/guide/en/observability/master/apm-sampling.html#distributed-tracing-examples) of before/after this PR:

| Before<br>(`h10`, no formatting) | After<br>(`h3`, with formatting) |
|---|---|
| <img width="1422" alt="Screenshot 2024-09-10 at 2 57 48 PM" src="https://github.com/user-attachments/assets/b2fc2410-142f-4ceb-a875-29fbad65e832">  | <img width="1415" alt="Screenshot 2024-09-10 at 2 59 55 PM" src="https://github.com/user-attachments/assets/18215119-3f06-47f2-a566-16e7971f2c59"> |

Note: Headings beyond `h6` are not technically valid HTML tags, but the build system will create them so we should handle them appropriately.