### PR TITLE
 Test wildcard pattern in `build_pr.sh` (part 2)

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -68,7 +68,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     # test glob
     "ecs-logging")
       git fetch origin "$GITHUB_PR_TARGET_BRANCH"
-      docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- ./docs/**/*.asciidoc)
+      docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- "*/*.asciidoc")
       ;;
 
     # repositories with a docs dir

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -68,7 +68,7 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     # test glob
     "ecs-logging")
       git fetch origin "$GITHUB_PR_TARGET_BRANCH"
-      docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- "*/*.asciidoc")
+      docs_diff=$(git diff --stat "origin/$GITHUB_PR_TARGET_BRANCH"...HEAD -- "**/*.asciidoc")
       ;;
 
     # repositories with a docs dir


### PR DESCRIPTION
Test out using a wildcard pattern in `build_pr.sh` to determine when we should run the AsciiDoc preview build. If this works, it will be an imperfect solution because it would not build if only an image was updated in a PR, but that might be ok. 🤷 

This PR builds on https://github.com/elastic/docs/pull/3182 by wrapping the path in quotes. It looks like that _could_ be necessary in some environments when using wildcards, and since `"origin/$GITHUB_PR_TARGET_BRANCH"` is wrapped in quotes even though it works without them on my local machine... I'm hoping this is the trick. I also expanded the matching pattern to include any AsciiDoc file. (I'm not sure if there's a better way to test this.)

To test this we'll have to:

1. Merge this PR
2. Open a test PR in elastic/ecs-logging

Then come back here and update the other repos.

@bmorelli25 what do you think about this approach? 