### PR TITLE
add missing curator v8 page to v3 mapping

### DIFF
--- a/resources/asciidoctor/lib/chunker/v3-mapping.json
+++ b/resources/asciidoctor/lib/chunker/v3-mapping.json
@@ -3856,6 +3856,7 @@
     "/en/elasticsearch/client/curator/*/option_ignore.html": "/docs/reference/elasticsearch/curator/option_ignore",
     "/en/elasticsearch/client/curator/*/option_include_aliases.html": "/docs/reference/elasticsearch/curator/option_include_aliases",
     "/en/elasticsearch/client/curator/*/option_include_gs.html": "/docs/reference/elasticsearch/curator/option_include_gs",
+    "/en/elasticsearch/client/curator/*/option_include_hidden.html": "/docs/reference/elasticsearch/curator/option_include_hidden",
     "/en/elasticsearch/client/curator/*/option_indices.html": "/docs/reference/elasticsearch/curator/option_indices",
     "/en/elasticsearch/client/curator/*/option_key.html": "/docs/reference/elasticsearch/curator/option_key",
     "/en/elasticsearch/client/curator/*/option_max_age.html": "/docs/reference/elasticsearch/curator/option_max_age",


### PR DESCRIPTION
Page was added to curator v8 post migration. Adding a mapping to the v9/docs v3 docs for this page.
