### PR TITLE
Bumps the docs version to 8.19.9

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.8
+:version:                8.19.9
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.8
-:logstash_version:       8.19.8
-:elasticsearch_version:  8.19.8
-:kibana_version:         8.19.8
-:apm_server_version:     8.19.8
+:bare_version:           8.19.9
+:logstash_version:       8.19.9
+:elasticsearch_version:  8.19.9
+:kibana_version:         8.19.9
+:apm_server_version:     8.19.9
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
DO NOT MERGE UNTIL RELEASE DAY

[docs release issue](https://github.com/elastic/dev/issues/3397)