### PR TITLE
Update Cloud current to ms-115

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,7 +80,7 @@ variables:
   stackcurrent: &stackcurrent 8.15
   stacklive: &stacklive [ 8.15, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-114
+  cloudSaasCurrent: &cloudSaasCurrent ms-115
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Elastic Cloud docs to ms-115

Do not merge until release day.