### PR TITLE
Change current for ECE docs to 3.8

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -86,6 +86,7 @@ variables:
   cloudSaasCurrent: &cloudSaasCurrent ms-119
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
+    ms-119: main
     ms-105: main
     ms-92: main
     ms-81: main
@@ -2115,8 +2116,9 @@ contents:
             prefix:     en/cloud-enterprise
             tags:       CloudEnterprise/Reference
             subject:    ECE
-            current:    ms-105
+            current:    ms-119
             live:
+              - ms-119
               - ms-105
               - ms-92
               - ms-81
@@ -2126,6 +2128,7 @@ contents:
               - ms-70
               - ms-69
             branches:
+              - ms-119: 3.8
               - ms-105: 3.7
               - ms-92: 3.6
               - ms-81: 3.5
@@ -2169,6 +2172,7 @@ contents:
                 repo:   cloud-assets
                 path:   docs
                 map_branches:
+                  ms-119: master
                   ms-105: master
                   ms-92: master
                   ms-81: master

--- a/shared/versions/ece/current.asciidoc
+++ b/shared/versions/ece/current.asciidoc
@@ -1,1 +1,1 @@
-include::ms-105.asciidoc[]
+include::ms-119.asciidoc[]

--- a/shared/versions/ece/master.asciidoc
+++ b/shared/versions/ece/master.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.8.1
-:ece-version-short:  3.8
-:ece-version-link: 3.8
+:ece-version:  4.0.0
+:ece-version-short:  4.0
+:ece-version-link: 4.0

--- a/shared/versions/ece/ms-119.asciidoc
+++ b/shared/versions/ece/ms-119.asciidoc
@@ -1,0 +1,3 @@
+:ece-version:  3.8.0
+:ece-version-short:  3.8
+:ece-version-link: 3.8


### PR DESCRIPTION
This changes "current" for the ECE docs to version 3.8.0.
Do not merge until release day (~February 5th~ April 4th 2025)