### PR TITLE
Add Search UI to config

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -62,6 +62,7 @@ repos:
     logstash-docs:        https://github.com/elastic/logstash-docs.git
     observability-docs:   https://github.com/elastic/observability-docs.git
     package-spec:         https://github.com/elastic/package-spec.git
+    search-ui:            https://github.com/elastic/search-ui.git
     security-docs:        https://github.com/elastic/security-docs.git
     sense:                https://github.com/elastic/sense.git
     stack-docs:           https://github.com/elastic/stack-docs.git
@@ -126,6 +127,24 @@ variables:
 
 toc_extra: extra/docs_landing.html
 contents:
+    -   title:          Search UI
+        sections:
+          - title:      Search UI
+            prefix:     en/search-ui
+            current:    main
+            branches:   [ main ]
+            # Uncomment next line when content is ready
+            # live:       [ main ]
+            # Remove next line when content is ready
+            noindex:    1
+            index:      docs/index.asciidoc
+            chunk:      3
+            tags:       Search UI/Guide
+            subject:    Search UI
+            sources:
+              -
+                repo:   search-ui
+                path:   docs
     -   title:          Integrations
         sections:
           - title:      Integrations

--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -15,6 +15,9 @@ alias docbldserverless='$GIT_HOME/docs/build_docs --doc $GIT_HOME/docs-content/s
 # Integrations
 alias docbldintegration='$GIT_HOME/docs/build_docs --doc $GIT_HOME/integration-docs/dist/index.asciidoc --chunk 2'
 
+# Search UI
+alias docbldsearchui='$GIT_HOME/docs/build_docs --doc $GIT_HOME/search-ui/docs/index.asciidoc --chunk 3'
+
 # Elasticsearch
 alias docbldesx='$GIT_HOME/docs/build_docs --doc $GIT_HOME/elasticsearch/docs/reference/index.asciidoc --chunk 1'
 


### PR DESCRIPTION
⚠️ Dependent on https://github.com/elastic/search-ui/pull/1093

Adds a new Search UI book to the config. This is part of an effort to move the [current Search UI docs](https://www.elastic.co/docs/current/search-ui/overview) to AsciiDoc. There is a bit of a 🐔 / 🥚 problem with this process:

* This PR is dependent on a PR in elastic/search-ui that adds an AsciiDoc index file (https://github.com/elastic/search-ui/pull/1093).
* This PR adds a stub Search UI book with just a single index page from the elastic/search-ui repo. This stub book will _not_ be indexable by search engines. 
* After this PR is merged, I will open a PR in elastic/search-ui to add all the AsciiDoc content. That PR will include a preview that the docs and search teams can use to validate the AsciiDoc version of the Search UI docs.
* After the elastic/search-ui PR is merged and the full Search UI book is live, I'll open _another_ PR in this repo to remove `noindex` so the book will start being indexed by search engines.

