### PR TITLE
Update shared cloud signup instructions to account for serverless GA being the new default

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -191,7 +191,7 @@ Elastic Cloud
 :cloud:       https://www.elastic.co/guide/en/cloud/current
 :ess-utm-params: ?page=docs&placement=docs-body
 :ess-baymax:  {ess-utm-params}
-:ess-trial:   https://www.elastic.co/cloud/elasticsearch-service/signup{ess-utm-params}
+:ess-trial:   https://cloud.elastic.co/registration{ess-utm-params}
 :ess-product: https://www.elastic.co/cloud/elasticsearch-service{ess-utm-params}
 :ess-console: https://cloud.elastic.co{ess-utm-params}
 :ess-console-name: {ess} Console

--- a/shared/cloud/ess-getting-started.asciidoc
+++ b/shared/cloud/ess-getting-started.asciidoc
@@ -4,19 +4,13 @@
 //[[cloud-ess-getting-started]]
 //== Get started with {ess}
 
-There's no faster way to get started than with our hosted {ess} on Elastic Cloud:
+There's no faster way to get started than with Elastic Cloud:
 
 // tag::generic[]
-. {ess-trial}[Get a free trial].
+. {ess-trial}[Sign up for a free trial].
 
-. Log into {ess-console}[Elastic Cloud].
-
-. Click *Create deployment*.
-
-. Give your deployment a name.
-
-. Click *Create deployment* and download the password for the `elastic` user.
+. Follow the on-screen steps to create your first project.
 // end::generic[]
 
-That’s it! Now that you are up and running, it’s time to get some data into
-{kib}. {kib} will open as soon as your deployment is ready.
+That’s it! You're ready to get some data into your
+project.


### PR DESCRIPTION
[Merge only when the signup will switch to serverless by default]

@KOTungseth As I'm heading out for a few weeks, I'll give you ownership of this PR, as you may have a better sense of when the eng teams plan on making the switch (signups defaulting to serverless instead of deployments as it is right now)

This PR updates the shared cloud signup instructions. It's kind of short now but at least it's correct, I don't think it's worth describing each step as the UX is self-sufficient.
The ess trial URL variable also looked odd so I took the liberty of updating it with a more direct URL.

Rel: https://github.com/elastic/platform-docs-team/issues/485 