### PR TITLE
Update Cloud current to ms-116

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -81,7 +81,7 @@ variables:
   stackcurrent: &stackcurrent 8.16
   stacklive: &stacklive [ 8.16, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-115
+  cloudSaasCurrent: &cloudSaasCurrent ms-116
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Elastic Cloud docs to ms-116

Do not merge until release day.