### PR TITLE
feature/build only branches with legacy asciidoc

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -12,7 +12,6 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]", "elastic-observability-automation[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "target_branch": ["8.x", "8.19", "8.18", "8.17", "8.16", "8.15", "8.14", "8.13", "8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "8.5", "8.4", "8.3", "8.2", "8.1", "8.0"],
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [

--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -12,6 +12,7 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]", "elastic-observability-automation[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
+      "target_branch": ["8.x", "8.19", "8.18", "8.17", "8.16", "8.15", "8.14", "8.13", "8.12", "8.11", "8.10", "8.9", "8.8", "8.7", "8.6", "8.5", "8.4", "8.3", "8.2", "8.1", "8.0"],
       "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
       "skip_ci_labels": [

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -8,6 +8,12 @@ if [ -z ${GITHUB_PR_TARGET_BRANCH+set} ] || [ -z ${GITHUB_PR_NUMBER+set} ] || [ 
   exit 1
 fi
 
+# We only want to build PRs if the target branch is a major version < 9
+if ! [[ $GITHUB_PR_TARGET_BRANCH =~ ^([0-8])\.[0-9]+$ ]]; then
+  echo "Target branch '$GITHUB_PR_TARGET_BRANCH' is not a valid version branch (must be in format X.Y where X <= 8)"
+  exit 0
+fi
+
 # Configure the git author and committer information
 export GIT_AUTHOR_NAME='Buildkite CI'
 export GIT_AUTHOR_EMAIL='docs-status+buildkite@elastic.co'
@@ -263,5 +269,5 @@ buildkite-agent annotate \
   "<br>Preview url: ${PREVIEW_URL}"
 
 buildkite-agent meta-data set pr_comment:doc-preview:head " * Documentation preview
-   - 📚 [HTML diff](${PREVIEW_URL}/diff)
-   - 📙 [Preview](${PREVIEW_URL})"
+   - [HTML diff](${PREVIEW_URL}/diff)
+   - [Preview](${PREVIEW_URL})"


### PR DESCRIPTION
## Changes

Only build 8.x target branches.

## Context

According to https://github.com/elastic/buildkite-pr-bot?tab=readme-ov-file#configuration-1 you can actually set the `target_branch` in `pull-requests.org-wide.json`.

However, the `buildkite/docs-build-pr` status check is usually a required check.

In this PR we exit early if the target branch doesn't match the pattern, so that the status check will still be green.
