### PR TITLE
bump the docs version to 8.19.7

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.6
+:version:                8.19.7
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.6
-:logstash_version:       8.19.6
-:elasticsearch_version:  8.19.6
-:kibana_version:         8.19.6
-:apm_server_version:     8.19.6
+:bare_version:           8.19.7
+:logstash_version:       8.19.7
+:elasticsearch_version:  8.19.7
+:kibana_version:         8.19.7
+:apm_server_version:     8.19.7
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
**DO NOT MERGE UNTIL THE DAY OF RELEASE**
Linked to https://github.com/elastic/dev/issues/3361
bumps the docs version to 8.19.7