### PR TITLE
Add shared attribute for classic docs

### DIFF
--- a/shared/attributes.asciidoc
+++ b/shared/attributes.asciidoc
@@ -182,6 +182,7 @@ Elastic Cloud
 :ecloud:      Elastic Cloud
 :esf:         Elastic Serverless Forwarder
 :ess:         Elasticsearch Service
+:ech:         Elastic Cloud Hosted
 :ece:         Elastic Cloud Enterprise
 :eck:         Elastic Cloud on Kubernetes
 :serverless-full:  Elastic Cloud Serverless


### PR DESCRIPTION
Logstash plugin docs need this attribute in order to resolve correctly for 8.x and earlier versions.