### PR TITLE
[TEST!] Publish Logstash plugins from `main` to be consumed by `logstash-docs-md`

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -3086,14 +3086,8 @@ contents:
           ##################################################################
           - title:      Logstash Plugins only 👻
             prefix:     en/logstash-plugins-only
-            # We're using `8.19` because it is the latest branch of the
-            # logstash repo that contains AsciiDoc files. We will NOT
-            # actually be using the `8.19` content in
-            # https://www.elastic.co/docs/reference/logstash/plugins.
-            # That content will come from the logstash-docs repo's
-            # `main` branch.
-            current:    8.19
-            branches:   [ { 8.19: main } ]
+            current:    9.0
+            branches:   { 9.0: 9.x }
             index:      docs/index.x.asciidoc
             private:    1
             chunk:      1
@@ -3103,16 +3097,8 @@ contents:
             subject:    Logstash
             sources:
               -
-                repo:   logstash
-                path:   docs/
-              -
                 repo:   logstash-docs
                 path:   docs/plugins
-                # Use the files on the `main` branch instead of on the
-                # `8.19` branch just for plugin pages coming from the
-                # logstash-docs repo.
-                map_branches:
-                  main:   8.19
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -3087,7 +3087,7 @@ contents:
           - title:      Logstash Plugins only 👻
             prefix:     en/logstash-plugins-only
             current:    9.0
-            branches:   { 9.0: 9.x }
+            branches:   [ { 9.0: 9.x } ]
             index:      docs/index.x.asciidoc
             private:    1
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -3088,7 +3088,7 @@ contents:
             prefix:     en/logstash-plugins-only
             current:    9.0
             branches:   [ { 9.0: 9.x } ]
-            index:      docs/index.x.asciidoc
+            index:      docs/index.asciidoc
             private:    1
             chunk:      1
             # We do _not_ want these pages to be indexed.

--- a/conf.yaml
+++ b/conf.yaml
@@ -1646,9 +1646,9 @@ contents:
                 exclude_branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
           - title:      Logstash Plugins
             prefix:     en/logstash-plugins
-            current:    main
-            branches:   [ main ]
-            index:      docs/plugins/index.asciidoc
+            current:    8.19
+            branches:   [ { 8.19: 8.x } ]
+            index:      docs/index.x.asciidoc
             private:    1
             chunk:      1
             noindex:    1
@@ -1656,8 +1656,13 @@ contents:
             subject:    Logstash
             sources:
               -
+                repo:   logstash
+                path:   docs/
+              -
                 repo:   logstash-docs
                 path:   docs/plugins
+                map_branches:
+                  main:   8.19
               -
                 repo:   docs
                 path:   shared/attributes.asciidoc

--- a/conf.yaml
+++ b/conf.yaml
@@ -1644,6 +1644,23 @@ contents:
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
+          - title:      Logstash Plugins
+            prefix:     en/logstash-plugins
+            current:    main
+            branches:   [ main ]
+            index:      docs/plugins/index.asciidoc
+            private:    1
+            chunk:      1
+            noindex:    1
+            tags:       Logstash/Plugin Reference
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash-docs
+                path:   docs/plugins
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -1644,28 +1644,6 @@ contents:
                 repo:   docs
                 path:   shared/legacy-attrs.asciidoc
                 exclude_branches:   [ 8.x, 8.18, 8.17, 8.16, 8.15, 8.14, 8.13, 8.12, 8.11, 8.10, 8.9, 8.8, 8.7, 8.6, 8.5, 8.4, 8.3, 8.2, 8.1, 8.0, 7.17, 7.16, 7.15, 7.14, 7.13, 7.12, 7.11, 7.10, 7.9, 7.8, 7.7, 7.6, 7.5, 7.4, 7.3, 7.2, 7.1, 7.0, 6.8, 6.7, 6.6, 6.5, 6.4, 6.3, 6.2, 6.1, 6.0, 5.6, 5.5, 5.4, 5.3, 5.2, 5.1, 5.0, 2.4, 2.3, 2.2, 2.1, 2.0]
-          - title:      Logstash Plugins
-            prefix:     en/logstash-plugins
-            current:    8.19
-            branches:   [ { 8.19: 8.x } ]
-            index:      docs/index.x.asciidoc
-            private:    1
-            chunk:      1
-            noindex:    1
-            tags:       Logstash/Plugin Reference
-            subject:    Logstash
-            sources:
-              -
-                repo:   logstash
-                path:   docs/
-              -
-                repo:   logstash-docs
-                path:   docs/plugins
-                map_branches:
-                  main:   8.19
-              -
-                repo:   docs
-                path:   shared/attributes.asciidoc
           - title:      Logstash Versioned Plugin Reference
             prefix:     en/logstash-versioned-plugins
             current:    versioned_plugin_docs
@@ -3096,6 +3074,48 @@ contents:
                     repo: x-pack-elasticsearch
                     path: /docs/kr
                     prefix: elasticsearch-extra/x-pack-elasticsearch
+
+          ##################################################################
+          ## DO NOT DELETE !!
+          ## This book is used to generate the Markdown files that end up
+          ## in the elastic/logstash-docs-md repo. Those files are used to
+          ## publish the pages in this section of the new docs site:
+          ## https://www.elastic.co/docs/reference/logstash/plugins
+          ##
+          ## For more context see: https://github.com/elastic/docs/pull/3235
+          ##################################################################
+          - title:      Logstash Plugins only 👻
+            prefix:     en/logstash-plugins-only
+            # We're using `8.19` because it is the latest branch of the
+            # logstash repo that contains AsciiDoc files. We will NOT
+            # actually be using the `8.19` content in
+            # https://www.elastic.co/docs/reference/logstash/plugins.
+            # That content will come from the logstash-docs repo's
+            # `main` branch.
+            current:    8.19
+            branches:   [ { 8.19: 9.x } ]
+            index:      docs/index.x.asciidoc
+            private:    1
+            chunk:      1
+            # We do _not_ want these pages to be indexed.
+            noindex:    1
+            tags:       Logstash/Plugin Reference
+            subject:    Logstash
+            sources:
+              -
+                repo:   logstash
+                path:   docs/
+              -
+                repo:   logstash-docs
+                path:   docs/plugins
+                # Use the files on the `main` branch instead of on the
+                # `8.19` branch just for plugin pages coming from the
+                # logstash-docs repo.
+                map_branches:
+                  main:   8.19
+              -
+                repo:   docs
+                path:   shared/attributes.asciidoc
 
 redirects:
     -

--- a/conf.yaml
+++ b/conf.yaml
@@ -3088,7 +3088,7 @@ contents:
             prefix:     en/logstash-plugins-only
             current:    9.0
             branches:   [ { 9.0: 9.x } ]
-            index:      docs/index.asciidoc
+            index:      docs/plugins/index.asciidoc
             private:    1
             chunk:      1
             # We do _not_ want these pages to be indexed.

--- a/conf.yaml
+++ b/conf.yaml
@@ -3087,7 +3087,7 @@ contents:
           - title:      Logstash Plugins only 👻
             prefix:     en/logstash-plugins-only
             current:    9.0
-            branches:   [ { 9.0: 9.x } ]
+            branches:   [ 9.0 ]
             index:      docs/plugins/index.asciidoc
             private:    1
             chunk:      1

--- a/conf.yaml
+++ b/conf.yaml
@@ -3093,7 +3093,7 @@ contents:
             # That content will come from the logstash-docs repo's
             # `main` branch.
             current:    8.19
-            branches:   [ { 8.19: 9.x } ]
+            branches:   [ { 8.19: main } ]
             index:      docs/index.x.asciidoc
             private:    1
             chunk:      1


### PR DESCRIPTION
Publishes Logstash plugin pages (like [this page](https://www.elastic.co/guide/en/logstash/8.18/plugins-integrations-aws.html) in the Logstash Reference guide) from `main` so they can be consumed by `logstash-docs-md` to be published on elastic.co/docs.