### PR TITLE
Fix collapsible animation

### DIFF
--- a/resources/web/style/base_styles.pcss
+++ b/resources/web/style/base_styles.pcss
@@ -68,7 +68,7 @@ html {
   }
 
   details[open] {
-    summary {
+    > summary {
       &:before {
         transform: translate(-3.5px, 0px) rotate(90deg);
         transition: .1s ease-in-out;


### PR DESCRIPTION
In collapsible blocks, only animate the icon before the `summary` that is a direct child of the `details` element.  