### PR TITLE
Add ECS 8.17 to documentation.

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1031,8 +1031,8 @@ contents:
             prefix:     en/ecs
             # Please do not update current to 8.17
             current:    8.16
-            branches:   [ {main: master}, 8.16, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
-            live:       [ 8.16, 1.12 ]
+            branches:   [ {main: master}, 8.17, 8.16, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            live:       [ 8.17,  8.16, 1.12 ]
             index:      docs/index.asciidoc
             chunk:      2
             tags:       Elastic Common Schema (ECS)/Reference

--- a/shared/versions/stack/8.17.asciidoc
+++ b/shared/versions/stack/8.17.asciidoc
@@ -14,7 +14,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.16
+:ecs_version:            8.17
 :esf_version:            master
 :ece-version-link:       current
 //////////

--- a/shared/versions/stack/8.x.asciidoc
+++ b/shared/versions/stack/8.x.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     7.x
 :prev-major-last:        7.17
 :major-version-only:     8
-:ecs_version:            8.16
+:ecs_version:            8.17
 :esf_version:            master
 :ece-version-link:       current
 //////////

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -13,7 +13,7 @@ bare_version never includes -alpha or -beta
 :prev-major-version:     8.x
 :prev-major-last:        8.17
 :major-version-only:     9
-:ecs_version:            8.16
+:ecs_version:            8.17
 :esf_version:            master
 :ece-version-link:       current
 //////////


### PR DESCRIPTION
The next ECS version, 8.17.0, is being prepared. This adds ECS 8.17 to documentation. The "current" ECS version in conf.yaml is intentionally not updated yet, as ECS 8.17 isn't released yet, so it's not the current version yet.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
