### PR TITLE
[Cloud Hosted] Make ms-122 current

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -83,7 +83,7 @@ variables:
   stackcurrent: &stackcurrent 8.17
   stacklive: &stacklive [ 8.17, 7.17 ]
 
-  cloudSaasCurrent: &cloudSaasCurrent ms-121
+  cloudSaasCurrent: &cloudSaasCurrent ms-122
 
   mapCloudEceToClientsTeam: &mapCloudEceToClientsTeam
     ms-105: main


### PR DESCRIPTION
This PR changes the current version of the Elastic Cloud Hosted docs to ms-122. This should be the last milestone published with the current asciidoc system.

To merge on release day (currently scheduled for March 25)

Closes: https://github.com/elastic/dev/issues/3070