### PR TITLE
Bump current to 8.16

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -77,8 +77,8 @@ contents_title:     Elastic documentation
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.15
-  stacklive: &stacklive [ 8.15, 7.17 ]
+  stackcurrent: &stackcurrent 8.16
+  stacklive: &stacklive [ 8.16, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-115
 

--- a/shared/versions/stack/8.15.asciidoc
+++ b/shared/versions/stack/8.15.asciidoc
@@ -28,7 +28,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/8.16.asciidoc
+++ b/shared/versions/stack/8.16.asciidoc
@@ -24,12 +24,12 @@ Keep the :esf_version: attribute value as master.
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    false
+:is-current-version:    true
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.15.asciidoc[]
+include::8.16.asciidoc[]


### PR DESCRIPTION
Do not merge until release day

The following PRs/issues address broken links:

- https://github.com/elastic/kibana/pull/198854
- https://github.com/elastic/cloud/pull/133754
- https://github.com/elastic/search-docs-team/issues/220
- https://github.com/elastic/observability-docs/issues/4479