### PR TITLE
Add elastic/integration-docs to pull-requests template file

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -67,6 +67,7 @@
         "elastic/enterprise-search-ruby",
         "elastic/go-elasticsearch",
         "elastic/ingest-docs",
+        "elastic/integration-docs",
         "elastic/kibana",
         "elastic/logstash",
         "elastic/logstash-docs",


### PR DESCRIPTION
Adds elastic/integration-docs repo to the pull-requests template file to enable PR previews in integration-docs.