### PR TITLE
Draft some new admonitions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,4 +37,4 @@ Metrics/ClassLength:
   Max: 120
 
 Metrics/MethodLength:
-  Max: 20
+  Max: 35

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1399,23 +1399,16 @@ The path should be as specific as possible because we skip rebuilding books if
 changes to the referenced repository don't change the referenced path.
 
 [[changes]]
-== Additions and deprecations
+== Additions, deprecations, and discontinuations
 
-Documentation is built for various branches, eg `0.90`,
-`1.00`, `master`.  However, we release versions
-`0.90.0`, `0.90.1`, etc, which are all based on the
-`0.90` branch.
+When adding, deprecating, or discontinuing functionality, you can mark the change as
+_coming_, _generally available_ (formerly _added_), _deprecated_, or _discontinued_.
 
-When adding new functionality to a branch, or deprecating
-existing functionality, you can mark the change as
-_added_, _coming_ or _deprecated_. Use `coming` when the addition is
-in an as yet unreleased version of the current branch, and `added` when
-the functionality is already released.
+Use `coming` when the addition is in an as yet unreleased version of the current branch.
+Use `generally_available` when the functionality is released and no longer in a beta, dev, or preview state.
 
-The `update_versions.pl` script can be used to change `coming` notices
-to `added` notices when doing a new release, and can also be used
-to remove `added`, `coming` and `deprecated` notices completely.
-
+For Elastic Serverless and Elasticsearch Service content, there currently isn't a public identifier for individual releases.
+In other contexts, you can qualify the addition, deprecation, or discontinuation with a specific version number.
 
 === Inline notifications
 
@@ -1425,32 +1418,19 @@ the addition or deprecation of individual parameters.
 [source,asciidoc]
 ----------------------------------
 [horizontal]
-`foo.bar`::   Does XYZ. added:[0.90.4]
-`foo.bar`::   Does XYZ. coming:[0.90.4]
-`foo.baz`::   Does XYZ. deprecated:[0.90.4]
+`foo.bar`::   Does XYZ. ga_stack:[0.90.4]
+`foo.bar`::   Does XYZ. coming:[0.90.4] coming_serverless:[] coming_ess:[]
+`foo.baz`::   Does XYZ. deprecated:[0.90.4] deprecated_serverless:[] deprecated_ess:[]
 ----------------------------------
 
-[horizontal]
-`foo.bar`::   Does XYZ. added:[0.90.4]
-`foo.bar`::   Does XYZ. coming:[0.90.4]
-`foo.baz`::   Does XYZ. deprecated:[0.90.4]
-
-You can also include details about additional
-notes in the notifications which show up when the
-user hovers over it:
+Some annotations also enable you add custom notes that show up when the user hovers over it:
 
 [source,asciidoc]
 ----------------------------------
 [horizontal]
-`foo.bar`::   Does XYZ. added:[0.90.4,Replaces `foo.baz`]
 `foo.bar`::   Does XYZ. coming:[0.90.4,Replaces `foo.baz`]
 `foo.baz`::   Does XYZ. deprecated:[0.90.4,Replaced by `foo.bar`]
 ----------------------------------
-
-[horizontal]
-`foo.bar`::   Does XYZ. added:[0.90.4,Replaces `foo.baz`]
-`foo.bar`::   Does XYZ. coming:[0.90.4,Replaces `foo.baz`]
-`foo.baz`::   Does XYZ. deprecated:[0.90.4,Replaced by `foo.bar`]
 
 [NOTE]
 ====
@@ -1463,98 +1443,48 @@ deprecated::[1.1.0,"Span started automatically by <<apm-start-span,apm.startSpan
 
 === Section notifications
 
-Use section notifications to mark an entire chapter or
-section as _added_/_deleted_.  Notifications can just refer
-to the version in which the change was made:
+Use section notifications to annotate an entire page or section. 
 
 [source,asciidoc]
 ----------------------------------
 ==== New section
 
-added::[0.90.4]
+ga_stack::[0.90.4]
 
 Text about new functionality...
 
 ==== New section not yet released
 
-coming::[0.90.9]
+coming_ess::[]
 
 Text about new functionality...
 
 ==== Old section
 
-deprecated::[0.90.4]
+deprecated_serverless::[]
 
 Text about old functionality...
 ----------------------------------
 
-==== New section
-
-added::[0.90.4]
-
-Text about new functionality...
-
-==== New section not yet released
-
-coming::[0.90.9]
-
-Text about new functionality...
-
-==== Old section
-
-deprecated::[0.90.4]
-
-Text about old functionality...
-
-[[with_details]]
-==== With details...
-
-Or they can include extra text, including more
-Asciidoc markup:
+In some cases you can add extra text, including more Asciidoc markup.
+For example:
 
 [source,asciidoc]
 ----------------------------------
-[[new-section]]
-==== New section
-
-added::[0.90.4,Replaces `foo.bar`. See <<old-section>>]
-
-Text about new functionality...
-
 [[coming-section]]
 ==== New section not yet released
 
 coming::[0.90.9,Replaces `foo.bar`. See <<old-section>>]
 
 Text about new functionality...
-
-[[old-section]]
-==== Old section
-
-deprecated::[0.90.4,Replace by `foo.baz`. See <<new-section>>]
-
-Text about old functionality...
 ----------------------------------
-
-[[new-section]]
-==== New section
-
-added::[0.90.4,Replaces `foo.bar`. See <<old-section>>]
-
-Text about new functionality...
-
-[[old-section]]
-==== Old section
-
-deprecated::[0.90.4,Replace by `foo.baz`. See <<new-section>>]
-
-Text about old functionality...
 
 [[experimental]]
 == Beta, Dev, and Preview (experimental)
 
-APIs or parameters that are in beta, in development, or in technical preview (formerly experimental) can be
+Functionality that is in beta, in development, or in technical preview (formerly experimental) can be
 marked as such, using markup similar to that used in <<changes>>.
+Since a feature might be in different lifecycle stages in different contexts, there are multiple variations of each admonition (for example, `beta`, `beta_ess`, and `beta_serverless`).
 
 In the block format, you have the option of adding a related GitHub issue link.
 If both custom text and a GitHub link are provided, the GitHub link **must** be
@@ -1570,15 +1500,15 @@ attribute in place of the GitHub issue link.
 
 beta::[]
 
-beta::[https://github.com/elastic/docs/issues/505]
+beta_serverless::[https://github.com/elastic/docs/issues/505]
 
 beta::[{issue}505]
 
-beta::["Custom text goes here."]
+beta_ess::["Custom text goes here."]
 
 beta::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
 
-beta::["Custom text goes here.",{issue}505]
+beta_serverless::["Custom text goes here.",{issue}505]
 
 Text about new feature...
 
@@ -1592,11 +1522,11 @@ a new parameter that's in beta:
 This param has been around for ages and won't change.
 
 `beta_param`::
-beta:[]
+beta:[] 
 This param is in beta and may change in the future.
 
 `beta_param`::
-beta:["Custom text goes here."]
+beta_serverless:["Custom text goes here."]
 This param is in beta and may change in the future.
 ----
 
@@ -1609,15 +1539,15 @@ This param is in beta and may change in the future.
 
 dev::[]
 
-dev::[https://github.com/elastic/docs/issues/505]
+dev_serverless::[https://github.com/elastic/docs/issues/505]
 
 dev::[{issue}505]
 
-dev::["Custom text goes here."]
+dev_ess::["Custom text goes here."]
 
 dev::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
 
-dev::["Custom text goes here.",{issue}505]
+dev_serverless::["Custom text goes here.",{issue}505]
 
 Text about feature in development...
 
@@ -1635,7 +1565,7 @@ dev:[]
 This param is in development and may change in the future.
 
 `dev_param`::
-dev:["Custom text goes here."]
+dev_ess:["Custom text goes here."]
 This param is in development and may change in the future.
 ----
 
@@ -1656,15 +1586,15 @@ See below.
 
 preview::[]
 
-preview::[https://github.com/elastic/docs/issues/505]
+preview_serverless::[https://github.com/elastic/docs/issues/505]
 
 preview::[{issue}505]
 
-preview::["Custom text goes here."]
+preview_ess::["Custom text goes here."]
 
 preview::["Custom text goes here.",https://github.com/elastic/docs/issues/505]
 
-preview::["Custom text goes here.",{issue}505]
+preview_serverless::["Custom text goes here.",{issue}505]
 
 Text about new feature...
 
@@ -1682,7 +1612,7 @@ preview:[]
 This param is in technical preview and may change in the future.
 
 `experimental_param`::
-preview:["Custom text goes here."]
+preview_ess:["Custom text goes here."]
 This param is in technical preview and may change in the future.
 ----
 

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -3,16 +3,43 @@
 require 'asciidoctor/extensions'
 
 ##
-# Extensions for marking something as `beta`, `dev`, or technical `preview`.
+# Extensions for marking something as `beta`, `beta_serverless`, `beta_ess`,
+# `dev`, `dev_serverless`, `dev_ess`, technical `preview`, `preview_serverless`,
+# `preview_ess`, `ga_serverless`, `ga_ess`.
 #
 # Usage
 #
 #   beta::[]
 #   dev::[]
 #   preview::[]
+#   beta_ess::[]
+#   beta_serverless::[]
+#   dev_ess::[]
+#   dev_serverless::[]
+#   ga_serverless::[]
+#   deprecated_ess::[]
+#   deprecated_serverless::[]
+#   discontinued_ess::[]
+#   discontinued_serverless::[]
+#   coming_ess::[]
+#   coming_serverless::[]
 #   Foo beta:[]
 #   Foo dev:[]
 #   Foo preview:[]
+#   Foo beta_ess:[]
+#   Foo beta_serverless:[]
+#   Foo dev_ess:[]
+#   Foo dev_serverless:[]
+#   Foo preview_ess:[]
+#   Foo preview_serverless:[]
+#   Foo ga_ess:[]
+#   Foo ga_serverless:[]
+#   Foo deprecated_ess:[]
+#   Foo deprecated_serverless:[]
+#   Foo discontinued_ess:[]
+#   Foo discontinued_serverless:[]
+#   Foo coming_ess:[]
+#   Foo coming_serverless::[]
 #
 # !! `experimental:[]` is supported as a deprecated alternative to `preview:[]`.
 # !! But please use `preview:[]` instead.
@@ -21,19 +48,83 @@ class CareAdmonition < Asciidoctor::Extensions::Group
   BETA_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
   TEXT
+  BETA_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is in beta in Elastic Serverless and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+  TEXT
+  BETA_ESS_TEXT = <<~TEXT.strip
+    This functionality is in beta in Elasticsearch Service and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+  TEXT
   DEV_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
+  DEV_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is in development in Elastic Serverless and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
+  TEXT
+  DEV_ESS_TEXT = <<~TEXT.strip
+    This functionality is in development in Elasticsearch Service and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
+  TEXT
   PREVIEW_DEFAULT_TEXT = <<~TEXT.strip
     This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  TEXT
+  PREVIEW_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is in technical preview in Elastic Serverless and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  TEXT
+  PREVIEW_ESS_TEXT = <<~TEXT.strip
+    This functionality is in technical in preview in Elasticsearch Service and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+  TEXT
+  DEPRECATED_ESS_TEXT = <<~TEXT.strip
+    This functionality is deprecated in Elasticsearch Service and will be removed in a future release.
+  TEXT
+  DEPRECATED_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is deprecated in Elastic Serverless and will be removed in a future release.
+  TEXT
+  DISCONTINUED_ESS_TEXT = <<~TEXT.strip
+    This functionality is discontinued in Elasticsearch Service.
+  TEXT
+  DISCONTINUED_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is discontinued in Elastic Serverless.
+  TEXT
+  COMING_ESS_TEXT = <<~TEXT.strip
+    This functionality is coming in Elasticsearch Service.
+  TEXT
+  COMING_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is coming in Elastic Serverless.
+  TEXT
+  GA_ESS_TEXT = <<~TEXT.strip
+    This functionality is generally available in Elasticsearch Service.
+  TEXT
+  GA_SERVERLESS_TEXT = <<~TEXT.strip
+    This functionality is generally available in Elastic Serverless.
   TEXT
 
   def activate(registry)
     [
       [:beta, 'beta', BETA_DEFAULT_TEXT],
+      [:beta_serverless, 'Serverless:beta', BETA_SERVERLESS_TEXT],
+      [:beta_ess, 'ESS:beta', BETA_ESS_TEXT],
       [:dev, 'dev', DEV_DEFAULT_TEXT],
+      [:dev_serverless, 'Serverless:dev', DEV_SERVERLESS_TEXT],
+      [:dev_ess, 'ESS:dev', DEV_ESS_TEXT],
       [:experimental, 'preview', PREVIEW_DEFAULT_TEXT],
       [:preview, 'preview', PREVIEW_DEFAULT_TEXT],
+      [:preview_serverless, 'Serverless:preview', PREVIEW_SERVERLESS_TEXT],
+      [:preview_ess, 'ESS:preview', PREVIEW_ESS_TEXT],
+      [
+        :deprecated_serverless,
+        'Serverless:deprecated',
+        DEPRECATED_SERVERLESS_TEXT,
+      ],
+      [:deprecated_ess, 'ESS:deprecated', DEPRECATED_ESS_TEXT],
+      [
+        :discontinued_serverless,
+        'Serverless:discontinued',
+        DISCONTINUED_SERVERLESS_TEXT,
+      ],
+      [:discontinued_ess, 'ESS:discontinued', DISCONTINUED_ESS_TEXT],
+      [:coming_serverless, 'Serverless:coming', COMING_SERVERLESS_TEXT],
+      [:coming_ess, 'ESS:coming', COMING_ESS_TEXT],
+      [:ga_serverless, 'Serverless:GA', GA_SERVERLESS_TEXT],
+      [:ga_ess, 'ESS:GA', GA_ESS_TEXT],
     ].each do |(name, role, default_text)|
       registry.block_macro ChangeAdmonitionBlock.new(role, default_text), name
       registry.inline_macro ChangeAdmonitionInline.new(role, default_text), name

--- a/resources/asciidoctor/lib/care_admonition/extension.rb
+++ b/resources/asciidoctor/lib/care_admonition/extension.rb
@@ -49,7 +49,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in beta and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
   TEXT
   BETA_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is in beta in Elastic Serverless and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
+    This functionality is in beta in Elastic Cloud Serverless and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
   TEXT
   BETA_ESS_TEXT = <<~TEXT.strip
     This functionality is in beta in Elasticsearch Service and is subject to change. The design and code is less mature than official GA features and is being provided as-is with no warranties. Beta features are not subject to the support SLA of official GA features.
@@ -58,7 +58,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in development and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   DEV_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is in development in Elastic Serverless and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
+    This functionality is in development in Elastic Cloud Serverless and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
   TEXT
   DEV_ESS_TEXT = <<~TEXT.strip
     This functionality is in development in Elasticsearch Service and may be changed or removed completely in a future release. These features are unsupported and not subject to the support SLA of official GA features.
@@ -67,7 +67,7 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is in technical preview and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
   PREVIEW_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is in technical preview in Elastic Serverless and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
+    This functionality is in technical preview in Elastic Cloud Serverless and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
   TEXT
   PREVIEW_ESS_TEXT = <<~TEXT.strip
     This functionality is in technical in preview in Elasticsearch Service and may be changed or removed in a future release. Elastic will work to fix any issues, but features in technical preview are not subject to the support SLA of official GA features.
@@ -76,25 +76,25 @@ class CareAdmonition < Asciidoctor::Extensions::Group
     This functionality is deprecated in Elasticsearch Service and will be removed in a future release.
   TEXT
   DEPRECATED_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is deprecated in Elastic Serverless and will be removed in a future release.
+    This functionality is deprecated in Elastic Cloud Serverless and will be removed in a future release.
   TEXT
   DISCONTINUED_ESS_TEXT = <<~TEXT.strip
     This functionality is discontinued in Elasticsearch Service.
   TEXT
   DISCONTINUED_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is discontinued in Elastic Serverless.
+    This functionality is discontinued in Elastic Cloud Serverless.
   TEXT
   COMING_ESS_TEXT = <<~TEXT.strip
     This functionality is coming in Elasticsearch Service.
   TEXT
   COMING_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is coming in Elastic Serverless.
+    This functionality is coming in Elastic Cloud Serverless.
   TEXT
   GA_ESS_TEXT = <<~TEXT.strip
     This functionality is generally available in Elasticsearch Service.
   TEXT
   GA_SERVERLESS_TEXT = <<~TEXT.strip
-    This functionality is generally available in Elastic Serverless.
+    This functionality is generally available in Elastic Cloud Serverless.
   TEXT
 
   def activate(registry)

--- a/resources/asciidoctor/lib/change_admonition/extension.rb
+++ b/resources/asciidoctor/lib/change_admonition/extension.rb
@@ -9,17 +9,29 @@ require 'asciidoctor/extensions'
 # Usage
 #
 #   added::[6.0.0-beta1]
+#   ga_stack::[8.10]
 #   coming::[6.0.0-beta1]
 #   deprecated::[6.0.0-beta1]
+#   discontinued_stack::[9.0.0]
 #   Foo added:[6.0.0-beta1]
 #   Foo coming:[6.0.0-beta1]
 #   Foo deprecated:[6.0.0-beta1]
+#   Foo ga_stack:[8.10]
+#   Foo discontinued_stack:[9.0.0]
 #
 class ChangeAdmonition < Asciidoctor::Extensions::Group
   MACRO_CONF = [
     [:added, 'added', 'note', 'Added in', nil],
     [:coming, 'changed', 'note', 'Coming in', nil],
     [:deprecated, 'deleted', 'warning', 'Deprecated in', ' u-strikethrough'],
+    [:ga_stack, 'added', 'note', 'Generally available in Elack Stack in', nil],
+    [
+      :discontinued_stack,
+      'deleted',
+      'warning',
+      'Discontinued in',
+      ' u-strikethrough',
+    ],
   ].freeze
   def activate(registry)
     MACRO_CONF.each do |(name, revisionflag, tag, message, title_class)|

--- a/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
+++ b/resources/asciidoctor/lib/elastic_compat_preprocessor/extension.rb
@@ -12,10 +12,14 @@ require_relative '../migration_log'
 #   added[6.0.0-beta1]
 #   coming[6.0.0-beta1]
 #   deprecated[6.0.0-beta1]
+#   discontinued-stack[9.0.0]
+#   ga_stack[8.10]
 # Into
 #   added::[6.0.0-beta1]
 #   coming::[6.0.0-beta1]
 #   deprecated::[6.0.0-beta1]
+#   discontinued-stack[9.0.0]
+#   ga_stack::[8.10]
 # Because `::` is required by asciidoctor to invoke block macros but isn't
 # required by asciidoc.
 #
@@ -23,10 +27,14 @@ require_relative '../migration_log'
 #   words words added[6.0.0-beta1]
 #   words words changed[6.0.0-beta1]
 #   words words deprecated[6.0.0-beta1]
+#   words words discontinued[9.0.0]
+#   words words ga_stack[8.10]
 # Into
 #   words words added:[6.0.0-beta1]
 #   words words changed:[6.0.0-beta1]
 #   words words deprecated:[6.0.0-beta1]
+#   words words discontinued:[9.0.0]
+#   words words ga_stack:[8.10]
 # Because `:` is required by asciidoctor to invoke inline macros but isn't
 # required by asciidoc.
 #
@@ -116,9 +124,17 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
     /^\["source", ?"[^"]+", ?subs="(#{Asciidoctor::CC_ANY}+)"\]$/
   CODE_BLOCK_RX = /^-----*$/
   SNIPPET_RX = %r{^//\s*(AUTOSENSE|KIBANA|CONSOLE|SENSE:[^\n<]+)$}
-  LEGACY_MACROS = 'added|beta|coming|deprecated|dev|experimental'
-  LEGACY_BLOCK_MACRO_RX = /^\s*(#{LEGACY_MACROS})\[(.*)\]\s*$/
-  LEGACY_INLINE_MACRO_RX = /(#{LEGACY_MACROS})\[(.*)\]/
+  LEGACY = 'added|experimental'
+  BETA = 'beta|beta_serverless|beta_ess'
+  COMING = 'coming|coming_serverless|coming_ess'
+  DEP = 'deprecated|deprecated_serverless|deprecated_ess'
+  DEV = 'dev|dev_serverless|dev_ess'
+  DISC = 'discontinued_stack|discontinued_ess|discontinued_serverless'
+  GA = 'ga_stack|ga_serverless|ga_ess'
+  PREV = 'preview_serverless|preview_ess'
+  MACROS = "#{LEGACY}|#{BETA}|#{COMING}|#{DEP}|#{DEV}|#{DISC}|#{GA}|#{PREV}"
+  BLOCK_MACRO_RX = /^\s*(#{MACROS})\[(.*)\]\s*$/
+  INLINE_MACRO_RX = /(#{MACROS})\[(.*)\]/
 
   def process(_document, reader)
     reader.extend ReaderExtension
@@ -205,11 +221,10 @@ class ElasticCompatPreprocessor < Asciidoctor::Extensions::Preprocessor
 
       # First convert the "block" version of these macros. We convert them
       # to block macros because they are alone on a line
-      line.gsub!(LEGACY_BLOCK_MACRO_RX, '\1::[\2]')
+      line.gsub!(BLOCK_MACRO_RX, '\1::[\2]')
       # Then convert the "inline" version of these macros. We convert them
       # to inline macros because they are *not* at the start of the line....
-      line.gsub!(LEGACY_INLINE_MACRO_RX, '\1:[\2]')
-
+      line.gsub!(INLINE_MACRO_RX, '\1:[\2]')
       # Transform Elastic's traditional comment based marking for
       # AUTOSENSE/KIBANA/CONSOLE snippets into a marker that we can pick
       # up during tree processing to turn the snippet into a marked up

--- a/resources/asciidoctor/spec/change_admonition_spec.rb
+++ b/resources/asciidoctor/spec/change_admonition_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ChangeAdmonition do
           HTML
         end
       end
-      context 'without content' do
+      context 'with version content' do
         let(:input) do
           <<~ASCIIDOC
             #{key}::[7.0.0-beta1]
@@ -206,6 +206,13 @@ RSpec.describe ChangeAdmonition do
     let(:key) { 'deprecated' }
     let(:admon_class) { 'warning' }
     let(:message) { 'Deprecated' }
+    let(:extra_class) { ' u-strikethrough' }
+    include_examples 'change admonition'
+  end
+  context 'discontinued in stack' do
+    let(:key) { 'discontinued_stack' }
+    let(:admon_class) { 'warning' }
+    let(:message) { 'Discontinued' }
     let(:extra_class) { ' u-strikethrough' }
     include_examples 'change admonition'
   end

--- a/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
+++ b/resources/asciidoctor/spec/elastic_compat_preprocessor_spec.rb
@@ -116,7 +116,25 @@ RSpec.describe ElasticCompatPreprocessor do
       let(:block_admon_class) { 'note' }
       let(:inline_admon_class) { 'change' }
     end
+    context 'for ga in stack' do
+      include_context 'change admonition'
+      let(:name) { 'ga_stack' }
+      let(:block_admon_class) { 'note' }
+      let(:inline_admon_class) { 'change' }
+    end
     context 'for coming' do
+      include_context 'change admonition'
+      let(:name) { 'coming' }
+      let(:block_admon_class) { 'note' }
+      let(:inline_admon_class) { 'change' }
+    end
+    context 'for coming in serverless' do
+      include_context 'change admonition'
+      let(:name) { 'coming' }
+      let(:block_admon_class) { 'note' }
+      let(:inline_admon_class) { 'change' }
+    end
+    context 'for coming in ESS' do
       include_context 'change admonition'
       let(:name) { 'coming' }
       let(:block_admon_class) { 'note' }
@@ -128,7 +146,6 @@ RSpec.describe ElasticCompatPreprocessor do
       let(:block_admon_class) { 'warning' }
       let(:inline_admon_class) { 'change' }
     end
-
     shared_examples 'care admonition' do
       include_examples 'admonition'
       let(:invocation) { "#{name}[]" }
@@ -140,15 +157,75 @@ RSpec.describe ElasticCompatPreprocessor do
       let(:name) { 'beta' }
       let(:inline_admon_class) { 'beta' }
     end
+    context 'for beta in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'beta_serverless' }
+      let(:inline_admon_class) { 'Serverless:beta' }
+    end
+    context 'for beta in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'beta_ess' }
+      let(:inline_admon_class) { 'ESS:beta' }
+    end
     context 'for dev' do
       include_context 'care admonition'
       let(:name) { 'dev' }
       let(:inline_admon_class) { 'dev' }
     end
+    context 'for dev in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'dev_serverless' }
+      let(:inline_admon_class) { 'Serverless:dev' }
+    end
+    context 'for dev in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'dev_ess' }
+      let(:inline_admon_class) { 'ESS:dev' }
+    end
     context 'for experimental' do
       include_context 'care admonition'
       let(:name) { 'experimental' }
       let(:inline_admon_class) { 'preview' }
+    end
+    context 'for preview in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'preview_serverless' }
+      let(:inline_admon_class) { 'Serverless:preview' }
+    end
+    context 'for preview in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'preview_ess' }
+      let(:inline_admon_class) { 'ESS:preview' }
+    end
+    context 'for ga in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'ga_serverless' }
+      let(:inline_admon_class) { 'Serverless:GA' }
+    end
+    context 'for ga in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'ga_ess' }
+      let(:inline_admon_class) { 'ESS:GA' }
+    end
+    context 'for discontinued in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'discontinued_serverless' }
+      let(:inline_admon_class) { 'Serverless:discontinued' }
+    end
+    context 'for discontinued in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'discontinued_ess' }
+      let(:inline_admon_class) { 'ESS:discontinued' }
+    end
+    context 'for deprecated in serverless' do
+      include_context 'care admonition'
+      let(:name) { 'deprecated_serverless' }
+      let(:inline_admon_class) { 'Serverless:deprecated' }
+    end
+    context 'for deprecated in ESS' do
+      include_context 'care admonition'
+      let(:name) { 'deprecated_ess' }
+      let(:inline_admon_class) { 'ESS:deprecated' }
     end
   end
 

--- a/resources/web/docs_js/index-v1.js
+++ b/resources/web/docs_js/index-v1.js
@@ -87,7 +87,7 @@ export function init_headers(sticky_content, lang_strings) {
 
         // Build list items for all headings except the page title
         if (0 < items++) {
-          title_container.find('a,.added,.coming,.deprecated,.experimental')
+          title_container.find('a,.added,.ga_stack,.ga_serverless,.ga_ess,.coming,.coming_serverless,.coming_ess,.deprecated,.deprecated_serverless,.deprecated_ess,.experimental,.preview_serverless,.preview_ess,.beta,.beta_serverless,.beta_ess,.dev,.dev_serverless,.dev_ess,.discontinued_stack,.discontinued_ess,.discontinued_serverless')
             .remove();
           var text = title_container.html();
           if (hLevel !== null) {

--- a/resources/web/style/toc.pcss
+++ b/resources/web/style/toc.pcss
@@ -118,11 +118,27 @@
     }
 
     .added,
+    .ga_stack,
+    .ga_serverless,
+    .ga_ess,
     .beta,
+    .beta_serverless,
+    .beta_ess,
     .coming,
+    .coming_serverless,
+    .coming_ess,
     .deprecated,
+    .deprecated_serverless,
+    .deprecated_ess,
+    .discontinued_stack,
+    .discontinued_serverless,
+    .discontinued_ess,
     .dev,
-    .experimental {
+    .dev_serverless,
+    .dev_ess,
+    .experimental,
+    .experimental_serverless,
+    .experimental_ess{
         display: none;
     }
   }


### PR DESCRIPTION
This PR adds some admonitions for serverless- and ESS-specific admonitions:

- beta_ess
- beta_serverless
- dev_ess
- dev_serverless
- ga_serverless
- ga_stack
- ga_ess
- deprecated_ess
- deprecated_serverless
- discontinued_ess
- discontinued_serverless
- discontinued_stack
- coming_ess
- coming_serverless

The work similar to the existing admonitions, for example:

![image](https://github.com/user-attachments/assets/8478f973-eed3-44e6-b2d6-a05b1771bebe)

NOTE: The rubocop config file change works around the following make error:

> lib/care_admonition/extension.rb:100:3: C: Metrics/MethodLength: Method has too many lines. [31/20]

TBD: Are there other combinations that we'll need (e.g. "ga_all" to have a single admonition that covers all contexts)?