### PR TITLE
Add api-es shared attribute

### DIFF
--- a/shared/versions/stack/8.16.asciidoc
+++ b/shared/versions/stack/8.16.asciidoc
@@ -73,3 +73,4 @@ Synthetics
 API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8
+:api-es:               https://www.elastic.co/docs/api/doc/elasticsearch/v8

--- a/shared/versions/stack/8.17.asciidoc
+++ b/shared/versions/stack/8.17.asciidoc
@@ -73,3 +73,4 @@ Synthetics
 API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8
+:api-es:               https://www.elastic.co/docs/api/doc/elasticsearch/v8

--- a/shared/versions/stack/8.x.asciidoc
+++ b/shared/versions/stack/8.x.asciidoc
@@ -72,3 +72,4 @@ Synthetics
 API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8
+:api-es:               https://www.elastic.co/docs/api/doc/elasticsearch/v8

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -72,6 +72,7 @@ Synthetics
 API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana
+:api-es:               https://www.elastic.co/docs/api/doc/elasticsearch
 
 ////
 Feature flags


### PR DESCRIPTION
This PR adds a shared attribute to link to the appropriate branch in https://www.elastic.co/docs/api/doc/elasticsearch