### PR TITLE
Buildkite: fetch SSH keys from Vault at step start

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -24,10 +24,20 @@ function retry {
 
 export BUILD_MACHINE_TYPE="n2-standard-4"
 
+function configure_elasticmachine_ssh_key {
+    # Temporary workaround until we can move to HTTPS auth.
+    # Fetch SSH keys while the job Vault token is still valid.
+    mkdir -p "$HOME/.ssh"
+    retry 5 vault read -field=private-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa"
+    retry 5 vault read -field=public-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa.pub"
+    chmod 600 "$HOME/.ssh/id_rsa"
+}
+
 # Secrets must be redacted
 # https://buildkite.com/docs/pipelines/managing-log-output#redacted-environment-variables
 if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
     export BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/buildkite_token)
+    configure_elasticmachine_ssh_key
     if [[ ${GITHUB_PR_BASE_REPO:="unset"} == "docs" ]]; then
         # Docs PR require a full rebuild - so let's boost the builds so they don't take 2 hours
         export BUILD_MACHINE_TYPE="n2-highcpu-32"
@@ -35,6 +45,7 @@ if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]];then
 elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build" ]];then
     export BUILD_MACHINE_TYPE="n2-highcpu-32"
     export BUILDKITE_API_TOKEN=$(retry 5 vault kv get -field=value secret/ci/elastic-docs/buildkite_token)
+    configure_elasticmachine_ssh_key
 elif [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-air-gapped" ]] && [[ "$BUILDKITE_STEP_KEY" == "publish-air-gapped-doc" ]]; then
     export DOCKER_USERNAME=$(retry 5 vault kv get -field=username secret/ci/elastic-docs/docker.elastic.co)
     export DOCKER_PASSWORD=$(retry 5 vault kv get -field=password secret/ci/elastic-docs/docker.elastic.co)

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -31,11 +31,8 @@ fi
 # The docs build can use the ssh agent's authentication socket
 # but can't use ssh keys directly so we start an ssh-agent.
 
-# Temporary workaround until we can move to HTTPS auth
-vault read -field=private-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa"
-vault read -field=public-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa.pub"
+# SSH keys are fetched from Vault in .buildkite/hooks/pre-command.
 ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
-chmod 600 "$HOME/.ssh/id_rsa"
 
 ssh-agent bash -c "
   ssh-add &&

--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -247,11 +247,8 @@ build_cmd="./build_docs --all \
 echo "The following build command will be used"
 echo $build_cmd
 
-# Temporary workaround until we can move to HTTPS auth
-vault read -field=private-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa"
-vault read -field=public-key secret/ci/elastic-docs/elasticmachine-ssh-key > "$HOME/.ssh/id_rsa.pub"
+# SSH keys are fetched from Vault in .buildkite/hooks/pre-command.
 ssh-keyscan github.com >> "$HOME/.ssh/known_hosts"
-chmod 600 "$HOME/.ssh/id_rsa"
 
 # Kick off the build
 ssh-agent bash -c "ssh-add && $build_cmd"


### PR DESCRIPTION
## What

- Fetch elasticmachine SSH keys from Vault in the Buildkite pre-command hook for docs PR and docs build pipelines
- Remove mid-script Vault reads from the build scripts

## Why

- Buildkite job Vault tokens expire after about 10–20 minutes
- Docs PR builds can run longer than that, especially when product repo setup runs before the build
- Late Vault access can fail with an expired token error

## Notes

- SSH keys stay on disk with `chmod 600`, not in environment variables
- `ssh-keyscan` and `ssh-agent` behavior in the build scripts is unchanged


Made with [Cursor](https://cursor.com)