### PR TITLE
Make ECK 2.15.0 the current version

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2172,7 +2172,7 @@ contents:
             prefix:     en/cloud-on-k8s
             tags:       Kubernetes/Reference
             subject:    ECK
-            current:    2.14
+            current:    2.15
             branches:   [ {main: master}, 2.15, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1


### PR DESCRIPTION
This PR sets the ECK 2.15 branch as the current version.

This PR depends on https://github.com/elastic/docs/pull/3100 which should be merged first. It's submitted early only to get approval, I'll rebase on Wed, November 06 once https://github.com/elastic/docs/pull/3100 is merged.

Do not merge before ECK 2.15 release date (November 7, 2024).