### PR TITLE
Add elastic/search-ui to pull-requests template

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -73,6 +73,7 @@
         "elastic/logstash-docs",
         "elastic/observability-docs",
         "elastic/observability-robots-playground",
+        "elastic/search-ui",
         "elastic/security-docs",
         "elastic/stack-docs",
         "elastic/tech-content",


### PR DESCRIPTION
Adds `elastic/search-ui` repo to the pull-requests template file to enable PR previews in [elastic/search-ui](https://github.com/elastic/search-ui).