### PR TITLE
Bump up version for ECE 3.7.3

### DIFF
--- a/shared/versions/ece/ms-105.asciidoc
+++ b/shared/versions/ece/ms-105.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.7.2
+:ece-version:  3.7.3
 :ece-version-short:  3.7
 :ece-version-link: 3.7


### PR DESCRIPTION
This change bumps version to cater t ECE 3.7.3 release.
