### PR TITLE
Buildkite: post docs-build-pr GitHub status from a follow-up step

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -2,10 +2,23 @@
 
 set -euo pipefail
 
-if [[ "$BUILDKITE_PIPELINE_SLUG" == "docs-build-pr" ]] && [[ "$BUILDKITE_STEP_KEY" == "build-pr" ]]; then
+# Do not call GitHub from this hook. build-pr can run longer than the
+# ephemeral VAULT_GITHUB_TOKEN TTL. Upload a short follow-up step instead
+# so the environment hook mints a fresh token for the status POST.
+if [[ "${BUILDKITE_PIPELINE_SLUG:-}" == "docs-build-pr" ]] && [[ "${BUILDKITE_STEP_KEY:-}" == "build-pr" ]]; then
     status_state=failure
     if [[ "${BUILDKITE_COMMAND_EXIT_STATUS:-1}" -eq 0 ]]; then
         status_state=success
     fi
-    "${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite/scripts/build_pr_commit_status.sh" "$status_state" || true
+
+    echo "Uploading GitHub status step (${status_state})"
+
+    # Checkout is required so build_pr_commit_status.sh is on disk. The job
+    # is short; the environment hook mints a fresh VAULT_GITHUB_TOKEN.
+    cat <<YAML | buildkite-agent pipeline upload
+steps:
+  - key: "github-status-${BUILDKITE_JOB_ID}"
+    label: "GitHub status"
+    command: ".buildkite/scripts/build_pr_commit_status.sh ${status_state}"
+YAML
 fi

--- a/.buildkite/scripts/build_pr_commit_status.sh
+++ b/.buildkite/scripts/build_pr_commit_status.sh
@@ -24,10 +24,11 @@ githubPublishStatus="https://api.github.com/repos/${GITHUB_PR_BASE_OWNER}/${GITH
 data='{"state":"'$status_state'","target_url":"'$BUILDKITE_BUILD_URL'","description":"'$description'","context":"buildkite/'$BUILDKITE_PIPELINE_SLUG'"}'
 
 echo "Setting commit status: buildkite/${BUILDKITE_PIPELINE_SLUG} - ${status_state}"
-curl -s -L \
+curl --fail -sS -L \
   -X POST \
   -H "Accept: application/vnd.github+json" \
   -H "Authorization: Bearer ${VAULT_GITHUB_TOKEN}" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   "${githubPublishStatus}" \
   -d "${data}"
+echo


### PR DESCRIPTION
## Why

- Long `docs-build-pr` jobs expire `VAULT_GITHUB_TOKEN` before `pre-exit` posts the final GitHub status
- GitHub then stays pending while the Buildkite build is already green

## What

- Upload a short follow-up step from `pre-exit` to post the final GitHub status with a fresh token
- Fail the status step when GitHub rejects the POST

## Notes

- The uploaded step checks out the repo so the status script is on disk
- The step key includes `BUILDKITE_JOB_ID` so a UI retry of `build-pr` can post status again

Made with [Cursor](https://cursor.com)