### PR TITLE
Fix docs-build-pr not triggering on elastic/docs PRs

### DIFF
--- a/.buildkite/pull-requests.org-wide.json
+++ b/.buildkite/pull-requests.org-wide.json
@@ -91,6 +91,7 @@
       "allowed_list": ["github-actions[bot]", "renovate[bot]", "mergify[bot]"],
       "build_on_commit": true,
       "build_on_comment": true,
+      "ignore_pipeline_branch_filters": true,
       "trigger_comment_regex": "^run docs-build ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "always_trigger_comment_regex": "^buildkite test this ?(?<rebuild_opt>rebuild)? ?(?<warn_opt>warnlinkcheck)? ?(?<skip_opt>skiplinkcheck)?\\s*?$",
       "skip_ci_labels": [


### PR DESCRIPTION
## Problem

The `docs-build-pr` Buildkite pipeline has a branch filter configured to only allow `master`. All other repos use job 0 which has `always_trigger_branch: master` — so builds always trigger against the master branch and pass the filter.

The standalone `elastic/docs` entry (job 1) has no `always_trigger_branch`, so the pr-bot triggers against the PR's feature branch, which the pipeline filter silently rejects. No build, no GitHub check.

> **Note:** This change affects `elastic/docs` only. All other repositories (`elastic/elasticsearch`, `elastic/kibana`, etc.) use a separate job (job 0) with `always_trigger_branch: master` and are not affected by this change.

## Why it appeared to work before

Previously, builds appeared to trigger because the `doc-preview` GitHub Actions workflow posts a comment on every new PR containing the text `` `run docs-build` ``. The old `trigger_comment_regex` had no `^`/`$` anchors, so it matched any comment *containing* "run docs-build" — accidentally triggering a build via the comment path.

Tightening the regex with anchors in #3327 correctly stopped that partial match, but also removed the only mechanism that was making it work.

## Fix

Add `ignore_pipeline_branch_filters: true` to job 1. This tells the Buildkite API to bypass the pipeline's branch filter when triggering, allowing `build_on_commit` and comment triggers to work as intended per the [buildkite-pr-bot](https://github.com/elastic/buildkite-pr-bot) design.

Security is still enforced by `allow_org_users: true` and `allowed_repo_permissions: [admin, write]` — external contributors cannot trigger builds.

## Testing

After merge, verify that PR #3331 (`test/buildkite-docs-build-pr-trigger`) shows a `buildkite/docs-build-pr` check on the next push or `buildkite test this` comment.