### PR TITLE
[apm] Publish APM Python agent docs from `6.x`

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -659,9 +659,9 @@ contents:
                         path:   CHANGELOG.asciidoc
                   - title:      APM Python Agent
                     prefix:     python
-                    current:    do-not-delete_legacy-docs
-                    branches:   [ { do-not-delete_legacy-docs: 6.x }, 5.x, 4.x, 3.x, 2.x, 1.x ]
-                    live:       [ do-not-delete_legacy-docs, 5.x ]
+                    current:    6.x
+                    branches:   [ 6.x, 5.x, 4.x, 3.x, 2.x, 1.x ]
+                    live:       [ 6.x ]
                     index:      docs/index.asciidoc
                     tags:       APM Python Agent/Reference
                     subject:    APM
@@ -678,8 +678,6 @@ contents:
                         repo:   apm-aws-lambda
                         path:   docs
                         exclude_branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x ]
-                        map_branches:
-                          6.x:  do-not-delete_legacy-docs
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    do-not-delete_legacy-docs

--- a/conf.yaml
+++ b/conf.yaml
@@ -678,6 +678,8 @@ contents:
                         repo:   apm-aws-lambda
                         path:   docs
                         exclude_branches:   [ 5.x, 4.x, 3.x, 2.x, 1.x ]
+                        map_branches:
+                          6.x:  main
                   - title:      APM Ruby Agent
                     prefix:     ruby
                     current:    do-not-delete_legacy-docs


### PR DESCRIPTION
Publishes APM Python agent docs from `6.x`.