### PR TITLE
Add esre-ref attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -130,6 +130,7 @@ Elastic-level pages
 :integrations-devguide: https://www.elastic.co/guide/en/integrations-developer/current
 :time-units:           {ref}/api-conventions.html#time-units
 :byte-units:           {ref}/api-conventions.html#byte-units
+:esre-ref:             https://www.elastic.co/guide/en/esre/{branch}
 
 //////////
 APM agents


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/3160

There are some hard-coded links to the [ESRE guide](https://www.elastic.co/guide/en/esre/current/index.html) that ought to vary by branch. This PR adds a variable for that purpose.