### PR TITLE
Scope patch release workflow write permissions to its job

### DIFF
--- a/.github/workflows/patch-release-version-bump.yml
+++ b/.github/workflows/patch-release-version-bump.yml
@@ -15,9 +15,14 @@ on:
         description: 'Patch version (new)'
         options: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25']
 
+permissions: {}
+
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- add `permissions: {}` at the workflow level for `patch-release-version-bump.yml`
- grant `contents: write` and `pull-requests: write` only to the `create-pull-request` job
- keep the workflow compatible with a read-only default `GITHUB_TOKEN`

Contributes to elastic/docs-actions#187.

## Test plan
- [x] Reviewed the workflow to confirm it uses `secrets.GITHUB_TOKEN` for `create-pull-request`
- [x] Verified the diff only scopes the required explicit permissions
- [ ] Optional: run the workflow in GitHub if runtime confirmation is needed

Made with [Cursor](https://cursor.com)