### PR TITLE
Bump docs version to `9.0.0-rc1`

### DIFF
--- a/shared/versions/stack/9.0.asciidoc
+++ b/shared/versions/stack/9.0.asciidoc
@@ -1,4 +1,4 @@
-:version:                9.0.0-beta1
+:version:                9.0.0-rc1
 ////
 bare_version never includes -alpha or -beta
 ////


### PR DESCRIPTION
**DO NOT MERGE UNTIL RELEASE DAY!** (March 24, 2025)

Bumps the `version` attribute to `9.0.0-rc1`. 
