### PR TITLE
Add ECK 2.15

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2173,7 +2173,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.14
-            branches:   [ {main: master}, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ {main: master}, 2.15, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
This adds the ECK 2.15 branch to the build list. ECK 2.15.0 is planned for release on Thu, November 07, 2024. Please do not merge until the day before (Wed, November 06).