### PR TITLE
Change admonition title style/syntax

### DIFF
--- a/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
+++ b/resources/asciidoctor/lib/docbook_compat/convert_admonition.rb
@@ -20,10 +20,10 @@ module DocbookCompat
       return node.id ? %(<a id="#{node.id}"></a>) : nil unless node.title
 
       [
-        '<h3>',
+        '<p class="admon_title">',
         node.title,
         node.id ? %(<a id="#{node.id}"></a>) : nil,
-        '</h3>',
+        '</p>',
       ].compact.join
     end
 

--- a/resources/asciidoctor/spec/change_admonition_spec.rb
+++ b/resources/asciidoctor/spec/change_admonition_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ChangeAdmonition do
         end
         it "renders with Elastic's custom template" do
           expect_block_admonition <<~HTML.strip
-            <h3>#{message} in 7.0.0-beta1.</h3>
+            <p class="admon_title">#{message} in 7.0.0-beta1.</p>
             <p>words</p>
           HTML
         end
@@ -58,7 +58,7 @@ RSpec.describe ChangeAdmonition do
         end
         it "renders with Elastic's custom template" do
           expect_block_admonition <<~HTML.strip
-            <h3>#{message} in 7.0.0-beta1.</h3>
+            <p class="admon_title">#{message} in 7.0.0-beta1.</p>
             <p>Like 2<sup>7</sup></p>
           HTML
         end

--- a/resources/asciidoctor/spec/docbook_compat_spec.rb
+++ b/resources/asciidoctor/spec/docbook_compat_spec.rb
@@ -1915,7 +1915,7 @@ RSpec.describe DocbookCompat do
               <div class="#{admon_class} admon">
               <div class="icon"></div>
               <div class="admon_content">
-              <h3>Title</h3>
+              <p class="admon_title">Title</p>
               <p>words</p>
               </div>
               </div>
@@ -1938,7 +1938,7 @@ RSpec.describe DocbookCompat do
                 <div class="#{admon_class} admon">
                 <div class="icon"></div>
                 <div class="admon_content">
-                <h3>Title<a id="id"></a></h3>
+                <p class="admon_title">Title<a id="id"></a></p>
                 <p>words</p>
                 </div>
                 </div>

--- a/resources/web/style/admonishment.pcss
+++ b/resources/web/style/admonishment.pcss
@@ -84,14 +84,14 @@
   }
 
   .admon_content {
-    margin-left: 80px;
+    margin-left: 100px;
     /* On page load, the heading level may be changed,
     but we always what to style it the same way  */
-    h2, h3, h4, h5, h6 {
-      margin: 3px 0;
-      font-size: 22px;
-      font-weight: 600;
-      a { font-weight: 600; }
+    .admon_title {
+      font-size: 16px;
+      margin-bottom: 4px;
+      font-weight: 700;
+      a { font-weight: 700; }
     }
     p:last-of-type {
       margin-bottom: 0em;


### PR DESCRIPTION
The new AsciiDoc serverless docs have lots of admonitions with titles. Admonition titles are currently `h3`s. I'd like to change them to:

* _Not_ use a heading tag. Using an `h3` messes with the "On this page" list of headings and can result in headings that are not necessarily incremental (admonitions can come after `h3`s, `h4`s, etc).
* Style using bold text instead of larger text. This is subjective. I just think the current text is too big. 

| Before | After |
|---|---|
| <img width="819" alt="Screenshot 2024-11-06 at 5 03 33 PM" src="https://github.com/user-attachments/assets/ea6099d0-4afc-4c7e-9224-2dbe930d067e"> | <img width="819" alt="Screenshot 2024-11-06 at 5 03 54 PM" src="https://github.com/user-attachments/assets/dfe0c1be-1cd6-49d6-8832-811fa71fb480"> |