### PR TITLE
Adds api-kibana-serverless attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -207,6 +207,7 @@ Elastic Cloud
 :ess-skip-section: If you use {ess}, skip this section. {ess} handles these changes for you.
 :api-cloud:  https://www.elastic.co/docs/api/doc/cloud
 :api-ece:    https://www.elastic.co/docs/api/doc/cloud-enterprise
+:api-kibana-serverless:  https://www.elastic.co/docs/api/doc/serverless
 //////////
 Elasticsearch
 //////////


### PR DESCRIPTION
This PR adds a shared attribute for https://www.elastic.co/docs/api/doc/serverless.