### PR TITLE
Add 8.x in Observability, Fleet, APM Guides

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -406,7 +406,7 @@ contents:
           - title:      Observability
             prefix:     en/observability
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
+            branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9 ]
             live:       *stacklive
             index:      docs/en/observability/index.asciidoc
             chunk:      4
@@ -450,7 +450,7 @@ contents:
                 toc_extra:  extra/apm_guide_landing.html
                 index:      docs/en/apm-server/integrations-index.asciidoc
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 chunk:      2
                 tags:       APM Guide
@@ -1485,7 +1485,7 @@ contents:
           - title:      Fleet and Elastic Agent Guide
             prefix:     en/fleet
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/en/ingest-management/index.asciidoc
             chunk:      2

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -560,11 +560,8 @@ Without these if directives, the links fail and break the build.
 ifdef::8x-missing-links[]
 :kibana-ref:                   https://www.elastic.co/guide/en/kibana/master
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/master
-:observability-guide:          https://www.elastic.co/guide/en/observability/master
 :stack-ref:                    https://www.elastic.co/guide/en/elastic-stack/master
 :security-guide:               https://www.elastic.co/guide/en/security/master
-:fleet-guide:                  https://www.elastic.co/guide/en/fleet/master
-:apm-guide-ref:                https://www.elastic.co/guide/en/apm/guide/master
 :es-dotnet-client:             https://www.elastic.co/guide/en/elasticsearch/client/net-api/master
 :es-php-client:                https://www.elastic.co/guide/en/elasticsearch/client/php-api/master
 :jsclient:                     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master


### PR DESCRIPTION
This PR updates the conf.yaml to start building 8.16 doc from the 8.x branch that now exist in the apm-server and observability-docs repos.  It removes attributes that were added to work around broken links from other books.