### PR TITLE
Only run the legacy docs build in elastic/docs-content when needed

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -77,6 +77,11 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
       docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs ./changelogs CHANGELOG.asciidoc)
       ;;
 
+    "docs-content")
+      git fetch origin "$GITHUB_PR_TARGET_BRANCH"
+      docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./serverless)
+      ;;
+
     "beats")
       git fetch origin "$GITHUB_PR_TARGET_BRANCH"
       docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./auditbeat ./CHANGELOG.asciidoc ./docs ./filebeat ./heartbeat ./journalbeat ./libbeat/docs ./libbeat/outputs/*/docs/* ./libbeat/processors/*/docs/* ./metricbeat ./packetbeat ./topbeat/docs ./winlogbeat ./x-pack/auditbeat ./x-pack/dockerlogbeat/docs ./x-pack/filebeat/docs ./x-pack/filebeat/processors/*/docs/* ./x-pack/functionbeat ./x-pack/libbeat/docs ./x-pack/libbeat/processors/*/docs/* ./x-pack/metricbeat/module)


### PR DESCRIPTION
This PR updates the legacy doc build to only run in https://github.com/elastic/docs-content when the serverless dir has changes. All other updates made in that repo impact V3.