### PR TITLE
remove more master branches

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2228,7 +2228,7 @@ contents:
             tags:       Kubernetes/Reference
             subject:    ECK
             current:    2.16
-            branches:   [ {main: master}, 2.16, 2.15, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
+            branches:   [ 2.16, 2.15, 2.14, 2.13, 2.12, 2.11, 2.10, 2.9, 2.8, 2.7, 2.6, 2.5, 2.4, 2.3, 2.2, 2.1, 2.0, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0, 1.0-beta, 0.9, 0.8 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:
@@ -2247,7 +2247,7 @@ contents:
             tags:       CloudControl/Reference
             subject:    ECCTL
             current:    1.14
-            branches:   [ master, 1.14, 1.13, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
+            branches:   [ 1.14, 1.13, 1.12, 1.11, 1.10, 1.9, 1.8, 1.7, 1.6, 1.5, 1.4, 1.3, 1.2, 1.1, 1.0 ]
             index:      docs/index.asciidoc
             chunk:      1
             sources:


### PR DESCRIPTION
Follow up to https://github.com/elastic/docs/pull/3173.

Removes `master` from the doc build in `cloud-on-k8s` and `ecctl`