### PR TITLE
Test: verify docs-build-pr pipeline triggers for elastic/docs PRs

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -91,6 +91,7 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
+      "ignore_pipeline_branch_filters": true,
       "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "skip_ci_labels": [

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,3 +1,4 @@
+# Repo and book configuration for the Elastic docs build.
 repos:
     apm-aws-lambda:       https://github.com/elastic/apm-aws-lambda.git
     apm-k8s-attacher:     https://github.com/elastic/apm-k8s-attacher.git


### PR DESCRIPTION
Adds a comment line to `conf.yaml` as a minimal change to test whether the `docs-build-pr` Buildkite pipeline triggers correctly for PRs to this repo.

**Do not merge** — this PR exists solely to verify CI trigger behaviour.