### PR TITLE
Add 8.x for security-docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -923,7 +923,7 @@ contents:
           - title:      Elastic Security
             prefix:     en/security
             current:    *stackcurrent
-            branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
+            branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8 ]
             live:       *stacklive
             index:      docs/index.asciidoc
             chunk:      1

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -561,7 +561,6 @@ ifdef::8x-missing-links[]
 :kibana-ref:                   https://www.elastic.co/guide/en/kibana/master
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/master
 :stack-ref:                    https://www.elastic.co/guide/en/elastic-stack/master
-:security-guide:               https://www.elastic.co/guide/en/security/master
 :es-dotnet-client:             https://www.elastic.co/guide/en/elasticsearch/client/net-api/master
 :es-php-client:                https://www.elastic.co/guide/en/elasticsearch/client/php-api/master
 :jsclient:                     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -559,6 +559,7 @@ Without these if directives, the links fail and break the build.
 
 ifdef::8x-missing-links[]
 :kibana-ref:                   https://www.elastic.co/guide/en/kibana/master
+:apm-app-ref:                  https://www.elastic.co/guide/en/kibana/master
 :enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/master
 :stack-ref:                    https://www.elastic.co/guide/en/elastic-stack/master
 :es-dotnet-client:             https://www.elastic.co/guide/en/elasticsearch/client/net-api/master


### PR DESCRIPTION
This PR starts publishing the Security Guide from the 8.x branch
