### PR TITLE
test: figure out how to enable the merge-queue in elastic/observability-robots-playground

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -71,6 +71,7 @@
         "elastic/logstash",
         "elastic/logstash-docs",
         "elastic/observability-docs",
+        "elastic/observability-robots-playground",
         "elastic/security-docs",
         "elastic/stack-docs",
         "elastic/tech-content",

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -142,6 +142,12 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
       docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs/en)
       ;;
 
+    "observability-robots-playground")
+      git fetch origin "$GITHUB_PR_TARGET_BRANCH"
+      echo "This project is only for testing purposes"
+      exit 0
+      ;;
+
     "packagespec")
       git fetch origin "$GITHUB_PR_TARGET_BRANCH"
       docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./versions ./spec)


### PR DESCRIPTION
### What

Add docs PR builds for https://github.com/elastic/observability-robots-playground

### Why

I'm figuring out how the buildkite-pr-bot works for the Organization so I can support the case of enabling the merge-queue for the APM Server and other projects.

For that reason, I only want to enable the docs-builds in https://github.com/elastic/observability-robots-playground without actually building anything, but I want to exit as soon as the repository is cloned.


Part of https://github.com/elastic/observability-robots/issues/2009