### PR TITLE
bump master version for ECE to 3.8

### DIFF
--- a/shared/versions/ece/master.asciidoc
+++ b/shared/versions/ece/master.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.7.1
-:ece-version-short:  3.7
-:ece-version-link: 3.7
+:ece-version:  3.8.-1
+:ece-version-short:  3.8
+:ece-version-link: 3.8


### PR DESCRIPTION
This PR bumps the ECE version of the cloud master branch to the unreleased 3.8. To re-align with the changes done [in this cloud PR](https://github.com/elastic/cloud/pull/132082)