### PR TITLE
Make ms-121 current for ESS/ECH

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,7 +83,7 @@ variables:
   stackcurrent: &stackcurrent 8.17
   stacklive: &stacklive [ 8.17, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-120
+  cloudSaasCurrent: &cloudSaasCurrent ms-121
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
To merge on release day (Currently scheduled to March 6)