### PR TITLE
Bumps the doc version to 8.16.1

### DIFF
--- a/shared/versions/stack/8.16.asciidoc
+++ b/shared/versions/stack/8.16.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.16.0
+:version:                8.16.1
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.16.0
-:logstash_version:       8.16.0
-:elasticsearch_version:  8.16.0
-:kibana_version:         8.16.0
-:apm_server_version:     8.16.0
+:bare_version:           8.16.1
+:logstash_version:       8.16.1
+:elasticsearch_version:  8.16.1
+:kibana_version:         8.16.1
+:apm_server_version:     8.16.1
 // branch is 8.16 instead of 8.x for long-term linking purposes
 :branch:                 8.16
 :minor-version:          8.16


### PR DESCRIPTION
DO NOT MERGE UNTIL 8.16.1 IS OFFICIALLY RELEASED

[Docs release issue](https://github.com/elastic/dev/issues/2884)