### PR TITLE
Build: increase default machine type to n2-highcpu-16

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -22,7 +22,7 @@ function retry {
     return 0
 }
 
-export BUILD_MACHINE_TYPE="n2-standard-4"
+export BUILD_MACHINE_TYPE="n2-highcpu-16"
 
 # Secrets must be redacted
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables

--- a/lib/ES/Repo.pm
+++ b/lib/ES/Repo.pm
@@ -279,7 +279,7 @@ sub _extract_from_ref {
     die "File <$tar> already exists" if -e $tar;
     run qw(git archive --format=tar -o), $tar, $ref, $path;
 
-    run qw(tar -x -C), $dest, '-f', $tar;
+    run qw(tar -xv -C), $dest, '-f', $tar;
     $tar->remove;
 }
 


### PR DESCRIPTION
## What
Increase the default Buildkite build machine from `n2-standard-4` (4 cores) to `n2-highcpu-16` (16 cores).

## Why
Faster builds across all pipelines that don't already override the machine type.

## How
One-line change to the default `BUILD_MACHINE_TYPE` in `.buildkite/hooks/pre-command`.

## Test plan
- Trigger a PR build on a non-docs repo and verify it uses `n2-highcpu-16`