### PR TITLE
ESS - Change current to ms-120

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,7 +83,7 @@ variables:
   stackcurrent: &stackcurrent 8.17
   stacklive: &stacklive [ 8.17, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-119
+  cloudSaasCurrent: &cloudSaasCurrent ms-120
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This changes "current" for the Cloud ~ESS~ ECH docs to ms-120.

Do not merge until release day.