### PR TITLE
Add api-ls shared attribute

### DIFF
--- a/shared/versions/stack/8.17.asciidoc
+++ b/shared/versions/stack/8.17.asciidoc
@@ -74,3 +74,4 @@ API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8
 :api-es:               https://www.elastic.co/docs/api/doc/elasticsearch/v8
+:api-ls:               https://www.elastic.co/docs/api/doc/logstash

--- a/shared/versions/stack/8.x.asciidoc
+++ b/shared/versions/stack/8.x.asciidoc
@@ -73,3 +73,4 @@ API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana/v8
 :api-es:               https://www.elastic.co/docs/api/doc/elasticsearch/v8
+:api-ls:               https://www.elastic.co/docs/api/doc/logstash

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -73,6 +73,7 @@ API URLs
 ////
 :api-kibana:           https://www.elastic.co/docs/api/doc/kibana
 :api-es:               https://www.elastic.co/docs/api/doc/elasticsearch
+:api-ls:               https://www.elastic.co/docs/api/doc/logstash
 
 ////
 Feature flags


### PR DESCRIPTION
This PR adds attributes for the Logstash API doc URL: https://www.elastic.co/docs/api/doc/logstash

At this time there's only a single branch/version of the new API docs, but I've put the attribute in the same location as the ES and Kibana URL attributes just in case that changes.