### PR TITLE
Add serverless shared attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -181,11 +181,13 @@ Elastic Cloud
 :ess:         Elasticsearch Service
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
-:serverless-full:  Elastic Cloud serverless
-:es-serverless: Elasticsearch on serverless
-:serverless-short: serverless
-:serverless-docs: https://docs.elastic.co/serverless
-:es3:         Elasticsearch Serverless
+:serverless-full:  Elastic Cloud Serverless
+:serverless-short: Serverless
+:es-serverless:    Elasticsearch Serverless
+:es3:              Elasticsearch Serverless
+:obs-serverless:   Elastic Observability Serverless
+:sec-serverless:   Elastic Security Serverless
+:serverless-docs:  https://docs.elastic.co/serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-utm-params: ?page=docs&placement=docs-body
 :ess-baymax:  {ess-utm-params}

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -184,7 +184,7 @@ Elastic Cloud
 :serverless-full:  Elastic Cloud Serverless
 :serverless-short: Serverless
 :es-serverless:    Elasticsearch Serverless
-:es3:              Elasticsearch Serverless
+:es3:              {es-serverless}
 :obs-serverless:   Elastic Observability Serverless
 :sec-serverless:   Elastic Security Serverless
 :serverless-docs:  https://docs.elastic.co/serverless

--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -185,6 +185,7 @@ Elastic Cloud
 :es-serverless: Elasticsearch on serverless
 :serverless-short: serverless
 :serverless-docs: https://docs.elastic.co/serverless
+:es3:         Elasticsearch Serverless
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-utm-params: ?page=docs&placement=docs-body
 :ess-baymax:  {ess-utm-params}
@@ -259,6 +260,20 @@ Kibana app and UI names
 :data-sources-caps:  Data Views
 :data-source-cap:    Data view
 :data-sources-cap:   Data views
+:project-settings:   Project settings
+:manage-app:         Management
+:index-manage-app:   Index Management
+:data-views-app:     Data Views
+:rules-app:          Rules
+:saved-objects-app:  Saved Objects
+:tags-app:           Tags
+:api-keys-app:       API keys
+:transforms-app:     Transforms
+:connectors-app:     Connectors
+:files-app:          Files
+:reports-app:        Reports
+:maps-app:           Maps
+:alerts-app:         Alerts
 // Use data-source-cap instead of Data-source
 // Use data-sources-cap instead of Data-sources
 // Use data-sources-caps instead of Data-Sources

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -72,3 +72,9 @@ Synthetics
 API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana
+
+////
+Feature flags
+////
+
+:serverlessCustomRoles: true


### PR DESCRIPTION
Relates to https://github.com/elastic/docs-content/pull/182

This PR moves the declarations from https://github.com/elastic/docs-content/blob/7602ddbdb3de8fe99b0850423c308f85e2952d6d/serverless/index.asciidoc?plain=1#L13 to the list of shared attributes so that they can be used in all books.