### PR TITLE
Update ECE version to 3.7.3

### DIFF
--- a/shared/versions/ece/ms-105.asciidoc
+++ b/shared/versions/ece/ms-105.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.7.2
+:ece-version:  3.7.3
 :ece-version-short:  3.7
 :ece-version-link: 3.7


### PR DESCRIPTION
This changes the version of the ms-105 branch in the ECE docs to version 3.7.3.
Do not merge until release day.