### PR TITLE
Update ECE version from 3.8.4 to 3.8.5

### DIFF
--- a/shared/versions/ece/ms-119.asciidoc
+++ b/shared/versions/ece/ms-119.asciidoc
@@ -1,3 +1,3 @@
-:ece-version:  3.8.4
+:ece-version:  3.8.5
 :ece-version-short:  3.8
 :ece-version-link: 3.8


### PR DESCRIPTION
Bumps `shared/versions/ece/ms-119.asciidoc` so the ECE 3.8 book interpolates **3.8.5**.

The 3.8.5 image is already promoted (`docker.elastic.co/cloud-enterprise/elastic-cloud-enterprise:3.8.5`). Companion `cloud` docs PRs (merge together):
- https://github.com/elastic/cloud/pull/157974 (versions / `ece-version.asciidoc`)
- https://github.com/elastic/cloud/pull/157975 (release notes)

Rel: https://github.com/elastic/dev/issues/3588
Rel: https://github.com/elastic/cp-hosted-team/issues/4697

## Test plan
- [ ] After merge, 3.8 guide shows 3.8.5 (docs-build; ~60 min)

<small>*(AI-authored via Cursor 🤖)*</small>

Made with [Cursor](https://cursor.com)