### PR TITLE
Fix invalid JSON escape \s in Buildkite trigger comment regexes

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -12,8 +12,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]", "dependabot[bot]", "elastic-renovate-prod[bot]", "elastic-observability-automation[bot]", "elastic-vault-github-plugin-prod[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
-      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
+      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
+      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -91,8 +91,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
-      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\s*?$",
+      "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
+      "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "skip_ci_labels": [
         "skip docs-build"
       ],
@@ -113,8 +113,8 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
-      "trigger_comment_regex": "^run docs-test\s*?$",
-      "always_trigger_comment_regex": "^run docs-test\s*?$",
+      "trigger_comment_regex": "^run docs-test\\s*?$",
+      "always_trigger_comment_regex": "^run docs-test\\s*?$",
       "skip_ci_labels": [],
       "skip_ci_on_only_changed": [],
       "always_require_ci_on_changed": [],


### PR DESCRIPTION
## Summary

- Commit 59dffc8b introduced `\s` into JSON string values in `.buildkite/pull-requests.org-wide.json`, but `\s` is not a valid JSON escape sequence
- This caused a `JSONDecodeError` on parse, preventing Buildkite from reading the pipeline config at all — no builds were triggering on any PR
- Fix replaces all 6 occurrences of `\s` with `\\s` (the correct way to embed a regex `\s` inside a JSON string)

Unblocks #3328 and #3329.

## Test plan

- [ ] JSON parses cleanly: `python3 -c "import json; json.load(open('.buildkite/pull-requests.org-wide.json'))"`
- [ ] After merge, verify a commit or `run docs-build` comment on a PR triggers a Buildkite build

🤖 Generated with [Claude Code](https://claude.ai/claude-code)