### PR TITLE
Updates URL for ECH release notes

### DIFF
--- a/resources/asciidoctor/lib/chunker/v3-mapping.json
+++ b/resources/asciidoctor/lib/chunker/v3-mapping.json
@@ -3339,7 +3339,7 @@
     "/en/cloud/*/ec-regional-deployment-aliases.html": "/docs/deploy-manage/deploy/elastic-cloud/custom-endpoint-aliases",
     "/en/cloud/*/ec-regions-templates-instances.html": "/docs/reference/cloud/cloud-hosted/ec-regions-templates-instances",
     "/en/cloud/*/ec-release-notes-2025-01-23.html": "/docs/release-notes/cloud-hosted/#elastic-cloud-hosted-012025-release-notes",
-    "/en/cloud/*/ec-release-notes.html": "/docs/release-notes/cloud-hosted",
+    "/en/cloud-hosted/*/ec-release-notes.html": "/docs/release-notes/cloud-hosted",
     "/en/cloud/*/ec-remote-cluster-ece.html": "/docs/deploy-manage/remote-clusters/ec-remote-cluster-ece",
     "/en/cloud/*/ec-remote-cluster-other-ess.html": "/docs/deploy-manage/remote-clusters/ec-remote-cluster-other-ess",
     "/en/cloud/*/ec-remote-cluster-same-ess.html": "/docs/deploy-manage/remote-clusters/ec-remote-cluster-same-ess",


### PR DESCRIPTION
Fixes the link from the /guide ECH release notes to the /docs ECH release notes
