### PR TITLE
Buildkite: Increase build agent disk to 200 GB

### DIFF
--- a/.buildkite/build_pipeline.yml
+++ b/.buildkite/build_pipeline.yml
@@ -36,7 +36,7 @@ steps:
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
-      diskSizeGb: 150
+      diskSizeGb: 200
       machineType: ${BUILD_MACHINE_TYPE}
     concurrency_group: build-docs-${BUILDKITE_BRANCH}
     concurrency: 1

--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -25,7 +25,7 @@ steps:
     agents:
       provider: "gcp"
       image: family/docs-ubuntu-2204
-      diskSizeGb: 150
+      diskSizeGb: 200
       machineType: ${BUILD_MACHINE_TYPE}
   - key: "teardown"
     label: "teardown"


### PR DESCRIPTION
## What
Bumps `diskSizeGb` from 150 → 200 GB on GCP build agents in both the full build and PR build pipelines.

## Why
Build is failing during `tar -x` while extracting the kibana git archive, likely due to running out of disk space. The 50 GB increase provides headroom for the git bare clone + working copy extraction + build output that all live on disk simultaneously.

## How
One-line change to `diskSizeGb` in each pipeline YAML.

## Test plan
- Trigger a PR build against a kibana PR and confirm the tar extraction step completes successfully.

## Notes
If the failure persists after this change, disk space can be ruled out and we should investigate permissions or archive corruption.