### PR TITLE
Remove `(current)` from the version dropdown

### DIFF
--- a/.github/workflows/patch-release-version-bump.yml
+++ b/.github/workflows/patch-release-version-bump.yml
@@ -4,11 +4,11 @@ on:
    inputs:
       MAJOR_VERSION:
         type: choice
-        description: 'Major version (current)'
+        description: 'Major version'
         options: ['7', '8']
       MINOR_VERSION:
         type: choice
-        description: 'Minor version (current)'
+        description: 'Minor version'
         options: ['12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25']
       PATCH_VERSION:
         type: choice

--- a/integtest/spec/all_books_change_detection_spec.rb
+++ b/integtest/spec/all_books_change_detection_spec.rb
@@ -196,16 +196,14 @@ RSpec.describe 'building all books' do
     shared_examples 'toc and version drop down' do
       shared_examples 'correct' do
         context 'the version drop down' do
-          let(:master_current) { current == 'master' ? ' (current)' : '' }
           let(:master_option) do
             <<~HTML.strip
-              <option value="master"#{master_selected}>master#{master_current}</option>
+              <option value="master"#{master_selected}>master</option>
             HTML
           end
-          let(:foo_current) { current == 'foo' ? ' (current)' : '' }
           let(:foo_option) do
             <<~HTML.strip
-              <option value="foo"#{foo_selected}>foo#{foo_current}</option>
+              <option value="foo"#{foo_selected}>foo</option>
             HTML
           end
           it 'contains all versions' do

--- a/integtest/spec/all_books_spec.rb
+++ b/integtest/spec/all_books_spec.rb
@@ -625,14 +625,14 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains only the live branches' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="master" selected>master</option><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="other">other versions</option></select>
+            <select id="live_versions"><option value="master" selected>master</option><option value="0.10">0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="other">other versions</option></select>
           HTML
         end
       end
       context 'the other versions drop down' do
         it 'contains all branches' do
           expect(body).to include(<<~HTML.strip)
-            <span id="other_versions">other versions: <select><option value="master" selected>master</option><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
+            <span id="other_versions">other versions: <select><option value="master" selected>master</option><option value="0.10">0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
           HTML
         end
       end
@@ -662,14 +662,14 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains only the live branches' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="0.10" selected>0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="other">other versions</option></select>
+            <select id="live_versions"><option value="0.10" selected>0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="other">other versions</option></select>
           HTML
         end
       end
       context 'the other versions drop down' do
         it 'contains all branches' do
           expect(body).to include(<<~HTML.strip)
-            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10" selected>0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
+            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10" selected>0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
           HTML
         end
       end
@@ -695,14 +695,14 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains only the live branches' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="other">other versions</option></select>
+            <select id="live_versions"><option value="0.10">0.10</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="other">other versions</option></select>
           HTML
         end
       end
       context 'the other versions drop down' do
         it 'contains all branches' do
           expect(body).to include(<<~HTML.strip)
-            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
+            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10">0.10</option><option value="0.9_oldbutlive" selected>0.9_oldbutlive</option><option value="0.8_nonlive">0.8_nonlive</option></select>
           HTML
         end
       end
@@ -734,14 +734,14 @@ RSpec.describe 'building all books' do
       context 'the live versions drop down' do
         it 'contains the deprecated branch' do
           expect(body).to include(<<~HTML.strip)
-            <select id="live_versions"><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive" selected>0.8_nonlive</option><option value="other">other versions</option>
+            <select id="live_versions"><option value="0.10">0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive" selected>0.8_nonlive</option><option value="other">other versions</option>
           HTML
         end
       end
       context 'the other versions drop down' do
         it 'contains all branches' do
           expect(body).to include(<<~HTML.strip)
-            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10">0.10 (current)</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive" selected>0.8_nonlive</option></select>
+            <span id="other_versions">other versions: <select><option value="master">master</option><option value="0.10">0.10</option><option value="0.9_oldbutlive">0.9_oldbutlive</option><option value="0.8_nonlive" selected>0.8_nonlive</option></select>
           HTML
         end
       end

--- a/lib/ES/Book.pm
+++ b/lib/ES/Book.pm
@@ -202,20 +202,13 @@ sub build {
         $latest = 0;
 
         my $version = $self->branch_title($branch);
-        if ( $branch eq $self->current ) {  # TODO: when "current" is a version, change this.
-            $toc->add_entry(
-                {   title => "$title: $version (current)",
-                    url   => "current/index.html"
-                }
-            );
+        $toc->add_entry(
+            {   title => "$title: $version",
+                url   => "$version/index.html"
+            }
+        );
+        if ( $branch eq $self->current ) {
             $rebuilding_current_branch = $building;
-        }
-        else {
-            $toc->add_entry(
-                {   title => "$title: $version",
-                    url   => "$version/index.html"
-                }
-            );
         }
     }
     $pm->wait_all_children();
@@ -372,7 +365,6 @@ sub _update_title_and_version_drop_downs {
         $title .= '<option value="' . $version . '"';
         $title .= ' selected'  if $branch eq $b;
         $title .= '>' . $version;
-        $title .= ' (current)' if $self->current eq $b;  # TODO: change when "current" is a version
         $title .= '</option>';
     }
     $title .= '<option value="other">other versions</option>' if $removed_any;
@@ -385,7 +377,6 @@ sub _update_title_and_version_drop_downs {
             $title .= '<option value="' . $version . '"';
             $title .= ' selected'  if $branch eq $b;
             $title .= '>' . $version;
-            $title .= ' (current)' if $self->current eq $b; # TODO: change when "current" is a version
             $title .= '</option>';
         }
         $title .= '</select>';


### PR DESCRIPTION
Removes `(current)` from the version dropdown to avoid confusion about which version is the latest now that the latest docs have been migrated to docs-builder and elastic.co/docs.

<img width="1105" alt="Screenshot 2025-04-25 at 8 45 04 AM" src="https://github.com/user-attachments/assets/7c8ab640-4335-4f35-9498-ab47437e2fa7" />

Note: This will remove `(current)` from version dropdowns in _all_ books &mdash; even books that were _not_ migrated to elastic.co/docs. Let me know if there are any concerns about this. 