### PR TITLE
Bump the 8.19 stack version to 8.19.8

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.7
+:version:                8.19.8
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.7
-:logstash_version:       8.19.7
-:elasticsearch_version:  8.19.7
-:kibana_version:         8.19.7
-:apm_server_version:     8.19.7
+:bare_version:           8.19.8
+:logstash_version:       8.19.8
+:elasticsearch_version:  8.19.8
+:kibana_version:         8.19.8
+:apm_server_version:     8.19.8
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
DO NOT MERGE UNTIL THE DAY OF RELEASE
Linked to https://github.com/elastic/dev/issues/3378 

bumps the 8.19 stack version to 8.19.8

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
