### PR TITLE
buildkite: fix GitHub status after build-pr retry

### DIFF
--- a/.buildkite/build_pr_pipeline.yml
+++ b/.buildkite/build_pr_pipeline.yml
@@ -27,23 +27,3 @@ steps:
       image: family/docs-ubuntu-2204
       diskSizeGb: 150
       machineType: ${BUILD_MACHINE_TYPE}
-  - key: "teardown"
-    label: "teardown"
-    command: |
-      status_state=failure
-      if [ $$(buildkite-agent step get "outcome" --step "build-pr") == "passed" ]; then
-        status_state=success
-      fi
-      export status_state
-      curl -s -L \
-        -X POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "Authorization: Bearer $${VAULT_GITHUB_TOKEN}" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        "https://api.github.com/repos/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}/statuses/${GITHUB_PR_TRIGGERED_SHA}" \
-        -d '{"state":"'$$status_state'","target_url":"'$BUILDKITE_BUILD_URL'","description":"Build finished","context":"buildkite/'$BUILDKITE_PIPELINE_SLUG'"}'
-    depends_on:
-      - step: "build-pr"
-        allow_failure: true
-    plugins:
-      - 'uber-workflow/run-without-clone':

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -41,5 +41,5 @@ elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-air-gapped" ]] && [[ "$BUILDKI
 fi
 
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]] && [[ "$BUILDKITE_STEP_KEY" == "build-pr" ]]; then
-    .buildkite/scripts/build_pr_commit_status.sh pending || true
+    "${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite/scripts/build_pr_commit_status.sh" pending || true
 fi

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -39,3 +39,7 @@ elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-air-gapped" ]] && [[ "$BUILDKI
     export DOCKER_USERNAME=$(retry 5 vault kv get -field=username secret/ci/elastic-docs/docker.elastic.co)
     export DOCKER_PASSWORD=$(retry 5 vault kv get -field=password secret/ci/elastic-docs/docker.elastic.co)
 fi
+
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]] && [[ "$BUILDKITE_STEP_KEY" == "build-pr" ]]; then
+    .buildkite/scripts/build_pr_commit_status.sh pending || true
+fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -7,5 +7,5 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]] && [[ "$BUILDKITE_STEP_KE
     if [[ "${BUILDKITE_COMMAND_EXIT_STATUS:-1}" -eq 0 ]]; then
         status_state=success
     fi
-    .buildkite/scripts/build_pr_commit_status.sh "$status_state" || true
+    "${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite/scripts/build_pr_commit_status.sh" "$status_state" || true
 fi

--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]] && [[ "$BUILDKITE_STEP_KEY" == "build-pr" ]]; then
+    status_state=failure
+    if [[ "${BUILDKITE_COMMAND_EXIT_STATUS:-1}" -eq 0 ]]; then
+        status_state=success
+    fi
+    .buildkite/scripts/build_pr_commit_status.sh "$status_state" || true
+fi

--- a/.buildkite/scripts/build_pr_commit_status.sh
+++ b/.buildkite/scripts/build_pr_commit_status.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script should only be invoked for builds triggered by the Buildkite PR bot
+if [ -z ${GITHUB_PR_BASE_OWNER+set} ] || [ -z ${GITHUB_PR_BASE_REPO+set} ] || [ -z ${GITHUB_PR_TRIGGERED_SHA+set} ]; then
+  exit 0
+fi
+
+status_state=$1
+description=''
+
+case $status_state in
+    pending)
+      description='Build started';;
+    success|failure|error)
+      description='Build finished';;
+    *)
+      echo "Invalid state $status_state"
+      exit 1;;
+esac
+
+githubPublishStatus="https://api.github.com/repos/${GITHUB_PR_BASE_OWNER}/${GITHUB_PR_BASE_REPO}/statuses/${GITHUB_PR_TRIGGERED_SHA}"
+data='{"state":"'$status_state'","target_url":"'$BUILDKITE_BUILD_URL'","description":"'$description'","context":"buildkite/'$BUILDKITE_PIPELINE_SLUG'"}'
+
+echo "Setting commit status: buildkite/${BUILDKITE_PIPELINE_SLUG} - ${status_state}"
+curl -s -L \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${VAULT_GITHUB_TOKEN}" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "${githubPublishStatus}" \
+  -d "${data}"


### PR DESCRIPTION
## What

- Move GitHub commit status updates from a separate teardown step into the `build-pr` job lifecycle
- Post `pending` when `build-pr` starts and `success` or `failure` when it finishes, including on retries

## Why

- When a user retries a failed `build-pr` step, Buildkite only reruns that step
- The teardown step already ran and does not rerun, so GitHub keeps the old `failure` status even when the build passes

## Notes

- The early `build-pr-setup` step still posts `pending` while the GCP agent starts
- Status posting failures do not fail the build

Made with [Cursor](https://cursor.com)