### PR TITLE
Updates version to 8.19.17

### DIFF
--- a/shared/versions/stack/8.19.asciidoc
+++ b/shared/versions/stack/8.19.asciidoc
@@ -1,12 +1,12 @@
-:version:                8.19.16
+:version:                8.19.17
 ////
 bare_version never includes -alpha or -beta
 ////
-:bare_version:           8.19.16
-:logstash_version:       8.19.16
-:elasticsearch_version:  8.19.16
-:kibana_version:         8.19.16
-:apm_server_version:     8.19.16
+:bare_version:           8.19.17
+:logstash_version:       8.19.17
+:elasticsearch_version:  8.19.17
+:kibana_version:         8.19.17
+:apm_server_version:     8.19.17
 :branch:                 8.19
 :minor-version:          8.19
 :major-version:          8.x


### PR DESCRIPTION
Updates the Asciidoc /guide docs version to 8.19.17
