### PR TITLE
Change the search-ui branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -123,9 +123,9 @@ contents:
         sections:
           - title:      Search UI
             prefix:     en/search-ui
-            current:    main
-            branches:   [ main ]
-            live:       [ main ]
+            current:    do-not-delete_legacy-docs
+            branches:   [{do-not-delete_legacy-docs: main}]
+            live:       [ do-not-delete_legacy-docs ]
             index:      docs/index.asciidoc
             chunk:      3
             tags:       Search UI/Guide


### PR DESCRIPTION
Follow up to https://github.com/elastic/docs/pull/3173

Removes the elastic/search-ui `main` branch from the documentation build so we can reserve `main` for Markdown files.