### PR TITLE
Bump APM Android agent to 1.x

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -531,7 +531,7 @@ contents:
                   - title:      APM Android Agent
                     prefix:     android
                     current:    do-not-delete_legacy-docs
-                    branches:   [ { do-not-delete_legacy-docs: 0.x } ]
+                    branches:   [ { do-not-delete_legacy-docs: 1.x }, 0.x ]
                     live:       [ do-not-delete_legacy-docs ]
                     index:      docs/index.asciidoc
                     tags:       APM Android Agent/Reference

--- a/shared/versions/stack/8.17.asciidoc
+++ b/shared/versions/stack/8.17.asciidoc
@@ -39,7 +39,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-android-branch:    0.x
+:apm-android-branch:    1.x
 :apm-go-branch:         2.x
 :apm-ios-branch:        1.x
 :apm-java-branch:       1.x

--- a/shared/versions/stack/8.18.asciidoc
+++ b/shared/versions/stack/8.18.asciidoc
@@ -39,7 +39,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-android-branch:    0.x
+:apm-android-branch:    1.x
 :apm-go-branch:         2.x
 :apm-ios-branch:        1.x
 :apm-java-branch:       1.x

--- a/shared/versions/stack/8.x.asciidoc
+++ b/shared/versions/stack/8.x.asciidoc
@@ -38,7 +38,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-android-branch:    0.x
+:apm-android-branch:    1.x
 :apm-go-branch:         2.x
 :apm-ios-branch:        1.x
 :apm-java-branch:       1.x

--- a/shared/versions/stack/9.0.asciidoc
+++ b/shared/versions/stack/9.0.asciidoc
@@ -38,7 +38,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-android-branch:    0.x
+:apm-android-branch:    1.x
 :apm-go-branch:         2.x
 :apm-ios-branch:        1.x
 :apm-java-branch:       1.x

--- a/shared/versions/stack/master.asciidoc
+++ b/shared/versions/stack/master.asciidoc
@@ -38,7 +38,7 @@ hide-xpack-tags defaults to "false" (they are shown unless set to "true")
 ////
 APM Agent versions
 ////
-:apm-android-branch:    0.x
+:apm-android-branch:    1.x
 :apm-go-branch:         2.x
 :apm-ios-branch:        1.x
 :apm-java-branch:       1.x


### PR DESCRIPTION
Bumps APM Android agent to 1.x. Related to https://github.com/elastic/apm-agent-android/pull/443. 