### PR TITLE
Update clients docs to use 8.19 branch

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -1073,6 +1073,8 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest/
+                    map_branches:
+                      8.x:  8.19
                   -
                     repo:   elasticsearch
                     path:   client
@@ -1214,8 +1216,6 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest
-                    map_branches:
-                      8.x:  8.19
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1079,7 +1079,7 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -1057,7 +1057,7 @@ contents:
               - title:      Java Client
                 prefix:     java-api-client
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1073,13 +1073,9 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest/
-                    map_branches:
-                      8.x:  8.19
                   -
                     repo:   elasticsearch
                     path:   client
-                    map_branches:
-                      8.x:  8.19
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    *stackcurrent

--- a/conf.yaml
+++ b/conf.yaml
@@ -249,29 +249,21 @@ contents:
                 repo:   elasticsearch-php
                 path:   docs/examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  8.19: 8.x
               -
                 alternatives: { source_lang: console, alternative_lang: python }
                 repo:   elasticsearch-py
                 path:   docs/examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  8.19: 8.x
               -
                 alternatives: { source_lang: console, alternative_lang: ruby }
                 repo:   elasticsearch-ruby
                 path:   docs/examples/guide
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  8.19: 8.x
               -
                 alternatives: { source_lang: console, alternative_lang: go }
                 repo:   go-elasticsearch
                 path:   .doc/examples/doc/
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  8.19: 8.x
               -
                 repo:   docs
                 path:   shared/versions/stack/{version}.asciidoc
@@ -289,8 +281,6 @@ contents:
                 repo:   elasticsearch-js
                 path:   docs/doc_examples
                 exclude_branches:   [ 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0, 1.7, 1.6, 1.5, 1.4, 1.3, 0.90 ]
-                map_branches:
-                  8.19: 8.x
               -
                 repo:   elasticsearch
                 path:   server/src/main/resources/org/elasticsearch/common
@@ -386,7 +376,7 @@ contents:
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
                 live:       [ *stackcurrent ]
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
@@ -401,7 +391,7 @@ contents:
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
@@ -416,7 +406,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -431,7 +421,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1083,8 +1073,6 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest/
-                    map_branches:
-                      8.x:  8.19
                   -
                     repo:   elasticsearch
                     path:   client
@@ -1106,7 +1094,7 @@ contents:
               - title:      Ruby Client
                 prefix:     ruby-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1119,7 +1107,7 @@ contents:
               - title:      Go Client
                 prefix:     go-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      .doc/index.asciidoc
                 chunk:      1
@@ -1132,7 +1120,7 @@ contents:
               - title:      .NET Clients
                 prefix:     net-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
@@ -1148,7 +1136,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1226,6 +1214,8 @@ contents:
                   -
                     repo:   elasticsearch
                     path:   docs/java-rest
+                    map_branches:
+                      8.x:  8.19
                   -
                     repo:   elasticsearch
                     path:   docs/Versions.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -376,7 +376,7 @@ contents:
               - title:      Enterprise Search Node.js client
                 prefix:     enterprise-search-node
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6 ]
                 live:       [ *stackcurrent ]
                 index:      packages/enterprise-search/docs/index.asciidoc
                 tags:       Enterprise Search Clients/Node.js
@@ -391,7 +391,7 @@ contents:
               - title:      Enterprise Search PHP client
                 prefix:     php
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/PHP
@@ -406,7 +406,7 @@ contents:
               - title:      Enterprise Search Python client
                 prefix:     python
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Python
@@ -421,7 +421,7 @@ contents:
               - title:      Enterprise Search Ruby client
                 prefix:     ruby
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 tags:       Enterprise Search Clients/Ruby
@@ -1057,7 +1057,7 @@ contents:
               - title:      Java Client
                 prefix:     java-api-client
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1079,7 +1079,7 @@ contents:
               - title:      JavaScript Client
                 prefix:     javascript-api
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1092,7 +1092,7 @@ contents:
               - title:      Ruby Client
                 prefix:     ruby-api
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1105,7 +1105,7 @@ contents:
               - title:      Go Client
                 prefix:     go-api
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      .doc/index.asciidoc
                 chunk:      1
@@ -1118,7 +1118,7 @@ contents:
               - title:      .NET Clients
                 prefix:     net-api
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 6.x, 5.x, 2.x, 1.x ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 tags:       Clients/.Net
@@ -1134,7 +1134,7 @@ contents:
               - title:      PHP Client
                 prefix:     php-api
                 current:    *stackcurrent
-                branches:   [ 8.19, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.x, 6.x, 5.x, 2.x, 1.x, 0.4 ]
                 live:       *stacklive
                 index:      docs/index.asciidoc
                 chunk:      1
@@ -1163,7 +1163,7 @@ contents:
               - title:      Python Client
                 prefix:     python-api
                 current:    *stackcurrent
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16 ]
                 live:       *stacklive
                 index:      docs/guide/index.asciidoc
                 chunk:     1
@@ -1189,7 +1189,7 @@ contents:
               - title:      Rust Client
                 prefix:     rust-api
                 current:    8.18
-                branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
+                branches:   [ { 8.19: 8.x }, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 live:       [ 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0 ]
                 index:      docs/index.asciidoc
                 chunk:     1


### PR DESCRIPTION
Attempts to fix broken build

@pquentin pointed to this list of repos that renamed 8.x to 8.19: https://github.com/elastic/devtools-team/blob/main/.github/workflows/scripts/clients.config