### PR TITLE
Add note to redirect 9.0+ local docs builders in readme

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,5 +1,11 @@
 = Docs HOWTO
 
+[IMPORTANT]  
+====
+This repo pertains to the asciidoc system used for pre-9.0 Elastic docs.
+To build the markdown docs for versions 9.0+, refer to https://elastic.github.io/docs-builder/contribute/locally/.
+====
+
 include::{docs-root}/shared/versions/stack/current.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 


### PR DESCRIPTION
Added a note about the repo's relevance to pre-9.0 Elastic docs and provided a link for building markdown docs for versions 9.0+.

Folks land here and get confused about the build system.

<