### PR TITLE
Revise CODEOWNERS for documentation ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 *.asciidoc @elastic/docs-repo-owners
 
 # Writers and Docs Eng share ownership of config files
+/extra/ @elastic/docs-engineering @elastic/docs-repo-owners
 ‎/resources/asciidoctor/lib/chunker/v3-mapping.json‎ @elastic/docs-engineering @elastic/docs-repo-owners
 /shared/ @elastic/docs-engineering @elastic/docs-repo-owners
 *.yaml @elastic/docs-engineering @elastic/docs-repo-owners


### PR DESCRIPTION
## Summary

Updated CODEOWNERS to better reflect ownership of this repository. Open to suggestions from all.

We could update the writer ownership parts to the elastic/docs team but previous feedback was that it was too noisy for some folks.

Inspired by https://github.com/elastic/docs/pull/3286 which should be owned by docs eng and not writers.

## What changed:

* Docs Eng will own the codebase.
* Writers and Docs Eng will share ownership of config files. This allows writers to move without approval from docs eng in release situations.
* Writers must approve readme changes (my least passionate change in this PR).

cc @elastic/docs-repo-owners and @elastic/docs-engineering.




