### PR TITLE
[migration] Update `current` branch for APM agent docs

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -530,9 +530,9 @@ contents:
                 sections:
                   - title:      APM Android Agent
                     prefix:     android
-                    current:    0.x
-                    branches:   [ 0.x ]
-                    live:       [ 0.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 0.x } ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM Android Agent/Reference
                     subject:    APM
@@ -546,9 +546,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Go Agent
                     prefix:     go
-                    current:    2.x
-                    branches:   [ 2.x, 1.x, 0.5 ]
-                    live:       [ 2.x, 1.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 2.x }, 1.x, 0.5 ]
+                    live:       [ do-not-delete_legacy-docs, 1.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Go Agent/Reference
                     subject:    APM
@@ -563,9 +563,9 @@ contents:
                         exclude_branches:   [ 0.5 ]
                   - title: APM iOS Agent
                     prefix: swift
-                    current: 1.x
-                    branches: [ 1.x, 0.x ]
-                    live: [ 1.x ]
+                    current: do-not-delete_legacy-docs
+                    branches: [ { do-not-delete_legacy-docs: 1.x }, 0.x ]
+                    live: [ do-not-delete_legacy-docs ]
                     index: docs/index.asciidoc
                     tags: APM iOS Agent/Reference
                     subject: APM
@@ -579,9 +579,9 @@ contents:
                         path: CHANGELOG.asciidoc
                   - title:      APM Java Agent
                     prefix:     java
-                    current:    1.x
-                    branches:   [ 1.x, 0.7, 0.6 ]
-                    live:       [ 1.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 1.x }, 0.7, 0.6 ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM Java Agent/Reference
                     subject:    APM
@@ -602,9 +602,9 @@ contents:
                           1.x:  do-not-delete_legacy-docs
                   - title:      APM .NET Agent
                     prefix:     dotnet
-                    current:    1.x
-                    branches:   [ 1.x, 1.8 ]
-                    live:       [ 1.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 1.x }, 1.8 ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM .NET Agent/Reference
                     subject:    APM
@@ -618,9 +618,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Node.js Agent
                     prefix:     nodejs
-                    current:    4.x
-                    branches:   [ 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ 4.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 4.x }, 3.x, 2.x, 1.x ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM Node.js Agent/Reference
                     subject:    APM
@@ -642,9 +642,9 @@ contents:
                           4.x:  do-not-delete_legacy-docs
                   - title:      APM PHP Agent
                     prefix:     php
-                    current:    1.x
-                    branches:   [ 1.x ]
-                    live:       [ 1.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 1.x } ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM PHP Agent/Reference
                     subject:    APM
@@ -658,9 +658,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Python Agent
                     prefix:     python
-                    current:    6.x
-                    branches:   [ 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ 6.x, 5.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 6.x }, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ do-not-delete_legacy-docs, 5.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM
@@ -681,9 +681,9 @@ contents:
                           6.x:  do-not-delete_legacy-docs
                   - title:      APM Ruby Agent
                     prefix:     ruby
-                    current:    4.x
-                    branches:   [ 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ 4.x ]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 4.x }, 3.x, 2.x, 1.x ]
+                    live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM Ruby Agent/Reference
                     subject:    APM
@@ -698,9 +698,9 @@ contents:
                         exclude_branches:   [ 1.x, 0.x ]
                   - title:      APM Real User Monitoring JavaScript Agent
                     prefix:     rum-js
-                    current:    5.x
-                    branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x, 0.x ]
-                    live:       [ 5.x, 4.x]
+                    current:    do-not-delete_legacy-docs
+                    branches:   [ { do-not-delete_legacy-docs: 5.x }, 4.x, 3.x, 2.x, 1.x, 0.x ]
+                    live:       [ do-not-delete_legacy-docs, 4.x]
                     index:      docs/index.asciidoc
                     tags:       APM Real User Monitoring JavaScript Agent/Reference
                     subject:    APM


### PR DESCRIPTION
Follow up to https://github.com/elastic/docs/pull/3173

We're migrating the latest major version of each APM agent's docs from AsciiDoc to Markdown. Because of the way APM agent teams manage release branches, it's important that they are able to force push from `main` to the latest major version branch.

In the initial migration PRs (https://github.com/elastic/docs-eng-team/issues/130), we deleted AsciiDoc files and added Markdown files to `main`. We should also do the same for the latest major version to make it easier for engineers to make changes to the latest version. But, if we delete the AsciiDoc files on the latest major version branch, we need to pull AsciiDoc files from a different branch for the next ~3 weeks (until the Markdown docs are live on `elastic.co`).

I created a new `do-not-delete_legacy-docs` branch off the latest major version branch in each apm-agent-* repo. We can use this temporary branch to continue publishing AsciiDoc docs until the new docs are live.

@bmorelli25 feel free to correct me and/or elaborate if I missed anything! 