### PR TITLE
feat(agent-go): skip build for if there are no code changes

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -52,8 +52,24 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
 
   cd ./product-repo &&
       git fetch origin pull/$GITHUB_PR_NUMBER/head:pr_$GITHUB_PR_NUMBER &&
-      git switch pr_$GITHUB_PR_NUMBER &&
-      cd ..
+      git switch pr_$GITHUB_PR_NUMBER
+
+  if [[ "${GITHUB_PR_BASE_REPO}" == 'apm-agent-go' ]]; then
+    git fetch origin "$GITHUB_PR_TARGET_BRANCH"
+    docs_diff=$(git diff --stat "$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs CHANGELOG.asciidoc)
+  else
+    docs_diff="always build"
+  fi
+
+  if [[ -z $docs_diff ]]; then
+    echo "${GITHUB_PR_TARGET_BRANCH} in ${GITHUB_PR_BASE_REPO} has no docs changes"
+    exit 0
+  fi
+
+  echo "diff:"
+  echo "$docs_diff"
+
+  cd ..
   # For product repos - context in https://github.com/elastic/docs/commit/5b06c2dc1f50208fcf6025eaed6d5c4e81200330
   build_args+=" --keep_hash"
   build_args+=" --sub_dir $GITHUB_PR_BASE_REPO:$GITHUB_PR_TARGET_BRANCH:./product-repo"


### PR DESCRIPTION
try to run the experiment with apm-agent-go for now
only run the diff command for apm-agent-go
fetch the target repo to avoid errors on repo different from main

apm-agent-go is in maintenance only mode so this should have no impact on a supported product.

I'll run some tests on different branches with different names to ensure everything is working and then we can do a gradual rollout to other repositories