### PR TITLE
Update debian base docker image to latest (bookworm).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .gradle
 bin
 .includepath

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 # regenerate Gemfile.lock or building the docker image will fail.
 source "https://rubygems.org"
 
-ruby "~> 2.5"
+ruby "~> 3.1"
 
 # We commit Gemfile.lock so we're not going to have "unexpected" version bumps
 # of our gems. This file specifies what we think *should* work. Gemfile.lock

--- a/build_docs.pl
+++ b/build_docs.pl
@@ -937,7 +937,7 @@ sub init_env {
     chomp($gid);
     print $override "docker:x:$uid:$gid:docker:/tmp:/bin/bash\n";
     close $override;
-    $ENV{LD_PRELOAD} = '/usr/lib/libnss_wrapper.so';
+    $ENV{LD_PRELOAD} = 'libnss_wrapper.so';
     $ENV{NSS_WRAPPER_PASSWD} = '/tmp/passwd';
     $ENV{NSS_WRAPPER_GROUP} = '/etc/group';
 }


### PR DESCRIPTION
Updated Docker base image from Debian Buster to Bookworm. Adjusted environment variables, package versions, and configuration for compatibility with Ruby 3.1 and newer libraries.

(include `.idea` in gitignore to ensure pycharm IDE files do not get checked in).
