### PR TITLE
Add alias for temporary Installation and Upgrade Guide

### DIFF
--- a/doc_build_aliases.sh
+++ b/doc_build_aliases.sh
@@ -69,6 +69,9 @@ docbldlsvpr() {
 # Ingest Overview
 alias docbldingest='$GIT_HOME/docs/build_docs --doc $GIT_HOME/ingest-docs/docs/en/ingest-guide/index.asciidoc --chunk 1'
 
+# Installation and Upgrade Guide 9.0
+alias docbldstk90='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --chunk 1'
+
 # Installation and Upgrade Guide 7.10 and later
 alias docbldstk='$GIT_HOME/docs/build_docs --doc $GIT_HOME/stack-docs/docs/en/install-upgrade/index.asciidoc --resource=$GIT_HOME/elasticsearch/docs/ --resource=$GIT_HOME/kibana/docs/ --resource=$GIT_HOME/beats/libbeat/docs/ --resource=$GIT_HOME/observability-docs/docs/en/observability --resource=$GIT_HOME/logstash/docs/ --resource=$GIT_HOME/elasticsearch-hadoop/docs/src/reference/asciidoc/ --resource=$GIT_HOME/security-docs/docs/ --chunk 1'
 


### PR DESCRIPTION
This PR adds an alias for the 9.0 Installation and Upgrade Guide, which uses a different set of sources that its earlier versions. The lack of asciidoc content in those folders otherwise causes build errors.