### PR TITLE
Accommodate sticky marketing nav

### DIFF
--- a/resources/web/style/base_styles.pcss
+++ b/resources/web/style/base_styles.pcss
@@ -40,10 +40,15 @@
   .sticky-top-md {
     position: -webkit-relative;
     position: relative;
-    @media screen and (min-width: 769px) {
+    @media screen and (min-width: 1200px) {
       position: -webkit-sticky;
       position: sticky;
-      top: 0;
+      top: 72px;
+    }
+    @media screen and (min-width: 769px) and (max-width: 1199px) {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 131px;
     }
   }
 
@@ -53,7 +58,12 @@
     @media screen and (min-width: 993px) {
       position: -webkit-sticky;
       position: sticky;
-      top: 0;
+      top: 72px;
+    }
+    @media screen and (min-width: 769px) and (max-width: 1199px) {
+      position: -webkit-sticky;
+      position: sticky;
+      top: 131px;
     }
   }
 

--- a/resources/web/style/base_styles.pcss
+++ b/resources/web/style/base_styles.pcss
@@ -55,7 +55,7 @@
   .sticky-top-lg {
     position: -webkit-relative;
     position: relative;
-    @media screen and (min-width: 993px) {
+    @media screen and (min-width: 1200px) {
       position: -webkit-sticky;
       position: sticky;
       top: 72px;


### PR DESCRIPTION
It looks like the marketing nav is now sticky when you scroll down the page. As a result it's covering the book title and version dropdown on the left and part of the "On this page" section on the right. 

| Before marketing nav change | Now (with sticky marketing nav) |
|---|---|
| <img width="1645" alt="Screenshot 2024-11-21 at 5 58 23 PM" src="https://github.com/user-attachments/assets/b6d9c949-7e2b-4dab-bb3a-fe5de305e2e1"> | <img width="1644" alt="Screenshot 2024-11-21 at 5 57 45 PM" src="https://github.com/user-attachments/assets/81db9d59-fa94-4a09-8211-4d95736e6341"> |

This PR adjusts the CSS to accommodate the new nav behavior. This fix is pretty fragile &mdash; if the height of the nav at any screen width changes, the docs content may have too much or too little space at the top. I'm not sure if there's a better solution.