### PR TITLE
Change 8.19 release state from unreleased to released

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -23,7 +23,7 @@ Keep the :esf_version: attribute value as master.
 //////////
 release-state can be: released | prerelease | unreleased
 //////////
-:release-state:          unreleased
+:release-state:          released
 
 //////////
 is-current-version can be: true | false


### PR DESCRIPTION
8.19 released a few months ago. need to change the release state so "this is unreleased" notes that rely on the state disappear