### PR TITLE
Updates landing page and conf.yaml to specify Elastic Stack 8.19 and earlier

### DIFF
--- a/conf.yaml
+++ b/conf.yaml
@@ -76,6 +76,11 @@ repos:
 
 contents_title:     Elastic Docs
 
+asciidoc:
+  attributes:
+    page-title: Elastic documentation for Elastic Stack 8.19 and earlier
+    page-description: View the guides, tutorials, and API reference documentation for the Elastic Stack 8.19 and earlier.
+
 # Each item should take the form:
 #   <key>: &<variable> <value>
 # The keys don't really matter, but by convention the are the same as the variable.

--- a/conf.yaml
+++ b/conf.yaml
@@ -75,8 +75,6 @@ repos:
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
 
 contents_title:     Elastic Docs
-page-title: Elastic documentation for Elastic Stack 8.19 and earlier
-page-description: View the guides, tutorials, and API reference documentation for the Elastic Stack 8.19 and earlier.
 
 # Each item should take the form:
 #   <key>: &<variable> <value>

--- a/conf.yaml
+++ b/conf.yaml
@@ -75,11 +75,8 @@ repos:
     x-pack-logstash:      https://github.com/elastic/x-pack-logstash.git
 
 contents_title:     Elastic Docs
-
-asciidoc:
-  attributes:
-    page-title: Elastic documentation for Elastic Stack 8.19 and earlier
-    page-description: View the guides, tutorials, and API reference documentation for the Elastic Stack 8.19 and earlier.
+page-title: Elastic documentation for Elastic Stack 8.19 and earlier
+page-description: View the guides, tutorials, and API reference documentation for the Elastic Stack 8.19 and earlier.
 
 # Each item should take the form:
 #   <key>: &<variable> <value>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -445,11 +445,17 @@
   }
 </style>
 
-<div class="old-elastic-experience-warning">
-  You are viewing the previous version of Elastic docs. To view the current docs, go to <a href="https://www.elastic.co/docs">elastic.co/docs</a>.
-</div>
-
 <div class="legalnotice"></div>
+
+<div class="row my-4">
+  <div class="col">
+    <p>
+      Welcome to the docs that cover all changes in Elastic Stack 8.19 and earlier.
+      To view the docs for the latest Elastic product versions, including Elastic Stack 9.1.0 and Elastic Cloud Serverless,
+      go to <a href="https://www.elastic.co/docs">elastic.co/docs</a>.
+    </p>
+  </div>
+</div>
 
 <div id="subnavigation" class="subnavigation">
   <p>

--- a/extra/docs_landing.html
+++ b/extra/docs_landing.html
@@ -445,13 +445,17 @@
   }
 </style>
 
+<div class="old-elastic-experience-warning">
+  You are viewing previous versions of the Elastic Docs. To view the latest versions, go to <a href="https://www.elastic.co/docs">elastic.co/docs</a>.
+</div>
+
 <div class="legalnotice"></div>
 
 <div class="row my-4">
   <div class="col">
     <p>
       Welcome to the docs that cover all changes in Elastic Stack 8.19 and earlier.
-      To view the docs for the latest Elastic product versions, including Elastic Stack 9.1.0 and Elastic Cloud Serverless,
+      To view the docs for the latest Elastic product versions, including Elastic Stack 9.1 and Elastic Cloud Serverless,
       go to <a href="https://www.elastic.co/docs">elastic.co/docs</a>.
     </p>
   </div>


### PR DESCRIPTION
Updates the /guide landing page to specify the Elastic Stack 8.19 and earlier. 

Adds SEO title and description meta data to specify the Elastic Stack 8.19 and earlier. 
