### PR TITLE
Add Cloud Hosted Release Notes book

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -2271,7 +2271,19 @@ contents:
               -
                 repo:   terraform-provider-ec
                 path:   docs-elastic/
-
+          - title:      Elastic Cloud Hosted Release Notes
+            prefix:     en/cloud-hosted
+            tags:       Cloud/Reference
+            subject:    Elastic Cloud
+            current:    master
+            branches:   [ master ]
+            index:      docs/saas/index.asciidoc
+            single:     1
+            chunk:      1
+            sources:
+              -
+                repo:   cloud
+                path:   docs/saas
     -   title:      Legacy Documentation
         sections:
           - title:      Elastic Stack and Google Cloud's Anthos


### PR DESCRIPTION
This PR is intended as an alternative to https://github.com/elastic/docs/pull/3201, which aims to continue publishing the old Cloud Hosted release notes in the old docs system.