### PR TITLE
add v3 mapping for failure store pages

### DIFF
--- a/resources/asciidoctor/lib/chunker/v3-mapping.json
+++ b/resources/asciidoctor/lib/chunker/v3-mapping.json
@@ -4915,6 +4915,8 @@
     "/en/elasticsearch/reference/*/explain-dfanalytics.html": "/docs/api/doc/elasticsearch/operation/operation-ml-explain-data-frame-analytics",
     "/en/elasticsearch/reference/*/explicit-mapping.html": "/docs/manage-data/data-store/mapping/explicit-mapping",
     "/en/elasticsearch/reference/*/fail-processor.html": "/docs/reference/enrich-processor/fail-processor",
+    "/en/elasticsearch/reference/*/failure-store.html": "/docs/manage-data/data-store/data-streams/failure-store",
+    "/en/elasticsearch/reference/*/failure-store-recipes.html": "/docs/manage-data/data-store/data-streams/failure-store-recipes",
     "/en/elasticsearch/reference/*/feature-migration-api.html": "/docs/api/doc/elasticsearch/operation/operation-migration-get-feature-upgrade-status",
     "/en/elasticsearch/reference/*/features-apis.html": "/docs/api/doc/elasticsearch/group/endpoint-features",
     "/en/elasticsearch/reference/*/field-alias.html": "/docs/reference/elasticsearch/mapping-reference/field-alias",


### PR DESCRIPTION
couple of missing mapped pages (this was an 8.19/9.1 feature)