### PR TITLE
Add 8.x for clients

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -342,7 +342,7 @@ contents:
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
@@ -357,7 +357,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -372,7 +372,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1014,7 +1014,7 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1027,7 +1027,7 @@ contents:
               - title:      Ruby Client
                 prefix:     ruby-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1040,7 +1040,7 @@ contents:
               - title:      Go Client
                 prefix:     go-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      .doc/index.asciidoc
                 chunk:      1
@@ -1053,7 +1053,7 @@ contents:
               - title:      .NET Clients
                 prefix:     net-api
                 current:    8.9
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 live:       [ main, 8.9, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
@@ -1069,7 +1069,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1098,7 +1098,7 @@ contents:
               - title:      Python Client
                 prefix:     python-api
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 chunk:     1
@@ -1124,7 +1124,7 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    main
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 live:       [ main, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1

--- a/conf.yaml
+++ b/conf.yaml
@@ -327,7 +327,7 @@ contents:
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 current:    *stackcurrent
-                branches:   [ {main: master}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
+                branches:   [ {main: master}, {8.x: 8.16}, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
                 live:       [ *stackcurrent ]
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -560,15 +560,6 @@ Without these if directives, the links fail and break the build.
 ifdef::8x-missing-links[]
 :kibana-ref:                   https://www.elastic.co/guide/en/kibana/master
 :apm-app-ref:                  https://www.elastic.co/guide/en/kibana/master
-:enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/master
 :stack-ref:                    https://www.elastic.co/guide/en/elastic-stack/master
-:es-dotnet-client:             https://www.elastic.co/guide/en/elasticsearch/client/net-api/master
-:es-php-client:                https://www.elastic.co/guide/en/elasticsearch/client/php-api/master
-:jsclient:                     https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/master
-:es-python-client:             https://www.elastic.co/guide/en/elasticsearch/client/python-api/master
-:es-ruby-client:               https://www.elastic.co/guide/en/elasticsearch/client/ruby-api/master
 :enterprise-search-node-ref:   https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/master
-:enterprise-search-php-ref:    https://www.elastic.co/guide/en/enterprise-search-clients/php/master
-:enterprise-search-python-ref: https://www.elastic.co/guide/en/enterprise-search-clients/python/master
-:enterprise-search-ruby-ref:   https://www.elastic.co/guide/en/enterprise-search-clients/ruby/master
 endif::[]

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -561,5 +561,4 @@ ifdef::8x-missing-links[]
 :kibana-ref:                   https://www.elastic.co/guide/en/kibana/master
 :apm-app-ref:                  https://www.elastic.co/guide/en/kibana/master
 :stack-ref:                    https://www.elastic.co/guide/en/elastic-stack/master
-:enterprise-search-node-ref:   https://www.elastic.co/guide/en/enterprise-search-clients/enterprise-search-node/master
 endif::[]


### PR DESCRIPTION
This PR adds the 8.x branches in all of the Elasticsearch and Enterprise Search client repos.
