### PR TITLE
[Stack 8.19.16] Bump Stack version attributes

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.15
+:version:                8.19.16
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.15
-:logstash_version:       8.19.15
-:elasticsearch_version:  8.19.15
-:kibana_version:         8.19.15
-:apm_server_version:     8.19.15
+:bare_version:           8.19.16
+:logstash_version:       8.19.16
+:elasticsearch_version:  8.19.16
+:kibana_version:         8.19.16
+:apm_server_version:     8.19.16
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
Do not merge until release day (GA Tue May 26, 2026).

This PR bumps shared/versions/stack/8.19.asciidoc to 8.19.16 for the upcoming patch release.

Docs release issue: https://github.com/elastic/dev/issues/3531


