### PR TITLE
Update logstash-docs in conf.yaml

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1622,8 +1622,6 @@ contents:
               -
                 repo:   logstash-docs
                 path:   docs/
-                map_branches:
-                  8.19: 8.x
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc


### PR DESCRIPTION
This PR updates conf.yaml since 8.x branch has been replaced by 8.19 in logstash-docs