### PR TITLE
[WIP] Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@
 # and takes longer to build but that is worth it.
 FROM bitnami/minideb:buster AS base
 
+RUN echo "deb http://archive.debian.org/debian/ buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security/ buster/updates main" >> /etc/apt/sources.list
+
 # TODO install_packages calls apt-get update and then nukes the list files after. We should avoid multiple calls to apt-get update.....
 # We could probably fix this by running the update and installs ourself with `RUN --mount type=cache` but that is "experimental"
 


### PR DESCRIPTION
Following its EOL, Debian Buster has been removed from upstream, breaking asciidoc builds. This PR will introduce an updated environment aiming for as little friction as possible with the current implementation.