### PR TITLE
Add ecs-logging URL attributes

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -555,6 +555,28 @@ Issue and pull request URLs
 :apm-issue:    {apm-repo}issues/
 :apm-pull:     {apm-repo}pull/
 :kibana-blob:  {kib-repo}blob/{branch}/
+
+:ecs-logging-ruby-repo:       https://github.com/elastic/ecs-logging-ruby
+:ecs-logging-ruby-blob:       {ecs-logging-ruby-repo}/blob/main
+:ecs-logging-python-repo:     https://github.com/elastic/ecs-logging-python
+:ecs-logging-python-blob:     {ecs-logging-python-repo}/blob/main
+:ecs-logging-php-repo:        https://github.com/elastic/ecs-logging-php
+:ecs-logging-php-blob:        {ecs-logging-php-repo}/blob/main
+:ecs-logging-nodejs-repo:     https://github.com/elastic/ecs-logging-nodejs
+:ecs-logging-nodejs-blob:     {ecs-logging-nodejs-repo}/blob/main
+:ecs-logging-java-repo:       https://github.com/elastic/ecs-logging-java
+:ecs-logging-java-blob:       {ecs-logging-java-repo}/blob/{ecs-logging-java}
+:ecs-logging-go-logrus-repo:  https://github.com/elastic/ecs-logging-go-logrus
+:ecs-logging-go-logrus-blob:  {ecs-logging-go-logrus-repo}/blob/main
+:ecs-logging-go-zap-repo:     https://github.com/elastic/ecs-logging-go-zap
+:ecs-logging-go-zap-blob:     {ecs-logging-go-zap-repo}/blob/main
+:ecs-logging-go-zerolog-repo: https://github.com/elastic/ecs-logging-go-zerolog
+:ecs-logging-go-zerolog-blob: {ecs-logging-go-zerolog-repo}/blob/main
+:ecs-logging-repo:            https://github.com/elastic/ecs-logging
+:ecs-logging-blob:            {ecs-logging-repo}/blob/main
+:ecs-dotnet-repo:             https://github.com/elastic/ecs-dotnet
+:ecs-dotnet-blob:             {ecs-dotnet-repo}/blob/main
+
 //////////
 Legacy definitions
 //////////


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/issues/1393

Adds ECS logging GitHub URL attributes.