### PR TITLE
bumping current docs to 8.18

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -80,8 +80,8 @@ contents_title:     Elastic documentation
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.
 variables:
-  stackcurrent: &stackcurrent 8.17
-  stacklive: &stacklive [ 8.17, 7.17 ]
+  stackcurrent: &stackcurrent 8.18
+  stacklive: &stacklive [ 8.18, 7.17 ]
 
   cloudSaasCurrent: &cloudSaasCurrent ms-121
 

--- a/shared/versions/stack/8.17.asciidoc
+++ b/shared/versions/stack/8.17.asciidoc
@@ -29,7 +29,7 @@ release-state can be: released | prerelease | unreleased
 //////////
 is-current-version can be: true | false
 //////////
-:is-current-version:    true
+:is-current-version:    false
 
 //////////
 hide-xpack-tags defaults to "false" (they are shown unless set to "true")

--- a/shared/versions/stack/current.asciidoc
+++ b/shared/versions/stack/current.asciidoc
@@ -1,1 +1,1 @@
-include::8.17.asciidoc[]
+include::8.18.asciidoc[]


### PR DESCRIPTION
Bumping current docs to 8.18.

Part of 8.18.0 docs release process (https://github.com/elastic/dev/issues/2993)