### PR TITLE
[Stack 8.19.15] Bump Stack version attributes

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.14
+:version:                8.19.15
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.14
-:logstash_version:       8.19.14
-:elasticsearch_version:  8.19.14
-:kibana_version:         8.19.14
-:apm_server_version:     8.19.14
+:bare_version:           8.19.15
+:logstash_version:       8.19.15
+:elasticsearch_version:  8.19.15
+:kibana_version:         8.19.15
+:apm_server_version:     8.19.15
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
## Summary

Bumps `shared/versions/stack/8.19.asciidoc` to **8.19.15** for the upcoming patch release.

**Do not merge until release day** (GA Tue Apr 28, 2026) per [docs patch release process](https://github.com/elastic/dev/issues/3500).

## Tracking

- Docs release issue: https://github.com/elastic/dev/issues/3500
- Stack release issue: _link when `[Stack release] 8.19.15` is filed in elastic/dev_

/cc @shainaraskas (docs release coordinator)

Made with [Cursor](https://cursor.com)