### PR TITLE
Update local installation URL in code widget

### DIFF
--- a/resources/web/docs_js/components/console_widget.jsx
+++ b/resources/web/docs_js/components/console_widget.jsx
@@ -150,7 +150,7 @@ export class _TryConsoleSelector extends Component {
           </a>
         <p> 
           <a
-            href="https://www.elastic.co/guide/en/elastic-stack/current/installing-elastic-stack.html"
+            href="https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html"
             target="_blank"
           >
              Install locally


### PR DESCRIPTION
Flagged by @serenachou, we didn't have this [nice local dev page](https://www.elastic.co/guide/en/elasticsearch/reference/current/run-elasticsearch-locally.html) when we updated the widget.

## Notes for reviewers

This only spins up ES and Kibana, so reviewer let me know if you agree with pointing there.

ℹ️ We'll update again to point to `start-local` when the time comes