### PR TITLE
support elastic-observability-automation in pull-requests.org-wide.json

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -9,7 +9,7 @@
         "admin",
         "write"
       ],
-      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]"],
+      "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]", "elastic-observability-automation[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",


### PR DESCRIPTION
### What

Grant build access to the `elastic-observability-automation` GitHub app - https://github.com/apps/elastic-observability-automation

### Why

Otherwise no docs builds are triggered automatically.

See https://github.com/elastic/apm-server/pull/14119

### Issues

Part of https://github.com/elastic/observability-robots/issues/2418
