### PR TITLE
8.19.2 Bump PR 

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.1
+:version:                8.19.2
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.1
-:logstash_version:       8.19.1
-:elasticsearch_version:  8.19.1
-:kibana_version:         8.19.1
-:apm_server_version:     8.19.1
+:bare_version:           8.19.2
+:logstash_version:       8.19.2
+:elasticsearch_version:  8.19.2
+:kibana_version:         8.19.2
+:apm_server_version:     8.19.2
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
❗ DO NOT MERGE UNTIL RELEASE DAY ❗ 

Related issue: https://github.com/elastic/dev/issues/3253

Bumps the version to `8.19.2`. 