### PR TITLE
Refine trigger comment regex patterns

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -12,8 +12,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]", "elastic-observability-automation[bot]", "elastic-vault-github-plugin-prod[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
-      "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
+      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -91,8 +91,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
-      "always_trigger_comment_regex": "buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?",
+      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
+      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -113,8 +113,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "run docs-test",
-      "always_trigger_comment_regex": "run docs-test",
+      "trigger_comment_regex": "^run docs-test\s*?$",
+      "always_trigger_comment_regex": "^run docs-test\s*?$",
       "skip_ci_labels": [],
       "skip_ci_on_only_changed": [],
       "always_require_ci_on_changed": [],


### PR DESCRIPTION
Updated regex patterns for trigger comments to enforce start of line matching.

<!--
This issues list is for bugs or feature requests in the **docs build process only**.

If you find an error in the documentation, you should open an issue or pull request
on the repository which contains the docs.  For instance, the elasticsearch docs
can be found in the main elasticsearch repository.

There is an "Edit Me" button next to every header in the docs for open source
products.  This can be used to edit the source docs directly and to send
a pull request to the correct repository.
-->
