### PR TITLE
Add 8.16 version attributes

### DIFF
--- a/shared/versions/stack/8.16.asciidoc
+++ b/shared/versions/stack/8.16.asciidoc
@@ -1,0 +1,75 @@
+:version:                8.16.0
+////
+bare_version never includes -alpha or -beta
+////
+:bare_version:           8.16.0
+:logstash_version:       8.16.0
+:elasticsearch_version:  8.16.0
+:kibana_version:         8.16.0
+:apm_server_version:     8.16.0
+// branch is 8.16 instead of 8.x for long-term linking purposes
+:branch:                 8.16
+:minor-version:          8.16
+:major-version:          8.x
+:prev-major-version:     7.x
+:prev-major-last:        7.17
+:major-version-only:     8
+:ecs_version:            8.11
+:esf_version:            master
+:ece-version-link:       current
+//////////
+Keep the :esf_version: attribute value as master.
+//////////
+
+//////////
+release-state can be: released | prerelease | unreleased
+//////////
+:release-state:          unreleased
+
+//////////
+is-current-version can be: true | false
+//////////
+:is-current-version:    false
+
+//////////
+hide-xpack-tags defaults to "false" (they are shown unless set to "true")
+//////////
+:hide-xpack-tags:       true
+
+////
+APM Agent versions
+////
+:apm-android-branch:    0.x
+:apm-go-branch:         2.x
+:apm-ios-branch:        1.x
+:apm-java-branch:       1.x
+:apm-rum-branch:        5.x
+:apm-node-branch:       4.x
+:apm-php-branch:        1.x
+:apm-py-branch:         6.x
+:apm-ruby-branch:       4.x
+:apm-dotnet-branch:     1.x
+
+////
+ECS Logging
+////
+:ecs-logging:           master
+:ecs-logging-go-logrus: master
+:ecs-logging-go-zap:    master
+:ecs-logging-go-zerolog: master
+:ecs-logging-java:      1.x
+:ecs-logging-dotnet:    master
+:ecs-logging-nodejs:    master
+:ecs-logging-php:       master
+:ecs-logging-python:    master
+:ecs-logging-ruby:      master
+
+////
+Synthetics
+////
+:synthetics_version: v1.3.0
+
+////
+API URLs
+////
+:api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8


### PR DESCRIPTION
This PR copies the contents of 8.x.asciidoc to a new 8.16.asciidoc file.

Updating the former to now reflect 8.17 will occur in a separate PR when all the necessary branches exist.