### PR TITLE
fix(apm-agent-go): always diff against the remote branch 

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -56,7 +56,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
 
   if [[ "${GITHUB_PR_BASE_REPO}" == 'apm-agent-go' ]]; then
     git fetch origin "$GITHUB_PR_TARGET_BRANCH"
-    docs_diff=$(git diff --stat "$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs CHANGELOG.asciidoc)
+    docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs CHANGELOG.asciidoc)
   else
     docs_diff="always build"
   fi


### PR DESCRIPTION
the check fails if we're targeting a branch that is not the default branch.
Since we run git fetch before the diff, we know for a fact that the remote branch exist so just specify the remote and use the remote branch in the diff.