### PR TITLE
Buildkite: install libyaml-perl when missing on PR agents

### DIFF
--- a/.buildkite/scripts/build_pr.sh
+++ b/.buildkite/scripts/build_pr.sh
@@ -51,6 +51,15 @@ if [[ "${GITHUB_PR_BASE_REPO}" != 'docs' ]]; then
     exit 0
   fi
 
+  # legacy_branches.pl needs YAML.pm on the host agent (not the Docker build
+  # image). Install it when missing so a stale docs-ubuntu image does not
+  # fail open and force a full clone/build for non-legacy branches.
+  if ! perl -MYAML -e1 >/dev/null 2>&1; then
+    echo "Perl YAML module missing on agent; installing libyaml-perl"
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq libyaml-perl
+  fi
+
   # Build only if conf.yaml lists the target branch as a legacy AsciiDoc branch
   # for this repo — otherwise skip but report success, since docs-build-pr is a
   # required check and we want it green rather than failing or left pending.


### PR DESCRIPTION
## Why

- `legacy_branches.pl` needs Perl `YAML.pm` on the host agent, but some `docs-ubuntu` images do not have `libyaml-perl`
- When the module is missing, the skip guard fails open and the pipeline clones and builds anyway (for example full Kibana PR builds)

## What

- Install `libyaml-perl` at the start of the legacy-branch check when `YAML.pm` is not already available

## Notes

- This is a pipeline-side guard while the agent image is updated
- `main`/`master` still exit early before this install path


Made with [Cursor](https://cursor.com)