### PR TITLE
Add stack-ref-90 attribute

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -59,6 +59,7 @@ Elastic-level pages
 :stack-ref-68:         https://www.elastic.co/guide/en/elastic-stack/6.8
 :stack-ref-70:         https://www.elastic.co/guide/en/elastic-stack/7.0
 :stack-ref-80:         https://www.elastic.co/guide/en/elastic-stack/8.0
+:stack-ref-90:         https://www.elastic.co/guide/en/elastic-stack/9.0
 :stack-ov:             https://www.elastic.co/guide/en/elastic-stack-overview/{branch}
 :stack-gs:             https://www.elastic.co/guide/en/elastic-stack-get-started/{branch}
 :stack-gs-current:     https://www.elastic.co/guide/en/elastic-stack-get-started/current


### PR DESCRIPTION
This PR adds a shared attribute for https://www.elastic.co/guide/en/elastic-stack/9.0/index.html for links to that book for release notes during the content migration.